### PR TITLE
feat: source-scoped memory reads + real-data stress pass (Checkpoint 1 + C2 slice)

### DIFF
--- a/docs/superpowers/specs/2026-06-07-sourcecado-post-memory-agent-runtime-design.md
+++ b/docs/superpowers/specs/2026-06-07-sourcecado-post-memory-agent-runtime-design.md
@@ -1,0 +1,337 @@
+# Sourcecado Post-Memory Agent Runtime Design
+
+Date: 2026-06-07
+Status: Draft for user review
+
+## Summary
+
+Sourcecado should evolve from a permissioned sourcing memory system into a
+memory-grounded agent runtime for sourcing work. The next stage should not turn
+Sourcecado into a generic CRM, clone The Hog, or jump straight to sandbox
+infrastructure. It should add a runtime spine after the current memory roadmap
+has a stable, permissioned read foundation.
+
+The recommended direction is a runtime spine:
+
+```text
+UI Run / Scheduled Run / API Trigger
+  -> Platform Service
+      auth, source scope, session, credits later, audit
+  -> Agent Service
+      executeAgent(agent_id, run_context)
+  -> Shared Memory Read Service
+      retrieval, temporal filters, citations, gaps, permissions
+  -> Tool Registry
+      read tools, write tools, admin_only tools
+  -> Runtime Adapter
+      local process first, worker/sandbox later
+  -> Run Ledger
+      runs, steps, tool calls, artifacts, logs, metrics
+```
+
+The product principle is:
+
+```text
+Memory first. Runtime second. Workflow automation third.
+```
+
+## Relationship To The Current Roadmap
+
+The current roadmap remains the immediate priority:
+
+1. Real data stress pass.
+2. Multi-user source-scoped foundation.
+3. Read-only MCP with permission enforcement.
+4. Temporal facts and as-of answers.
+5. Learned ontology suggestions.
+6. Thin Research Chat.
+
+The runtime roadmap begins after the shared read service is trustworthy enough
+for agents to use:
+
+7. Agent run ledger.
+8. Agent service with `executeAgent()`.
+9. Scoped tool registry.
+10. Trigger surfaces.
+11. Runtime adapter.
+12. Multi-agent sourcing workflows.
+
+The dividing line is the shared read service. Sourcecado should not build
+autonomous or scheduled agents until memory reads are permissioned, citeable,
+and temporal enough to trust.
+
+## Reference Role Of The Hog
+
+The Hog is a reference implementation, not a dependency or host platform.
+
+Patterns worth borrowing:
+
+- context injection from authenticated server state;
+- allowlisted tool registration;
+- run and tool observability;
+- background-job handoffs;
+- proposal and review patterns for risky actions;
+- CRM and sales tool ideas for later scoped tools.
+
+Patterns not to inherit as core Sourcecado scope:
+
+- broad GTM/CRM product shape;
+- sales dashboard ownership;
+- full agent tool suite before memory trust is proven;
+- external side effects as an early default behavior.
+
+Sourcecado's core should remain a sourcing operating system with durable memory,
+not a CRM that happens to have agents.
+
+## Runtime Architecture
+
+The stable center of the runtime is `executeAgent()`.
+
+Every surface should create the same kind of run:
+
+- manual CLI or UI run;
+- scheduled run;
+- API-triggered run.
+
+Those surfaces should differ in presentation and trigger metadata, not in core
+execution semantics. Each run passes through the platform service, resolves
+identity and source scope, receives a constrained tool set, executes through the
+agent service, and records its work in the run ledger.
+
+The agent service should not own sourcing truth. It consumes the shared memory
+read service for retrieval, temporal filtering, citation assembly, gaps, and
+permission filtering.
+
+The first runtime adapter can be intentionally simple: local process or worker
+execution. CREAO-style sandbox features such as filesystem snapshots,
+hot-swappable agent code, S3 FUSE mounts, and isolated runtime state should stay
+behind the adapter boundary until real workloads justify them.
+
+## Roadmap Scope
+
+Each runtime checkpoint should prove one platform primitive while still shipping
+a useful sourcing capability.
+
+### Checkpoint 1: Agent Run Ledger
+
+Add durable records for agent runs, steps, tool calls, artifacts, errors, and
+events.
+
+Purpose:
+
+- make agent work inspectable;
+- preserve partial progress after failures;
+- create the audit trail needed before scheduling or external actions;
+- avoid opaque chat transcripts as the system of record.
+
+### Checkpoint 2: Agent Service
+
+Add a small `executeAgent()` boundary that can run a named sourcing agent with
+injected identity, source scope, memory access, and constrained tools.
+
+The first version should support one manual run path before scheduling or API
+triggers.
+
+### Checkpoint 3: Scoped Tool Registry
+
+Register tools by capability class:
+
+- `read`;
+- `write`;
+- `admin_only`.
+
+The registry should inject server-side context and deny unavailable tool classes
+before the model sees them.
+
+### Checkpoint 4: Trigger Surfaces
+
+Add trigger surfaces in this order:
+
+1. CLI or manual run.
+2. Research Chat or UI run.
+3. Scheduled run.
+4. API trigger.
+
+All triggers should create the same run shape.
+
+### Checkpoint 5: Runtime Adapter
+
+Keep the first adapter local and simple. Add worker or sandbox execution later
+when agents need isolated code, long-running execution, hot-swappable runtime
+state, or stronger resource boundaries.
+
+### Checkpoint 6: Multi-Agent Sourcing Workflows
+
+Multi-agent design is intentionally unresolved in this spec.
+
+```text
+TODO: Define sourcing-workflow agents after deeper review of the Sourcing
+Director workflow.
+```
+
+Known direction:
+
+```text
+Sourcecado should model the real sourcing operating loop:
+find contacts -> research context -> prepare outreach -> manage follow-up
+-> capture outcomes into memory
+```
+
+The runtime spine should support future named agents safely, but this spec does
+not lock in agent names, handoffs, or orchestration.
+
+## Tool And Safety Model
+
+Sourcecado should start with three tool classes.
+
+```text
+read
+  Can inspect allowed memory and sources.
+  Example: ask_memory, search_memory, get_source, list_gaps.
+
+write
+  Can write low-risk internal Sourcecado state.
+  Example: remember_note, mark_gap_reviewed, save_run_artifact,
+  create_draft_artifact.
+
+admin_only
+  Can perform privileged operations or create user-facing proposals that
+  require review.
+  Example: ingest, refresh, change_permissions, approve_ontology_change,
+  propose_contact_update, draft_followup_for_review.
+```
+
+The enforcement model:
+
+```text
+caller identity + source scope + run type
+  -> allowed tool classes: read / write / admin_only
+  -> registered tools
+  -> server-injected context
+  -> audited tool execution
+```
+
+The important simplification is that proposal-required tools are folded into
+`admin_only`. Anything that could influence external workflows, user-facing
+records, ontology, permissions, or future team behavior should be available only
+in trusted/admin-created run contexts.
+
+A normal scheduled sourcing run can read memory and write internal artifacts. It
+cannot create official contact-change proposals, draft official follow-ups,
+approve ontology changes, ingest sources, or mutate permissions unless the run
+was started in an admin context.
+
+## Run Data Flow
+
+Every run follows one common flow:
+
+```text
+trigger request
+  -> authenticate caller
+  -> resolve source scope
+  -> create agent_run
+  -> compile run context
+  -> register allowed tools
+  -> execute agent through runtime adapter
+  -> record steps, tool calls, logs, artifacts, and errors
+  -> return result to caller
+```
+
+The run ledger is the system of record.
+
+Candidate records:
+
+```text
+agent_runs
+  id, trigger_type, caller_type, caller_id, source_scope, status, started_at,
+  completed_at
+
+agent_steps
+  run_id, step_index, agent_id, input_summary, output_summary, status
+
+tool_calls
+  run_id, step_id, tool_name, tool_class, input_summary, output_summary, status,
+  error
+
+run_artifacts
+  run_id, artifact_type, title, content_json, source_refs, created_by_step
+
+run_events
+  run_id, event_type, message, metadata_json, created_at
+```
+
+The first implementation can keep this compact, but agents should leave behind
+auditable work products that Sourcecado can inspect, replay, summarize, and
+eventually ingest into memory.
+
+## Error Handling
+
+Runtime errors should be explicit and recorded.
+
+```text
+auth/source-scope failures
+  -> deny before retrieval or tool registration
+
+tool validation failures
+  -> record failed tool_call with safe error summary
+
+agent/runtime failure
+  -> mark agent_run failed, preserve completed steps/artifacts
+
+scheduled/API trigger failure
+  -> record run_event, expose retry status later
+
+memory lookup gaps
+  -> return as structured gaps, not as runtime errors
+```
+
+Errors should not erase completed work. A failed run should still show what
+steps completed, what tool calls were attempted, which artifacts were produced,
+and which boundary failed.
+
+## Verification
+
+Verification should prove platform boundaries, not just answer quality.
+
+Core tests:
+
+- permission tests: the same task with different source scopes returns
+  different allowed evidence;
+- tool registry tests: read-only runs cannot register write or admin_only tools;
+- run ledger tests: every run records status, steps, tool calls, artifacts, and
+  errors;
+- trigger parity tests: CLI, UI, API, and scheduled triggers all create the
+  same run shape;
+- memory boundary tests: agent answers and tool calls use the shared read
+  service, not duplicate retrieval logic.
+
+For the first implementation plan, the acceptance bar should be:
+
+- one named agent;
+- one manual trigger;
+- a minimal run ledger;
+- read/write/admin_only tool classes;
+- proof that unauthorized tools and sources cannot leak into the run.
+
+## Out Of Scope
+
+The runtime stage should not include:
+
+- full CRM dashboards;
+- autonomous outreach sending;
+- broad sales tool suite;
+- billing as a core primitive;
+- sandbox snapshots or hot-swap implementation;
+- final multi-agent sourcing workflow design.
+
+Those can become later layers once the run system proves itself.
+
+## Open Decisions For The Implementation Plan
+
+- Which manual trigger should be first: CLI run or Research Chat/UI run?
+- What is the first named agent?
+- Which storage layer should hold the run ledger in the first implementation:
+  the existing local SQLite database or a hosted Postgres path?
+- Which initial read and write tools are enough to prove the registry boundary?
+- How should admin-created run contexts be represented before a full admin UI
+  exists?

--- a/docs/superpowers/specs/2026-06-07-sourcyavo-team-memory-roadmap-design.md
+++ b/docs/superpowers/specs/2026-06-07-sourcyavo-team-memory-roadmap-design.md
@@ -1,0 +1,402 @@
+# SourcyAvo Team Memory Roadmap Design
+
+Date: 2026-06-07
+Status: Draft for user review
+
+## Summary
+
+SourcyAvo should grow from its current local CLI into a small, permissioned
+team sourcing memory system. The roadmap should stay grounded: each checkpoint
+must ship a useful Codeology sourcing workflow and prove one serious memory
+system primitive.
+
+The next phase is not a generic company brain and not a full GBrain or Graphiti
+clone. It is a Codeology sourcing memory system that borrows proven patterns
+where they solve current product needs:
+
+- GBrain-style multi-user source scoping and MCP surfaces.
+- Graphiti-style temporal fact validity and invalidation.
+- Reviewed ontology evolution from messy real source material.
+
+## Current Baseline
+
+SourcyAvo currently has a local TypeScript CLI that can:
+
+- ingest exported `.md`, `.txt`, `.csv`, and `.eml` files;
+- create source records and memory chunks;
+- refresh structured entities, relationships, and semantic facts;
+- cache extraction runs;
+- answer questions with `Answer`, `Evidence`, `Gaps`, and `Next Action`;
+- surface candidate, conflicted, and stale memory as gaps.
+
+The current MVP is single-user local memory. That boundary no longer matches
+the intended use case because SourcyAvo will be shared by a team with different
+permission scopes.
+
+## Product Direction
+
+SourcyAvo should optimize for a hybrid goal:
+
+- teach modern memory-system architecture through real implementation, and
+- help Codeology Sourcing Directors answer real sourcing-history questions.
+
+The roadmap should avoid a vague grand vision. The product should move through
+grounded checkpoints that can be tested against real Codeology data and real
+sourcing questions.
+
+## Roadmap Checkpoints
+
+### Checkpoint 1: Real Data Stress Pass
+
+Run broad real Codeology source material through the existing local pipeline.
+This should include available sourcing Sheets, Notion/Drive exports, and email
+exports when safe to use.
+
+Purpose:
+
+- expose real ingestion, extraction, citation, retrieval, and ontology failures;
+- replace fixture-only confidence with actual sourcing-memory evidence;
+- define the true requirements for team access, MCP tools, temporal answers,
+  and Research Chat.
+
+Success criteria:
+
+- real exports ingest without one bad file stopping the run;
+- ingestion and extraction failures are recorded with actionable reasons;
+- benchmark sourcing questions can be run and misses can be classified as
+  extraction, retrieval, missing-source, temporal, citation, or permission
+  failures.
+
+### Checkpoint 2: Multi-User Source-Scoped Foundation
+
+Add the team-sharing foundation before exposing the system broadly.
+
+Core behavior:
+
+- each source/import has a stable `source_id`;
+- source-backed rows carry source identity;
+- users, sessions, and OAuth-style clients have explicit allowed source scopes;
+- scoped clients can represent agent/MCP callers without pretending every agent
+  is a full human user;
+- reads and writes are filtered through central source-scope helpers;
+- restricted source material is filtered before retrieval and answer synthesis.
+
+This borrows GBrain's important idea without importing all of GBrain's
+operational scale: scope must be enforced structurally, not by prompt wording.
+
+Success criteria:
+
+- at least two test users or clients can have different source access;
+- OAuth-style client identity can be mapped to an allowed source scope;
+- the same query returns different allowed evidence for different scopes;
+- restricted material does not appear in search results, source lookups,
+  citations, gaps, or final answers for unauthorized callers.
+
+### Checkpoint 3: Read-Only MCP With Permission Enforcement
+
+Expose SourcyAvo through MCP so Codex, Claude Code, or a similar agent can use
+the memory layer directly.
+
+Initial MCP tools should be read-only:
+
+- `ask`: ask a sourcing-memory question;
+- `search_memory`: retrieve relevant allowed memory;
+- `get_source`: inspect an allowed source/citation;
+- `list_gaps`: inspect missing, candidate, conflicted, stale, superseded, or
+  invalidated memory.
+
+Admin and mutation operations remain separate:
+
+- `ingest` stays CLI/admin-only;
+- `refresh` stays CLI/admin-only;
+- permission changes stay admin-only.
+
+Success criteria:
+
+- a scoped MCP caller can answer real sourcing questions;
+- MCP results are structured enough for an agent to use, not just terminal
+  prose;
+- every MCP read respects the caller's permission scope;
+- unauthorized callers cannot see restricted evidence or trigger admin actions.
+
+### Checkpoint 4: Temporal Facts And As-Of Answers
+
+Upgrade facts from flat statuses into a lightweight temporal model inspired by
+Graphiti.
+
+The current statuses are still useful as answer-facing projections:
+
+- `candidate`;
+- `accepted`;
+- `conflicted`;
+- `stale`;
+- `superseded`;
+- `invalidated`.
+
+But the underlying model should add temporal fields such as:
+
+- `observed_at`: when SourcyAvo learned or extracted the fact;
+- `valid_at`: when the fact became true in the world, if known;
+- `invalid_at`: when the fact stopped being true, if known;
+- `superseded_by_fact_id`: the newer fact that replaced this one, if any;
+- source provenance back to the source record/chunk.
+
+The key behavior is invalidation instead of deletion. If a contact was marked
+as needing follow-up in March and later marked as responded in April, the March
+fact should remain available for historical answers.
+
+Success criteria:
+
+- "Who needs follow-up now?" and "Who needed follow-up in March?" can return
+  different, explainable answers;
+- old facts remain citeable;
+- contradictory or superseding facts are surfaced as gaps or temporal notes
+  rather than silently overwritten;
+- temporal behavior is tested with fixtures and real-data snapshots.
+
+### Checkpoint 5: Learned Ontology Suggestions
+
+Add ontology learning as a reviewed suggestion workflow, not as automatic schema
+mutation.
+
+SourcyAvo starts with a prescribed sourcing ontology:
+
+- Contact;
+- Organization;
+- Outreach Attempt;
+- Outreach Outcome;
+- Domain;
+- Event;
+- Semester;
+- Source Material.
+
+During refresh, the system should detect recurring patterns that do not fit the
+current ontology, such as:
+
+- repeated unknown relationship names;
+- recurring source fields that are not mapped;
+- ambiguous outreach statuses;
+- entity types that repeatedly appear in real data;
+- facts that cannot be classified cleanly.
+
+Those become ontology suggestions. An admin can accept, rename, merge, or
+reject them. Only accepted ontology changes affect future extraction and
+answers.
+
+Success criteria:
+
+- refresh can produce ontology suggestions from real data;
+- suggestions include examples and source citations;
+- rejected suggestions do not affect extraction;
+- accepted suggestions become explicit, testable schema/extraction behavior.
+
+### Checkpoint 6: Thin Research Chat
+
+Build a simple web Research Chat for Sourcing Directors after the permissioned
+read layer and MCP surface are working.
+
+The UI should stay narrow:
+
+- question input;
+- four-section sourcing answer;
+- inspectable source citations;
+- visible gaps and temporal notes;
+- no CRM dashboard;
+- no automatic outreach.
+
+Research Chat must reuse the same shared read service as MCP. It should differ
+in presentation, not in retrieval semantics, permission filtering, or answer
+logic.
+
+Success criteria:
+
+- a Sourcing Director can answer the benchmark sourcing questions without using
+  CLI or MCP directly;
+- the UI never shows unauthorized source material;
+- citations and gaps are inspectable enough for manual verification.
+
+## Shared Architecture
+
+SourcyAvo should have one memory layer and multiple surfaces.
+
+```text
+Real Codeology Source Material
+  -> Source Records
+  -> Memory Chunks
+  -> Entities / Relationships
+  -> Temporal Semantic Facts
+  -> Shared Read Service
+      -> CLI ask
+      -> MCP read tools
+      -> Research Chat
+```
+
+The shared read service is the important boundary. It owns:
+
+- permission/source scope;
+- temporal filters;
+- retrieval;
+- citation assembly;
+- gap formatting;
+- answer contract.
+
+CLI, MCP, and Research Chat should not each implement their own retrieval or
+truth rules.
+
+## Identity And Permission Direction
+
+Team sharing is part of the product, not a later enterprise add-on. The first
+multi-user checkpoint should model identity explicitly enough to prove that
+SourcyAvo can be safely shared by multiple Codeology users and agent clients.
+
+Minimum model:
+
+- `users`: human teammates;
+- `oauth_clients`: scoped agent or app clients;
+- `sources`: imported source collections or files;
+- `source_permissions`: user/client access to allowed sources;
+- `audit_events`: reads, denied reads, permission changes, and admin actions.
+
+The exact auth provider is an implementation-plan decision. The architectural
+decision is already made: SourcyAvo needs login/client identity and source
+scope before retrieval, not after answer generation.
+
+## Temporal Fact Direction
+
+Temporal behavior should be lightweight but real. A fact should not disappear
+just because a later refresh found a better or newer version.
+
+Candidate fields:
+
+- `observed_at`: when SourcyAvo learned the fact;
+- `valid_at`: when the fact appears to have become true in the world;
+- `invalid_at`: when the fact appears to have stopped being true;
+- `expired_at`: when SourcyAvo stopped treating the fact as currently active;
+- `superseded_by_fact_id`: pointer to the newer fact;
+- `source_record_id` and `memory_chunk_id`: provenance.
+
+Answer logic can still present simple statuses, but storage should preserve
+enough history to answer "what did we believe then?" and "what appears true
+now?" without inventing facts.
+
+## Learned Ontology Direction
+
+Learned ontology machinery should help SourcyAvo adapt to real Codeology data
+without letting extraction drift mutate the system behind the team's back.
+
+Suggested flow:
+
+1. Refresh notices repeated unknown fields, labels, relationships, entity
+   shapes, or status phrases.
+2. SourcyAvo stores an ontology suggestion with examples, citations, frequency,
+   and proposed mapping.
+3. An admin accepts, renames, merges, or rejects the suggestion.
+4. Accepted changes become explicit extraction configuration and test cases.
+
+This gives the project the useful part of a learned ontology system: the memory
+layer can notice that its vocabulary is too small. It avoids the dangerous
+part: silently changing the schema or answer semantics without review.
+
+## Borrowed Patterns
+
+### Borrow From GBrain Now
+
+- Multi-user hosted access.
+- OAuth-scoped clients for agent and app access.
+- Source-scoped reads and writes.
+- MCP as an agent-native read surface.
+- Separation between user read tools and admin/local operations.
+- Auditability around requests and source access.
+
+### Borrow From GBrain Later
+
+- Large durable job queue.
+- Full dream-cycle automation.
+- Production-scale company-brain operating model.
+
+These should be added only when real refresh/runtime needs justify them.
+
+### Borrow From Graphiti Now
+
+- Temporal fact validity windows.
+- Fact invalidation and supersession instead of deletion.
+- "As of date X" answers.
+- Provenance from facts back to source material.
+
+### Borrow From Graphiti Carefully
+
+- Learned ontology machinery should enter as reviewed suggestions, not automatic
+  schema mutation.
+- Graph traversal should stay sourcing-specific at first.
+
+### Do Not Clone Yet
+
+- Full Python graph database engine.
+- Fully learned ontology without review.
+- Arbitrary graph traversal as the primary answer mechanism.
+- Per-row permission complexity beyond source/fact scope unless real data
+  proves it necessary.
+
+## Graph Traversal Scope
+
+Graph traversal is useful, but the first version should be constrained to
+sourcing workflows:
+
+- Contact -> Organization;
+- Contact -> Outreach Attempt -> Outreach Outcome;
+- Contact -> Domain;
+- Contact -> Semester/Event;
+- Contact -> Past Collaborator.
+
+The system should avoid broad arbitrary traversal until real questions require
+it. This keeps answers explainable and testable.
+
+## Out Of Scope
+
+- Autonomous outreach.
+- Sending email or messages.
+- Full CRM workflows.
+- Messenger integration unless privacy/access is explicitly solved.
+- Full GBrain minions/job architecture.
+- Full Graphiti graph engine.
+- Learned ontology that mutates accepted schema without review.
+- Generic company-brain product scope outside Codeology sourcing.
+
+## Verification Philosophy
+
+Every checkpoint should be tested against both controlled fixtures and real
+Codeology source snapshots.
+
+The most important verification rules:
+
+- permission checks must cover search, answers, citations, gaps, and source
+  lookup;
+- temporal tests must prove different answers at different dates;
+- ontology suggestions must be reviewable and reversible;
+- real-data failures should be turned into named categories rather than buried
+  in logs.
+
+## Benchmark Questions
+
+The roadmap should continue using the original sourcing benchmark questions,
+expanded with permission and temporal variants:
+
+- Who did we contact last semester for AI, biotech, startups, or design?
+- Who responded?
+- Who did not respond?
+- Who needs follow-up now?
+- Who needed follow-up during a specific month or semester?
+- Which companies or people worked with Codeology before?
+- What outreach style worked?
+- What did not work?
+- What facts are conflicted, stale, superseded, or missing?
+- What sources was this answer allowed to use?
+
+## Open Decisions For The Implementation Plan
+
+- Which concrete auth provider or local development auth shim should implement
+  the first OAuth-style user/client boundary?
+- What source taxonomy should be used for the first real Codeology data import?
+- Which real-data snapshot becomes the repeatable test corpus?
+- How should ontology suggestions be represented before there is an admin UI?
+- Whether MCP should be stdio-only first or support HTTP later.

--- a/docs/superpowers/specs/2026-06-07-sourcyavo-team-memory-roadmap-design.md
+++ b/docs/superpowers/specs/2026-06-07-sourcyavo-team-memory-roadmap-design.md
@@ -400,3 +400,509 @@ expanded with permission and temporal variants:
 - Which real-data snapshot becomes the repeatable test corpus?
 - How should ontology suggestions be represented before there is an admin UI?
 - Whether MCP should be stdio-only first or support HTTP later.
+
+## Eng Review Scope Decision
+
+The next implementation plan should not attempt all six roadmap checkpoints in
+one branch. That would turn a focused memory-system hardening pass into a broad
+rewrite across ingestion, permissions, MCP, temporal facts, ontology review, and
+web UI.
+
+Approved next scope:
+
+1. Checkpoint 1: real-data stress pass.
+2. The smallest useful slice of Checkpoint 2: source-scoped read enforcement.
+
+Everything else remains roadmap direction until the real-data and permission
+primitive is proven.
+
+The next branch should ship:
+
+- real Codeology export ingestion against safe source snapshots;
+- ingestion and extraction failure classification;
+- stable source identity for imported source material;
+- local test users or clients with different source scopes;
+- one shared read boundary used by CLI ask and reserved for MCP/chat later;
+- scoped answer, search, source lookup, citation, and gap behavior;
+- regression tests proving restricted material does not leak.
+
+It should not ship MCP, Research Chat, temporal fact migration, or ontology
+suggestion review yet.
+
+## What Already Exists
+
+SourcyAvo should reuse these pieces instead of rebuilding parallel flows:
+
+- `src/db.ts` already defines the local SQLite memory database, source records,
+  memory chunks, relationships, semantic facts, extraction runs, and ingest
+  errors.
+- `src/ingest.ts` already supports recursive ingestion, per-file error logging,
+  source records, chunking, embeddings, and citations.
+- `src/refresh.ts` already owns extraction caching, entity/relationship/fact
+  rebuilds, conflict marking, stale fact restoration, and source provenance.
+- `src/answer.ts` already owns the four-section answer contract and should be
+  wrapped by the new shared read boundary rather than copied for MCP or chat.
+- `docs/adr/0001-permissioned-memory-layer.md` already decides that prompt-only
+  secrecy and post-retrieval filtering are not acceptable.
+
+The current gap is not lack of source provenance. The current gap is that reads
+do not take a caller identity or source scope.
+
+## Shared Read Boundary
+
+Checkpoint 2 should introduce one explicit read boundary before any new surface
+is built.
+
+Recommended shape:
+
+```text
+Caller identity
+  -> AccessContext
+       actor_type: user | oauth_client | test_client
+       actor_id
+       allowed_source_ids
+       denied_source_ids
+       audit_label
+  -> MemoryReader
+       ask(question, options)
+       searchMemory(query, options)
+       getSource(source_id)
+       listGaps(options)
+  -> Scoped SQL helpers
+       where source_id in allowed_source_ids
+       record audit_events for reads and denied reads
+  -> Answer / Evidence / Gaps / Next Action
+```
+
+Rules:
+
+- CLI, MCP, and Research Chat must call `MemoryReader`; they must not query
+  `semantic_facts`, `memory_chunks`, or `source_records` directly.
+- `buildSourcingMemoryAnswer` should either accept `AccessContext` or become an
+  internal helper called only after scoped facts and chunks have been selected.
+- Scoping must happen before retrieval, ranking, citation assembly, gap
+  formatting, and answer synthesis.
+- Test clients are enough for the next branch. A real OAuth provider is deferred
+  until hosted HTTP MCP or Research Chat needs browser login.
+
+## Stable Source Identity
+
+The next branch should not rely on SQLite autoincrement IDs as the durable
+permission identity. `source_records.id` can remain the internal primary key,
+but permission tables and external callers need a stable text `source_id`.
+
+Recommended model:
+
+```text
+source_records
+  id              integer primary key
+  source_id       text unique not null
+  path            text unique not null
+  title           text not null
+  source_type     text not null
+  content_hash    text not null
+  raw_text        text not null
+
+source_permissions
+  principal_type  user | oauth_client | test_client
+  principal_id    text not null
+  source_id       text not null
+  access          read
+
+audit_events
+  actor_type
+  actor_id
+  action          ask | search_memory | get_source | list_gaps | denied_read
+  source_id
+  created_at
+```
+
+`source_id` should be deterministic from the import taxonomy, not the transient
+database row. For the real-data stress pass, use a simple explicit mapping file
+or frontmatter override before inventing a complex source registry.
+
+## Reviewed Next-Scope Data Flow
+
+```text
+Safe Codeology exports
+  -> sourcyavo ingest
+       -> source_records(source_id)
+       -> memory_chunks(source_id via source_record_id)
+       -> ingest_errors
+  -> sourcyavo refresh
+       -> extraction_runs
+       -> entities / relationships / semantic_facts
+       -> refresh failure categories
+  -> MemoryReader(access_context)
+       -> scoped facts
+       -> scoped chunks
+       -> scoped gaps
+       -> scoped citations
+  -> CLI ask
+       -> Answer
+       -> Evidence
+       -> Gaps
+       -> Next Action
+```
+
+The important property is that the same question can produce different evidence
+for different test clients, and unauthorized source material never enters the
+retrieval candidate set.
+
+## Test Coverage Plan
+
+Project test framework: Vitest, detected from `package.json` and
+`vitest.config.ts`.
+
+```text
+CODE PATHS                                             USER FLOWS
+[+] ingest real-data snapshot                          [+] Admin imports safe exports
+  |-- [GAP] supported files continue after failures       |-- [GAP] bad file does not stop import
+  |-- [GAP] failure reason categories are persisted       |-- [GAP] import report names skipped files
+  `-- [GAP] stable source_id assigned per source          `-- [GAP] source taxonomy is inspectable
+
+[+] MemoryReader(access_context)                       [+] Scoped CLI ask
+  |-- [GAP] allowed source facts are returned             |-- [GAP] same question differs by client
+  |-- [GAP] denied source facts are excluded              |-- [GAP] restricted citation is hidden
+  |-- [GAP] denied chunks are excluded before ranking      |-- [GAP] restricted gap is hidden
+  |-- [GAP] getSource denies unauthorized source_id        `-- [GAP] denied read is audited
+  `-- [GAP] listGaps respects allowed source_ids
+
+[+] answer assembly                                     [+] No-memory / no-access UX
+  |-- [GAP] evidence only cites allowed facts/chunks       |-- [GAP] caller sees clear no-access gap
+  |-- [GAP] gaps only mention allowed sources              `-- [GAP] no silent empty answer
+  `-- [GAP] next action cannot mention denied material
+
+COVERAGE TARGET: every path above covered before MCP work starts.
+QUALITY TARGET: behavior + edge + error tests for permission paths.
+```
+
+Required tests:
+
+- Unit tests for `AccessContext` construction and allowed-source resolution.
+- Unit tests for scoped SQL helpers with empty, single-source, multi-source, and
+  unknown-source scopes.
+- Regression tests showing current unscoped `ask` behavior would leak restricted
+  accepted facts, chunks, citations, and gaps.
+- Integration tests that seed two sources, two test clients, and the same
+  question, then assert different scoped answers.
+- `getSource` tests for allowed, denied, missing, and malformed source IDs.
+- Audit tests for successful reads and denied reads.
+- Real-data stress tests that classify misses as extraction, retrieval,
+  missing-source, temporal, citation, or permission failures.
+
+## Failure Modes
+
+- Bad export file during ingestion: covered if `ingest_errors` records a reason
+  and neighboring files still ingest. User should see the skipped file and
+  reason in the stress report.
+- Source ID changes after reimport: not covered until stable `source_id` tests
+  exist. This can silently break permissions, so it is a critical next-scope
+  test.
+- Restricted fact appears in `Answer`: not covered today because `answer.ts`
+  reads accepted facts globally. The next branch must add a regression test.
+- Restricted chunk appears in `Evidence`: not covered today because retrieval
+  reads all chunks globally. The next branch must add a regression test.
+- Restricted candidate/conflicted/stale fact appears in `Gaps`: not covered
+  today because gap loading is global. The next branch must add a regression
+  test.
+- Caller has no allowed sources: should return a clear no-access/no-memory style
+  answer, not a silent empty answer.
+- Real-data extraction fails on one source type: should be classified in the
+  stress report and should not prevent other sources from being refreshed.
+
+## Performance Review
+
+No production-scale performance work is needed in the next branch. The current
+local SQLite shape is boring and appropriate.
+
+One guardrail is required: source filtering must be pushed into SQL before
+ranking and embedding similarity. Do not retrieve all chunks and filter in
+JavaScript for scoped callers. That would be both a leak risk and a needless
+performance cost.
+
+Add indexes when the permission schema lands:
+
+- `source_records(source_id)`
+- `source_permissions(principal_type, principal_id, source_id)`
+- `memory_chunks(source_record_id)`
+- `semantic_facts(source_record_id, status)`
+- `audit_events(actor_type, actor_id, created_at)`
+
+## NOT In Scope For The Next Branch
+
+- MCP server implementation: defer until scoped read behavior is proven in CLI
+  tests.
+- Research Chat: defer until MCP/read service semantics are stable.
+- Real OAuth provider selection: use local test clients and `AccessContext`
+  first; hosted auth is a later integration decision.
+- Temporal fact migration: keep the roadmap direction, but do not mix temporal
+  semantics into the permission branch.
+- Ontology suggestions: defer until real-data stress failures prove which
+  ontology gaps repeat.
+- Full graph traversal: defer broad traversal; current sourcing-specific
+  relationships are enough for the next branch.
+- Distribution pipeline: no new binary, package, container, or hosted app is
+  introduced in the next branch.
+
+## Worktree Parallelization Strategy
+
+The next branch has three possible lanes after a short schema/API alignment
+step.
+
+| Step | Modules touched | Depends on |
+|---|---|---|
+| Stable source IDs and permissions schema | `src/db.ts`, `src/ingest.ts` | none |
+| Scoped read boundary | `src/answer.ts`, new read-service module | source IDs |
+| Real-data stress harness and reporting | `tests/`, docs/spec fixtures | source IDs |
+
+Recommended execution:
+
+- Lane A: stable source IDs and permission schema.
+- Lane B: scoped read boundary after Lane A.
+- Lane C: real-data stress harness can start in parallel with Lane B once source
+  taxonomy fixtures are agreed.
+
+Conflict flag: Lane A and Lane B both touch the memory schema/read path, so they
+should either run sequentially or merge Lane A first.
+
+## Implementation Tasks
+
+Synthesized from this eng review. Each task derives from a concrete finding
+above.
+
+- [ ] **T1 (P1, human: ~2h / CC: ~20min)** — Scope — Rewrite the next
+  implementation plan around Checkpoint 1 plus the permission choke point.
+  - Surfaced by: Step 0 scope challenge.
+  - Files: `docs/superpowers/specs/2026-06-07-sourcyavo-team-memory-roadmap-design.md`
+  - Verify: plan names MCP, Research Chat, temporal migration, and ontology
+    suggestions as out of scope for the next branch.
+
+- [ ] **T2 (P1, human: ~2h / CC: ~20min)** — Permissions — Add the
+  `MemoryReader` / shared read boundary and require CLI/MCP/chat to use it.
+  - Surfaced by: Architecture review.
+  - Files: `src/answer.ts`, new read-service module, tests.
+  - Verify: scoped answer/search/source/gap tests pass.
+
+- [ ] **T3 (P1, human: ~2h / CC: ~20min)** — Source Identity — Add stable text
+  `source_id` and source permission tables without replacing internal SQLite
+  primary keys.
+  - Surfaced by: Architecture and failure-mode review.
+  - Files: `src/db.ts`, `src/ingest.ts`, tests.
+  - Verify: reimport preserves source identity and permission mappings.
+
+- [ ] **T4 (P1, human: ~3h / CC: ~30min)** — Tests — Add permission regression
+  tests for facts, chunks, citations, gaps, source lookup, no-access answers,
+  and audit events.
+  - Surfaced by: Test review.
+  - Files: `tests/answer.test.ts`, new permission/read-service tests.
+  - Verify: `npm test`.
+
+- [ ] **T5 (P2, human: ~3h / CC: ~30min)** — Real Data Stress — Add a repeatable
+  safe real-data stress harness and classify misses by failure category.
+  - Surfaced by: Test and verification review.
+  - Files: tests or scripts for real-data snapshots, docs.
+  - Verify: stress report classifies ingestion, extraction, retrieval,
+    missing-source, temporal, citation, and permission misses.
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | not run | Optional for product direction |
+| Codex Review | `/codex review` | Independent 2nd opinion | 0 | not run | Outside voice skipped |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | clear | 5 issues converted into implementation tasks, 0 unresolved |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | not run | Not needed for backend/CLI next scope |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | not run | Not requested |
+
+- **UNRESOLVED:** 0.
+- **VERDICT:** ENG CLEARED for the reduced next implementation scope:
+  Checkpoint 1 plus the permission choke point.
+
+## Execution Issues (Vertical Slices)
+
+Generated by `/to-issues` on 2026-06-07. These break the approved next scope —
+Checkpoint 1 (real-data stress) plus the smallest slice of Checkpoint 2
+(source-scoped read enforcement) — into tracer-bullet vertical slices ready for
+workflow-style parallel agent execution. MCP, Research Chat, temporal facts, and
+ontology suggestions are out of scope for these issues.
+
+Dependency DAG: `S1 -> S2 -> {S3, S4}`, `S4 -> S5`, `S4 -> S6` (S1, S2 also feed
+S6). After S1 and S2 land, three lanes run in parallel: Lane A = S3, Lane B = S4
+then S5, Lane C = S6 (starts once S4 lands).
+
+---
+
+### S1 — Decision: source taxonomy, deterministic source_id, and test corpus
+
+**Type:** HITL — **RESOLVED 2026-06-07**
+
+**Decision:**
+- `source_id` = frontmatter `source_id:` override if present, else a slug of the
+  stable relative path (e.g. `spring-2026/cold-emailing/apollo-csv`). Never the
+  SQLite autoincrement `id`.
+- Test corpus = a committed synthetic, Codeology-shaped fixture set under
+  `tests/fixtures/stress/` (safe for CI; no private contacts). A `--snapshot`
+  flag points the stress harness at a real safe snapshot when one is available.
+
+#### What to build
+
+Agree the foundational data decisions that every later slice depends on. Decide
+the deterministic `source_id` derivation rule (frontmatter override plus a stable
+path/taxonomy-based fallback — explicitly NOT the SQLite autoincrement `id`),
+define the source taxonomy for the first real Codeology import, and pick the safe
+real-data snapshot that becomes the repeatable test corpus. Capture the outcome
+as a short committed decision note plus the fixture/snapshot source files that
+S2 and S6 build against. Prefer a simple explicit mapping file or frontmatter
+override over a complex source registry.
+
+#### Acceptance criteria
+
+- [ ] Deterministic `source_id` rule is written down and is stable across reimport.
+- [ ] First-import source taxonomy is defined and inspectable.
+- [ ] A safe real-data snapshot is selected and committed as the repeatable test corpus.
+- [ ] No restricted/private material is included in the committed corpus.
+
+#### Blocked by
+
+None - can start immediately.
+
+---
+
+### S2 — Stable source_id + permission/audit schema + scoped ingest
+
+**Type:** AFK
+
+#### What to build
+
+Add durable source identity and the permission/audit foundation end-to-end. Add
+a `source_records.source_id` (text, unique) column populated by ingest using the
+S1 derivation rule, plus `source_permissions` (principal_type/principal_id/
+source_id/access) and `audit_events` tables, with the indexes named in the
+Performance Review. Reimporting the same source must preserve its `source_id` and
+therefore its permission mappings. Internal SQLite primary keys stay as-is; only
+the external permission identity becomes the stable text `source_id`.
+
+#### Acceptance criteria
+
+- [ ] Ingest assigns a deterministic, stable `source_id` per source.
+- [ ] Reimport of the same source preserves `source_id` and any permission mappings.
+- [ ] `source_permissions` and `audit_events` tables and indexes exist.
+- [ ] Permissions can be seeded for at least two test principals against different sources.
+- [ ] Tests cover stable-ID-on-reimport and the empty/single/multi/unknown source-scope cases.
+
+#### Blocked by
+
+- S1 (source taxonomy, deterministic source_id, and test corpus).
+
+---
+
+### S3 — Ingest robustness + failure classification (Checkpoint 1)
+
+**Type:** AFK
+
+#### What to build
+
+Harden the ingest path so a single bad export file cannot stop the run. Each
+failure is recorded in `ingest_errors` with a categorized, actionable reason, and
+the import produces a report that names every skipped file with its reason.
+Neighboring files continue to ingest after a failure.
+
+> Shares `ingest.ts` with S2 — sequence after S2; do not run concurrently.
+
+#### Acceptance criteria
+
+- [ ] One malformed file does not halt ingestion of the remaining files.
+- [ ] Every ingest failure is persisted to `ingest_errors` with a categorized reason.
+- [ ] The import report lists each skipped file and why it was skipped.
+- [ ] Tests cover a mixed batch where good and bad files are processed in the same run.
+
+#### Blocked by
+
+- S2 (stable source_id + permission/audit schema + scoped ingest).
+
+---
+
+### S4 — MemoryReader + AccessContext scoped `ask` (tracer bullet)
+
+**Type:** AFK
+
+#### What to build
+
+Build the shared read boundary and prove the core permission primitive
+end-to-end. Introduce a read-service module owning `AccessContext` (actor_type,
+actor_id, allowed_source_ids, denied_source_ids, audit_label) and a `MemoryReader`
+whose `ask` routes the existing four-section answer logic through scoped queries.
+Source filtering must be pushed into SQL before retrieval and ranking for BOTH
+accepted facts and evidence chunks — never retrieve everything and filter in
+JavaScript. Wire CLI `ask --client <id>` (or equivalent) to construct an
+`AccessContext` and call `MemoryReader`. The same question asked by two test
+clients with different scopes must return different allowed Answer + Evidence,
+and a restricted accepted fact or chunk must never appear for an unauthorized
+caller.
+
+#### Acceptance criteria
+
+- [ ] `AccessContext` and `MemoryReader.ask` exist; CLI `ask` routes through them.
+- [ ] Scope filtering happens in SQL before retrieval/ranking for facts and chunks.
+- [ ] Two test clients asking the same question get different scoped Answer + Evidence.
+- [ ] Regression test proves a restricted accepted fact/chunk does not leak into Answer or Evidence.
+- [ ] `buildSourcingMemoryAnswer` is only reachable after scoping (wrapped, not bypassed).
+
+#### Blocked by
+
+- S2 (stable source_id + permission/audit schema + scoped ingest).
+
+---
+
+### S5 — Remaining scoped surfaces + audit + no-access UX
+
+**Type:** AFK
+
+#### What to build
+
+Extend the read boundary to the remaining surfaces so every read respects scope.
+Add scoped `searchMemory`, `getSource` (deny unauthorized, missing, and malformed
+`source_id`), and `listGaps`/Gaps that exclude restricted candidate/conflicted/
+stale facts. A caller with no allowed sources gets a clear no-access answer rather
+than a silent empty result. Every read and every denied read is recorded in
+`audit_events`.
+
+> Shares the read-service module with S4 — sequence after S4.
+
+#### Acceptance criteria
+
+- [ ] `searchMemory`, `getSource`, and `listGaps` all enforce the caller's scope.
+- [ ] `getSource` denies unauthorized, missing, and malformed `source_id` inputs.
+- [ ] Restricted candidate/conflicted/stale facts are hidden from Gaps.
+- [ ] A no-allowed-sources caller receives an explicit no-access answer, never a silent empty one.
+- [ ] Successful reads and denied reads are written to `audit_events` and covered by tests.
+
+#### Blocked by
+
+- S4 (MemoryReader + AccessContext scoped `ask`).
+
+---
+
+### S6 — Real-data stress harness + benchmark miss classification
+
+**Type:** AFK
+
+#### What to build
+
+Add a repeatable, safe real-data stress harness that runs the committed snapshot
+through ingest, refresh, and scoped `ask` over the benchmark sourcing questions,
+then classifies every miss by category: extraction, retrieval, missing-source,
+temporal, citation, or permission. Output a stress report that surfaces skipped
+files and categorized misses instead of burying them in logs.
+
+#### Acceptance criteria
+
+- [ ] The harness runs the committed real-data snapshot repeatably without manual edits.
+- [ ] Benchmark sourcing questions are executed through the scoped read boundary.
+- [ ] Each miss is classified as extraction, retrieval, missing-source, temporal, citation, or permission.
+- [ ] The stress report names skipped files and categorized misses.
+
+#### Blocked by
+
+- S4 (MemoryReader + AccessContext scoped `ask`); benefits from S1 and S2.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest run",
+    "stress": "tsx scripts/stress.ts",
     "sourcyavo": "node dist/src/cli.js"
   },
   "dependencies": {

--- a/scripts/stress.ts
+++ b/scripts/stress.ts
@@ -1,0 +1,76 @@
+import { runStressHarness, type StressReport } from "../tests/stress/harness.js";
+
+// Thin CLI over runStressHarness. Prints a human-readable report by default, or
+// the raw StressReport JSON with --json. Exit code is non-zero ONLY on a
+// harness-internal failure (a thrown error). Classified benchmark misses are a
+// normal, expected output and do NOT fail the process.
+async function main(): Promise<void> {
+  const asJson = process.argv.includes("--json");
+  const report = await runStressHarness();
+
+  if (asJson) {
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    return;
+  }
+
+  process.stdout.write(`${formatReport(report)}\n`);
+}
+
+function formatReport(report: StressReport): string {
+  const lines: string[] = [];
+  lines.push("Sourcyavo Stress Harness Report");
+  lines.push("===============================");
+  lines.push(`Snapshot: ${report.snapshotPath}`);
+  lines.push(`Permission evaluation: ${report.permissionState}`);
+  lines.push("");
+  lines.push(`Ingest: ${report.ingest.processed} processed, ${report.ingest.skipped} skipped`);
+  lines.push(
+    `Refresh: ${report.refresh.extracted} extracted, ${report.refresh.reused} reused, ${report.refresh.failed} failed (${report.refresh.chunksProcessed} chunks)`
+  );
+  lines.push("");
+
+  lines.push(`Skipped files (${report.skippedFiles.length}):`);
+  if (report.skippedFiles.length === 0) {
+    lines.push("  (none)");
+  } else {
+    for (const skipped of report.skippedFiles) {
+      lines.push(`  - ${basename(skipped.path)} [${skipped.category}]`);
+    }
+  }
+  lines.push("");
+
+  lines.push(`Extraction failures (${report.extractionFailures.length}):`);
+  if (report.extractionFailures.length === 0) {
+    lines.push("  (none)");
+  } else {
+    for (const failure of report.extractionFailures) {
+      lines.push(`  - chunk ${failure.chunkId ?? "?"}: ${failure.error}`);
+    }
+  }
+  lines.push("");
+
+  lines.push(`Cases (${report.passCount} pass / ${report.missCount} miss):`);
+  for (const result of report.cases) {
+    const tag = result.outcome === "pass" ? "PASS" : `MISS:${result.category}`;
+    lines.push(`  [${tag}] ${result.id} — ${result.detail}`);
+  }
+  lines.push("");
+
+  lines.push("Miss tally:");
+  for (const [category, count] of Object.entries(report.tally)) {
+    const note = category === "temporal" ? " (deferred — Checkpoint 4)" : "";
+    lines.push(`  ${category}: ${count}${note}`);
+  }
+
+  return lines.join("\n");
+}
+
+function basename(path: string): string {
+  const parts = path.split(/[\\/]/);
+  return parts[parts.length - 1] || path;
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`Stress harness failed: ${error instanceof Error ? error.stack : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/src/answer.ts
+++ b/src/answer.ts
@@ -1,5 +1,6 @@
 import type { MemoryDatabase } from "./db.js";
 import { cosineSimilarity, deserializeEmbedding, embedText } from "./embeddings.js";
+import { sourceIdInClause, type SourceScope } from "./read-service.js";
 
 interface FactRow {
   subject: string;
@@ -18,8 +19,12 @@ interface ChunkRow {
 
 type QuestionIntent = "follow_up" | "responded" | "no_response" | "worked_with" | "uncertainty" | "generic";
 
-export function buildSourcingMemoryAnswer(db: MemoryDatabase, question: string): string {
-  const sourceCount = getSourceRecordCount(db);
+export function buildSourcingMemoryAnswer(
+  db: MemoryDatabase,
+  question: string,
+  scope: SourceScope
+): string {
+  const sourceCount = getSourceRecordCount(db, scope);
   const questionLine = question.trim() ? ` for "${question.trim()}"` : "";
   const intent = questionIntent(question);
 
@@ -27,9 +32,9 @@ export function buildSourcingMemoryAnswer(db: MemoryDatabase, question: string):
     return noMemoryAnswer(questionLine);
   }
 
-  const acceptedFacts = loadFacts(db, "accepted", question, intent);
-  const gapFacts = loadGapFacts(db, question);
-  const chunks = retrieveRelevantChunks(db, question);
+  const acceptedFacts = loadFacts(db, "accepted", question, intent, scope);
+  const gapFacts = loadGapFacts(db, question, scope);
+  const chunks = retrieveRelevantChunks(db, question, scope);
 
   if (acceptedFacts.length === 0 && chunks.length === 0) {
     return noRelevantMemoryAnswer(questionLine, gapFacts);
@@ -57,8 +62,14 @@ export function buildSourcingMemoryAnswer(db: MemoryDatabase, question: string):
 
 export const buildNoMemoryAnswer = buildSourcingMemoryAnswer;
 
-function getSourceRecordCount(db: MemoryDatabase): number {
-  const row = db.prepare("select count(*) as count from source_records").get() as { count: number };
+function getSourceRecordCount(db: MemoryDatabase, scope: SourceScope): number {
+  if (scope.allowedSourceIds.length === 0) {
+    return 0;
+  }
+  const { sql, params } = sourceIdInClause(scope, "source_records");
+  const row = db
+    .prepare(`select count(*) as count from source_records where ${sql}`)
+    .get(...params) as { count: number };
   return row.count;
 }
 
@@ -99,38 +110,49 @@ function loadFacts(
   db: MemoryDatabase,
   status: string,
   question: string,
-  intent: QuestionIntent
+  intent: QuestionIntent,
+  scope: SourceScope
 ): FactRow[] {
+  if (scope.allowedSourceIds.length === 0) {
+    return [];
+  }
+  const { sql: scopeSql, params: scopeParams } = sourceIdInClause(scope, "sr");
   const rows = db
     .prepare(
       [
         "select semantic_facts.subject, semantic_facts.predicate, semantic_facts.object,",
         "semantic_facts.confidence, semantic_facts.status, memory_chunks.citation",
         "from semantic_facts",
+        "join source_records sr on sr.id = semantic_facts.source_record_id",
         "left join memory_chunks on memory_chunks.id = semantic_facts.source_chunk_id",
-        "where semantic_facts.status = ?",
+        `where semantic_facts.status = ? and ${scopeSql}`,
         "order by semantic_facts.confidence desc, semantic_facts.subject"
       ].join(" ")
     )
-    .all(status) as FactRow[];
+    .all(status, ...scopeParams) as FactRow[];
 
   const ranked = rankRows(rows, question, intent, (row) => `${row.subject} ${row.predicate} ${row.object}`);
   return ranked.slice(0, 6);
 }
 
-function loadGapFacts(db: MemoryDatabase, question: string): FactRow[] {
+function loadGapFacts(db: MemoryDatabase, question: string, scope: SourceScope): FactRow[] {
+  if (scope.allowedSourceIds.length === 0) {
+    return [];
+  }
+  const { sql: scopeSql, params: scopeParams } = sourceIdInClause(scope, "sr");
   const rows = db
     .prepare(
       [
         "select semantic_facts.subject, semantic_facts.predicate, semantic_facts.object,",
         "semantic_facts.confidence, semantic_facts.status, memory_chunks.citation",
         "from semantic_facts",
+        "join source_records sr on sr.id = semantic_facts.source_record_id",
         "left join memory_chunks on memory_chunks.id = semantic_facts.source_chunk_id",
-        "where semantic_facts.status in ('candidate', 'conflicted', 'stale')",
+        `where semantic_facts.status in ('candidate', 'conflicted', 'stale') and ${scopeSql}`,
         "order by semantic_facts.status, semantic_facts.subject"
       ].join(" ")
     )
-    .all() as FactRow[];
+    .all(...scopeParams) as FactRow[];
 
   if (asksForUncertainty(question)) {
     return rows.slice(0, 6);
@@ -139,10 +161,22 @@ function loadGapFacts(db: MemoryDatabase, question: string): FactRow[] {
   return rankRows(rows, question, "generic", (row) => `${row.subject} ${row.predicate} ${row.object}`).slice(0, 6);
 }
 
-function retrieveRelevantChunks(db: MemoryDatabase, question: string): ChunkRow[] {
+function retrieveRelevantChunks(db: MemoryDatabase, question: string, scope: SourceScope): ChunkRow[] {
+  if (scope.allowedSourceIds.length === 0) {
+    return [];
+  }
+  const { sql: scopeSql, params: scopeParams } = sourceIdInClause(scope, "sr");
   const chunks = db
-    .prepare("select text, citation, embedding from memory_chunks order by id")
-    .all() as ChunkRow[];
+    .prepare(
+      [
+        "select memory_chunks.text, memory_chunks.citation, memory_chunks.embedding",
+        "from memory_chunks",
+        "join source_records sr on sr.id = memory_chunks.source_record_id",
+        `where ${scopeSql}`,
+        "order by memory_chunks.id"
+      ].join(" ")
+    )
+    .all(...scopeParams) as ChunkRow[];
   const queryEmbedding = embedText(question);
 
   return chunks

--- a/src/chunk.ts
+++ b/src/chunk.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { parseCsvRecords, serializeCsvRecord } from "./csv.js";
+import { IngestError } from "./ingest-error.js";
 
 export interface TextChunk {
   chunkIndex: number;
@@ -26,7 +27,7 @@ export function chunkText(text: string): TextChunk[] {
   }
 
   if (chunks.length === 0) {
-    throw new Error("No chunks created");
+    throw new IngestError("parse-error", "No chunks created");
   }
 
   return chunks.map((chunk, index) => ({
@@ -39,12 +40,12 @@ export function chunkText(text: string): TextChunk[] {
 export function chunkCsvRows(text: string): TextChunk[] {
   const [headers, ...rows] = parseCsvRecords(text);
   if (!headers) {
-    throw new Error("CSV file has no header row");
+    throw new IngestError("parse-error", "CSV file has no header row");
   }
 
   const dataRows = rows.filter((row) => row.some((value) => value.trim()));
   if (dataRows.length === 0) {
-    throw new Error("CSV file has no data rows");
+    throw new IngestError("parse-error", "CSV file has no data rows");
   }
 
   return dataRows.map((row, index) => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,7 +57,7 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
     try {
       const result = ingestFolder(db, folder);
       console.log(formatIngestReport(result, folder));
-      return 0;
+      return result.skipped > 0 ? 1 : 0;
     } catch (error) {
       console.error(`Ingest failed: ${errorMessage(error)}`);
       return 1;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -104,12 +104,14 @@ function parseClientFlag(args: string[]): { client: string | null; rest: string[
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
     if (arg === "--client") {
-      client = args[index + 1] ?? null;
+      const next = args[index + 1] ?? null;
+      client = next && !next.startsWith("-") ? next : null;
       index += 1;
       continue;
     }
     if (arg.startsWith("--client=")) {
-      client = arg.slice("--client=".length) || null;
+      const value = arg.slice("--client=".length);
+      client = value && !value.startsWith("-") ? value : null;
       continue;
     }
     rest.push(arg);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,15 +1,15 @@
 #!/usr/bin/env node
 import { fileURLToPath } from "node:url";
-import { buildSourcingMemoryAnswer } from "./answer.js";
 import { DEFAULT_DATABASE_PATH, openMemoryDatabase } from "./db.js";
-import { ingestFolder } from "./ingest.js";
+import { formatIngestReport, ingestFolder } from "./ingest.js";
 import { loadProcedures } from "./procedures.js";
+import { MemoryReader, resolveAccessContext } from "./read-service.js";
 import { refreshMemory } from "./refresh.js";
 
 function help(): string {
   return [
     "Usage:",
-    "  sourcyavo ask \"Who needs follow-up?\"",
+    "  sourcyavo ask --client <id> \"Who needs follow-up?\"",
     "  sourcyavo ingest <dir>",
     "  sourcyavo refresh"
   ].join("\n");
@@ -24,16 +24,23 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
   }
 
   if (command === "ask") {
-    const question = args.join(" ").trim();
+    const { client, rest } = parseClientFlag(args);
+    const question = rest.join(" ").trim();
     if (!question) {
-      console.error("Usage: sourcyavo ask \"Who needs follow-up?\"");
+      console.error("Usage: sourcyavo ask --client <id> \"Who needs follow-up?\"");
+      return 1;
+    }
+    if (!client) {
+      console.error("Refusing unscoped read: pass --client <id> to scope the ask.");
       return 1;
     }
 
     const db = openMemoryDatabase(DEFAULT_DATABASE_PATH);
     loadProcedures();
     try {
-      console.log(buildSourcingMemoryAnswer(db, question));
+      const ctx = resolveAccessContext(db, { actorType: "test_client", actorId: client });
+      const reader = new MemoryReader(db, ctx);
+      console.log(reader.ask(question));
       return 0;
     } finally {
       db.close();
@@ -49,10 +56,8 @@ export async function main(argv = process.argv.slice(2)): Promise<number> {
     const db = openMemoryDatabase(DEFAULT_DATABASE_PATH);
     try {
       const result = ingestFolder(db, folder);
-      console.log(
-        `Ingested ${result.processed} source file${result.processed === 1 ? "" : "s"}; skipped ${result.skipped}.`
-      );
-      return result.processed > 0 || result.skipped >= 0 ? 0 : 1;
+      console.log(formatIngestReport(result, folder));
+      return 0;
     } catch (error) {
       console.error(`Ingest failed: ${errorMessage(error)}`);
       return 1;
@@ -90,4 +95,25 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function parseClientFlag(args: string[]): { client: string | null; rest: string[] } {
+  const rest: string[] = [];
+  let client: string | null = null;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--client") {
+      client = args[index + 1] ?? null;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--client=")) {
+      client = arg.slice("--client=".length) || null;
+      continue;
+    }
+    rest.push(arg);
+  }
+
+  return { client, rest };
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -202,9 +202,12 @@ function addIngestErrorCategory(db: MemoryDatabase): void {
 }
 
 // Deterministic slug of a stable relative path: lowercase, non-alphanumeric runs
-// collapse to '-', path separators are preserved.
+// collapse to '-', path separators are preserved. Windows backslash separators
+// are normalized to '/' first so the same logical path yields the same id on
+// every platform.
 export function slugifySourceId(relativeLabel: string): string {
   return relativeLabel
+    .replace(/\\/g, "/")
     .toLowerCase()
     .split("/")
     .map((segment) =>

--- a/src/db.ts
+++ b/src/db.ts
@@ -25,6 +25,7 @@ function migrate(db: MemoryDatabase): void {
     create table if not exists source_records (
       id integer primary key autoincrement,
       path text not null unique,
+      source_id text,
       title text not null,
       source_type text not null,
       content_hash text not null,
@@ -113,8 +114,104 @@ function migrate(db: MemoryDatabase): void {
     create table if not exists ingest_errors (
       id integer primary key autoincrement,
       path text not null,
+      category text,
       reason text not null,
       created_at text not null default (datetime('now'))
     );
+
+    create table if not exists source_permissions (
+      id integer primary key autoincrement,
+      principal_type text not null,
+      principal_id text not null,
+      source_id text not null,
+      access text not null default 'read',
+      created_at text not null default (datetime('now')),
+      unique (principal_type, principal_id, source_id)
+    );
+
+    create table if not exists audit_events (
+      id integer primary key autoincrement,
+      actor_type text not null,
+      actor_id text not null,
+      action text not null,
+      source_id text,
+      created_at text not null default (datetime('now'))
+    );
   `);
+
+  backfillSourceIds(db);
+  addIngestErrorCategory(db);
+
+  db.exec(`
+    create unique index if not exists idx_source_records_source_id
+      on source_records(source_id);
+    create index if not exists idx_source_permissions_principal
+      on source_permissions(principal_type, principal_id, source_id);
+    create index if not exists idx_memory_chunks_source_record
+      on memory_chunks(source_record_id);
+    create index if not exists idx_semantic_facts_source_status
+      on semantic_facts(source_record_id, status);
+    create index if not exists idx_audit_events_actor
+      on audit_events(actor_type, actor_id, created_at);
+  `);
+}
+
+interface ColumnInfo {
+  name: string;
+}
+
+interface SourceRecordRow {
+  id: number;
+  path: string;
+}
+
+// For pre-existing DBs created before source_id existed: add the column and
+// backfill a deterministic unique slug derived from each row's stored path,
+// all before the unique index is created. Idempotent across re-opens.
+function backfillSourceIds(db: MemoryDatabase): void {
+  const columns = db.prepare("pragma table_info(source_records)").all() as ColumnInfo[];
+  const hasSourceId = columns.some((column) => column.name === "source_id");
+  if (hasSourceId) {
+    return;
+  }
+
+  const run = db.transaction(() => {
+    db.exec("alter table source_records add column source_id text");
+
+    const rows = db.prepare("select id, path from source_records").all() as SourceRecordRow[];
+    const update = db.prepare("update source_records set source_id = ? where id = ?");
+    for (const row of rows) {
+      update.run(slugifySourceId(row.path), row.id);
+    }
+  });
+
+  run();
+}
+
+// For pre-existing DBs created before ingest_errors.category existed: add the
+// column. Existing rows keep a null category and fall back to 'internal-error'
+// at read time. Idempotent across re-opens.
+function addIngestErrorCategory(db: MemoryDatabase): void {
+  const columns = db.prepare("pragma table_info(ingest_errors)").all() as ColumnInfo[];
+  const hasCategory = columns.some((column) => column.name === "category");
+  if (hasCategory) {
+    return;
+  }
+
+  db.exec("alter table ingest_errors add column category text");
+}
+
+// Deterministic slug of a stable relative path: lowercase, non-alphanumeric runs
+// collapse to '-', path separators are preserved.
+export function slugifySourceId(relativeLabel: string): string {
+  return relativeLabel
+    .toLowerCase()
+    .split("/")
+    .map((segment) =>
+      segment
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+    )
+    .filter((segment) => segment.length > 0)
+    .join("/");
 }

--- a/src/frontmatter.ts
+++ b/src/frontmatter.ts
@@ -1,10 +1,12 @@
 import { extname, basename } from "node:path";
+import { IngestError } from "./ingest-error.js";
 import { SOURCE_TYPES, type SourceType } from "./types.js";
 
 export interface ParsedSource {
   title: string;
   sourceType: SourceType;
   rawText: string;
+  sourceId?: string;
 }
 
 const EXTENSION_SOURCE_TYPES = new Map<string, SourceType>([
@@ -25,23 +27,28 @@ export function defaultSourceTypeForPath(filePath: string): SourceType | undefin
 export function parseSourceFile(filePath: string, content: string): ParsedSource {
   const sourceTypeFromExtension = defaultSourceTypeForPath(filePath);
   if (!sourceTypeFromExtension) {
-    throw new Error(`Unsupported file extension: ${extname(filePath) || "(none)"}`);
+    throw new IngestError(
+      "unsupported-type",
+      `Unsupported file extension: ${extname(filePath) || "(none)"}`
+    );
   }
 
   const { metadata, body } =
     sourceTypeFromExtension === "markdown" ? parseFrontmatter(content) : { metadata: {}, body: content };
   const sourceType = parseSourceType(metadata.source_type) ?? sourceTypeFromExtension;
   const title = metadata.title?.trim() || basename(filePath, extname(filePath));
+  const sourceId = metadata.source_id?.trim() || undefined;
   const rawText = body.trim();
 
   if (!rawText) {
-    throw new Error("File is empty after parsing");
+    throw new IngestError("empty", "File is empty after parsing");
   }
 
   return {
     title,
     sourceType,
-    rawText
+    rawText,
+    sourceId
   };
 }
 
@@ -54,7 +61,7 @@ function parseFrontmatter(content: string): { metadata: Record<string, string>; 
   const closingFence = `${newline}---${newline}`;
   const closingIndex = content.indexOf(closingFence, 3);
   if (closingIndex === -1) {
-    throw new Error("Malformed frontmatter: missing closing fence");
+    throw new IngestError("parse-error", "Malformed frontmatter: missing closing fence");
   }
 
   const metadataText = content.slice(3 + newline.length, closingIndex);
@@ -76,7 +83,7 @@ function parseMetadata(metadataText: string): Record<string, string> {
 
     const separatorIndex = trimmed.indexOf(":");
     if (separatorIndex === -1) {
-      throw new Error(`Malformed frontmatter line: ${trimmed}`);
+      throw new IngestError("parse-error", `Malformed frontmatter line: ${trimmed}`);
     }
 
     const key = trimmed.slice(0, separatorIndex).trim();
@@ -109,5 +116,5 @@ function parseSourceType(value: string | undefined): SourceType | undefined {
     return value as SourceType;
   }
 
-  throw new Error(`Unsupported source_type metadata: ${value}`);
+  throw new IngestError("parse-error", `Unsupported source_type metadata: ${value}`);
 }

--- a/src/ingest-error.ts
+++ b/src/ingest-error.ts
@@ -1,0 +1,27 @@
+export const INGEST_ERROR_CATEGORIES = [
+  "unsupported-type",
+  "unreadable",
+  "empty",
+  "parse-error",
+  "embedding-error",
+  "internal-error"
+] as const;
+export type IngestErrorCategory = (typeof INGEST_ERROR_CATEGORIES)[number];
+
+export class IngestError extends Error {
+  readonly category: IngestErrorCategory;
+
+  constructor(category: IngestErrorCategory, message: string) {
+    super(message);
+    this.name = "IngestError";
+    this.category = category;
+  }
+}
+
+export function classifyIngestError(error: unknown): IngestErrorCategory {
+  if (error instanceof IngestError) {
+    return error.category;
+  }
+
+  return "internal-error";
+}

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -1,13 +1,25 @@
 import { readFileSync, readdirSync } from "node:fs";
 import { join, relative, resolve, sep } from "node:path";
-import type { MemoryDatabase } from "./db.js";
+import { slugifySourceId, type MemoryDatabase } from "./db.js";
 import { chunkCsvRows, chunkText, sha256, type TextChunk } from "./chunk.js";
 import { serializeEmbedding } from "./embeddings.js";
 import { isSupportedSourcePath, parseSourceFile } from "./frontmatter.js";
+import {
+  IngestError,
+  classifyIngestError,
+  type IngestErrorCategory
+} from "./ingest-error.js";
+
+export interface SkippedFile {
+  path: string;
+  category: IngestErrorCategory;
+  reason: string;
+}
 
 export interface IngestResult {
   processed: number;
   skipped: number;
+  skippedFiles: SkippedFile[];
 }
 
 interface SourceRecordInsertResult {
@@ -16,12 +28,16 @@ interface SourceRecordInsertResult {
 
 export function ingestFolder(db: MemoryDatabase, folderPath: string): IngestResult {
   const folder = resolve(folderPath);
-  const result: IngestResult = { processed: 0, skipped: 0 };
+  const result: IngestResult = { processed: 0, skipped: 0, skippedFiles: [] };
 
   for (const filePath of walkFiles(folder)) {
     if (!isSupportedSourcePath(filePath)) {
-      logIngestError(db, filePath, `Unsupported file extension: ${filePath}`);
-      result.skipped += 1;
+      recordSkip(
+        db,
+        result,
+        filePath,
+        new IngestError("unsupported-type", `Unsupported file extension: ${filePath}`)
+      );
       continue;
     }
 
@@ -29,12 +45,24 @@ export function ingestFolder(db: MemoryDatabase, folderPath: string): IngestResu
       ingestFile(db, filePath, folder);
       result.processed += 1;
     } catch (error) {
-      logIngestError(db, filePath, formatIngestError(error));
-      result.skipped += 1;
+      recordSkip(db, result, filePath, error);
     }
   }
 
   return result;
+}
+
+function recordSkip(
+  db: MemoryDatabase,
+  result: IngestResult,
+  filePath: string,
+  error: unknown
+): void {
+  const category = classifyIngestError(error);
+  const reason = errorMessage(error);
+  logIngestError(db, filePath, category, reason);
+  result.skipped += 1;
+  result.skippedFiles.push({ path: filePath, category, reason });
 }
 
 function ingestFile(db: MemoryDatabase, filePath: string, rootFolder: string): void {
@@ -43,17 +71,20 @@ function ingestFile(db: MemoryDatabase, filePath: string, rootFolder: string): v
     const parsed = parseSourceFile(path, content);
     const chunks = chunkSourceText(parsed.sourceType, parsed.rawText);
     const contentHash = sha256(parsed.rawText);
-    const citationLabel = sourceLabel(rootFolder, path);
+    const relativeLabel = sourceLabel(rootFolder, path);
+    const citationLabel = relativeLabel;
+    const sourceId = parsed.sourceId ?? slugifySourceId(relativeLabel);
 
-    const sourceId = upsertSourceRecord(db, {
+    const sourceRowId = upsertSourceRecord(db, {
       path,
+      sourceId,
       title: parsed.title,
       sourceType: parsed.sourceType,
       contentHash,
       rawText: parsed.rawText
     });
 
-    db.prepare("delete from memory_chunks where source_record_id = ?").run(sourceId);
+    db.prepare("delete from memory_chunks where source_record_id = ?").run(sourceRowId);
 
     const insertChunk = db.prepare(
       "insert into memory_chunks (source_record_id, chunk_index, text, chunk_hash, embedding, citation) values (?, ?, ?, ?, ?, ?)"
@@ -61,11 +92,11 @@ function ingestFile(db: MemoryDatabase, filePath: string, rootFolder: string): v
 
     for (const chunk of chunks) {
       insertChunk.run(
-        sourceId,
+        sourceRowId,
         chunk.chunkIndex,
         chunk.text,
         chunk.chunkHash,
-        serializeEmbedding(chunk.text),
+        embedChunk(chunk),
         citationForChunk(citationLabel, parsed.sourceType, chunk)
       );
     }
@@ -114,7 +145,15 @@ function readSourceFile(filePath: string): string {
   try {
     return readFileSync(filePath, "utf8");
   } catch (error) {
-    throw new Error(`Failed to read file: ${errorMessage(error)}`);
+    throw new IngestError("unreadable", `Failed to read file: ${errorMessage(error)}`);
+  }
+}
+
+function embedChunk(chunk: TextChunk): string {
+  try {
+    return serializeEmbedding(chunk.text);
+  } catch (error) {
+    throw new IngestError("embedding-error", `Failed to embed chunk: ${errorMessage(error)}`);
   }
 }
 
@@ -122,16 +161,19 @@ function upsertSourceRecord(
   db: MemoryDatabase,
   source: {
     path: string;
+    sourceId: string;
     title: string;
     sourceType: string;
     contentHash: string;
     rawText: string;
   }
 ): number {
+  // source_id is intentionally NOT updated on conflict: identity is preserved
+  // across reimports even when frontmatter source_id changes.
   db.prepare(
     [
-      "insert into source_records (path, title, source_type, content_hash, raw_text)",
-      "values (?, ?, ?, ?, ?)",
+      "insert into source_records (path, source_id, title, source_type, content_hash, raw_text)",
+      "values (?, ?, ?, ?, ?, ?)",
       "on conflict(path) do update set",
       "title = excluded.title,",
       "source_type = excluded.source_type,",
@@ -139,7 +181,14 @@ function upsertSourceRecord(
       "raw_text = excluded.raw_text,",
       "updated_at = datetime('now')"
     ].join(" ")
-  ).run(source.path, source.title, source.sourceType, source.contentHash, source.rawText);
+  ).run(
+    source.path,
+    source.sourceId,
+    source.title,
+    source.sourceType,
+    source.contentHash,
+    source.rawText
+  );
 
   const row = db.prepare("select id from source_records where path = ?").get(source.path) as
     | SourceRecordInsertResult
@@ -151,12 +200,50 @@ function upsertSourceRecord(
   return row.id;
 }
 
-function logIngestError(db: MemoryDatabase, filePath: string, reason: string): void {
-  db.prepare("insert into ingest_errors (path, reason) values (?, ?)").run(filePath, reason);
+function logIngestError(
+  db: MemoryDatabase,
+  filePath: string,
+  category: IngestErrorCategory,
+  reason: string
+): void {
+  db.prepare("insert into ingest_errors (path, category, reason) values (?, ?, ?)").run(
+    filePath,
+    category,
+    reason
+  );
 }
 
-function formatIngestError(error: unknown): string {
-  return errorMessage(error);
+export function formatIngestReport(result: IngestResult, rootFolder: string): string {
+  const summary = `Ingested ${result.processed} source file${
+    result.processed === 1 ? "" : "s"
+  }; skipped ${result.skipped}.`;
+
+  if (result.skipped === 0) {
+    return summary;
+  }
+
+  const root = resolve(rootFolder);
+  const lines = [summary, "", "Skipped files:"];
+  for (const skipped of result.skippedFiles) {
+    // Use the relative label only; raw reasons may embed absolute paths.
+    lines.push(`  - ${sourceLabel(root, skipped.path)} [${skipped.category}]`);
+  }
+
+  lines.push("", "Skipped by category:");
+  for (const [category, count] of tallyByCategory(result.skippedFiles)) {
+    lines.push(`  ${category}: ${count}`);
+  }
+
+  return lines.join("\n");
+}
+
+function tallyByCategory(skippedFiles: SkippedFile[]): Array<[IngestErrorCategory, number]> {
+  const tally = new Map<IngestErrorCategory, number>();
+  for (const skipped of skippedFiles) {
+    tally.set(skipped.category, (tally.get(skipped.category) ?? 0) + 1);
+  }
+
+  return [...tally.entries()].sort((a, b) => a[0].localeCompare(b[0]));
 }
 
 function errorMessage(error: unknown): string {

--- a/src/read-service.ts
+++ b/src/read-service.ts
@@ -1,0 +1,283 @@
+import { buildSourcingMemoryAnswer } from "./answer.js";
+import type { MemoryDatabase } from "./db.js";
+import { cosineSimilarity, deserializeEmbedding, embedText } from "./embeddings.js";
+
+export const READ_ACTIONS = [
+  "ask",
+  "search_memory",
+  "get_source",
+  "list_gaps",
+  "denied_read"
+] as const;
+export type ReadAction = (typeof READ_ACTIONS)[number];
+
+export const GET_SOURCE_DENIAL_REASONS = ["denied", "missing", "malformed"] as const;
+export type GetSourceDenialReason = (typeof GET_SOURCE_DENIAL_REASONS)[number];
+
+const MAX_SOURCE_ID_LENGTH = 512;
+const DEFAULT_SEARCH_LIMIT = 5;
+
+export interface SearchResultRow {
+  sourceId: string;
+  text: string;
+  citation: string;
+  score: number;
+}
+
+export interface SourceSummary {
+  sourceId: string;
+  title: string;
+  sourceType: string;
+  path: string;
+}
+
+export type GetSourceResult =
+  | { ok: true; source: SourceSummary }
+  | { ok: false; reason: GetSourceDenialReason };
+
+export interface GapItem {
+  subject: string;
+  predicate: string;
+  object: string;
+  status: string;
+  citation: string | null;
+}
+
+export const ACTOR_TYPES = ["user", "oauth_client", "test_client"] as const;
+export type ActorType = (typeof ACTOR_TYPES)[number];
+
+export interface AccessContext {
+  actorType: ActorType;
+  actorId: string;
+  allowedSourceIds: string[];
+  deniedSourceIds: string[];
+  auditLabel: string;
+}
+
+export interface SourceScope {
+  allowedSourceIds: string[];
+}
+
+export interface ActorIdentity {
+  actorType: ActorType;
+  actorId: string;
+}
+
+// Resolve a default-deny AccessContext from the source_permissions allowlist.
+// An empty allowedSourceIds means no access (default-deny enforced in SQL by
+// callers). deniedSourceIds is informational only and never used for filtering.
+export function resolveAccessContext(
+  db: MemoryDatabase,
+  { actorType, actorId }: ActorIdentity
+): AccessContext {
+  const allowedRows = db
+    .prepare(
+      "select source_id from source_permissions where principal_type = ? and principal_id = ? and access = 'read' order by source_id"
+    )
+    .all(actorType, actorId) as Array<{ source_id: string }>;
+  const allowedSourceIds = allowedRows.map((row) => row.source_id);
+
+  const allowedSet = new Set(allowedSourceIds);
+  const deniedRows = db
+    .prepare("select source_id from source_records order by source_id")
+    .all() as Array<{ source_id: string | null }>;
+  const deniedSourceIds = deniedRows
+    .map((row) => row.source_id)
+    .filter((sourceId): sourceId is string => sourceId !== null && !allowedSet.has(sourceId));
+
+  return {
+    actorType,
+    actorId,
+    allowedSourceIds,
+    deniedSourceIds,
+    auditLabel: `${actorType}:${actorId}`
+  };
+}
+
+// Build a parameterized `alias.source_id in (?, ?, ...)` clause from a scope.
+// An empty scope yields a clause that matches no rows, preserving default-deny
+// even if a caller forgets to short-circuit.
+export function sourceIdInClause(
+  scope: SourceScope,
+  alias = "sr"
+): { sql: string; params: string[] } {
+  if (scope.allowedSourceIds.length === 0) {
+    return { sql: "1 = 0", params: [] };
+  }
+  const placeholders = scope.allowedSourceIds.map(() => "?").join(", ");
+  return {
+    sql: `${alias}.source_id in (${placeholders})`,
+    params: [...scope.allowedSourceIds]
+  };
+}
+
+// Explicit no-access Answer rendered when a caller has zero allowed sources.
+// Every section is present and the language states plainly there is no access,
+// so the caller never receives a silent empty payload.
+function noAccessAnswer(question: string): string {
+  const questionLine = question.trim() ? ` for "${question.trim()}"` : "";
+  return [
+    "Answer:",
+    `You have no access to any sources, so I cannot answer${questionLine}.`,
+    "",
+    "Evidence:",
+    "- No accessible sources: you have no access to any sources.",
+    "",
+    "Gaps:",
+    "- Your access scope is empty; no candidate, conflicted, or stale memory is visible to you.",
+    "",
+    "Next Action:",
+    "- Request read access to the relevant sources, then ask again."
+  ].join("\n");
+}
+
+export class MemoryReader {
+  constructor(
+    private readonly db: MemoryDatabase,
+    private readonly ctx: AccessContext
+  ) {}
+
+  private get scope(): SourceScope {
+    return { allowedSourceIds: this.ctx.allowedSourceIds };
+  }
+
+  private hasNoAccess(): boolean {
+    return this.ctx.allowedSourceIds.length === 0;
+  }
+
+  // Append one audit row per read. Denied reads use action 'denied_read' and
+  // record the requested source_id when one was supplied.
+  private recordAudit(action: ReadAction, sourceId?: string): void {
+    this.db
+      .prepare(
+        "insert into audit_events (actor_type, actor_id, action, source_id) values (?, ?, ?, ?)"
+      )
+      .run(this.ctx.actorType, this.ctx.actorId, action, sourceId ?? null);
+  }
+
+  ask(question: string): string {
+    if (this.hasNoAccess()) {
+      this.recordAudit("denied_read");
+      return noAccessAnswer(question);
+    }
+    this.recordAudit("ask");
+    return buildSourcingMemoryAnswer(this.db, question, this.scope);
+  }
+
+  // Scope-filtered semantic search. Only chunks from allowed sources can be
+  // ranked or returned; the scope filter lives in SQL so a higher-scoring
+  // restricted chunk is never a retrieval candidate in the first place.
+  searchMemory(query: string, options: { limit?: number } = {}): SearchResultRow[] {
+    if (this.hasNoAccess()) {
+      this.recordAudit("denied_read");
+      return [];
+    }
+    this.recordAudit("search_memory");
+
+    const limit = normalizeLimit(options.limit);
+    const { sql: scopeSql, params } = sourceIdInClause(this.scope, "sr");
+    const rows = this.db
+      .prepare(
+        [
+          "select sr.source_id as sourceId, memory_chunks.text as text,",
+          "memory_chunks.citation as citation, memory_chunks.embedding as embedding",
+          "from memory_chunks",
+          "join source_records sr on sr.id = memory_chunks.source_record_id",
+          `where ${scopeSql}`,
+          "order by memory_chunks.id"
+        ].join(" ")
+      )
+      .all(...params) as Array<{
+      sourceId: string;
+      text: string;
+      citation: string;
+      embedding: string | null;
+    }>;
+
+    const queryEmbedding = embedText(query);
+    return rows
+      .map((row) => ({
+        sourceId: row.sourceId,
+        text: row.text,
+        citation: row.citation,
+        score: cosineSimilarity(queryEmbedding, deserializeEmbedding(row.embedding))
+      }))
+      .filter((result) => result.score > 0)
+      .sort((left, right) => right.score - left.score)
+      .slice(0, limit);
+  }
+
+  // Resolve a source the caller is allowed to read. Denials never reveal whether
+  // an out-of-scope id exists: any id not in the caller's allowed scope returns
+  // 'denied'. 'missing' is reserved for an allowed id that is absent from
+  // source_records (a permission referencing a deleted source).
+  getSource(sourceId: unknown): GetSourceResult {
+    if (
+      typeof sourceId !== "string" ||
+      sourceId.length === 0 ||
+      sourceId.length > MAX_SOURCE_ID_LENGTH
+    ) {
+      this.recordAudit("denied_read");
+      return { ok: false, reason: "malformed" };
+    }
+
+    if (this.hasNoAccess() || !this.ctx.allowedSourceIds.includes(sourceId)) {
+      this.recordAudit("denied_read", sourceId);
+      return { ok: false, reason: "denied" };
+    }
+
+    const { sql: scopeSql, params } = sourceIdInClause(this.scope, "sr");
+    const row = this.db
+      .prepare(
+        [
+          "select sr.source_id as sourceId, sr.title as title,",
+          "sr.source_type as sourceType, sr.path as path",
+          "from source_records sr",
+          `where ${scopeSql} and sr.source_id = ?`,
+          "limit 1"
+        ].join(" ")
+      )
+      .get(...params, sourceId) as SourceSummary | undefined;
+
+    if (!row) {
+      this.recordAudit("denied_read", sourceId);
+      return { ok: false, reason: "missing" };
+    }
+
+    this.recordAudit("get_source", sourceId);
+    return { ok: true, source: row };
+  }
+
+  // Scoped gaps: candidate/conflicted/stale facts from allowed sources only.
+  // Facts from restricted sources are filtered in SQL and never surface.
+  listGaps(): GapItem[] {
+    if (this.hasNoAccess()) {
+      this.recordAudit("denied_read");
+      return [];
+    }
+    this.recordAudit("list_gaps");
+
+    const { sql: scopeSql, params } = sourceIdInClause(this.scope, "sr");
+    return this.db
+      .prepare(
+        [
+          "select semantic_facts.subject as subject, semantic_facts.predicate as predicate,",
+          "semantic_facts.object as object, semantic_facts.status as status,",
+          "memory_chunks.citation as citation",
+          "from semantic_facts",
+          "join source_records sr on sr.id = semantic_facts.source_record_id",
+          "left join memory_chunks on memory_chunks.id = semantic_facts.source_chunk_id",
+          `where semantic_facts.status in ('candidate', 'conflicted', 'stale') and ${scopeSql}`,
+          "order by semantic_facts.status, semantic_facts.subject"
+        ].join(" ")
+      )
+      .all(...params) as GapItem[];
+  }
+}
+
+function normalizeLimit(limit: number | undefined): number {
+  if (typeof limit !== "number" || !Number.isFinite(limit) || limit <= 0) {
+    return DEFAULT_SEARCH_LIMIT;
+  }
+  return Math.floor(limit);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,21 @@ export const SEMANTIC_FACT_STATUSES = [
 ] as const;
 export type SemanticFactStatus = (typeof SEMANTIC_FACT_STATUSES)[number];
 
+export const PRINCIPAL_TYPES = ["user", "oauth_client", "test_client"] as const;
+export type PrincipalType = (typeof PRINCIPAL_TYPES)[number];
+
+export const ACCESS_LEVELS = ["read"] as const;
+export type AccessLevel = (typeof ACCESS_LEVELS)[number];
+
+export const AUDIT_ACTIONS = [
+  "ask",
+  "search_memory",
+  "get_source",
+  "list_gaps",
+  "denied_read"
+] as const;
+export type AuditAction = (typeof AUDIT_ACTIONS)[number];
+
 export type ExtractedCandidateKind = "entity" | "relationship" | "semantic_fact";
 
 export interface ExtractedCandidate {

--- a/tests/answer.test.ts
+++ b/tests/answer.test.ts
@@ -3,8 +3,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { buildSourcingMemoryAnswer } from "../src/answer.js";
-import { openMemoryDatabase } from "../src/db.js";
+import { openMemoryDatabase, type MemoryDatabase } from "../src/db.js";
 import { ingestFolder } from "../src/ingest.js";
+import type { SourceScope } from "../src/read-service.js";
 import { refreshMemory } from "../src/refresh.js";
 
 const tempDirs: string[] = [];
@@ -13,6 +14,15 @@ function tempDbPath(): string {
   const dir = mkdtempSync(join(tmpdir(), "sourcyavo-answer-test-"));
   tempDirs.push(dir);
   return join(dir, ".sourcyavo", "memory.db");
+}
+
+// Full-scope helper: grant every indexed source so these legacy tests stay
+// scope-agnostic and keep exercising the ranking/answer logic.
+function fullScope(db: MemoryDatabase): SourceScope {
+  const rows = db
+    .prepare("select source_id from source_records where source_id is not null")
+    .all() as Array<{ source_id: string }>;
+  return { allowedSourceIds: rows.map((row) => row.source_id) };
 }
 
 afterEach(() => {
@@ -24,7 +34,7 @@ afterEach(() => {
 describe("no-memory answer path", () => {
   it("returns all required sections with clear no-source language", () => {
     const db = openMemoryDatabase(tempDbPath());
-    const output = buildSourcingMemoryAnswer(db, "Who needs follow-up?");
+    const output = buildSourcingMemoryAnswer(db, "Who needs follow-up?", fullScope(db));
 
     expect(output).toContain("Answer:");
     expect(output).toContain("Evidence:");
@@ -54,7 +64,7 @@ describe("sourcing memory answers", () => {
     ingestFolder(db, dir);
     await refreshMemory(db);
 
-    const output = buildSourcingMemoryAnswer(db, "Who needs follow-up for AI safety?");
+    const output = buildSourcingMemoryAnswer(db, "Who needs follow-up for AI safety?", fullScope(db));
 
     expect(output).toContain("Answer:");
     expect(output).toContain("Miguel Alvarez");
@@ -81,7 +91,7 @@ describe("sourcing memory answers", () => {
     ingestFolder(db, dir);
     await refreshMemory(db);
 
-    const output = buildSourcingMemoryAnswer(db, "Who needs follow-up for AI safety?");
+    const output = buildSourcingMemoryAnswer(db, "Who needs follow-up for AI safety?", fullScope(db));
 
     expect(output).toContain("Miguel Alvarez needs follow-up");
     expect(output).not.toContain("Alex Rivera needs follow-up");
@@ -105,7 +115,7 @@ describe("sourcing memory answers", () => {
     ingestFolder(db, dir);
     await refreshMemory(db);
 
-    const output = buildSourcingMemoryAnswer(db, "Who responded?");
+    const output = buildSourcingMemoryAnswer(db, "Who responded?", fullScope(db));
 
     expect(output).toContain("Priya Shah status is Responded");
     expect(output).toContain("tracker.csv#row-1");
@@ -128,7 +138,7 @@ describe("sourcing memory answers", () => {
     ingestFolder(db, dir);
     await refreshMemory(db);
 
-    const output = buildSourcingMemoryAnswer(db, "Who did not respond?");
+    const output = buildSourcingMemoryAnswer(db, "Who did not respond?", fullScope(db));
 
     expect(output).toContain("Annette Lapham status is Rejected/ghosted");
     expect(output).toContain("tracker.csv#row-1");
@@ -139,8 +149,8 @@ describe("sourcing memory answers", () => {
   it("does not treat owner or interest metadata as prior Codeology collaboration", () => {
     const db = openMemoryDatabase(tempDbPath());
     db.prepare(
-      "insert into source_records (path, title, source_type, content_hash, raw_text) values (?, ?, ?, ?, ?)"
-    ).run("apollo.csv", "Apollo", "csv", "hash", "Alex Duffy codeology owner is Rohan Gulati.");
+      "insert into source_records (path, source_id, title, source_type, content_hash, raw_text) values (?, ?, ?, ?, ?, ?)"
+    ).run("apollo.csv", "apollo", "Apollo", "csv", "hash", "Alex Duffy codeology owner is Rohan Gulati.");
     db.prepare(
       "insert into memory_chunks (source_record_id, chunk_index, text, chunk_hash, citation) values (?, ?, ?, ?, ?)"
     ).run(1, 0, "Alex Duffy codeology owner is Rohan Gulati.", "chunk", "apollo.csv#row-1");
@@ -151,7 +161,7 @@ describe("sourcing memory answers", () => {
       "insert into semantic_facts (subject, predicate, object, source_record_id, source_chunk_id, confidence, status) values (?, ?, ?, ?, ?, ?, ?)"
     ).run("Alex Duffy", "interest", "Client project", 1, 1, 0.86, "accepted");
 
-    const output = buildSourcingMemoryAnswer(db, "Who worked with Codeology before?");
+    const output = buildSourcingMemoryAnswer(db, "Who worked with Codeology before?", fullScope(db));
 
     expect(output).toContain("I do not have accepted sourcing facts");
     expect(output).not.toContain("codeology owner");
@@ -163,8 +173,8 @@ describe("sourcing memory answers", () => {
   it("surfaces candidate and conflicted facts under gaps", () => {
     const db = openMemoryDatabase(tempDbPath());
     db.prepare(
-      "insert into source_records (path, title, source_type, content_hash, raw_text) values (?, ?, ?, ?, ?)"
-    ).run("memory.csv", "Memory", "csv", "hash", "raw");
+      "insert into source_records (path, source_id, title, source_type, content_hash, raw_text) values (?, ?, ?, ?, ?, ?)"
+    ).run("memory.csv", "memory", "Memory", "csv", "hash", "raw");
     db.prepare(
       "insert into memory_chunks (source_record_id, chunk_index, text, chunk_hash, citation) values (?, ?, ?, ?, ?)"
     ).run(1, 0, "Noor may be interested. Maya has conflicting status.", "chunk", "memory.csv#chunk-1");
@@ -175,7 +185,7 @@ describe("sourcing memory answers", () => {
       "insert into semantic_facts (subject, predicate, object, source_record_id, source_chunk_id, confidence, status) values (?, ?, ?, ?, ?, ?, ?)"
     ).run("Maya Chen", "status", "contacted", 1, 1, 0.9, "conflicted");
 
-    const output = buildSourcingMemoryAnswer(db, "What is uncertain?");
+    const output = buildSourcingMemoryAnswer(db, "What is uncertain?", fullScope(db));
 
     expect(output).toContain("Gaps:");
     expect(output).toContain("Noor Patel");
@@ -199,7 +209,7 @@ describe("sourcing memory answers", () => {
     ingestFolder(db, dir);
     await refreshMemory(db);
 
-    const output = buildSourcingMemoryAnswer(db, "What happened with quantum hardware?");
+    const output = buildSourcingMemoryAnswer(db, "What happened with quantum hardware?", fullScope(db));
 
     expect(output).toContain("I do not have accepted sourcing facts");
     expect(output).not.toContain("Miguel Alvarez outcome is interested");

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -68,6 +68,28 @@ describe("sourcyavo CLI", () => {
     expect(output).toContain("Evidence:");
   });
 
+  it("exits 1 when ingest skips a file but still reports it", async () => {
+    const dir = tempDir();
+    const seedData = join(dir, "seed-data");
+    mkdirSync(seedData);
+    writeFileSync(
+      join(seedData, "good.csv"),
+      [
+        "contact,organization,domain,status,outcome,notes,needs_follow_up,reason",
+        "Miguel Alvarez,Civic Data Lab,AI safety,contacted,interested,Asked for intro.,yes,Need intro"
+      ].join("\n")
+    );
+    writeFileSync(join(seedData, "empty.md"), "   \n");
+    process.chdir(dir);
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    await expect(Promise.resolve(main(["ingest", "seed-data"]))).resolves.toBe(1);
+
+    const output = log.mock.calls.flat().join("\n");
+    expect(output).toContain("empty.md");
+  });
+
   it("refuses an ask without --client and exits 1", async () => {
     const dir = tempDir();
     process.chdir(dir);

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { main } from "../src/cli.js";
+import { openMemoryDatabase } from "../src/db.js";
 
 const tempDirs: string[] = [];
 const originalCwd = process.cwd();
@@ -39,8 +40,25 @@ describe("sourcyavo CLI", () => {
 
     await expect(Promise.resolve(main(["ingest", "seed-data"]))).resolves.toBe(0);
     await expect(Promise.resolve(main(["refresh"]))).resolves.toBe(0);
+
+    // Grant the scoped client read access to every ingested source so the
+    // happy-path ask returns the ingested memory.
+    const grantDb = openMemoryDatabase(".sourcyavo/memory.db");
+    const sourceIds = (
+      grantDb
+        .prepare("select source_id from source_records where source_id is not null")
+        .all() as Array<{ source_id: string }>
+    ).map((row) => row.source_id);
+    const grant = grantDb.prepare(
+      "insert into source_permissions (principal_type, principal_id, source_id) values ('test_client', 'qa-client', ?)"
+    );
+    for (const sourceId of sourceIds) {
+      grant.run(sourceId);
+    }
+    grantDb.close();
+
     await expect(
-      Promise.resolve(main(["ask", "Who needs follow-up for AI safety?"]))
+      Promise.resolve(main(["ask", "--client", "qa-client", "Who needs follow-up for AI safety?"]))
     ).resolves.toBe(0);
 
     const output = log.mock.calls.flat().join("\n");
@@ -48,5 +66,19 @@ describe("sourcyavo CLI", () => {
     expect(output).toContain("Refresh complete");
     expect(output).toContain("Miguel Alvarez");
     expect(output).toContain("Evidence:");
+  });
+
+  it("refuses an ask without --client and exits 1", async () => {
+    const dir = tempDir();
+    process.chdir(dir);
+
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(
+      Promise.resolve(main(["ask", "Who needs follow-up for AI safety?"]))
+    ).resolves.toBe(1);
+
+    const output = error.mock.calls.flat().join("\n");
+    expect(output).toContain("Refusing unscoped read");
   });
 });

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -30,6 +30,7 @@ describe("SQLite memory schema", () => {
       .map((row) => (row as { name: string }).name);
 
     expect(tables).toEqual([
+      "audit_events",
       "entities",
       "entity_aliases",
       "extraction_runs",
@@ -37,6 +38,7 @@ describe("SQLite memory schema", () => {
       "memory_chunks",
       "relationships",
       "semantic_facts",
+      "source_permissions",
       "source_records"
     ]);
     expect(db.pragma("foreign_keys", { simple: true })).toBe(1);
@@ -93,6 +95,59 @@ describe("SQLite memory schema", () => {
     ).toThrow();
 
     db.close();
+  });
+
+  it("enforces a unique source_id across source records", () => {
+    const db = openMemoryDatabase(tempDbPath());
+
+    db.prepare(
+      "insert into source_records (path, source_id, title, source_type, content_hash, raw_text) values (?, ?, ?, ?, ?, ?)"
+    ).run("seed-data/a.md", "seed-data/a", "A", "markdown", "hash-a", "hello");
+    expect(() =>
+      db
+        .prepare(
+          "insert into source_records (path, source_id, title, source_type, content_hash, raw_text) values (?, ?, ?, ?, ?, ?)"
+        )
+        .run("seed-data/b.md", "seed-data/a", "B", "markdown", "hash-b", "world")
+    ).toThrow();
+
+    db.close();
+  });
+
+  it("enforces source_permissions uniqueness per principal and source", () => {
+    const db = openMemoryDatabase(tempDbPath());
+
+    db.prepare(
+      "insert into source_permissions (principal_type, principal_id, source_id) values (?, ?, ?)"
+    ).run("user", "alice", "seed-data/a");
+    expect(() =>
+      db
+        .prepare(
+          "insert into source_permissions (principal_type, principal_id, source_id) values (?, ?, ?)"
+        )
+        .run("user", "alice", "seed-data/a")
+    ).toThrow();
+
+    db.close();
+  });
+
+  it("re-opens an existing database file without throwing (idempotent migrate)", () => {
+    const dbPath = tempDbPath();
+
+    const first = openMemoryDatabase(dbPath);
+    first.prepare(
+      "insert into source_records (path, source_id, title, source_type, content_hash, raw_text) values (?, ?, ?, ?, ?, ?)"
+    ).run("seed-data/a.md", "seed-data/a", "A", "markdown", "hash-a", "hello");
+    first.close();
+
+    expect(() => {
+      const second = openMemoryDatabase(dbPath);
+      const rows = second
+        .prepare("select source_id from source_records")
+        .all() as Array<{ source_id: string }>;
+      expect(rows).toEqual([{ source_id: "seed-data/a" }]);
+      second.close();
+    }).not.toThrow();
   });
 
   it("enforces chunk and relationship foreign keys", () => {

--- a/tests/fixtures/stress/benchmark.ts
+++ b/tests/fixtures/stress/benchmark.ts
@@ -1,0 +1,113 @@
+import type { ActorType } from "../../../src/read-service.js";
+
+// Stable source_id slugs produced by the path-slug rule for the committed
+// stress corpus under tests/fixtures/stress/corpus/. Centralized here so the
+// harness, the permission seeding, and the benchmark expectations all agree on
+// identity. NEVER a SQLite autoincrement id.
+export const STRESS_SOURCE_IDS = {
+  ai: "spring-2026/ai/outreach-ai-csv",
+  robotics: "spring-2026/robotics/outreach-robotics-csv",
+  biotech: "spring-2026/biotech/apollo-biotech-csv",
+  restrictedBiotech: "spring-2026/biotech/restricted-biotech-csv",
+  broken: "spring-2026/ai/broken-csv"
+} as const;
+
+// The non-restricted corpus a standard sourcing client is allowed to read. The
+// restricted biotech source is intentionally excluded; scope is enforced in SQL
+// before retrieval (ADR 0001), never by post-filtering the answer text.
+export const STRESS_ALLOWED_SOURCE_IDS: readonly string[] = [
+  STRESS_SOURCE_IDS.ai,
+  STRESS_SOURCE_IDS.robotics,
+  STRESS_SOURCE_IDS.biotech
+];
+
+// A subject that lives only in the restricted biotech source. It must never
+// appear in any answer produced for a client without restricted access, and
+// never in the rendered StressReport text.
+export const RESTRICTED_SUBJECTS: readonly string[] = ["Odalys Brennan", "Lior Kessler"];
+
+export const STRESS_CLIENT: { actorType: ActorType; actorId: string } = {
+  actorType: "test_client",
+  actorId: "stress-bench-client"
+};
+
+export interface BenchmarkCase {
+  id: string;
+  question: string;
+  // Principal asking the question. Defaults to STRESS_CLIENT when omitted by
+  // the harness; carried explicitly so future cases can model other clients.
+  client: { actorType: ActorType; actorId: string };
+  expectations: {
+    // Subjects (people/orgs) that MUST be named somewhere in the Answer text.
+    mustMentionSubjects: string[];
+    // Citation fragments that MUST appear in the Evidence section.
+    mustCiteSources: string[];
+    // Subjects that MUST NOT appear anywhere in the rendered answer.
+    forbiddenSubjects: string[];
+    // Whether the case expects any substantive answer at all.
+    expectSomeAnswer: boolean;
+  };
+}
+
+// Drawn from the spec 'Benchmark Questions'. CSV-only and deterministic so the
+// harness needs no API key.
+export const BENCHMARK_CASES: readonly BenchmarkCase[] = [
+  {
+    id: "ai-responded",
+    question: "Who responded for AI?",
+    client: STRESS_CLIENT,
+    expectations: {
+      mustMentionSubjects: ["Nadia Okonkwo"],
+      mustCiteSources: ["outreach-ai.csv"],
+      forbiddenSubjects: [...RESTRICTED_SUBJECTS],
+      expectSomeAnswer: true
+    }
+  },
+  {
+    id: "robotics-needs-follow-up",
+    question: "Who needs follow-up for robotics?",
+    client: STRESS_CLIENT,
+    expectations: {
+      mustMentionSubjects: ["Bao Tran"],
+      mustCiteSources: ["outreach-robotics.csv"],
+      forbiddenSubjects: [...RESTRICTED_SUBJECTS],
+      expectSomeAnswer: true
+    }
+  },
+  {
+    id: "biotech-no-response",
+    question: "Who did not respond for biotech?",
+    client: STRESS_CLIENT,
+    expectations: {
+      mustMentionSubjects: ["Felix Nakamura"],
+      mustCiteSources: ["apollo-biotech.csv"],
+      forbiddenSubjects: [...RESTRICTED_SUBJECTS],
+      expectSomeAnswer: true
+    }
+  },
+  {
+    id: "biotech-worked-with",
+    question: "Which companies or people worked with Codeology before in biotech?",
+    client: STRESS_CLIENT,
+    expectations: {
+      mustMentionSubjects: ["Soren Halvorsen"],
+      mustCiteSources: ["apollo-biotech.csv"],
+      forbiddenSubjects: [...RESTRICTED_SUBJECTS],
+      expectSomeAnswer: true
+    }
+  },
+  {
+    id: "restricted-leak-guard",
+    question: "Who needs follow-up for confidential biotech?",
+    client: STRESS_CLIENT,
+    expectations: {
+      // The restricted source is out of scope; we expect NO restricted subject
+      // and certainly no restricted citation. expectSomeAnswer is false because
+      // a correctly scoped client has nothing to surface here.
+      mustMentionSubjects: [],
+      mustCiteSources: [],
+      forbiddenSubjects: [...RESTRICTED_SUBJECTS],
+      expectSomeAnswer: false
+    }
+  }
+];

--- a/tests/fixtures/stress/corpus/spring-2026/ai/broken.csv
+++ b/tests/fixtures/stress/corpus/spring-2026/ai/broken.csv
@@ -1,0 +1,1 @@
+contact,company,domain,status,outcome,notes,needs_follow_up,reason

--- a/tests/fixtures/stress/corpus/spring-2026/ai/outreach-ai.csv
+++ b/tests/fixtures/stress/corpus/spring-2026/ai/outreach-ai.csv
@@ -1,0 +1,5 @@
+contact,company,domain,status,outcome,notes,needs_follow_up,reason,owner
+Nadia Okonkwo,Lumen AI Labs,AI safety,responded,interested,"Replied within a day and asked for a syllabus.",no,,Priya Desai
+Theo Marchetti,Driftwood Intelligence,AI tooling,ghosted,no response,"Sent two notes, never heard back.",yes,Re-engage with a warmer intro,Priya Desai
+Sasha Brandt,Northwind Models,AI research,needs follow-up,pending,"Asked us to circle back after their funding round closes.",yes,Funding round closing this month,Priya Desai
+Imani Vance,Cobalt Reasoning,AI alignment,locked in,signed,"Confirmed as a workshop sponsor for spring.",no,,Priya Desai

--- a/tests/fixtures/stress/corpus/spring-2026/biotech/apollo-biotech.csv
+++ b/tests/fixtures/stress/corpus/spring-2026/biotech/apollo-biotech.csv
@@ -1,0 +1,5 @@
+First Name,Last Name,Title,Company Name,Email,Email Status,Status,Notes,Needs Follow Up,Reason,Contact Owner
+Camila,Rosario,Head of Partnerships,Verdant Biolabs,camila@verdantbiolabs.example,verified,responded,"Replied and asked about lab tour logistics.",no,,Dana Okafor
+Felix,Nakamura,Research Lead,Helix Commons,felix@helixcommons.example,verified,ghosted,"No reply after two outreach attempts.",yes,Re-send with a referral,Dana Okafor
+Wren,Adesanya,Program Director,Mycelia Bioworks,wren@myceliabioworks.example,guessed,needs follow-up,"Asked us to follow up after their grant decision.",yes,Grant decision pending,Dana Okafor
+Soren,Halvorsen,Founder,Tideglass Genomics,soren@tideglass.example,verified,locked in,"Committed as a biotech track sponsor.",no,,Dana Okafor

--- a/tests/fixtures/stress/corpus/spring-2026/biotech/restricted-biotech.csv
+++ b/tests/fixtures/stress/corpus/spring-2026/biotech/restricted-biotech.csv
@@ -1,0 +1,3 @@
+contact,company,domain,status,outcome,notes,needs_follow_up,reason,owner
+Odalys Brennan,Quietharbor Therapeutics,confidential biotech,locked in,signed,"Confidential partnership; details under NDA.",no,,Dana Okafor
+Lior Kessler,Blackvine Genomics,confidential biotech,needs follow-up,pending,"Restricted deal; do not surface outside leads.",yes,NDA review pending,Dana Okafor

--- a/tests/fixtures/stress/corpus/spring-2026/robotics/outreach-robotics.csv
+++ b/tests/fixtures/stress/corpus/spring-2026/robotics/outreach-robotics.csv
@@ -1,0 +1,5 @@
+contact,company,domain,status,outcome,notes,needs_follow_up,reason,owner
+Renzo Calderon,Gearbox Robotics Guild,robotics,responded,interested,"Wants to co-host a build night next month.",no,,Marcus Lyoung
+Hadley Stern,Tin Owl Automation,robotics education,ghosted,no response,"Cold email bounced around, no reply after follow-up.",yes,Try a different contact at the org,Marcus Lyoung
+Bao Tran,Pivot Arm Systems,industrial robotics,needs follow-up,pending,"Interested but waiting on internal approval.",yes,Awaiting internal approval,Marcus Lyoung
+Galen Whitfield,Lodestar Mechatronics,robotics,locked in,signed,"Signed on as a demo-night partner.",no,,Marcus Lyoung

--- a/tests/ingest.source-id.test.ts
+++ b/tests/ingest.source-id.test.ts
@@ -1,0 +1,150 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createDatabase, type MemoryDatabase } from "../src/db.js";
+import { ingestFolder } from "../src/ingest.js";
+
+const tempDirs: string[] = [];
+
+function tempDir(prefix = "sourcyavo-source-id-test-"): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function tempDb(dir: string): MemoryDatabase {
+  return createDatabase(join(dir, ".sourcyavo", "memory.db"));
+}
+
+function sourceRows(
+  db: MemoryDatabase
+): Array<{ id: number; path: string; source_id: string }> {
+  return db
+    .prepare("select id, path, source_id from source_records order by id")
+    .all() as Array<{ id: number; path: string; source_id: string }>;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("ingest source_id", () => {
+  it("derives a deterministic source_id from the stable relative path", () => {
+    const dir = tempDir();
+    const nested = join(dir, "Spring 2026", "Cold Emailing");
+    mkdirSync(nested, { recursive: true });
+    writeFileSync(join(nested, "Apollo.csv"), "name,status\nJane,contacted\n");
+
+    const db = tempDb(dir);
+    ingestFolder(db, dir);
+
+    const rows = sourceRows(db);
+    expect(rows).toHaveLength(1);
+    // The relative path retains the .csv extension, so it slugs into the id.
+    expect(rows[0].source_id).toBe("spring-2026/cold-emailing/apollo-csv");
+
+    db.close();
+  });
+
+  it("lets a frontmatter source_id override win over the path slug", () => {
+    const dir = tempDir();
+    writeFileSync(
+      join(dir, "spring.md"),
+      [
+        "---",
+        "source_id: custom/identity-key",
+        "---",
+        "Jane Doe met the AI safety group."
+      ].join("\n")
+    );
+
+    const db = tempDb(dir);
+    ingestFolder(db, dir);
+
+    const rows = sourceRows(db);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].source_id).toBe("custom/identity-key");
+
+    db.close();
+  });
+
+  it("preserves source_id and row id on reimport even when frontmatter source_id changes", () => {
+    const dir = tempDir();
+    const file = join(dir, "spring.md");
+    writeFileSync(
+      file,
+      ["---", "source_id: original-id", "---", "First version of the note."].join("\n")
+    );
+
+    const db = tempDb(dir);
+    ingestFolder(db, dir);
+    const before = sourceRows(db);
+    expect(before).toHaveLength(1);
+    expect(before[0].source_id).toBe("original-id");
+
+    writeFileSync(
+      file,
+      ["---", "source_id: changed-id", "---", "Second version of the note."].join("\n")
+    );
+    ingestFolder(db, dir);
+
+    const after = sourceRows(db);
+    expect(after).toHaveLength(1);
+    expect(after[0].id).toBe(before[0].id);
+    expect(after[0].source_id).toBe("original-id");
+
+    db.close();
+  });
+
+  it("preserves a seeded source_permissions mapping across reimport", () => {
+    const dir = tempDir();
+    const file = join(dir, "notes.txt");
+    writeFileSync(file, "Sourcing note for Alex.");
+
+    const db = tempDb(dir);
+    ingestFolder(db, dir);
+
+    const sourceId = sourceRows(db)[0].source_id;
+    db.prepare(
+      "insert into source_permissions (principal_type, principal_id, source_id) values (?, ?, ?)"
+    ).run("user", "alice", sourceId);
+
+    writeFileSync(file, "Updated sourcing note for Alex.");
+    ingestFolder(db, dir);
+
+    const permissions = db
+      .prepare("select principal_id, source_id from source_permissions")
+      .all() as Array<{ principal_id: string; source_id: string }>;
+    expect(permissions).toEqual([{ principal_id: "alice", source_id: sourceId }]);
+
+    db.close();
+  });
+
+  it("logs a duplicate source_id across different paths as an ingest error", () => {
+    const dir = tempDir();
+    writeFileSync(
+      join(dir, "a.md"),
+      ["---", "source_id: shared-id", "---", "First doc."].join("\n")
+    );
+    writeFileSync(
+      join(dir, "b.md"),
+      ["---", "source_id: shared-id", "---", "Second doc."].join("\n")
+    );
+
+    const db = tempDb(dir);
+    const result = ingestFolder(db, dir);
+
+    expect(result).toMatchObject({ processed: 1, skipped: 1 });
+    expect(sourceRows(db)).toHaveLength(1);
+    const errors = db
+      .prepare("select path, reason from ingest_errors")
+      .all() as Array<{ path: string; reason: string }>;
+    expect(errors).toHaveLength(1);
+    expect(errors[0].reason).toMatch(/unique/i);
+
+    db.close();
+  });
+});

--- a/tests/ingest.test.ts
+++ b/tests/ingest.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { createDatabase, type MemoryDatabase } from "../src/db.js";
-import { ingestFolder } from "../src/ingest.js";
+import { formatIngestReport, ingestFolder } from "../src/ingest.js";
 
 const tempDirs: string[] = [];
 
@@ -65,7 +65,7 @@ describe("ingestFolder", () => {
     }>(db, "memory_chunks");
     const errors = getRows<{ path: string; reason: string }>(db, "ingest_errors");
 
-    expect(result).toEqual({ processed: 4, skipped: 0 });
+    expect(result).toMatchObject({ processed: 4, skipped: 0, skippedFiles: [] });
     expect(sources).toHaveLength(4);
     expect(sources.map((source) => source.source_type).sort()).toEqual([
       "csv",
@@ -115,7 +115,7 @@ describe("ingestFolder", () => {
       .prepare("select text, citation from memory_chunks where source_record_id = ? order by chunk_index")
       .all(csvSource?.id) as Array<{ text: string; citation: string }>;
 
-    expect(result).toEqual({ processed: 2, skipped: 0 });
+    expect(result).toMatchObject({ processed: 2, skipped: 0 });
     expect(sources).toHaveLength(2);
     expect(csvChunks).toHaveLength(40);
     expect(csvChunks[0].text).toContain("First Name,Last Name,Title,Company Name,Email");
@@ -137,12 +137,13 @@ describe("ingestFolder", () => {
 
     const sources = getRows<{ path: string }>(db, "source_records");
     const chunks = getRows<{ text: string }>(db, "memory_chunks");
-    const errors = getRows<{ path: string; reason: string }>(db, "ingest_errors");
+    const errors = getRows<{ path: string; category: string; reason: string }>(db, "ingest_errors");
 
-    expect(result).toEqual({ processed: 1, skipped: 1 });
+    expect(result).toMatchObject({ processed: 1, skipped: 1 });
     expect(sources).toHaveLength(1);
     expect(chunks).toHaveLength(1);
     expect(basename(errors[0].path)).toBe("image.png");
+    expect(errors[0].category).toBe("unsupported-type");
     expect(errors[0].reason).toContain("Unsupported file extension");
 
     db.close();
@@ -155,11 +156,11 @@ describe("ingestFolder", () => {
     const db = tempDb(dir);
     const result = ingestFolder(db, dir);
 
-    expect(result).toEqual({ processed: 0, skipped: 1 });
+    expect(result).toMatchObject({ processed: 0, skipped: 1 });
     expect(getRows(db, "source_records")).toEqual([]);
     expect(getRows(db, "memory_chunks")).toEqual([]);
-    expect(getRows<{ path: string; reason: string }>(db, "ingest_errors")).toMatchObject([
-      { reason: "File is empty after parsing" }
+    expect(getRows<{ path: string; category: string; reason: string }>(db, "ingest_errors")).toMatchObject([
+      { category: "empty", reason: "File is empty after parsing" }
     ]);
 
     db.close();
@@ -178,17 +179,138 @@ describe("ingestFolder", () => {
     const result = ingestFolder(db, dir);
 
     const sources = getRows<{ path: string; title: string }>(db, "source_records");
-    const errors = getRows<{ path: string; reason: string }>(db, "ingest_errors");
+    const errors = getRows<{ path: string; category: string; reason: string }>(db, "ingest_errors");
 
-    expect(result).toEqual({ processed: 1, skipped: 1 });
+    expect(result).toMatchObject({ processed: 1, skipped: 1 });
     expect(sources).toHaveLength(1);
     expect(sources[0].title).toBe("after");
     expect(basename(errors[0].path)).toBe("broken.txt");
+    expect(errors[0].category).toBe("unreadable");
     expect(errors[0].reason).toContain("Failed to read file");
 
     db.close();
   });
+
+  it("classifies a mixed batch and leaves no orphan rows for skipped files", () => {
+    const dir = writeMixedBatch();
+
+    const db = tempDb(dir);
+    const result = ingestFolder(db, dir);
+
+    const sources = getRows<{ path: string }>(db, "source_records");
+    const errors = getRows<{ path: string; category: string; reason: string }>(db, "ingest_errors");
+
+    // good md + good csv processed; the rest skipped.
+    expect(result).toMatchObject({ processed: 2, skipped: 5 });
+    expect(sources).toHaveLength(2);
+    expect(sources.map((source) => basename(source.path)).sort()).toEqual(["good.csv", "good.md"]);
+
+    // No orphan source/chunk rows for any skipped file.
+    const skippedNames = result.skippedFiles.map((skipped) => basename(skipped.path));
+    for (const name of skippedNames) {
+      expect(sources.some((source) => basename(source.path) === name)).toBe(false);
+    }
+
+    const categoryByName = new Map(
+      errors.map((error) => [basename(error.path), error.category] as const)
+    );
+    expect(categoryByName.get("unsupported.png")).toBe("unsupported-type");
+    expect(categoryByName.get("empty.md")).toBe("empty");
+    expect(categoryByName.get("broken.txt")).toBe("unreadable");
+    expect(categoryByName.get("header-only.csv")).toBe("parse-error");
+    expect(categoryByName.get("bad-frontmatter.md")).toBe("parse-error");
+    expect(errors).toHaveLength(5);
+
+    db.close();
+  });
+
+  it("renders a report that names skipped files with a tally and no absolute paths", () => {
+    const dir = writeMixedBatch();
+
+    const db = tempDb(dir);
+    const result = ingestFolder(db, dir);
+    const report = formatIngestReport(result, dir);
+
+    expect(report).toContain("Ingested 2 source files; skipped 5.");
+    expect(report).toContain("Skipped files:");
+    expect(report).toContain("unsupported.png [unsupported-type]");
+    expect(report).toContain("empty.md [empty]");
+    expect(report).toContain("broken.txt [unreadable]");
+    expect(report).toContain("header-only.csv [parse-error]");
+    expect(report).toContain("bad-frontmatter.md [parse-error]");
+    expect(report).toContain("Skipped by category:");
+    expect(report).toContain("parse-error: 2");
+    expect(report).toContain("empty: 1");
+    expect(report).toContain("unreadable: 1");
+    expect(report).toContain("unsupported-type: 1");
+    expect(report).not.toContain(dir);
+
+    db.close();
+  });
+
+  it("prints only the summary line when nothing was skipped", () => {
+    const dir = tempDir();
+    writeFileSync(join(dir, "ok.txt"), "Supported note.");
+
+    const db = tempDb(dir);
+    const result = ingestFolder(db, dir);
+    const report = formatIngestReport(result, dir);
+
+    expect(report).toBe("Ingested 1 source file; skipped 0.");
+
+    db.close();
+  });
+
+  it("keeps ingesting neighbors after a skipped file regardless of ordering", () => {
+    const dir = tempDir();
+    // Names chosen so a failing file sorts between two good files.
+    writeFileSync(join(dir, "a-before.txt"), "Indexed before the failure.");
+    writeFileSync(join(dir, "m-empty.md"), "   \n\t");
+    writeFileSync(join(dir, "z-after.txt"), "Indexed after the failure.");
+
+    const db = tempDb(dir);
+    const result = ingestFolder(db, dir);
+
+    const sources = getRows<{ path: string }>(db, "source_records");
+
+    expect(result).toMatchObject({ processed: 2, skipped: 1 });
+    expect(sources.map((source) => basename(source.path)).sort()).toEqual([
+      "a-before.txt",
+      "z-after.txt"
+    ]);
+    expect(result.skippedFiles.map((skipped) => basename(skipped.path))).toEqual(["m-empty.md"]);
+
+    db.close();
+  });
+
+  // The current deterministic hashing embedder cannot throw, so there is no
+  // honest way to exercise the embedding-error path without faking it.
+  it.todo("classifies embedding failures as embedding-error");
 });
+
+function writeMixedBatch(): string {
+  const dir = tempDir();
+  writeFileSync(
+    join(dir, "good.md"),
+    ["---", "title: Good Note", "---", "Jane Doe needs follow-up."].join("\n")
+  );
+  writeFileSync(join(dir, "good.csv"), "name,status\nJane,contacted\n");
+  writeFileSync(join(dir, "unsupported.png"), "not really an image");
+  writeFileSync(join(dir, "empty.md"), "  \n\t");
+  writeFileSync(join(dir, "header-only.csv"), "name,status\n");
+  writeFileSync(
+    join(dir, "bad-frontmatter.md"),
+    ["---", "title: Missing closing fence", "Body without a closing fence."].join("\n")
+  );
+
+  const brokenTarget = join(dir, "missing-target.txt");
+  const brokenLink = join(dir, "broken.txt");
+  if (!existsSync(brokenTarget)) {
+    symlinkSync(brokenTarget, brokenLink);
+  }
+
+  return dir;
+}
 
 function mkdirRecursive(path: string): void {
   mkdirSync(path, { recursive: true });

--- a/tests/permissions.test.ts
+++ b/tests/permissions.test.ts
@@ -1,0 +1,103 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createDatabase, type MemoryDatabase } from "../src/db.js";
+import { resolveAccessContext } from "../src/read-service.js";
+
+const tempDirs: string[] = [];
+
+function tempDb(): MemoryDatabase {
+  const dir = mkdtempSync(join(tmpdir(), "sourcyavo-permissions-test-"));
+  tempDirs.push(dir);
+  return createDatabase(join(dir, ".sourcyavo", "memory.db"));
+}
+
+// Exercises the production allowlist resolver through its public AccessContext
+// surface, so the permission predicate (including access = 'read') lives in
+// exactly one place.
+function resolveAllowedSourceIds(
+  db: MemoryDatabase,
+  actorType: string,
+  actorId: string
+): string[] {
+  return resolveAccessContext(db, { actorType: actorType as never, actorId })
+    .allowedSourceIds;
+}
+
+function grant(
+  db: MemoryDatabase,
+  principalType: string,
+  principalId: string,
+  sourceId: string
+): void {
+  db.prepare(
+    "insert into source_permissions (principal_type, principal_id, source_id) values (?, ?, ?)"
+  ).run(principalType, principalId, sourceId);
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("resolveAllowedSourceIds", () => {
+  it("returns an empty scope when the principal has no permissions", () => {
+    const db = tempDb();
+    expect(resolveAllowedSourceIds(db, "user", "alice")).toEqual([]);
+    db.close();
+  });
+
+  it("returns a single granted source id", () => {
+    const db = tempDb();
+    grant(db, "user", "alice", "spring-2026/apollo");
+    expect(resolveAllowedSourceIds(db, "user", "alice")).toEqual(["spring-2026/apollo"]);
+    db.close();
+  });
+
+  it("returns multiple granted source ids", () => {
+    const db = tempDb();
+    grant(db, "user", "alice", "spring-2026/apollo");
+    grant(db, "user", "alice", "spring-2026/cold-emailing");
+    expect(resolveAllowedSourceIds(db, "user", "alice")).toEqual([
+      "spring-2026/apollo",
+      "spring-2026/cold-emailing"
+    ]);
+    db.close();
+  });
+
+  it("returns an empty scope for an unknown principal", () => {
+    const db = tempDb();
+    grant(db, "user", "alice", "spring-2026/apollo");
+    expect(resolveAllowedSourceIds(db, "user", "mallory")).toEqual([]);
+    db.close();
+  });
+
+  it("keeps two principals' scopes disjoint", () => {
+    const db = tempDb();
+    grant(db, "user", "alice", "spring-2026/apollo");
+    grant(db, "oauth_client", "bob-app", "fall-2026/referrals");
+
+    expect(resolveAllowedSourceIds(db, "user", "alice")).toEqual(["spring-2026/apollo"]);
+    expect(resolveAllowedSourceIds(db, "oauth_client", "bob-app")).toEqual([
+      "fall-2026/referrals"
+    ]);
+
+    db.close();
+  });
+
+  it("excludes grants that are not read access", () => {
+    const db = tempDb();
+    grant(db, "user", "alice", "spring-2026/apollo");
+    db.prepare(
+      "insert into source_permissions (principal_type, principal_id, source_id, access) values (?, ?, ?, ?)"
+    ).run("user", "alice", "spring-2026/restricted", "write");
+
+    expect(resolveAllowedSourceIds(db, "user", "alice")).toEqual([
+      "spring-2026/apollo"
+    ]);
+
+    db.close();
+  });
+});

--- a/tests/permissions.test.ts
+++ b/tests/permissions.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { createDatabase, type MemoryDatabase } from "../src/db.js";
-import { resolveAccessContext } from "../src/read-service.js";
+import { resolveAccessContext, type ActorType } from "../src/read-service.js";
 
 const tempDirs: string[] = [];
 
@@ -18,11 +18,10 @@ function tempDb(): MemoryDatabase {
 // exactly one place.
 function resolveAllowedSourceIds(
   db: MemoryDatabase,
-  actorType: string,
+  actorType: ActorType,
   actorId: string
 ): string[] {
-  return resolveAccessContext(db, { actorType: actorType as never, actorId })
-    .allowedSourceIds;
+  return resolveAccessContext(db, { actorType, actorId }).allowedSourceIds;
 }
 
 function grant(

--- a/tests/read-service.test.ts
+++ b/tests/read-service.test.ts
@@ -1,0 +1,484 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createDatabase, type MemoryDatabase } from "../src/db.js";
+import { serializeEmbedding } from "../src/embeddings.js";
+import {
+  MemoryReader,
+  resolveAccessContext,
+  sourceIdInClause
+} from "../src/read-service.js";
+
+const tempDirs: string[] = [];
+
+function tempDb(): MemoryDatabase {
+  const dir = mkdtempSync(join(tmpdir(), "sourcyavo-read-service-test-"));
+  tempDirs.push(dir);
+  return createDatabase(join(dir, ".sourcyavo", "memory.db"));
+}
+
+function seedSource(
+  db: MemoryDatabase,
+  sourceId: string,
+  options: {
+    factSubject: string;
+    factObject: string;
+    chunkText: string;
+    citation: string;
+  }
+): void {
+  const sourceRecordId = db
+    .prepare(
+      "insert into source_records (path, source_id, title, source_type, content_hash, raw_text) values (?, ?, ?, ?, ?, ?) returning id"
+    )
+    .get(
+      `${sourceId}.csv`,
+      sourceId,
+      sourceId,
+      "csv",
+      `hash-${sourceId}`,
+      options.chunkText
+    ) as { id: number };
+
+  const chunkId = db
+    .prepare(
+      "insert into memory_chunks (source_record_id, chunk_index, text, chunk_hash, embedding, citation) values (?, ?, ?, ?, ?, ?) returning id"
+    )
+    .get(
+      sourceRecordId.id,
+      0,
+      options.chunkText,
+      `chunk-${sourceId}`,
+      serializeEmbedding(options.chunkText),
+      options.citation
+    ) as { id: number };
+
+  db.prepare(
+    "insert into semantic_facts (subject, predicate, object, source_record_id, source_chunk_id, confidence, status) values (?, ?, ?, ?, ?, ?, ?)"
+  ).run(
+    options.factSubject,
+    "needs_follow_up",
+    options.factObject,
+    sourceRecordId.id,
+    chunkId.id,
+    0.9,
+    "accepted"
+  );
+}
+
+function grant(
+  db: MemoryDatabase,
+  principalType: string,
+  principalId: string,
+  sourceId: string
+): void {
+  db.prepare(
+    "insert into source_permissions (principal_type, principal_id, source_id, access) values (?, ?, ?, 'read')"
+  ).run(principalType, principalId, sourceId);
+}
+
+function seedGapFact(
+  db: MemoryDatabase,
+  sourceId: string,
+  options: { subject: string; object: string; status: string }
+): void {
+  const sourceRecordId = db
+    .prepare("select id from source_records where source_id = ?")
+    .get(sourceId) as { id: number };
+  const chunkId = db
+    .prepare("select id from memory_chunks where source_record_id = ? limit 1")
+    .get(sourceRecordId.id) as { id: number };
+
+  db.prepare(
+    "insert into semantic_facts (subject, predicate, object, source_record_id, source_chunk_id, confidence, status) values (?, ?, ?, ?, ?, ?, ?)"
+  ).run(
+    options.subject,
+    "needs_follow_up",
+    options.object,
+    sourceRecordId.id,
+    chunkId.id,
+    0.4,
+    options.status
+  );
+}
+
+function auditRows(
+  db: MemoryDatabase
+): Array<{ actor_type: string; actor_id: string; action: string; source_id: string | null }> {
+  return db
+    .prepare("select actor_type, actor_id, action, source_id from audit_events order by id")
+    .all() as Array<{
+    actor_type: string;
+    actor_id: string;
+    action: string;
+    source_id: string | null;
+  }>;
+}
+
+function seedTwoSources(db: MemoryDatabase): void {
+  // Both chunks lexically match "robotics" so a scope leak would surface src-beta
+  // content for client-a if the filter were post-retrieval instead of in SQL.
+  seedSource(db, "src-alpha", {
+    factSubject: "Alpha Contact",
+    factObject: "robotics intro for alpha",
+    chunkText: "Alpha Contact needs a follow-up about the robotics partnership.",
+    citation: "src-alpha.csv#row-1"
+  });
+  seedSource(db, "src-beta", {
+    factSubject: "Beta Contact",
+    factObject: "robotics intro for beta",
+    chunkText: "Beta Contact needs a follow-up about the robotics partnership.",
+    citation: "src-beta.csv#row-1"
+  });
+
+  grant(db, "test_client", "client-a", "src-alpha");
+  grant(db, "test_client", "client-b", "src-beta");
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("resolveAccessContext", () => {
+  it("resolves a single granted source for a principal", () => {
+    const db = tempDb();
+    seedTwoSources(db);
+
+    const ctx = resolveAccessContext(db, { actorType: "test_client", actorId: "client-a" });
+    expect(ctx.allowedSourceIds).toEqual(["src-alpha"]);
+    expect(ctx.auditLabel).toBe("test_client:client-a");
+    expect(ctx.deniedSourceIds).toContain("src-beta");
+    db.close();
+  });
+
+  it("resolves multiple granted sources", () => {
+    const db = tempDb();
+    seedTwoSources(db);
+    grant(db, "test_client", "client-a", "src-beta");
+
+    const ctx = resolveAccessContext(db, { actorType: "test_client", actorId: "client-a" });
+    expect(ctx.allowedSourceIds).toEqual(["src-alpha", "src-beta"]);
+    expect(ctx.deniedSourceIds).toEqual([]);
+    db.close();
+  });
+
+  it("default-denies an unknown principal", () => {
+    const db = tempDb();
+    seedTwoSources(db);
+
+    const ctx = resolveAccessContext(db, { actorType: "test_client", actorId: "mallory" });
+    expect(ctx.allowedSourceIds).toEqual([]);
+    expect(ctx.deniedSourceIds).toEqual(["src-alpha", "src-beta"]);
+    db.close();
+  });
+});
+
+describe("sourceIdInClause", () => {
+  it("builds a never-matching clause for an empty scope", () => {
+    const clause = sourceIdInClause({ allowedSourceIds: [] });
+    expect(clause.sql).toBe("1 = 0");
+    expect(clause.params).toEqual([]);
+  });
+
+  it("builds a parameterized in-clause with the given alias", () => {
+    const clause = sourceIdInClause({ allowedSourceIds: ["a", "b"] }, "x");
+    expect(clause.sql).toBe("x.source_id in (?, ?)");
+    expect(clause.params).toEqual(["a", "b"]);
+  });
+});
+
+describe("MemoryReader scoped ask", () => {
+  it("returns different answers and evidence for two clients on the same question", () => {
+    const db = tempDb();
+    seedTwoSources(db);
+
+    const ctxA = resolveAccessContext(db, { actorType: "test_client", actorId: "client-a" });
+    const ctxB = resolveAccessContext(db, { actorType: "test_client", actorId: "client-b" });
+
+    const answerA = new MemoryReader(db, ctxA).ask("Who needs follow-up for robotics?");
+    const answerB = new MemoryReader(db, ctxB).ask("Who needs follow-up for robotics?");
+
+    expect(answerA).not.toBe(answerB);
+    expect(answerA).toContain("Alpha Contact");
+    expect(answerA).toContain("src-alpha.csv#row-1");
+    expect(answerB).toContain("Beta Contact");
+    expect(answerB).toContain("src-beta.csv#row-1");
+    db.close();
+  });
+
+  it("never leaks a restricted fact, chunk, or citation across the scope boundary", () => {
+    const db = tempDb();
+    seedTwoSources(db);
+
+    const ctxA = resolveAccessContext(db, { actorType: "test_client", actorId: "client-a" });
+    const answerA = new MemoryReader(db, ctxA).ask("Who needs follow-up for robotics?");
+
+    // The restricted accepted fact subject and object must be absent.
+    expect(answerA).not.toContain("Beta Contact");
+    expect(answerA).not.toContain("robotics intro for beta");
+    // The restricted chunk's citation must be absent even though its text
+    // lexically matches the query ("robotics").
+    expect(answerA).not.toContain("src-beta.csv#row-1");
+    db.close();
+  });
+
+  it("returns the explicit no-access answer for an unknown principal without querying globally", () => {
+    const db = tempDb();
+    seedTwoSources(db);
+
+    const ctx = resolveAccessContext(db, { actorType: "test_client", actorId: "mallory" });
+    const answer = new MemoryReader(db, ctx).ask("Who needs follow-up for robotics?");
+
+    expect(answer.toLowerCase()).toContain("no access to any sources");
+    expect(answer).not.toContain("Alpha Contact");
+    expect(answer).not.toContain("Beta Contact");
+    db.close();
+  });
+});
+
+describe("MemoryReader.searchMemory", () => {
+  it("returns only chunks from allowed sources, ranked by score", () => {
+    const db = tempDb();
+    seedTwoSources(db);
+
+    const ctxA = resolveAccessContext(db, { actorType: "test_client", actorId: "client-a" });
+    const results = new MemoryReader(db, ctxA).searchMemory("robotics partnership follow-up");
+
+    expect(results.length).toBeGreaterThan(0);
+    for (const result of results) {
+      expect(result.sourceId).toBe("src-alpha");
+    }
+    expect(results.map((result) => result.citation)).toContain("src-alpha.csv#row-1");
+    db.close();
+  });
+
+  it("never surfaces a higher-lexical-score restricted chunk", () => {
+    const db = tempDb();
+    seedTwoSources(db);
+    // A restricted source whose chunk is an even stronger lexical/semantic match
+    // for the query than the allowed one. A post-retrieval filter could rank it
+    // first and then expose it; an in-SQL scope filter must drop it entirely.
+    seedSource(db, "src-secret", {
+      factSubject: "Secret Contact",
+      factObject: "robotics robotics robotics partnership",
+      chunkText:
+        "robotics robotics robotics partnership follow-up robotics partnership robotics.",
+      citation: "src-secret.csv#row-1"
+    });
+
+    const ctxA = resolveAccessContext(db, { actorType: "test_client", actorId: "client-a" });
+    const results = new MemoryReader(db, ctxA).searchMemory("robotics partnership follow-up");
+
+    expect(results.every((result) => result.sourceId === "src-alpha")).toBe(true);
+    expect(results.map((result) => result.citation)).not.toContain("src-secret.csv#row-1");
+    db.close();
+  });
+
+  it("returns an empty list for a zero-scope caller", () => {
+    const db = tempDb();
+    seedTwoSources(db);
+
+    const ctx = resolveAccessContext(db, { actorType: "test_client", actorId: "mallory" });
+    expect(new MemoryReader(db, ctx).searchMemory("robotics")).toEqual([]);
+    db.close();
+  });
+});
+
+describe("MemoryReader.getSource", () => {
+  it("returns the source for an allowed id", () => {
+    const db = tempDb();
+    seedTwoSources(db);
+
+    const ctxA = resolveAccessContext(db, { actorType: "test_client", actorId: "client-a" });
+    const result = new MemoryReader(db, ctxA).getSource("src-alpha");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.source.sourceId).toBe("src-alpha");
+      expect(result.source.sourceType).toBe("csv");
+    }
+    db.close();
+  });
+
+  it("denies an existing but out-of-scope id without leaking existence", () => {
+    const db = tempDb();
+    seedTwoSources(db);
+
+    const ctxA = resolveAccessContext(db, { actorType: "test_client", actorId: "client-a" });
+    const reader = new MemoryReader(db, ctxA);
+
+    // src-beta exists but is not in client-a's scope.
+    expect(reader.getSource("src-beta")).toEqual({ ok: false, reason: "denied" });
+    // A non-existent id must produce the SAME response so existence cannot be
+    // probed by comparing reasons.
+    expect(reader.getSource("src-does-not-exist")).toEqual({ ok: false, reason: "denied" });
+    db.close();
+  });
+
+  it("reports missing only for an allowed id absent from source_records", () => {
+    const db = tempDb();
+    seedTwoSources(db);
+    // Grant read on a source_id that has no source_records row (e.g. deleted).
+    grant(db, "test_client", "client-a", "src-deleted");
+
+    const ctxA = resolveAccessContext(db, { actorType: "test_client", actorId: "client-a" });
+    expect(new MemoryReader(db, ctxA).getSource("src-deleted")).toEqual({
+      ok: false,
+      reason: "missing"
+    });
+    db.close();
+  });
+
+  it("reports malformed for empty, non-string, or oversize input", () => {
+    const db = tempDb();
+    seedTwoSources(db);
+
+    const ctxA = resolveAccessContext(db, { actorType: "test_client", actorId: "client-a" });
+    const reader = new MemoryReader(db, ctxA);
+
+    expect(reader.getSource("")).toEqual({ ok: false, reason: "malformed" });
+    expect(reader.getSource(42)).toEqual({ ok: false, reason: "malformed" });
+    expect(reader.getSource(null)).toEqual({ ok: false, reason: "malformed" });
+    expect(reader.getSource("x".repeat(1000))).toEqual({ ok: false, reason: "malformed" });
+    db.close();
+  });
+
+  it("denies every getSource for a zero-scope caller", () => {
+    const db = tempDb();
+    seedTwoSources(db);
+
+    const ctx = resolveAccessContext(db, { actorType: "test_client", actorId: "mallory" });
+    expect(new MemoryReader(db, ctx).getSource("src-alpha")).toEqual({
+      ok: false,
+      reason: "denied"
+    });
+    db.close();
+  });
+});
+
+describe("MemoryReader.listGaps", () => {
+  it("returns only gaps from allowed sources and hides restricted gaps", () => {
+    const db = tempDb();
+    seedTwoSources(db);
+    seedGapFact(db, "src-alpha", {
+      subject: "Alpha Contact",
+      object: "candidate alpha detail",
+      status: "candidate"
+    });
+    seedGapFact(db, "src-beta", {
+      subject: "Beta Contact",
+      object: "candidate beta detail",
+      status: "candidate"
+    });
+
+    const ctxA = resolveAccessContext(db, { actorType: "test_client", actorId: "client-a" });
+    const gaps = new MemoryReader(db, ctxA).listGaps();
+
+    expect(gaps.length).toBe(1);
+    expect(gaps[0]?.subject).toBe("Alpha Contact");
+    expect(gaps.every((gap) => gap.object !== "candidate beta detail")).toBe(true);
+    db.close();
+  });
+
+  it("returns an empty list for a zero-scope caller", () => {
+    const db = tempDb();
+    seedTwoSources(db);
+    seedGapFact(db, "src-alpha", {
+      subject: "Alpha Contact",
+      object: "candidate alpha detail",
+      status: "candidate"
+    });
+
+    const ctx = resolveAccessContext(db, { actorType: "test_client", actorId: "mallory" });
+    expect(new MemoryReader(db, ctx).listGaps()).toEqual([]);
+    db.close();
+  });
+});
+
+describe("MemoryReader no-access UX", () => {
+  it("renders an explicit no-access Answer with all four sections from ask", () => {
+    const db = tempDb();
+    seedTwoSources(db);
+
+    const ctx = resolveAccessContext(db, { actorType: "test_client", actorId: "mallory" });
+    const answer = new MemoryReader(db, ctx).ask("Who needs follow-up for robotics?");
+
+    expect(answer).toContain("Answer:");
+    expect(answer).toContain("Evidence:");
+    expect(answer).toContain("Gaps:");
+    expect(answer).toContain("Next Action:");
+    expect(answer.toLowerCase()).toContain("no access to any sources");
+    expect(answer).not.toContain("Alpha Contact");
+    expect(answer).not.toContain("Beta Contact");
+    db.close();
+  });
+});
+
+describe("MemoryReader audit", () => {
+  it("writes a success audit row with correct actor and action for each read", () => {
+    const db = tempDb();
+    seedTwoSources(db);
+    seedGapFact(db, "src-alpha", {
+      subject: "Alpha Contact",
+      object: "candidate alpha detail",
+      status: "candidate"
+    });
+
+    const ctxA = resolveAccessContext(db, { actorType: "test_client", actorId: "client-a" });
+    const reader = new MemoryReader(db, ctxA);
+
+    reader.ask("Who needs follow-up for robotics?");
+    reader.searchMemory("robotics");
+    reader.getSource("src-alpha");
+    reader.listGaps();
+
+    const rows = auditRows(db);
+    expect(rows.map((row) => row.action)).toEqual([
+      "ask",
+      "search_memory",
+      "get_source",
+      "list_gaps"
+    ]);
+    for (const row of rows) {
+      expect(row.actor_type).toBe("test_client");
+      expect(row.actor_id).toBe("client-a");
+    }
+    const getSourceRow = rows.find((row) => row.action === "get_source");
+    expect(getSourceRow?.source_id).toBe("src-alpha");
+    db.close();
+  });
+
+  it("writes a denied_read audit row on denied getSource", () => {
+    const db = tempDb();
+    seedTwoSources(db);
+
+    const ctxA = resolveAccessContext(db, { actorType: "test_client", actorId: "client-a" });
+    new MemoryReader(db, ctxA).getSource("src-beta");
+
+    const rows = auditRows(db);
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.action).toBe("denied_read");
+    expect(rows[0]?.actor_type).toBe("test_client");
+    expect(rows[0]?.actor_id).toBe("client-a");
+    expect(rows[0]?.source_id).toBe("src-beta");
+    db.close();
+  });
+
+  it("writes a denied_read audit row for a zero-scope ask", () => {
+    const db = tempDb();
+    seedTwoSources(db);
+
+    const ctx = resolveAccessContext(db, { actorType: "test_client", actorId: "mallory" });
+    new MemoryReader(db, ctx).ask("Who needs follow-up?");
+
+    const rows = auditRows(db);
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.action).toBe("denied_read");
+    expect(rows[0]?.actor_id).toBe("mallory");
+    expect(rows[0]?.source_id).toBe(null);
+    db.close();
+  });
+});

--- a/tests/slugify.test.ts
+++ b/tests/slugify.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { slugifySourceId } from "../src/db.js";
+
+describe("slugifySourceId", () => {
+  it("lowercases and collapses non-alphanumeric runs while preserving separators", () => {
+    expect(slugifySourceId("Spring 2026/Cold Emailing/Apollo.csv")).toBe(
+      "spring-2026/cold-emailing/apollo-csv"
+    );
+  });
+
+  it("produces the same id for Windows backslash and POSIX separators", () => {
+    const posix = slugifySourceId("spring-2026/ai/outreach.csv");
+    const windows = slugifySourceId("spring-2026\\ai\\outreach.csv");
+    expect(windows).toBe(posix);
+    expect(windows).toBe("spring-2026/ai/outreach-csv");
+  });
+
+  it("drops empty segments from leading or repeated separators", () => {
+    expect(slugifySourceId("/spring-2026//ai/")).toBe("spring-2026/ai");
+  });
+});

--- a/tests/stress/harness.ts
+++ b/tests/stress/harness.ts
@@ -72,9 +72,10 @@ export interface StressHarnessOptions {
   // Override the cases to run. Defaults to the committed benchmark set.
   cases?: readonly BenchmarkCase[];
   // Source ids the stress client is granted read access to. Defaults to the
-  // committed non-restricted allowlist. An empty array models a permission
-  // gap; `null` models S2 being unavailable (no grants written at all).
-  allowedSourceIds?: readonly string[] | null;
+  // committed non-restricted allowlist. An empty array models a permission gap
+  // (client present, zero grants). S2 being unavailable is modeled separately
+  // by simulateMissingPermissions.
+  allowedSourceIds?: readonly string[];
   // Forwarded to refreshMemory so a test can inject a deterministic extractor
   // (e.g. one that yields nothing) to seed an extraction miss. No LLM is ever
   // called by the default path.

--- a/tests/stress/harness.ts
+++ b/tests/stress/harness.ts
@@ -1,0 +1,427 @@
+import { cpSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createDatabase, type MemoryDatabase } from "../../src/db.js";
+import { ingestFolder } from "../../src/ingest.js";
+import { refreshMemory, type RefreshMemoryOptions } from "../../src/refresh.js";
+import { MemoryReader, resolveAccessContext } from "../../src/read-service.js";
+import {
+  BENCHMARK_CASES,
+  STRESS_ALLOWED_SOURCE_IDS,
+  STRESS_CLIENT,
+  type BenchmarkCase
+} from "../fixtures/stress/benchmark.js";
+
+// Six fixed miss categories evaluated first-match-wins in this order. 'temporal'
+// is structurally out of scope (Checkpoint 4) and is a declared deferred bucket
+// (always count 0) rather than a fabricated pass.
+export const MISS_CATEGORIES = [
+  "permission",
+  "missing-source",
+  "extraction",
+  "retrieval",
+  "citation",
+  "temporal"
+] as const;
+export type MissCategory = (typeof MISS_CATEGORIES)[number];
+
+export type CaseOutcome = "pass" | "miss";
+
+// When S2 permissions cannot be evaluated, the permission bucket degrades to
+// this honest sentinel instead of silently passing.
+export const PERMISSION_UNREACHABLE = "unreachable-pending" as const;
+export type PermissionState = "reachable" | typeof PERMISSION_UNREACHABLE;
+
+export interface CaseResult {
+  id: string;
+  question: string;
+  client: { actorType: string; actorId: string };
+  outcome: CaseOutcome;
+  category: MissCategory | null;
+  detail: string;
+}
+
+export interface StressReport {
+  snapshotPath: string;
+  ingest: {
+    processed: number;
+    skipped: number;
+  };
+  // Relative-ish labels of files that ingest skipped (from ingest_errors).
+  skippedFiles: Array<{ path: string; category: string; reason: string }>;
+  // Refresh/extraction failures (extraction_runs with status='failed').
+  extractionFailures: Array<{ chunkId: number | null; error: string }>;
+  refresh: {
+    chunksProcessed: number;
+    extracted: number;
+    reused: number;
+    failed: number;
+  };
+  cases: CaseResult[];
+  // Six-category tally. 'temporal' is always present with count 0.
+  tally: Record<MissCategory, number>;
+  permissionState: PermissionState;
+  passCount: number;
+  missCount: number;
+}
+
+export interface StressHarnessOptions {
+  // Source folder to ingest. Defaults to the committed stress corpus. Tests
+  // point this at a seeded-failure corpus to drive specific categories.
+  corpusPath?: string;
+  // Override the cases to run. Defaults to the committed benchmark set.
+  cases?: readonly BenchmarkCase[];
+  // Source ids the stress client is granted read access to. Defaults to the
+  // committed non-restricted allowlist. An empty array models a permission
+  // gap; `null` models S2 being unavailable (no grants written at all).
+  allowedSourceIds?: readonly string[] | null;
+  // Forwarded to refreshMemory so a test can inject a deterministic extractor
+  // (e.g. one that yields nothing) to seed an extraction miss. No LLM is ever
+  // called by the default path.
+  refreshOptions?: RefreshMemoryOptions;
+  // When true, do not write any source_permissions rows and report the
+  // permission bucket as 'unreachable-pending'. Models S2 being absent.
+  simulateMissingPermissions?: boolean;
+}
+
+interface FactRow {
+  subject: string;
+  predicate: string;
+  object: string;
+  status: string;
+  citation: string | null;
+  source_id: string;
+}
+
+const DEFAULT_CORPUS = new URL("../fixtures/stress/corpus/", import.meta.url).pathname;
+
+export async function runStressHarness(
+  options: StressHarnessOptions = {}
+): Promise<StressReport> {
+  const corpusPath = options.corpusPath ?? DEFAULT_CORPUS;
+  const cases = options.cases ?? BENCHMARK_CASES;
+  const tempRoot = mkdtempSync(join(tmpdir(), "sourcyavo-stress-"));
+
+  try {
+    const corpusCopy = join(tempRoot, "corpus");
+    cpSync(corpusPath, corpusCopy, { recursive: true });
+
+    const snapshotPath = join(tempRoot, ".sourcyavo", "memory.db");
+    const db = createDatabase(snapshotPath);
+
+    try {
+      return await buildReport(db, corpusCopy, snapshotPath, cases, options);
+    } finally {
+      db.close();
+    }
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+async function buildReport(
+  db: MemoryDatabase,
+  corpusCopy: string,
+  snapshotPath: string,
+  cases: readonly BenchmarkCase[],
+  options: StressHarnessOptions
+): Promise<StressReport> {
+  const ingestResult = ingestFolder(db, corpusCopy);
+  const refresh = await refreshMemory(db, options.refreshOptions);
+
+  const permissionState: PermissionState = options.simulateMissingPermissions
+    ? PERMISSION_UNREACHABLE
+    : "reachable";
+
+  if (permissionState === "reachable") {
+    seedPermissions(db, options.allowedSourceIds ?? STRESS_ALLOWED_SOURCE_IDS);
+  }
+
+  const skippedFiles = loadSkippedFiles(db);
+  const extractionFailures = loadExtractionFailures(db);
+
+  const tally = emptyTally();
+  const caseResults: CaseResult[] = [];
+
+  for (const benchmark of cases) {
+    const result = evaluateCase(db, benchmark, permissionState);
+    caseResults.push(result);
+    if (result.category) {
+      tally[result.category] += 1;
+    }
+  }
+
+  const passCount = caseResults.filter((c) => c.outcome === "pass").length;
+  const missCount = caseResults.length - passCount;
+
+  return {
+    snapshotPath,
+    ingest: { processed: ingestResult.processed, skipped: ingestResult.skipped },
+    skippedFiles: skippedFiles.map((row) => ({
+      path: row.path,
+      category: row.category,
+      reason: row.reason
+    })),
+    extractionFailures,
+    refresh,
+    cases: caseResults,
+    tally,
+    permissionState,
+    passCount,
+    missCount
+  };
+}
+
+function seedPermissions(db: MemoryDatabase, sourceIds: readonly string[]): void {
+  const insert = db.prepare(
+    "insert or ignore into source_permissions (principal_type, principal_id, source_id, access) values (?, ?, ?, 'read')"
+  );
+  for (const sourceId of sourceIds) {
+    insert.run(STRESS_CLIENT.actorType, STRESS_CLIENT.actorId, sourceId);
+  }
+}
+
+function evaluateCase(
+  db: MemoryDatabase,
+  benchmark: BenchmarkCase,
+  permissionState: PermissionState
+): CaseResult {
+  const ctx = resolveAccessContext(db, {
+    actorType: benchmark.client.actorType,
+    actorId: benchmark.client.actorId
+  });
+  const reader = new MemoryReader(db, ctx);
+  const answer = reader.ask(benchmark.question);
+  const evidence = extractEvidenceSection(answer);
+
+  const base = {
+    id: benchmark.id,
+    question: benchmark.question,
+    client: { actorType: benchmark.client.actorType, actorId: benchmark.client.actorId }
+  };
+
+  const category = classifyOutcome(db, benchmark, ctx.allowedSourceIds, answer, evidence, permissionState);
+  if (!category) {
+    return { ...base, outcome: "pass", category: null, detail: "all expectations met" };
+  }
+  return { ...base, outcome: "miss", category: category.category, detail: category.detail };
+}
+
+// First-match-wins classification in the fixed order:
+// permission -> missing-source -> extraction -> retrieval -> citation -> temporal.
+function classifyOutcome(
+  db: MemoryDatabase,
+  benchmark: BenchmarkCase,
+  allowedSourceIds: string[],
+  answer: string,
+  evidence: string,
+  permissionState: PermissionState
+): { category: MissCategory; detail: string } | null {
+  const { expectations } = benchmark;
+  const answerLower = answer.toLowerCase();
+
+  // 1. permission: a forbidden subject or restricted citation leaked.
+  if (permissionState === "reachable") {
+    const leaked = expectations.forbiddenSubjects.find((subject) =>
+      answerLower.includes(subject.toLowerCase())
+    );
+    if (leaked) {
+      return {
+        category: "permission",
+        detail: `forbidden subject leaked into answer: ${leaked}`
+      };
+    }
+  }
+  // When permissions are unreachable we do not run the permission check; the
+  // bucket is declared via permissionState and never silently passes.
+
+  // For cases that legitimately expect no answer (e.g. a correctly scoped
+  // client asking about a restricted topic), the only failure mode is a leak,
+  // which was checked above. No leak => pass.
+  if (!expectations.expectSomeAnswer) {
+    return null;
+  }
+
+  // 2. missing-source: an expected cited source is absent from source_records
+  // or present in ingest_errors.
+  for (const expectedCitation of expectations.mustCiteSources) {
+    const sourceRow = findSourceByCitationFragment(db, expectedCitation);
+    if (!sourceRow) {
+      return {
+        category: "missing-source",
+        detail: `expected source absent from source_records: ${expectedCitation}`
+      };
+    }
+    if (sourceWasSkipped(db, expectedCitation)) {
+      return {
+        category: "missing-source",
+        detail: `expected source recorded in ingest_errors: ${expectedCitation}`
+      };
+    }
+  }
+
+  // Load scoped accepted facts once for the remaining structural checks.
+  const scopedFacts = loadScopedFacts(db, allowedSourceIds);
+
+  for (const subject of expectations.mustMentionSubjects) {
+    const subjectInAnswer = answerLower.includes(subject.toLowerCase());
+    const acceptedForSubject = scopedFacts.filter(
+      (fact) => fact.status === "accepted" && fact.subject.toLowerCase() === subject.toLowerCase()
+    );
+
+    // 3. extraction: a chunk exists for the subject's source but no semantic
+    // fact was produced for that subject at all.
+    if (acceptedForSubject.length === 0) {
+      const anyFactForSubject = scopedFacts.some(
+        (fact) => fact.subject.toLowerCase() === subject.toLowerCase()
+      );
+      if (!anyFactForSubject && chunkExistsForSubject(db, allowedSourceIds, subject)) {
+        return {
+          category: "extraction",
+          detail: `chunk present but no semantic_facts for subject: ${subject}`
+        };
+      }
+    }
+
+    // 4. retrieval: an accepted fact exists in scope for the subject but the
+    // subject never made it into the Answer.
+    if (acceptedForSubject.length > 0 && !subjectInAnswer) {
+      return {
+        category: "retrieval",
+        detail: `accepted fact present but subject missing from answer: ${subject}`
+      };
+    }
+  }
+
+  // 5. citation: a required subject is in the Answer but its expected citation
+  // is missing from the Evidence section.
+  const evidenceLower = evidence.toLowerCase();
+  if (expectations.mustMentionSubjects.length > 0) {
+    for (const expectedCitation of expectations.mustCiteSources) {
+      if (!evidenceLower.includes(expectedCitation.toLowerCase())) {
+        return {
+          category: "citation",
+          detail: `expected citation missing from evidence: ${expectedCitation}`
+        };
+      }
+    }
+  }
+
+  // Any remaining unmet mustMention (e.g. subject absent and no accepted fact to
+  // explain it) is reported as a retrieval miss so it is never silently passed.
+  for (const subject of expectations.mustMentionSubjects) {
+    if (!answerLower.includes(subject.toLowerCase())) {
+      return {
+        category: "retrieval",
+        detail: `expected subject not surfaced in answer: ${subject}`
+      };
+    }
+  }
+
+  // 6. temporal: structurally out of scope (Checkpoint 4). Never reached; the
+  // bucket exists in the tally with count 0 by construction.
+
+  return null;
+}
+
+function loadScopedFacts(db: MemoryDatabase, allowedSourceIds: string[]): FactRow[] {
+  if (allowedSourceIds.length === 0) {
+    return [];
+  }
+  const placeholders = allowedSourceIds.map(() => "?").join(", ");
+  return db
+    .prepare(
+      [
+        "select semantic_facts.subject as subject, semantic_facts.predicate as predicate,",
+        "semantic_facts.object as object, semantic_facts.status as status,",
+        "memory_chunks.citation as citation, sr.source_id as source_id",
+        "from semantic_facts",
+        "join source_records sr on sr.id = semantic_facts.source_record_id",
+        "left join memory_chunks on memory_chunks.id = semantic_facts.source_chunk_id",
+        `where sr.source_id in (${placeholders})`
+      ].join(" ")
+    )
+    .all(...allowedSourceIds) as FactRow[];
+}
+
+function chunkExistsForSubject(
+  db: MemoryDatabase,
+  allowedSourceIds: string[],
+  subject: string
+): boolean {
+  if (allowedSourceIds.length === 0) {
+    return false;
+  }
+  const placeholders = allowedSourceIds.map(() => "?").join(", ");
+  const row = db
+    .prepare(
+      [
+        "select count(*) as count",
+        "from memory_chunks",
+        "join source_records sr on sr.id = memory_chunks.source_record_id",
+        `where sr.source_id in (${placeholders})`,
+        "and lower(memory_chunks.text) like ?"
+      ].join(" ")
+    )
+    .get(...allowedSourceIds, `%${subject.toLowerCase()}%`) as { count: number };
+  return row.count > 0;
+}
+
+function findSourceByCitationFragment(
+  db: MemoryDatabase,
+  fragment: string
+): { source_id: string } | undefined {
+  return db
+    .prepare("select source_id from source_records where path like ? limit 1")
+    .get(`%${fragment}%`) as { source_id: string } | undefined;
+}
+
+function sourceWasSkipped(db: MemoryDatabase, fragment: string): boolean {
+  const row = db
+    .prepare("select count(*) as count from ingest_errors where path like ?")
+    .get(`%${fragment}%`) as { count: number };
+  return row.count > 0;
+}
+
+function loadSkippedFiles(
+  db: MemoryDatabase
+): Array<{ path: string; category: string; reason: string }> {
+  return db
+    .prepare(
+      "select path, coalesce(category, 'internal-error') as category, reason from ingest_errors order by path"
+    )
+    .all() as Array<{ path: string; category: string; reason: string }>;
+}
+
+function loadExtractionFailures(
+  db: MemoryDatabase
+): Array<{ chunkId: number | null; error: string }> {
+  return db
+    .prepare(
+      "select source_chunk_id as chunkId, coalesce(error, '') as error from extraction_runs where status = 'failed' order by id"
+    )
+    .all() as Array<{ chunkId: number | null; error: string }>;
+}
+
+function extractEvidenceSection(answer: string): string {
+  const lines = answer.split("\n");
+  const start = lines.findIndex((line) => line.trim() === "Evidence:");
+  if (start === -1) {
+    return "";
+  }
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((line) => /^[A-Z][A-Za-z ]+:$/.test(line.trim()));
+  const sectionLines = end === -1 ? rest : rest.slice(0, end);
+  return sectionLines.join("\n");
+}
+
+function emptyTally(): Record<MissCategory, number> {
+  return {
+    permission: 0,
+    "missing-source": 0,
+    extraction: 0,
+    retrieval: 0,
+    citation: 0,
+    temporal: 0
+  };
+}

--- a/tests/stress/stress.test.ts
+++ b/tests/stress/stress.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+import { createMockExtractor } from "../../src/extractors/mock.js";
+import {
+  runStressHarness,
+  type MissCategory,
+  type StressReport
+} from "./harness.js";
+import {
+  BENCHMARK_CASES,
+  RESTRICTED_SUBJECTS,
+  STRESS_ALLOWED_SOURCE_IDS,
+  STRESS_CLIENT,
+  STRESS_SOURCE_IDS,
+  type BenchmarkCase
+} from "../fixtures/stress/benchmark.js";
+
+const STRESS_CLIENT_REF = STRESS_CLIENT;
+
+function reportText(report: StressReport): string {
+  return JSON.stringify(report);
+}
+
+describe("runStressHarness", () => {
+  it("produces a deterministic tally and case set across repeated runs", async () => {
+    const first = await runStressHarness();
+    const second = await runStressHarness();
+
+    // Snapshot paths are temp-unique; everything else must be deep-equal.
+    expect(second.tally).toEqual(first.tally);
+    expect(stripSnapshot(second.cases)).toEqual(stripSnapshot(first.cases));
+    expect(second.passCount).toEqual(first.passCount);
+    expect(second.missCount).toEqual(first.missCount);
+  });
+
+  it("always declares all six categories with temporal deferred at zero", async () => {
+    const report = await runStressHarness();
+
+    const keys = Object.keys(report.tally).sort();
+    expect(keys).toEqual(
+      (["citation", "extraction", "missing-source", "permission", "retrieval", "temporal"] as MissCategory[]).sort()
+    );
+    expect(report.tally.temporal).toBe(0);
+    expect(report.permissionState).toBe("reachable");
+  });
+
+  it("surfaces the broken file in skippedFiles while its neighbors survive", async () => {
+    const report = await runStressHarness();
+
+    expect(report.ingest.skipped).toBeGreaterThanOrEqual(1);
+    expect(report.skippedFiles.some((file) => file.path.includes("broken.csv"))).toBe(true);
+
+    // The good AI/robotics/biotech sources still got processed and answered.
+    expect(report.ingest.processed).toBeGreaterThanOrEqual(3);
+    const aiResponded = report.cases.find((c) => c.id === "ai-responded");
+    expect(aiResponded?.outcome).toBe("pass");
+  });
+
+  it("includes at least one passing case in the default benchmark", async () => {
+    const report = await runStressHarness();
+    expect(report.passCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("never leaks a restricted subject into the rendered report (no-leak invariant)", async () => {
+    const report = await runStressHarness();
+    const text = reportText(report);
+    for (const subject of RESTRICTED_SUBJECTS) {
+      expect(text).not.toContain(subject);
+    }
+    // The restricted leak-guard case must pass: a correctly scoped client gets
+    // no restricted content.
+    const guard = report.cases.find((c) => c.id === "restricted-leak-guard");
+    expect(guard?.outcome).toBe("pass");
+  });
+
+  it("classifies a missing expected source as missing-source", async () => {
+    const cases: BenchmarkCase[] = [
+      {
+        id: "seed-missing-source",
+        question: "Who responded for AI?",
+        client: STRESS_CLIENT_REF,
+        expectations: {
+          mustMentionSubjects: ["Nadia Okonkwo"],
+          mustCiteSources: ["does-not-exist.csv"],
+          forbiddenSubjects: [...RESTRICTED_SUBJECTS],
+          expectSomeAnswer: true
+        }
+      }
+    ];
+    const report = await runStressHarness({ cases });
+    expectCategory(report, "missing-source");
+  });
+
+  it("classifies present-chunk-but-no-facts as extraction", async () => {
+    // Inject a CSV extractor that yields nothing: chunks are ingested but no
+    // semantic_facts are produced. Deterministic, no LLM.
+    const emptyExtractor = createMockExtractor([]);
+    const cases: BenchmarkCase[] = [
+      {
+        id: "seed-extraction",
+        question: "Who responded for AI?",
+        client: STRESS_CLIENT_REF,
+        expectations: {
+          mustMentionSubjects: ["Nadia Okonkwo"],
+          mustCiteSources: ["outreach-ai.csv"],
+          forbiddenSubjects: [...RESTRICTED_SUBJECTS],
+          expectSomeAnswer: true
+        }
+      }
+    ];
+    const report = await runStressHarness({
+      cases,
+      refreshOptions: { extractorsBySourceType: { csv: emptyExtractor } }
+    });
+    expectCategory(report, "extraction");
+  });
+
+  it("classifies an accepted-but-unsurfaced fact as retrieval", async () => {
+    // Nadia responded; asking the no-response question means the strict
+    // intent filters her out of the answer even though her accepted facts are
+    // in scope. That gap is a retrieval miss, not extraction or citation.
+    const cases: BenchmarkCase[] = [
+      {
+        id: "seed-retrieval",
+        question: "Who did not respond for AI?",
+        client: STRESS_CLIENT_REF,
+        expectations: {
+          mustMentionSubjects: ["Nadia Okonkwo"],
+          mustCiteSources: ["outreach-ai.csv"],
+          forbiddenSubjects: [...RESTRICTED_SUBJECTS],
+          expectSomeAnswer: true
+        }
+      }
+    ];
+    const report = await runStressHarness({ cases });
+    expectCategory(report, "retrieval");
+  });
+
+  it("classifies a surfaced subject with a missing citation as citation", async () => {
+    // Scope the client to the AI source only. Nadia is surfaced with her real
+    // AI citation, but we demand a citation from the robotics source. Robotics
+    // genuinely exists in source_records (so not missing-source) yet is out of
+    // this client's scope and therefore never appears in the evidence -> a
+    // citation miss.
+    const cases: BenchmarkCase[] = [
+      {
+        id: "seed-citation",
+        question: "Who responded for AI?",
+        client: STRESS_CLIENT_REF,
+        expectations: {
+          mustMentionSubjects: ["Nadia Okonkwo"],
+          mustCiteSources: ["outreach-ai.csv", "outreach-robotics.csv"],
+          forbiddenSubjects: [...RESTRICTED_SUBJECTS],
+          expectSomeAnswer: true
+        }
+      }
+    ];
+    const report = await runStressHarness({
+      cases,
+      allowedSourceIds: [STRESS_SOURCE_IDS.ai]
+    });
+    expectCategory(report, "citation");
+  });
+
+  it("classifies a leaked forbidden subject as permission when S2 is present", async () => {
+    // Grant the restricted source to the client, then ask the restricted
+    // question while forbidding the restricted subject. The leak proves scope
+    // was not enforced -> permission category.
+    const cases: BenchmarkCase[] = [
+      {
+        id: "seed-permission",
+        question: "Who needs follow-up for confidential biotech?",
+        client: STRESS_CLIENT_REF,
+        expectations: {
+          mustMentionSubjects: [],
+          mustCiteSources: [],
+          forbiddenSubjects: [...RESTRICTED_SUBJECTS],
+          expectSomeAnswer: false
+        }
+      }
+    ];
+    const report = await runStressHarness({
+      cases,
+      allowedSourceIds: [...STRESS_ALLOWED_SOURCE_IDS, STRESS_SOURCE_IDS.restrictedBiotech]
+    });
+    expectCategory(report, "permission");
+  });
+
+  it("degrades permission to an unreachable-pending bucket when S2 is unavailable", async () => {
+    const report = await runStressHarness({ simulateMissingPermissions: true });
+    expect(report.permissionState).toBe("unreachable-pending");
+    // With no permissions written, scoped clients see nothing; the leak-guard
+    // case still cannot leak because there is no access at all.
+    const text = reportText(report);
+    for (const subject of RESTRICTED_SUBJECTS) {
+      expect(text).not.toContain(subject);
+    }
+  });
+});
+
+function expectCategory(report: StressReport, category: MissCategory): void {
+  expect(report.tally[category]).toBeGreaterThanOrEqual(1);
+  expect(report.cases.some((c) => c.category === category)).toBe(true);
+}
+
+function stripSnapshot(cases: StressReport["cases"]): StressReport["cases"] {
+  return cases.map((c) => ({ ...c }));
+}
+
+// Reference the imported default cases so the import is exercised and the
+// benchmark set stays wired to the harness default.
+void BENCHMARK_CASES;


### PR DESCRIPTION
## Summary

Implements the approved next scope of the [SourcyAvo team-memory roadmap](docs/superpowers/specs/2026-06-07-sourcyavo-team-memory-roadmap-design.md): **Checkpoint 1 (real-data stress)** plus the **smallest slice of Checkpoint 2 (source-scoped read enforcement)**. MCP, Research Chat, temporal facts, and ontology suggestions remain out of scope.

Built as six tracer-bullet vertical slices (S1 decision → S2–S6), each gated on a green `tsc` + `vitest` before the next.

| Slice | What landed |
|-------|-------------|
| **S2** | Stable text `source_records.source_id` (frontmatter override → relative-path slug; never the autoincrement id) enforced by a unique index; `source_permissions` + `audit_events` tables + indexes; idempotent ALTER+backfill migrations ordered before the unique index; **reimport preserves `source_id`** (on-conflict update omits it) so permission mappings survive re-import |
| **S3** | Tagged `IngestError` with a closed category set — one bad file no longer halts the run; failures persisted to `ingest_errors` with categories; import report names skipped files |
| **S4** | New `read-service` owning `AccessContext` + `MemoryReader`; CLI `ask --client` routes through it and refuses unscoped reads; **source scoping pushed into SQL** (`source_id in (...)`) before retrieval/ranking for facts, gap facts, and chunks — closes the old fetch-all-then-rank leak path (ADR-0001) |
| **S5** | `searchMemory`, `getSource` (non-leaky deny), `listGaps` all scope-enforced; zero-scope callers get an explicit no-access answer, never a silent empty; reads + denied reads recorded in `audit_events` |
| **S6** | Synthetic Codeology-shaped corpus + benchmark questions run through the scoped read path; misses classified as extraction/retrieval/missing-source/citation/permission; temporal bucket honestly declared deferred |

## Review

A principal-engineer review verified **no permission-leak path**, stable reimport identity, idempotent migrations, and audit + no-access UX. Follow-ups applied in this branch:
- Removed the test-only `resolveAllowedSourceIds` duplicate; repointed the permission test at the production `resolveAccessContext` so the allowlist predicate (incl. `access = 'read'`) lives in one place.
- Added a test locking in the read-access filter.

## Verification

- `npx tsc -p tsconfig.json --noEmit` → exit 0
- `npx vitest run` → **92 passed | 1 todo (93), 12 files**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented scoped access control: users and clients can now be restricted to specific data sources with fine-grained read permissions.
  * Added audit logging to track read actions and access attempts.
  * Enhanced data import with categorized error reporting and detailed skip reasons.

* **Tests**
  * Added comprehensive stress-test framework with deterministic benchmark scenarios.
  * Expanded test coverage for access control enforcement and permission validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->