### PR TITLE
fix(f2): enable pgvector via baseline migration + runnable migrate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,21 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000) to see the app. Navigate to `/chat` for the Research Chat interface.
 
+## Database (local Postgres + pgvector)
+
+The app uses Postgres with the `vector` extension. `DATABASE_URL` is read from the
+environment (there is no `.env` auto-loading yet), so export it before running migrations
+or DB-backed tests.
+
+```bash
+docker compose up -d          # Postgres + pgvector on :5432
+export DATABASE_URL=postgresql://sourcecado:sourcecado@localhost:5432/sourcecado
+npm run migrate               # enables pgvector + applies the baseline migration
+```
+
+`.env.example` documents the connection variables. Migrations live in `src/migrations/`
+and are applied in filename order; `npm run migrate` is idempotent.
+
 ## Health check
 
 ```
@@ -24,6 +39,11 @@ Ping this endpoint to confirm the app is up.
 ```bash
 npm test
 ```
+
+The DB-backed tests (`tests/db-client.test.ts`, `tests/migrate.test.ts`) require Postgres
+running and `DATABASE_URL` exported (see [Database](#database-local-postgres--pgvector)).
+The legacy SQLite CLI suite is currently broken (`better-sqlite3` native bindings — see
+[TODOS.md](TODOS.md)); the web app tests are unaffected.
 
 ## Project structure
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "test": "vitest run",
+    "migrate": "tsx scripts/migrate.ts",
     "stress": "tsx scripts/stress.ts"
   },
   "dependencies": {

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,0 +1,17 @@
+import { closeDb, getDb } from "../src/lib/db.js";
+import { runMigrations } from "../src/lib/migrate.js";
+
+async function main(): Promise<void> {
+  const db = getDb();
+  try {
+    await runMigrations(db);
+    process.stdout.write("Migrations applied.\n");
+  } finally {
+    await closeDb();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/migrations/000_baseline.sql
+++ b/src/migrations/000_baseline.sql
@@ -1,0 +1,3 @@
+-- 000_baseline.sql — F2 baseline migration.
+-- Enables pgvector so later migrations can add vector columns. Idempotent.
+CREATE EXTENSION IF NOT EXISTS vector;


### PR DESCRIPTION
## Why

Verifying merged F2 against the [task breakdown](docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md) surfaced two acceptance gaps that also block F3:

- **F2.1** — `vector` extension was never enabled. The `pgvector/pgvector:pg16` image only makes it *available*; nothing ran `CREATE EXTENSION vector`.
- **F2.3** — the migration runner shipped **no baseline migration** (no `src/migrations/` dir, so it returned early) and was only ever invoked by tests — no way to apply migrations to a real DB.

## What

- `src/migrations/000_baseline.sql` — idempotent baseline that enables pgvector, so A1+ migrations can add vector columns.
- `scripts/migrate.ts` + `npm run migrate` — thin CLI reusing `getDb()`/`runMigrations()`, mirroring `scripts/stress.ts`. Portable to managed prod Postgres (not docker-only).
- `README.md` — new "Database (local Postgres + pgvector)" section + test-prerequisite and legacy-suite notes.

## Verification

With `docker compose up -d` + `DATABASE_URL` exported:

1. Dropped `vector` + `schema_migrations`, then `npm run migrate` → `Migrations applied.`
2. `SELECT extname FROM pg_extension WHERE extname='vector'` → `vector` ✅ (F2.1)
3. Re-ran `npm run migrate` → idempotent; `schema_migrations` holds `000_baseline.sql` once ✅ (F2.3)
4. `npx vitest run tests/health.test.ts tests/db-client.test.ts tests/migrate.test.ts` → **5 passed**

## Out of scope (flagged)

- Legacy `better-sqlite3` SQLite tests still fail (`npm test` red overall) — tracked P0 in TODOS.md.
- No `.env` auto-loading (`DATABASE_URL` exported manually); documented rather than adding `dotenv`.

Unblocks **F3**: F3.1 drops `001_model_calls.sql` into `src/migrations/` and applies it with the same command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes two F2 acceptance gaps by adding an idempotent baseline migration that enables pgvector and a thin `npm run migrate` CLI that applies it against a real Postgres instance.

- `src/migrations/000_baseline.sql` runs `CREATE EXTENSION IF NOT EXISTS vector` inside the existing transactional migration runner, unblocking future vector-column migrations.
- `scripts/migrate.ts` follows the `stress.ts` pattern: calls `getDb()` / `runMigrations()` / `closeDb()` in a `finally` block, exits non-zero on failure, and is wired to `package.json` as `npm run migrate`.
- `README.md` documents the local Postgres setup, migration command, and the known broken SQLite test suite.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the migration is idempotent and the CLI correctly closes the connection in all exit paths.

The changes are small and well-scoped. The only nit is that the success message "Migrations applied." is printed even on idempotent re-runs where nothing actually changed, which could mislead operators monitoring output.

scripts/migrate.ts — success message wording.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/migrate.ts | New CLI wrapper that calls getDb()/runMigrations()/closeDb(); mirrors stress.ts pattern. finally-block closeDb() is correct. Minor: success message is printed even when no new migrations ran. |
| src/migrations/000_baseline.sql | Idempotent CREATE EXTENSION IF NOT EXISTS vector — correct baseline for pgvector enablement. |
| package.json | Adds "migrate": "tsx scripts/migrate.ts" npm script alongside the existing stress script — straightforward and correct. |
| README.md | Adds database setup section and test-prerequisite notes; accurate and complete. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer
    participant CLI as scripts/migrate.ts
    participant DB as db.ts (getDb/closeDb)
    participant MIG as migrate.ts (runMigrations)
    participant PG as Postgres

    Dev->>CLI: npm run migrate
    CLI->>DB: getDb()
    DB-->>CLI: postgres.Sql connection
    CLI->>MIG: runMigrations(db)
    MIG->>PG: CREATE TABLE IF NOT EXISTS schema_migrations
    MIG->>PG: SELECT applied migrations
    PG-->>MIG: []  (first run)
    MIG->>PG: BEGIN
    MIG->>PG: CREATE EXTENSION IF NOT EXISTS vector
    MIG->>PG: INSERT INTO schema_migrations (000_baseline.sql)
    PG-->>MIG: COMMIT
    MIG-->>CLI: done
    CLI->>Dev: "Migrations applied."
    CLI->>DB: closeDb()
    DB->>PG: end connection
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer
    participant CLI as scripts/migrate.ts
    participant DB as db.ts (getDb/closeDb)
    participant MIG as migrate.ts (runMigrations)
    participant PG as Postgres

    Dev->>CLI: npm run migrate
    CLI->>DB: getDb()
    DB-->>CLI: postgres.Sql connection
    CLI->>MIG: runMigrations(db)
    MIG->>PG: CREATE TABLE IF NOT EXISTS schema_migrations
    MIG->>PG: SELECT applied migrations
    PG-->>MIG: []  (first run)
    MIG->>PG: BEGIN
    MIG->>PG: CREATE EXTENSION IF NOT EXISTS vector
    MIG->>PG: INSERT INTO schema_migrations (000_baseline.sql)
    PG-->>MIG: COMMIT
    MIG-->>CLI: done
    CLI->>Dev: "Migrations applied."
    CLI->>DB: closeDb()
    DB->>PG: end connection
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(f2): enable pgvector via baseline mi..."](https://github.com/fisherxz/sourcecado/commit/ea8a35fb33763149ce0352b13f362b1fac33eee7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38529356)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->