### PR TITLE
feat(f5): Agent Harness ReAct loop + Anthropic provider + minimal Research Chat

### DIFF
--- a/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
+++ b/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
@@ -149,21 +149,23 @@ the trace for one run.
 - [ ] F4.4 Run inspector view (read-only trace render) (~1.5h) · AFK (build with src/components/ui primitives)
 
 ## F5 — Agent Harness ReAct loop
-Type: AFK · Blocked by: F3, F4
+Type: AFK · Blocked by: F3, F4 · Done: 2026-06-23
 
 **What to build:** The ReAct-style tool-use loop, a tool registry with permission
 classes (`read`/`enrich`/`reason`/`draft`/`write_internal`/`admin`), and one `echo`
-tool. Every step writes to the Run Ledger via F4.
+tool. Every step writes to the Run Ledger via F4. See
+`docs/superpowers/specs/2026-06-23-f5-agent-harness-react-loop-design.md` and
+`docs/superpowers/plans/2026-06-23-f5-agent-harness-react-loop.md`.
 
 **Acceptance criteria:**
-- [ ] A run executes a multi-step loop that calls the model via the gateway and at least one registered tool
-- [ ] Tool registry enforces permission classes (a tool above the run's allowed class is refused and logged)
-- [ ] The full run (steps, tool calls, model calls, status) appears in the run inspector
+- [x] A run executes a multi-step loop that calls the model via the gateway and at least one registered tool
+- [x] Tool registry enforces permission classes (a tool above the run's allowed class is refused and logged)
+- [x] The full run (steps, tool calls, model calls, status) appears in the run inspector
 
 **Tasks:**
-- [ ] F5.1 ReAct loop (observation → model → tool → repeat, with stop condition) (~2h) · AFK
-- [ ] F5.2 Tool registry + permission classes + class enforcement (~1.5h) · AFK
-- [ ] F5.3 `echo` reference tool + wire loop end-to-end to ledger (~1h) · AFK
+- [x] F5.1 ReAct loop (observation → model → tool → repeat, with stop condition) (~2h) · AFK
+- [x] F5.2 Tool registry + permission classes + class enforcement (~1.5h) · AFK
+- [x] F5.3 `echo` reference tool + wire loop end-to-end to ledger (~1h) · AFK
 
 **FOUNDATION DEMO:** type a question in `/chat`, the harness runs a multi-step loop,
 calls the model through the gateway and the echo tool, writes the whole trace to the Run

--- a/docs/superpowers/plans/2026-06-23-f5-agent-harness-react-loop.md
+++ b/docs/superpowers/plans/2026-06-23-f5-agent-harness-react-loop.md
@@ -1,0 +1,871 @@
+# F5 Agent Harness ReAct Loop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a permission-gated ReAct tool-use loop that runs a multi-step agent through the F3 Model Gateway and writes the full trace to the F4 Run Ledger, demoable via a thin API trigger and the existing run inspector.
+
+**Architecture:** A `runAgent()` loop asks the model for a typed decision (`tool` or `final`) via the gateway's `generate_object`, dispatches tool calls through a permission-checked registry, and records every step/tool-call/model-call in the ledger. Tool errors, permission refusals, and bad args become observations fed back to the model (the model recovers); only a gateway error or the step cap fails the run.
+
+**Tech Stack:** TypeScript, Next.js 15 (app-router API route), Zod v4, `postgres` (Sql), Vitest against live Postgres, the existing `src/lib/model-gateway.ts` and `src/lib/ledger.ts`.
+
+## Global Constraints
+
+- Tool selection is **structured output** via `callModel({ kind: "generate_object" })` — no native tool-calling, no text parsing.
+- Permission model is an **allowed-set per run**, `allow | deny` only — no ranked hierarchy, no interactive `ask` tier.
+- Default allowed classes: `new Set(["read", "reason"])`. Default `maxSteps`: `8`. `echo` tool class: `read`.
+- Tool error / permission refusal / invalid args → recorded as a **failed tool call** AND returned as an observation; the loop continues. Only an unrecoverable `ModelGatewayError` or exceeding `maxSteps` fails the run.
+- **No app-level retries** (transport retries already live in the `ai` SDK).
+- Reuse `callModel`, the ledger write path, `getRunTrace`, and the `/runs/[id]` inspector unchanged.
+- TDD: every behavior gets a failing test first. DB tests reset ledger tables + `runMigrations` in `beforeEach` and inject a mock `ModelGatewayProvider` (no real model API). Run tests with `DATABASE_URL` pointing at the local Postgres (`postgresql://sourcecado:sourcecado@localhost:5432/sourcecado`, container `sourcecado-db-1`).
+- The six permission classes are exactly: `read`, `enrich`, `reason`, `draft`, `write_internal`, `admin`.
+- Permission classes are `PermissionClass`; tools implement `Tool<TArgs, TResult>`; the registry is `ToolRegistry` from `createToolRegistry(tools?)`.
+
+---
+
+### Task 1: Tool types + registry
+
+**Files:**
+- Create: `src/lib/tools/types.ts`
+- Create: `src/lib/tools/registry.ts`
+- Test: `tests/tool-registry.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (greenfield).
+- Produces:
+  - `type PermissionClass = "read"|"enrich"|"reason"|"draft"|"write_internal"|"admin"`
+  - `interface ToolContext { db: Sql; runId: number; parentStepId: number }`
+  - `interface Tool<TArgs=unknown,TResult=unknown> { name: string; description: string; permissionClass: PermissionClass; argsSchema: z.ZodType<TArgs>; execute(args: TArgs, ctx: ToolContext): Promise<TResult> }`
+  - `interface ToolRegistry { register(tool: Tool): void; get(name: string): Tool | undefined; list(allowed: Set<PermissionClass>): Tool[] }`
+  - `function createToolRegistry(tools?: Tool[]): ToolRegistry`
+
+- [ ] **Step 1: Write `src/lib/tools/types.ts`**
+
+```ts
+import type postgres from "postgres";
+import type { z } from "zod";
+
+export type Sql = postgres.Sql;
+
+export type PermissionClass =
+  | "read"
+  | "enrich"
+  | "reason"
+  | "draft"
+  | "write_internal"
+  | "admin";
+
+export const PERMISSION_CLASSES: readonly PermissionClass[] = [
+  "read",
+  "enrich",
+  "reason",
+  "draft",
+  "write_internal",
+  "admin",
+];
+
+export interface ToolContext {
+  db: Sql;
+  runId: number;
+  parentStepId: number;
+}
+
+export interface Tool<TArgs = unknown, TResult = unknown> {
+  name: string;
+  description: string;
+  permissionClass: PermissionClass;
+  argsSchema: z.ZodType<TArgs>;
+  execute(args: TArgs, ctx: ToolContext): Promise<TResult>;
+}
+```
+
+- [ ] **Step 2: Write the failing registry test**
+
+Create `tests/tool-registry.test.ts`:
+
+```ts
+import { z } from "zod";
+import { createToolRegistry } from "@/lib/tools/registry";
+import type { Tool } from "@/lib/tools/types";
+
+function fakeTool(name: string, permissionClass: Tool["permissionClass"]): Tool {
+  return {
+    name,
+    description: `${name} tool`,
+    permissionClass,
+    argsSchema: z.object({}),
+    execute: async () => ({ ok: true }),
+  };
+}
+
+describe("createToolRegistry", () => {
+  it("registers and retrieves tools by name", () => {
+    const registry = createToolRegistry([fakeTool("a", "read")]);
+    expect(registry.get("a")?.name).toBe("a");
+    expect(registry.get("missing")).toBeUndefined();
+  });
+
+  it("throws on duplicate tool name", () => {
+    const registry = createToolRegistry([fakeTool("a", "read")]);
+    expect(() => registry.register(fakeTool("a", "read"))).toThrow(/already registered/);
+  });
+
+  it("lists only tools whose class is in the allowed set", () => {
+    const registry = createToolRegistry([
+      fakeTool("r", "read"),
+      fakeTool("d", "draft"),
+      fakeTool("a", "admin"),
+    ]);
+    const names = registry
+      .list(new Set(["read", "draft"]))
+      .map((t) => t.name)
+      .sort();
+    expect(names).toEqual(["d", "r"]);
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `export DATABASE_URL="postgresql://sourcecado:sourcecado@localhost:5432/sourcecado"; npx vitest run tests/tool-registry.test.ts`
+Expected: FAIL — cannot find module `@/lib/tools/registry`.
+
+- [ ] **Step 4: Write `src/lib/tools/registry.ts`**
+
+```ts
+import type { PermissionClass, Tool } from "./types";
+
+export interface ToolRegistry {
+  register(tool: Tool): void;
+  get(name: string): Tool | undefined;
+  list(allowed: Set<PermissionClass>): Tool[];
+}
+
+export function createToolRegistry(tools: Tool[] = []): ToolRegistry {
+  const byName = new Map<string, Tool>();
+
+  const registry: ToolRegistry = {
+    register(tool) {
+      if (byName.has(tool.name)) {
+        throw new Error(`Tool "${tool.name}" is already registered.`);
+      }
+      byName.set(tool.name, tool);
+    },
+    get(name) {
+      return byName.get(name);
+    },
+    list(allowed) {
+      return [...byName.values()].filter((tool) => allowed.has(tool.permissionClass));
+    },
+  };
+
+  for (const tool of tools) {
+    registry.register(tool);
+  }
+  return registry;
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `export DATABASE_URL="postgresql://sourcecado:sourcecado@localhost:5432/sourcecado"; npx vitest run tests/tool-registry.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/tools/types.ts src/lib/tools/registry.ts tests/tool-registry.test.ts
+git commit -m "feat(f5): tool contract + permission-aware registry"
+```
+
+---
+
+### Task 2: echo reference tool
+
+**Files:**
+- Create: `src/lib/tools/echo.ts`
+- Test: `tests/echo-tool.test.ts`
+
+**Interfaces:**
+- Consumes: `Tool` from `src/lib/tools/types.ts`.
+- Produces:
+  - `const echoArgsSchema = z.object({ text: z.string() })`
+  - `type EchoArgs = { text: string }`
+  - `const echoTool: Tool<EchoArgs, { echoed: string }>` with `name: "echo"`, `permissionClass: "read"`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/echo-tool.test.ts`:
+
+```ts
+import { getDb } from "@/lib/db";
+import { echoTool } from "@/lib/tools/echo";
+
+describe("echoTool", () => {
+  it("echoes the provided text", async () => {
+    const result = await echoTool.execute(
+      { text: "hello" },
+      { db: getDb(), runId: 0, parentStepId: 0 },
+    );
+    expect(result).toEqual({ echoed: "hello" });
+  });
+
+  it("is a read-class tool named echo", () => {
+    expect(echoTool.name).toBe("echo");
+    expect(echoTool.permissionClass).toBe("read");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `export DATABASE_URL="postgresql://sourcecado:sourcecado@localhost:5432/sourcecado"; npx vitest run tests/echo-tool.test.ts`
+Expected: FAIL — cannot find module `@/lib/tools/echo`.
+
+- [ ] **Step 3: Write `src/lib/tools/echo.ts`**
+
+```ts
+import { z } from "zod";
+import type { Tool } from "./types";
+
+export const echoArgsSchema = z.object({ text: z.string() });
+export type EchoArgs = z.infer<typeof echoArgsSchema>;
+
+export const echoTool: Tool<EchoArgs, { echoed: string }> = {
+  name: "echo",
+  description: "Echo back the provided text. A reference tool for the harness.",
+  permissionClass: "read",
+  argsSchema: echoArgsSchema,
+  async execute(args) {
+    return { echoed: args.text };
+  },
+};
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `export DATABASE_URL="postgresql://sourcecado:sourcecado@localhost:5432/sourcecado"; npx vitest run tests/echo-tool.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/tools/echo.ts tests/echo-tool.test.ts
+git commit -m "feat(f5): echo reference tool"
+```
+
+---
+
+### Task 3: ReAct loop (`runAgent`)
+
+**Files:**
+- Create: `src/lib/harness.ts`
+- Test: `tests/harness.test.ts`
+
+**Interfaces:**
+- Consumes:
+  - `getDb()` from `src/lib/db.ts`.
+  - From `src/lib/ledger.ts`: `startRun(db,{runType,title?,input?})`, `startRunStep(db,{runId,parentStepId?,stepKind,name,input?})`, `finishRunStep(db,{runStepId,output?})`, `failRunStep(db,{runStepId,errorType,errorMessage})`, `startToolCall(db,{runId,runStepId,toolName,arguments?,metadata?})`, `finishToolCall(db,{toolCallId,result?})`, `failToolCall(db,{toolCallId,errorType,errorMessage})`, `finishRun(db,{runId,output?})`, `failRun(db,{runId,errorType,errorMessage})`, `getRunTrace(db,runId)`.
+  - From `src/lib/model-gateway.ts`: `callModel<T>(db,input)`, `ModelGatewayError`, `type ModelGatewayProvider`.
+  - From `src/lib/tools/types.ts`: `PermissionClass`, `Sql`. From `src/lib/tools/registry.ts`: `ToolRegistry`.
+- Produces:
+  - `const agentDecisionSchema` (Zod discriminated union on `action`).
+  - `type AgentDecision = { action:"tool"; tool:string; args:Record<string,unknown>; thought?:string } | { action:"final"; answer:string; thought?:string }`
+  - `interface RunAgentInput { question:string; registry:ToolRegistry; allowedClasses?:Set<PermissionClass>; maxSteps?:number; provider?:ModelGatewayProvider; db?:Sql }`
+  - `interface RunAgentResult { runId:number; status:"succeeded"|"failed"; answer?:string; steps:number }`
+  - `function runAgent(input: RunAgentInput): Promise<RunAgentResult>`
+
+- [ ] **Step 1: Write the failing happy-path test**
+
+Create `tests/harness.test.ts`:
+
+```ts
+import { vi } from "vitest";
+import { z } from "zod";
+import { closeDb, getDb } from "@/lib/db";
+import { getRunTrace } from "@/lib/ledger";
+import { runMigrations } from "@/lib/migrate";
+import type { ModelGatewayProvider } from "@/lib/model-gateway";
+import { runAgent } from "@/lib/harness";
+import { createToolRegistry } from "@/lib/tools/registry";
+import { echoTool } from "@/lib/tools/echo";
+import type { Tool } from "@/lib/tools/types";
+
+async function resetLedgerTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS tool_calls CASCADE`;
+  await db`DROP TABLE IF EXISTS model_calls CASCADE`;
+  await db`DROP TABLE IF EXISTS run_steps CASCADE`;
+  await db`DROP TABLE IF EXISTS runs CASCADE`;
+  await db`DROP TABLE IF EXISTS schema_migrations CASCADE`;
+  await runMigrations(db);
+}
+
+const ALLOWED = new Set<Tool["permissionClass"]>(["read", "reason"]);
+
+describe("runAgent", () => {
+  beforeEach(async () => {
+    await resetLedgerTables();
+  });
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("runs a multi-step loop (tool then final) and traces it fully", async () => {
+    const db = getDb();
+    const registry = createToolRegistry([echoTool]);
+    const provider = vi
+      .fn<ModelGatewayProvider>()
+      .mockResolvedValueOnce({ object: { action: "tool", tool: "echo", args: { text: "hello" } } })
+      .mockResolvedValueOnce({ object: { action: "final", answer: "Echoed hello" } });
+
+    const result = await runAgent({
+      question: "echo hello",
+      registry,
+      allowedClasses: ALLOWED,
+      provider,
+    });
+
+    expect(result.status).toBe("succeeded");
+    expect(result.answer).toBe("Echoed hello");
+    expect(provider).toHaveBeenCalledTimes(2);
+
+    const trace = await getRunTrace(db, result.runId);
+    expect(trace?.status).toBe("succeeded");
+    const agentStep = trace?.steps[0];
+    expect(agentStep?.stepKind).toBe("agent");
+
+    // Each callModel(trace) creates a child "model" step holding the model call.
+    const modelSteps = agentStep?.children.filter((s) => s.stepKind === "model") ?? [];
+    expect(modelSteps).toHaveLength(2);
+    expect(modelSteps[0]?.modelCalls).toHaveLength(1);
+
+    const toolStep = agentStep?.children.find((s) => s.stepKind === "tool" && s.name === "echo");
+    expect(toolStep?.toolCalls[0]).toMatchObject({
+      toolName: "echo",
+      status: "succeeded",
+      result: { echoed: "hello" },
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `export DATABASE_URL="postgresql://sourcecado:sourcecado@localhost:5432/sourcecado"; npx vitest run tests/harness.test.ts`
+Expected: FAIL — cannot find module `@/lib/harness`.
+
+- [ ] **Step 3: Write `src/lib/harness.ts`**
+
+```ts
+import { z } from "zod";
+import { getDb } from "./db";
+import {
+  failRun,
+  failRunStep,
+  failToolCall,
+  finishRun,
+  finishRunStep,
+  finishToolCall,
+  startRun,
+  startRunStep,
+  startToolCall,
+} from "./ledger";
+import { callModel, ModelGatewayError, type ModelGatewayProvider } from "./model-gateway";
+import type { ToolRegistry } from "./tools/registry";
+import type { PermissionClass, Sql } from "./tools/types";
+
+export const agentDecisionSchema = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("tool"),
+    tool: z.string(),
+    args: z.record(z.unknown()),
+    thought: z.string().optional(),
+  }),
+  z.object({
+    action: z.literal("final"),
+    answer: z.string(),
+    thought: z.string().optional(),
+  }),
+]);
+export type AgentDecision = z.infer<typeof agentDecisionSchema>;
+
+export interface RunAgentInput {
+  question: string;
+  registry: ToolRegistry;
+  allowedClasses?: Set<PermissionClass>;
+  maxSteps?: number;
+  provider?: ModelGatewayProvider;
+  db?: Sql;
+}
+
+export interface RunAgentResult {
+  runId: number;
+  status: "succeeded" | "failed";
+  answer?: string;
+  steps: number;
+}
+
+const DEFAULT_ALLOWED: PermissionClass[] = ["read", "reason"];
+const DEFAULT_MAX_STEPS = 8;
+
+export async function runAgent(input: RunAgentInput): Promise<RunAgentResult> {
+  const db = input.db ?? getDb();
+  const allowed = input.allowedClasses ?? new Set(DEFAULT_ALLOWED);
+  const maxSteps = input.maxSteps ?? DEFAULT_MAX_STEPS;
+
+  const run = await startRun(db, {
+    runType: "agent_chat",
+    title: input.question.slice(0, 80),
+    input: { question: input.question },
+  });
+  const agentStep = await startRunStep(db, {
+    runId: run.id,
+    stepKind: "agent",
+    name: "react_loop",
+    input: { question: input.question },
+  });
+
+  const transcript: string[] = [];
+  let step = 0;
+
+  try {
+    for (step = 1; step <= maxSteps; step++) {
+      const decision = await decide(db, {
+        runId: run.id,
+        parentStepId: agentStep.id,
+        question: input.question,
+        registry: input.registry,
+        allowed,
+        transcript,
+        provider: input.provider,
+      });
+
+      if (decision.action === "final") {
+        await finishRunStep(db, {
+          runStepId: agentStep.id,
+          output: { answer: decision.answer, steps: step },
+        });
+        await finishRun(db, {
+          runId: run.id,
+          output: { answer: decision.answer, steps: step },
+        });
+        return { runId: run.id, status: "succeeded", answer: decision.answer, steps: step };
+      }
+
+      const observation = await executeToolCall(db, {
+        decision,
+        registry: input.registry,
+        allowed,
+        runId: run.id,
+        parentStepId: agentStep.id,
+      });
+      transcript.push(`Step ${step}: called ${decision.tool} -> ${observation}`);
+    }
+
+    const message = `Agent did not finish within ${maxSteps} steps.`;
+    await failRunStep(db, {
+      runStepId: agentStep.id,
+      errorType: "max_steps_exceeded",
+      errorMessage: message,
+    });
+    await failRun(db, {
+      runId: run.id,
+      errorType: "max_steps_exceeded",
+      errorMessage: message,
+    });
+    return { runId: run.id, status: "failed", steps: maxSteps };
+  } catch (error) {
+    const code = error instanceof ModelGatewayError ? error.code : "harness_error";
+    const message = error instanceof Error ? error.message : String(error);
+    await failRunStep(db, { runStepId: agentStep.id, errorType: code, errorMessage: message });
+    await failRun(db, { runId: run.id, errorType: code, errorMessage: message });
+    return { runId: run.id, status: "failed", steps: step };
+  }
+}
+
+interface DecideOptions {
+  runId: number;
+  parentStepId: number;
+  question: string;
+  registry: ToolRegistry;
+  allowed: Set<PermissionClass>;
+  transcript: string[];
+  provider?: ModelGatewayProvider;
+}
+
+async function decide(db: Sql, opts: DecideOptions): Promise<AgentDecision> {
+  const tools = opts.registry.list(opts.allowed);
+  const result = await callModel<AgentDecision>(db, {
+    kind: "generate_object",
+    taskName: "agent_react_decide",
+    promptVersion: "1",
+    system: buildSystemPrompt(tools),
+    prompt: buildUserPrompt(opts.question, opts.transcript),
+    schema: agentDecisionSchema,
+    schemaName: "agent_decision",
+    trace: { runId: opts.runId, parentStepId: opts.parentStepId },
+    provider: opts.provider,
+  });
+  return result.object;
+}
+
+function buildSystemPrompt(tools: { name: string; description: string; permissionClass: string }[]): string {
+  const catalog = tools
+    .map((t) => `- ${t.name} (${t.permissionClass}): ${t.description}`)
+    .join("\n");
+  return [
+    "You are a sourcing agent. Decide the next action.",
+    "Either call one tool, or give a final answer.",
+    "Respond with a decision object: {action:'tool', tool, args} or {action:'final', answer}.",
+    "Available tools:",
+    catalog || "(none)",
+  ].join("\n");
+}
+
+function buildUserPrompt(question: string, transcript: string[]): string {
+  const history = transcript.length ? `\n\nObservations so far:\n${transcript.join("\n")}` : "";
+  return `Question: ${question}${history}`;
+}
+
+interface ExecuteToolOptions {
+  decision: Extract<AgentDecision, { action: "tool" }>;
+  registry: ToolRegistry;
+  allowed: Set<PermissionClass>;
+  runId: number;
+  parentStepId: number;
+}
+
+async function executeToolCall(db: Sql, opts: ExecuteToolOptions): Promise<string> {
+  const { decision, registry, allowed, runId, parentStepId } = opts;
+  const toolName = decision.tool;
+  const tool = registry.get(toolName);
+
+  const toolStep = await startRunStep(db, {
+    runId,
+    parentStepId,
+    stepKind: "tool",
+    name: toolName,
+    input: { args: decision.args },
+  });
+  const toolCall = await startToolCall(db, {
+    runId,
+    runStepId: toolStep.id,
+    toolName,
+    arguments: decision.args,
+    metadata: { permissionClass: tool?.permissionClass ?? null },
+  });
+
+  if (!tool) {
+    return failTool(db, toolStep.id, toolCall.id, "unknown_tool", `Unknown tool: ${toolName}.`);
+  }
+  if (!allowed.has(tool.permissionClass)) {
+    return failTool(
+      db,
+      toolStep.id,
+      toolCall.id,
+      "permission_denied",
+      `Tool ${toolName} (class ${tool.permissionClass}) is not permitted for this run.`,
+    );
+  }
+  const parsed = tool.argsSchema.safeParse(decision.args);
+  if (!parsed.success) {
+    return failTool(
+      db,
+      toolStep.id,
+      toolCall.id,
+      "invalid_args",
+      `Invalid arguments for ${toolName}: ${parsed.error.message}`,
+    );
+  }
+
+  try {
+    const result = await tool.execute(parsed.data, { db, runId, parentStepId: toolStep.id });
+    await finishToolCall(db, { toolCallId: toolCall.id, result });
+    await finishRunStep(db, { runStepId: toolStep.id, output: result });
+    return `Success: ${JSON.stringify(result)}`;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return failTool(db, toolStep.id, toolCall.id, "tool_error", `Tool ${toolName} failed: ${message}`);
+  }
+}
+
+async function failTool(
+  db: Sql,
+  runStepId: number,
+  toolCallId: number,
+  errorType: string,
+  message: string,
+): Promise<string> {
+  await failToolCall(db, { toolCallId, errorType, errorMessage: message });
+  await failRunStep(db, { runStepId, errorType, errorMessage: message });
+  return `Error (${errorType}): ${message}`;
+}
+```
+
+- [ ] **Step 4: Run the happy-path test to verify it passes**
+
+Run: `export DATABASE_URL="postgresql://sourcecado:sourcecado@localhost:5432/sourcecado"; npx vitest run tests/harness.test.ts`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Add the permission-refusal, max-steps, tool-error, and invalid-args tests**
+
+Append these inside the `describe("runAgent", ...)` block in `tests/harness.test.ts`:
+
+```ts
+  it("refuses and logs a tool whose class is not in the allowed set", async () => {
+    const db = getDb();
+    const adminTool: Tool = {
+      name: "danger",
+      description: "admin-only action",
+      permissionClass: "admin",
+      argsSchema: z.object({}),
+      execute: async () => ({ ok: true }),
+    };
+    const registry = createToolRegistry([echoTool, adminTool]);
+    const provider = vi
+      .fn<ModelGatewayProvider>()
+      .mockResolvedValueOnce({ object: { action: "tool", tool: "danger", args: {} } })
+      .mockResolvedValueOnce({ object: { action: "final", answer: "could not use danger" } });
+
+    const result = await runAgent({ question: "do danger", registry, allowedClasses: ALLOWED, provider });
+
+    expect(result.status).toBe("succeeded"); // refusal is not a run failure
+    const trace = await getRunTrace(db, result.runId);
+    const toolStep = trace?.steps[0]?.children.find((s) => s.name === "danger");
+    expect(toolStep?.toolCalls[0]).toMatchObject({
+      toolName: "danger",
+      status: "failed",
+      errorType: "permission_denied",
+    });
+  });
+
+  it("fails the run when maxSteps is exceeded", async () => {
+    const db = getDb();
+    const registry = createToolRegistry([echoTool]);
+    const provider = vi
+      .fn<ModelGatewayProvider>()
+      .mockResolvedValue({ object: { action: "tool", tool: "echo", args: { text: "again" } } });
+
+    const result = await runAgent({
+      question: "loop forever",
+      registry,
+      allowedClasses: ALLOWED,
+      maxSteps: 3,
+      provider,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.steps).toBe(3);
+    expect(provider).toHaveBeenCalledTimes(3);
+    const trace = await getRunTrace(db, result.runId);
+    expect(trace?.status).toBe("failed");
+    expect(trace?.errorType).toBe("max_steps_exceeded");
+  });
+
+  it("feeds a tool execution error back and lets the model recover", async () => {
+    const db = getDb();
+    const boomTool: Tool = {
+      name: "boom",
+      description: "always throws",
+      permissionClass: "read",
+      argsSchema: z.object({}),
+      execute: async () => {
+        throw new Error("kaboom");
+      },
+    };
+    const registry = createToolRegistry([boomTool]);
+    const provider = vi
+      .fn<ModelGatewayProvider>()
+      .mockResolvedValueOnce({ object: { action: "tool", tool: "boom", args: {} } })
+      .mockResolvedValueOnce({ object: { action: "final", answer: "recovered" } });
+
+    const result = await runAgent({ question: "x", registry, allowedClasses: ALLOWED, provider });
+
+    expect(result.status).toBe("succeeded");
+    const trace = await getRunTrace(db, result.runId);
+    const toolStep = trace?.steps[0]?.children.find((s) => s.name === "boom");
+    expect(toolStep?.toolCalls[0]).toMatchObject({ status: "failed", errorType: "tool_error" });
+  });
+
+  it("feeds invalid tool args back and lets the model recover", async () => {
+    const db = getDb();
+    const registry = createToolRegistry([echoTool]); // echo requires { text: string }
+    const provider = vi
+      .fn<ModelGatewayProvider>()
+      .mockResolvedValueOnce({ object: { action: "tool", tool: "echo", args: { wrong: 1 } } })
+      .mockResolvedValueOnce({ object: { action: "final", answer: "ok" } });
+
+    const result = await runAgent({ question: "x", registry, allowedClasses: ALLOWED, provider });
+
+    expect(result.status).toBe("succeeded");
+    const trace = await getRunTrace(db, result.runId);
+    const toolStep = trace?.steps[0]?.children.find((s) => s.name === "echo");
+    expect(toolStep?.toolCalls[0]).toMatchObject({ status: "failed", errorType: "invalid_args" });
+  });
+```
+
+- [ ] **Step 6: Run the full harness test file to verify all pass**
+
+Run: `export DATABASE_URL="postgresql://sourcecado:sourcecado@localhost:5432/sourcecado"; npx vitest run tests/harness.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/harness.ts tests/harness.test.ts
+git commit -m "feat(f5): ReAct loop with permission enforcement and ledger tracing"
+```
+
+---
+
+### Task 4: Thin API trigger
+
+**Files:**
+- Create: `src/app/api/agent/route.ts`
+- Reference (read for style): `src/app/api/health/route.ts`
+- Test: `tests/agent-route.test.ts`
+
+**Interfaces:**
+- Consumes: `runAgent` from `src/lib/harness.ts`, `createToolRegistry` from `src/lib/tools/registry.ts`, `echoTool` from `src/lib/tools/echo.ts`.
+- Produces: a `POST` handler that accepts `{ question: string }` and returns `RunAgentResult` JSON (`200` on `succeeded`, `500` on `failed`, `400` on missing question).
+
+- [ ] **Step 1: Write the failing route test**
+
+Create `tests/agent-route.test.ts`:
+
+```ts
+import { vi } from "vitest";
+
+const runAgentMock = vi.fn();
+vi.mock("@/lib/harness", () => ({ runAgent: runAgentMock }));
+
+import { POST } from "@/app/api/agent/route";
+
+function postRequest(body: unknown): Request {
+  return new Request("http://localhost/api/agent", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/agent", () => {
+  beforeEach(() => {
+    runAgentMock.mockReset();
+  });
+
+  it("returns 400 when question is missing", async () => {
+    const res = await POST(postRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("runs the agent and returns the run id on success", async () => {
+    runAgentMock.mockResolvedValue({ runId: 7, status: "succeeded", answer: "hi", steps: 2 });
+    const res = await POST(postRequest({ question: "echo hi" }));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ runId: 7, status: "succeeded" });
+    expect(runAgentMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 500 when the run fails", async () => {
+    runAgentMock.mockResolvedValue({ runId: 9, status: "failed", steps: 8 });
+    const res = await POST(postRequest({ question: "loop" }));
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toMatchObject({ runId: 9, status: "failed" });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `export DATABASE_URL="postgresql://sourcecado:sourcecado@localhost:5432/sourcecado"; npx vitest run tests/agent-route.test.ts`
+Expected: FAIL — cannot find module `@/app/api/agent/route`.
+
+- [ ] **Step 3: Write `src/app/api/agent/route.ts`**
+
+```ts
+import { NextResponse } from "next/server";
+import { runAgent } from "@/lib/harness";
+import { echoTool } from "@/lib/tools/echo";
+import { createToolRegistry } from "@/lib/tools/registry";
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+  const question = (body as { question?: unknown } | null)?.question;
+  if (typeof question !== "string" || !question.trim()) {
+    return NextResponse.json({ error: "question is required" }, { status: 400 });
+  }
+
+  const registry = createToolRegistry([echoTool]);
+  const result = await runAgent({ question, registry });
+  return NextResponse.json(result, { status: result.status === "succeeded" ? 200 : 500 });
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `export DATABASE_URL="postgresql://sourcecado:sourcecado@localhost:5432/sourcecado"; npx vitest run tests/agent-route.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/api/agent/route.ts tests/agent-route.test.ts
+git commit -m "feat(f5): POST /api/agent trigger for the harness"
+```
+
+---
+
+### Task 5: Full verification + plan checkbox update
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md` (check off F5 tasks/criteria)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `export DATABASE_URL="postgresql://sourcecado:sourcecado@localhost:5432/sourcecado"; npx vitest run`
+Expected: PASS — all prior suites plus the 4 new F5 files (tool-registry, echo-tool, harness, agent-route) green.
+
+- [ ] **Step 2: Lint**
+
+Run: `npm run lint`
+Expected: `✔ No ESLint warnings or errors`.
+
+- [ ] **Step 3: Build**
+
+Run: `npm run build`
+Expected: build succeeds; route list includes `ƒ /api/agent` alongside the existing routes.
+
+- [ ] **Step 4: Manual end-to-end smoke (optional but recommended)**
+
+Run in one terminal: `export DATABASE_URL="postgresql://sourcecado:sourcecado@localhost:5432/sourcecado"; npm run dev`
+Then: `curl -s -X POST localhost:3000/api/agent -H 'content-type: application/json' -d '{"question":"echo hello"}'`
+Expected: JSON with a `runId`. Open `http://localhost:3000/runs/<runId>` and confirm the trace shows the agent step with model + echo tool children. (Note: without a real `DEEPSEEK_API_KEY`, the live model call fails and the run is recorded as `failed` — still inspectable. The mocked tests are the source of truth for behavior.)
+
+- [ ] **Step 5: Check off F5 in the task breakdown**
+
+In `docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md`, mark the F5 acceptance criteria and tasks F5.1/F5.2/F5.3 as `[x]`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
+git commit -m "docs(f5): mark F5 agent harness complete"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Tool contract + registry (spec §Components) → Task 1.
+- echo tool (spec §echo) → Task 2.
+- ReAct loop, decision schema, executeToolCall permission/validation/ledger table (spec §The loop, §executeToolCall) → Task 3.
+- Thin trigger (spec §Trigger) → Task 4.
+- Existing inspector reused unchanged (spec §UI scope) → no task needed; verified in Task 5 step 4.
+- Acceptance criteria #1 (multi-step loop via gateway + tool) → Task 3 happy-path test. #2 (refused + logged) → Task 3 refusal test. #3 (full trace in inspector) → Task 3 trace asserts + Task 5 smoke.
+- Loop guardrails (final/cap/error-feedback/no-retries) → Task 3 tests (happy, max-steps, tool-error, invalid-args, refusal).
+
+**Placeholder scan:** No TBD/TODO; every code and test step contains full content.
+
+**Type consistency:** `runAgent`/`RunAgentInput`/`RunAgentResult`, `Tool`/`ToolRegistry`/`createToolRegistry`, `agentDecisionSchema`/`AgentDecision`, `echoTool`, and the ledger/gateway signatures are used identically across Tasks 1–4. The gateway creates a child `model` step per `callModel`, so Task 3's trace assertions look for model calls on `model`-kind children of the agent step (not on the agent step itself).

--- a/docs/superpowers/plans/2026-06-23-f5-agent-harness-react-loop.md
+++ b/docs/superpowers/plans/2026-06-23-f5-agent-harness-react-loop.md
@@ -736,7 +736,8 @@ Create `tests/agent-route.test.ts`:
 ```ts
 import { vi } from "vitest";
 
-const runAgentMock = vi.fn();
+// vi.mock is hoisted; declare the mock via vi.hoisted so the factory can see it.
+const { runAgentMock } = vi.hoisted(() => ({ runAgentMock: vi.fn() }));
 vi.mock("@/lib/harness", () => ({ runAgent: runAgentMock }));
 
 import { POST } from "@/app/api/agent/route";

--- a/docs/superpowers/specs/2026-06-23-f5-agent-harness-react-loop-design.md
+++ b/docs/superpowers/specs/2026-06-23-f5-agent-harness-react-loop-design.md
@@ -1,0 +1,257 @@
+# F5 — Agent Harness ReAct Loop: Design
+
+Date: 2026-06-23
+Status: Approved for implementation
+Slice: F5 (Foundation cluster) from
+`docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md`
+Blocked by: F3 (Model Gateway), F4 (Run Ledger) — both merged to `main` (PR #6).
+
+## Purpose
+
+Build the ReAct-style tool-use loop that turns the F3 gateway and F4 ledger into a
+runnable agent: a run executes a multi-step loop, calls the model through the
+gateway, invokes registered tools through a permission-gated registry, and writes
+the entire trace to the Run Ledger so it renders in the existing run inspector.
+
+This is the spine. Nothing sourcing-specific yet — the only tool is `echo`.
+
+## Decisions (locked during brainstorming)
+
+1. **Tool selection = structured output.** Each iteration the model returns a typed
+   decision via `callModel(kind: "generate_object")` against a discriminated union
+   (`tool` or `final`). Reuses the existing gateway and Zod; no gateway changes;
+   deterministic and testable with the mock provider. (Rejected: native tool-calling
+   API — needs gateway extension; free-text ReAct parsing — brittle.)
+2. **Permission model = allowed-set per run, allow/deny only.** A run is started with
+   an explicit set of allowed permission classes. A tool whose class is not in the
+   set is refused and logged. No ranked hierarchy (the six classes do not form a
+   meaningful linear order). No interactive `ask` tier — F5 runs are headless
+   (ADR-0003 manual-first; the human gate is at artifact review, not mid-loop).
+3. **UI scope = thin trigger + existing inspector.** F5 ships a minimal API route
+   (`POST` a question → run the loop → return a run id). The rich Research Chat UI is
+   Feature A6. The existing `/runs/[id]` inspector renders the trace unchanged.
+4. **Loop guardrails (Option 1, validated against Claude Code's loop):**
+   - terminate on model `{action: "final"}` → run succeeds.
+   - iteration cap (default 8) → run fails with `max_steps_exceeded`.
+   - tool error / permission refusal / invalid args → recorded as a failed tool call
+     AND fed back to the model as an observation; the loop continues (the model is
+     the recovery mechanism).
+   - unrecoverable model/gateway error → fail the run.
+   - no app-level retries (transport retries already live in the `ai` SDK, mirroring
+     Claude Code's `withRetry`).
+   - deferred (YAGNI): token/cost budget, wall-clock timeout, parallel tool
+     execution, `isReadOnly`/`isConcurrencySafe` metadata, sub-agents.
+
+### Reference: Claude Code orchestration (informing, not copied)
+
+The loop shape mirrors Claude Code's `query.ts` orchestration, adapted to a headless
+run + Run Ledger:
+
+- One turn = decide → execute tools → feed results back → repeat (CC `while(true)`
+  async generator; ours is a bounded `for` loop).
+- Done signal = model emits no tool call. Ours: `{action: "final"}`.
+- Tool errors and permission denials are surfaced back to the model as error
+  observations, not aborts (CC `toolExecution.ts`: `tool_result` with `is_error`).
+- Retries live at the transport layer only (CC `withRetry`); the agent layer does
+  not retry.
+- F5 deliberately drops CC's `ask` (human-prompt) permission behavior, which exists
+  because CC is interactive; F5 keeps only `allow | deny`.
+
+## Module structure
+
+Greenfield unless marked REUSE.
+
+```
+src/lib/tools/types.ts      Tool interface, PermissionClass, ToolContext
+src/lib/tools/registry.ts   createToolRegistry(): register / get / list
+src/lib/tools/echo.ts       echo reference tool (class: read)
+src/lib/harness.ts          runAgent() — the ReAct loop
+src/app/api/agent/route.ts  thin trigger: POST { question } -> { runId }
+REUSE src/lib/model-gateway.ts  callModel()
+REUSE src/lib/ledger.ts         startRun/startRunStep/startToolCall/... + getRunTrace
+REUSE src/app/runs/[id]/page.tsx run inspector (no changes)
+```
+
+## Components
+
+### Tool contract (`src/lib/tools/types.ts`)
+
+```ts
+export type PermissionClass =
+  | "read" | "enrich" | "reason" | "draft" | "write_internal" | "admin";
+
+export interface ToolContext {
+  db: Sql;
+  runId: number;
+  parentStepId: number; // the tool's own run step, for nested logging
+}
+
+export interface Tool<TArgs = unknown, TResult = unknown> {
+  name: string;
+  description: string;            // surfaced to the model in the prompt
+  permissionClass: PermissionClass;
+  argsSchema: z.ZodType<TArgs>;   // validated before execute()
+  execute(args: TArgs, ctx: ToolContext): Promise<TResult>;
+}
+```
+
+### Registry (`src/lib/tools/registry.ts`)
+
+A small Map-backed factory. No global singleton — the caller builds a registry and
+passes it to `runAgent`, which keeps tests isolated.
+
+```ts
+export interface ToolRegistry {
+  register(tool: Tool): void;        // throws on duplicate name
+  get(name: string): Tool | undefined;
+  list(allowed: Set<PermissionClass>): Tool[]; // tools the run may use (for the prompt)
+}
+export function createToolRegistry(tools?: Tool[]): ToolRegistry;
+```
+
+### echo tool (`src/lib/tools/echo.ts`)
+
+```ts
+// permissionClass: "read"; argsSchema: { text: string }
+// execute: returns { echoed: text }
+```
+
+### The loop (`src/lib/harness.ts`)
+
+```ts
+const agentDecisionSchema = z.discriminatedUnion("action", [
+  z.object({ action: z.literal("tool"), tool: z.string(),
+             args: z.record(z.unknown()), thought: z.string().optional() }),
+  z.object({ action: z.literal("final"), answer: z.string(),
+             thought: z.string().optional() }),
+]);
+
+interface RunAgentInput {
+  question: string;
+  registry: ToolRegistry;
+  allowedClasses: Set<PermissionClass>;  // default {read, reason}
+  maxSteps?: number;                      // default 8
+  provider?: ModelGatewayProvider;        // for tests; default = gateway default
+  db?: Sql;                               // default getDb()
+}
+interface RunAgentResult {
+  runId: number;
+  status: "succeeded" | "failed";
+  answer?: string;
+  steps: number;
+}
+export async function runAgent(input: RunAgentInput): Promise<RunAgentResult>;
+```
+
+Flow:
+
+1. `startRun({ runType: "agent_chat", input: { question } })`.
+2. `startRunStep({ stepKind: "agent", name: "react_loop" })` — the parent step.
+3. For up to `maxSteps` iterations:
+   - Build the prompt: system instructions + tool catalog (name, description, args
+     JSON schema) restricted to `registry.list(allowedClasses)` + the running
+     observation transcript.
+   - `callModel({ kind: "generate_object", schema: agentDecisionSchema,
+     taskName: "agent_react_decide", promptVersion: "1",
+     trace: { runId, parentStepId: agentStep.id }, provider })`
+     — the model call is auto-logged by the gateway.
+   - `final` → `finishRunStep(agentStep, { output: { answer } })`,
+     `finishRun({ output: { answer, steps } })`, return succeeded.
+   - `tool` → `executeToolCall(...)`; push `{ decision, observation }` to the
+     transcript; continue.
+4. Cap reached → `failRunStep(agentStep, ...)`,
+   `failRun({ errorType: "max_steps_exceeded" })`, return failed.
+5. Unrecoverable `ModelGatewayError` from `callModel` → fail step + run, return failed.
+
+### `executeToolCall` (permission + validation + ledger)
+
+Every attempt opens a tool step + tool call so it appears in the trace. Each branch
+returns an observation string that is fed back to the model.
+
+| Case | Ledger record | Observation fed back |
+|---|---|---|
+| tool not in registry | tool_call failed `unknown_tool` | "Unknown tool: X" |
+| class not in allowed-set | tool_call failed `permission_denied` | "Tool X (class Y) is not permitted for this run" |
+| args fail Zod parse | tool_call failed `invalid_args` | the Zod error summary |
+| `execute` throws | tool_call failed `tool_error` | the error message |
+| success | tool_call succeeded + result | the JSON result |
+
+Steps:
+
+```
+toolStep = startRunStep({ runId, parentStepId: agentStep.id,
+                          stepKind: "tool", name: decision.tool })
+toolCall = startToolCall({ runId, runStepId: toolStep.id,
+                          toolName: decision.tool, arguments: decision.args,
+                          metadata: { permissionClass } })
+// on success:  finishToolCall(result) + finishRunStep(output: result)
+// on any failure: failToolCall(errorType, message) + failRunStep(...)
+```
+
+Permission refusal and invalid args are *not* run failures — they are logged failed
+tool calls plus an observation, satisfying "a tool above the run's allowed class is
+refused and logged" while letting the model adapt.
+
+## Data flow
+
+```
+POST /api/agent { question }
+  -> runAgent({ question, registry(echo), allowedClasses:{read,reason} })
+       startRun -> startRunStep(agent)
+         loop: callModel(generate_object) --(gateway logs model_call)
+               -> decision.tool -> executeToolCall
+                    startRunStep(tool) -> startToolCall
+                      [permission/validate/execute]
+                    finish|fail toolCall + step
+               -> decision.final -> finishRun
+  -> { runId }
+GET /runs/[id]  -> getRunTrace -> existing inspector renders the tree
+```
+
+## Error handling
+
+- Tool/permission/arg failures: logged as failed tool calls, returned to the model
+  as observations, loop continues.
+- Model/gateway failure (`ModelGatewayError`): fail the agent step and the run with
+  the gateway error code; return `status: "failed"`.
+- Max steps: fail the run with `errorType: "max_steps_exceeded"`; the partial trace
+  is preserved and inspectable.
+- The API route catches and maps any thrown error to a 500 with the run id when one
+  exists, so a failed run is still inspectable.
+
+## Testing (TDD, live Postgres — same harness as F3/F4)
+
+Tests reset ledger tables and run migrations in `beforeEach`, and inject a mock
+`ModelGatewayProvider` so no real model API is called.
+
+- `tests/harness.test.ts`
+  - multi-step happy path: provider returns one `tool` decision then `final`; assert
+    the trace has an agent step with a tool child, a recorded tool_call (succeeded),
+    model_calls present, run `succeeded`, and the answer returned. (Acceptance #1, #3)
+  - permission refusal: register a higher-class tool; allowed-set excludes it;
+    provider calls it, then finals. Assert a failed tool_call with
+    `permission_denied` exists in the trace and the run still succeeds. (Acceptance #2)
+  - max steps: provider always returns a `tool` decision; assert the run fails with
+    `max_steps_exceeded` after `maxSteps` iterations.
+  - tool error: tool `execute` throws; assert failed tool_call `tool_error`, then the
+    model finals and the run succeeds.
+  - invalid args: provider returns args failing the schema; assert failed tool_call
+    `invalid_args`, then recovery.
+- `tests/tool-registry.test.ts`: register/get, duplicate-name throws,
+  list filters by allowed classes.
+- `tests/echo-tool.test.ts`: echo returns its input.
+
+## Acceptance criteria (from the task breakdown)
+
+- [ ] A run executes a multi-step loop that calls the model via the gateway and at
+      least one registered tool.
+- [ ] Tool registry enforces permission classes (a tool above the run's allowed class
+      is refused and logged).
+- [ ] The full run (steps, tool calls, model calls, status) appears in the run
+      inspector.
+
+## Maps to plan tasks
+
+- F5.1 ReAct loop → `src/lib/harness.ts` (§ The loop)
+- F5.2 Tool registry + permission classes + enforcement → `src/lib/tools/*` + `executeToolCall`
+- F5.3 `echo` tool + end-to-end ledger wiring → `src/lib/tools/echo.ts` + `POST /api/agent` + inspector

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "sourcecado",
       "version": "0.2.0",
       "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.85",
         "@ai-sdk/deepseek": "^2.0.39",
         "@ai-sdk/openai": "^3.0.73",
         "ai": "^6.0.208",
@@ -49,6 +50,22 @@
       "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.85",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.85.tgz",
+      "integrity": "sha512-fNeDB644l5wbRNQU0FnI+F7UTtOenMnPtACfMPUJaS2zJfuBlseEa1TMg+otHkETZgaJB+6Na51NQEv0+m7czw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.30"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
     },
     "node_modules/@ai-sdk/deepseek": {
       "version": "2.0.39",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "stress": "tsx scripts/stress.ts"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.85",
     "@ai-sdk/deepseek": "^2.0.39",
     "@ai-sdk/openai": "^3.0.73",
     "ai": "^6.0.208",

--- a/src/app/api/agent/route.ts
+++ b/src/app/api/agent/route.ts
@@ -11,6 +11,11 @@ export async function POST(request: Request) {
   }
 
   const registry = createToolRegistry([echoTool]);
-  const result = await runAgent({ question, registry });
-  return NextResponse.json(result, { status: result.status === "succeeded" ? 200 : 500 });
+  try {
+    const result = await runAgent({ question, registry });
+    return NextResponse.json(result, { status: result.status === "succeeded" ? 200 : 500 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "agent run failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
 }

--- a/src/app/api/agent/route.ts
+++ b/src/app/api/agent/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { runAgent } from "@/lib/harness";
+import { echoTool } from "@/lib/tools/echo";
+import { createToolRegistry } from "@/lib/tools/registry";
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+  const question = (body as { question?: unknown } | null)?.question;
+  if (typeof question !== "string" || !question.trim()) {
+    return NextResponse.json({ error: "question is required" }, { status: 400 });
+  }
+
+  const registry = createToolRegistry([echoTool]);
+  const result = await runAgent({ question, registry });
+  return NextResponse.json(result, { status: result.status === "succeeded" ? 200 : 500 });
+}

--- a/src/app/chat/ChatClient.tsx
+++ b/src/app/chat/ChatClient.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { Button, Card, Input } from "@/components/ui";
+
+interface AgentResult {
+  runId: number;
+  status: "succeeded" | "failed";
+  answer?: string;
+  steps: number;
+}
+
+export function ChatClient() {
+  const [question, setQuestion] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<AgentResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(event: FormEvent) {
+    event.preventDefault();
+    if (!question.trim() || loading) return;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await fetch("/api/agent", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ question }),
+      });
+      const data = (await res.json()) as AgentResult & { error?: string };
+      if (data.error) {
+        setError(data.error);
+      } else {
+        setResult(data);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Request failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 px-6 py-8">
+      <div>
+        <h1 className="text-xl font-semibold tracking-tight text-text">Research Chat</h1>
+        <p className="mt-1 text-[13px] text-muted">
+          Ask a question. The agent runs a traced multi-step loop through the gateway and tools.
+        </p>
+      </div>
+
+      <form onSubmit={onSubmit} className="flex gap-2">
+        <Input
+          aria-label="Question"
+          placeholder="Ask the agent (e.g. echo hello)"
+          value={question}
+          onChange={(event) => setQuestion(event.target.value)}
+          disabled={loading}
+        />
+        <Button type="submit" disabled={loading || !question.trim()}>
+          {loading ? "Running…" : "Run"}
+        </Button>
+      </form>
+
+      {error && (
+        <Card>
+          <div className="text-[13px] text-text">Error: {error}</div>
+        </Card>
+      )}
+
+      {result && (
+        <Card>
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-[13px] font-medium text-text">
+              Run #{result.runId} — {result.status} ({result.steps} step{result.steps === 1 ? "" : "s"})
+            </span>
+            <a className="text-[13px] text-accent-deep underline" href={`/runs/${result.runId}`}>
+              View trace
+            </a>
+          </div>
+          {result.answer ? (
+            <p className="mt-3 whitespace-pre-wrap text-[13px] text-text">{result.answer}</p>
+          ) : (
+            <p className="mt-3 text-[13px] text-muted">
+              No answer — the run ended as {result.status}. Open the trace for details.
+            </p>
+          )}
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/app/chat/ChatClient.tsx
+++ b/src/app/chat/ChatClient.tsx
@@ -65,7 +65,7 @@ export function ChatClient() {
 
       {error && (
         <Card>
-          <div className="text-[13px] text-text">Error: {error}</div>
+          <div role="alert" className="text-[13px] text-text">Error: {error}</div>
         </Card>
       )}
 

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,12 +1,5 @@
-import { EmptyState } from "@/components/ui";
+import { ChatClient } from "./ChatClient";
 
 export default function ChatPage() {
-  return (
-    <div className="flex min-h-[60vh] items-center justify-center px-6">
-      <EmptyState
-        title="Research Chat is coming soon"
-        description="Ask sourcing questions here and get cited answers with knowledge gaps. The agent run lands in Feature A."
-      />
-    </div>
-  );
+  return <ChatClient />;
 }

--- a/src/lib/harness.ts
+++ b/src/lib/harness.ts
@@ -1,0 +1,250 @@
+import { z } from "zod";
+import { getDb } from "./db";
+import {
+  failRun,
+  failRunStep,
+  failToolCall,
+  finishRun,
+  finishRunStep,
+  finishToolCall,
+  startRun,
+  startRunStep,
+  startToolCall,
+} from "./ledger";
+import { callModel, ModelGatewayError, type ModelGatewayProvider } from "./model-gateway";
+import type { ToolRegistry } from "./tools/registry";
+import type { PermissionClass, Sql } from "./tools/types";
+
+export const agentDecisionSchema = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("tool"),
+    tool: z.string(),
+    args: z.record(z.string(), z.unknown()),
+    thought: z.string().optional(),
+  }),
+  z.object({
+    action: z.literal("final"),
+    answer: z.string(),
+    thought: z.string().optional(),
+  }),
+]);
+export type AgentDecision = z.infer<typeof agentDecisionSchema>;
+
+export interface RunAgentInput {
+  question: string;
+  registry: ToolRegistry;
+  allowedClasses?: Set<PermissionClass>;
+  maxSteps?: number;
+  provider?: ModelGatewayProvider;
+  db?: Sql;
+}
+
+export interface RunAgentResult {
+  runId: number;
+  status: "succeeded" | "failed";
+  answer?: string;
+  steps: number;
+}
+
+const DEFAULT_ALLOWED: PermissionClass[] = ["read", "reason"];
+const DEFAULT_MAX_STEPS = 8;
+
+export async function runAgent(input: RunAgentInput): Promise<RunAgentResult> {
+  const db = input.db ?? getDb();
+  const allowed = input.allowedClasses ?? new Set(DEFAULT_ALLOWED);
+  const maxSteps = input.maxSteps ?? DEFAULT_MAX_STEPS;
+
+  const run = await startRun(db, {
+    runType: "agent_chat",
+    title: input.question.slice(0, 80),
+    input: { question: input.question },
+  });
+  const agentStep = await startRunStep(db, {
+    runId: run.id,
+    stepKind: "agent",
+    name: "react_loop",
+    input: { question: input.question },
+  });
+
+  const transcript: string[] = [];
+  let step = 0;
+
+  try {
+    for (step = 1; step <= maxSteps; step++) {
+      const decision = await decide(db, {
+        runId: run.id,
+        parentStepId: agentStep.id,
+        question: input.question,
+        registry: input.registry,
+        allowed,
+        transcript,
+        provider: input.provider,
+      });
+
+      if (decision.action === "final") {
+        await finishRunStep(db, {
+          runStepId: agentStep.id,
+          output: { answer: decision.answer, steps: step },
+        });
+        await finishRun(db, {
+          runId: run.id,
+          output: { answer: decision.answer, steps: step },
+        });
+        return { runId: run.id, status: "succeeded", answer: decision.answer, steps: step };
+      }
+
+      const observation = await executeToolCall(db, {
+        decision,
+        registry: input.registry,
+        allowed,
+        runId: run.id,
+        parentStepId: agentStep.id,
+      });
+      transcript.push(`Step ${step}: called ${decision.tool} -> ${observation}`);
+    }
+
+    const message = `Agent did not finish within ${maxSteps} steps.`;
+    await failRunStep(db, {
+      runStepId: agentStep.id,
+      errorType: "max_steps_exceeded",
+      errorMessage: message,
+    });
+    await failRun(db, {
+      runId: run.id,
+      errorType: "max_steps_exceeded",
+      errorMessage: message,
+    });
+    return { runId: run.id, status: "failed", steps: maxSteps };
+  } catch (error) {
+    const code = error instanceof ModelGatewayError ? error.code : "harness_error";
+    const message = error instanceof Error ? error.message : String(error);
+    await failRunStep(db, { runStepId: agentStep.id, errorType: code, errorMessage: message });
+    await failRun(db, { runId: run.id, errorType: code, errorMessage: message });
+    return { runId: run.id, status: "failed", steps: step };
+  }
+}
+
+interface DecideOptions {
+  runId: number;
+  parentStepId: number;
+  question: string;
+  registry: ToolRegistry;
+  allowed: Set<PermissionClass>;
+  transcript: string[];
+  provider?: ModelGatewayProvider;
+}
+
+async function decide(db: Sql, opts: DecideOptions): Promise<AgentDecision> {
+  const tools = opts.registry.list(opts.allowed);
+  const result = await callModel<AgentDecision>(db, {
+    kind: "generate_object",
+    taskName: "agent_react_decide",
+    promptVersion: "1",
+    system: buildSystemPrompt(tools),
+    prompt: buildUserPrompt(opts.question, opts.transcript),
+    schema: agentDecisionSchema,
+    schemaName: "agent_decision",
+    trace: { runId: opts.runId, parentStepId: opts.parentStepId },
+    provider: opts.provider,
+  });
+  if (!result.object) {
+    throw new ModelGatewayError("invalid_output", "Model did not return a decision object.");
+  }
+  return result.object;
+}
+
+function buildSystemPrompt(
+  tools: { name: string; description: string; permissionClass: string }[],
+): string {
+  const catalog = tools
+    .map((t) => `- ${t.name} (${t.permissionClass}): ${t.description}`)
+    .join("\n");
+  return [
+    "You are a sourcing agent. Decide the next action.",
+    "Either call one tool, or give a final answer.",
+    "Respond with a decision object: {action:'tool', tool, args} or {action:'final', answer}.",
+    "Available tools:",
+    catalog || "(none)",
+  ].join("\n");
+}
+
+function buildUserPrompt(question: string, transcript: string[]): string {
+  const history = transcript.length
+    ? `\n\nObservations so far:\n${transcript.join("\n")}`
+    : "";
+  return `Question: ${question}${history}`;
+}
+
+interface ExecuteToolOptions {
+  decision: Extract<AgentDecision, { action: "tool" }>;
+  registry: ToolRegistry;
+  allowed: Set<PermissionClass>;
+  runId: number;
+  parentStepId: number;
+}
+
+async function executeToolCall(db: Sql, opts: ExecuteToolOptions): Promise<string> {
+  const { decision, registry, allowed, runId, parentStepId } = opts;
+  const toolName = decision.tool;
+  const tool = registry.get(toolName);
+
+  const toolStep = await startRunStep(db, {
+    runId,
+    parentStepId,
+    stepKind: "tool",
+    name: toolName,
+    input: { args: decision.args },
+  });
+  const toolCall = await startToolCall(db, {
+    runId,
+    runStepId: toolStep.id,
+    toolName,
+    arguments: decision.args,
+    metadata: { permissionClass: tool?.permissionClass ?? null },
+  });
+
+  if (!tool) {
+    return failTool(db, toolStep.id, toolCall.id, "unknown_tool", `Unknown tool: ${toolName}.`);
+  }
+  if (!allowed.has(tool.permissionClass)) {
+    return failTool(
+      db,
+      toolStep.id,
+      toolCall.id,
+      "permission_denied",
+      `Tool ${toolName} (class ${tool.permissionClass}) is not permitted for this run.`,
+    );
+  }
+  const parsed = tool.argsSchema.safeParse(decision.args);
+  if (!parsed.success) {
+    return failTool(
+      db,
+      toolStep.id,
+      toolCall.id,
+      "invalid_args",
+      `Invalid arguments for ${toolName}: ${parsed.error.message}`,
+    );
+  }
+
+  try {
+    const result = await tool.execute(parsed.data, { db, runId, parentStepId: toolStep.id });
+    await finishToolCall(db, { toolCallId: toolCall.id, result });
+    await finishRunStep(db, { runStepId: toolStep.id, output: result });
+    return `Success: ${JSON.stringify(result)}`;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return failTool(db, toolStep.id, toolCall.id, "tool_error", `Tool ${toolName} failed: ${message}`);
+  }
+}
+
+async function failTool(
+  db: Sql,
+  runStepId: number,
+  toolCallId: number,
+  errorType: string,
+  message: string,
+): Promise<string> {
+  await failToolCall(db, { toolCallId, errorType, errorMessage: message });
+  await failRunStep(db, { runStepId, errorType, errorMessage: message });
+  return `Error (${errorType}): ${message}`;
+}

--- a/src/lib/harness.ts
+++ b/src/lib/harness.ts
@@ -59,22 +59,24 @@ export async function runAgent(input: RunAgentInput): Promise<RunAgentResult> {
   const allowed = input.allowedClasses ?? new Set(DEFAULT_ALLOWED);
   const maxSteps = input.maxSteps ?? DEFAULT_MAX_STEPS;
 
-  const run = await startRun(db, {
-    runType: "agent_chat",
-    title: input.question.slice(0, 80),
-    input: { question: input.question },
-  });
-  const agentStep = await startRunStep(db, {
-    runId: run.id,
-    stepKind: "agent",
-    name: "react_loop",
-    input: { question: input.question },
-  });
-
+  let run: Awaited<ReturnType<typeof startRun>> | null = null;
+  let agentStep: Awaited<ReturnType<typeof startRunStep>> | null = null;
   const transcript: string[] = [];
   let step = 0;
 
   try {
+    run = await startRun(db, {
+      runType: "agent_chat",
+      title: input.question.slice(0, 80),
+      input: { question: input.question },
+    });
+    agentStep = await startRunStep(db, {
+      runId: run.id,
+      stepKind: "agent",
+      name: "react_loop",
+      input: { question: input.question },
+    });
+
     for (step = 1; step <= maxSteps; step++) {
       const decision = await decide(db, {
         runId: run.id,
@@ -123,9 +125,13 @@ export async function runAgent(input: RunAgentInput): Promise<RunAgentResult> {
   } catch (error) {
     const code = error instanceof ModelGatewayError ? error.code : "harness_error";
     const message = error instanceof Error ? error.message : String(error);
-    await failRunStep(db, { runStepId: agentStep.id, errorType: code, errorMessage: message });
-    await failRun(db, { runId: run.id, errorType: code, errorMessage: message });
-    return { runId: run.id, status: "failed", steps: step };
+    if (agentStep) {
+      await failRunStep(db, { runStepId: agentStep.id, errorType: code, errorMessage: message });
+    }
+    if (run) {
+      await failRun(db, { runId: run.id, errorType: code, errorMessage: message });
+    }
+    return { runId: run?.id ?? 0, status: "failed", steps: step };
   }
 }
 

--- a/src/lib/harness.ts
+++ b/src/lib/harness.ts
@@ -13,13 +13,18 @@ import {
 } from "./ledger";
 import { callModel, ModelGatewayError, type ModelGatewayProvider } from "./model-gateway";
 import type { ToolRegistry } from "./tools/registry";
-import type { PermissionClass, Sql } from "./tools/types";
+import type { PermissionClass, Sql, Tool } from "./tools/types";
 
 export const agentDecisionSchema = z.discriminatedUnion("action", [
   z.object({
     action: z.literal("tool"),
     tool: z.string(),
-    args: z.record(z.string(), z.unknown()),
+    // A JSON object string, not a nested object: constrained/structured
+    // generation reliably fills a string but leaves a free-form object empty.
+    args: z
+      .string()
+      .describe('JSON object string of the tool arguments, e.g. {"text":"hi"}')
+      .optional(),
     thought: z.string().optional(),
   }),
   z.object({
@@ -140,7 +145,7 @@ async function decide(db: Sql, opts: DecideOptions): Promise<AgentDecision> {
     kind: "generate_object",
     taskName: "agent_react_decide",
     promptVersion: "1",
-    system: buildSystemPrompt(tools),
+    system: buildAgentSystemPrompt(tools),
     prompt: buildUserPrompt(opts.question, opts.transcript),
     schema: agentDecisionSchema,
     schemaName: "agent_decision",
@@ -153,16 +158,23 @@ async function decide(db: Sql, opts: DecideOptions): Promise<AgentDecision> {
   return result.object;
 }
 
-function buildSystemPrompt(
-  tools: { name: string; description: string; permissionClass: string }[],
-): string {
+export function buildAgentSystemPrompt(tools: Tool[]): string {
   const catalog = tools
-    .map((t) => `- ${t.name} (${t.permissionClass}): ${t.description}`)
+    .map((tool) => {
+      let schema = "{}";
+      try {
+        schema = JSON.stringify(z.toJSONSchema(tool.argsSchema));
+      } catch {
+        schema = "{}";
+      }
+      return `- ${tool.name} (${tool.permissionClass}): ${tool.description}\n  args JSON schema: ${schema}`;
+    })
     .join("\n");
   return [
     "You are a sourcing agent. Decide the next action.",
     "Either call one tool, or give a final answer.",
     "Respond with a decision object: {action:'tool', tool, args} or {action:'final', answer}.",
+    "When calling a tool, set `args` to a JSON object STRING matching that tool's args JSON schema exactly (e.g. \"{\\\"text\\\":\\\"hi\\\"}\").",
     "Available tools:",
     catalog || "(none)",
   ].join("\n");
@@ -188,18 +200,30 @@ async function executeToolCall(db: Sql, opts: ExecuteToolOptions): Promise<strin
   const toolName = decision.tool;
   const tool = registry.get(toolName);
 
+  // The model returns args as a JSON object string; decode before validating.
+  let decodedArgs: unknown = {};
+  let decodeError: string | null = null;
+  const rawArgs = decision.args?.trim();
+  if (rawArgs) {
+    try {
+      decodedArgs = JSON.parse(rawArgs);
+    } catch (error) {
+      decodeError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
   const toolStep = await startRunStep(db, {
     runId,
     parentStepId,
     stepKind: "tool",
     name: toolName,
-    input: { args: decision.args },
+    input: { args: decodeError ? decision.args : decodedArgs },
   });
   const toolCall = await startToolCall(db, {
     runId,
     runStepId: toolStep.id,
     toolName,
-    arguments: decision.args,
+    arguments: decodeError ? { raw: decision.args } : decodedArgs,
     metadata: { permissionClass: tool?.permissionClass ?? null },
   });
 
@@ -215,7 +239,16 @@ async function executeToolCall(db: Sql, opts: ExecuteToolOptions): Promise<strin
       `Tool ${toolName} (class ${tool.permissionClass}) is not permitted for this run.`,
     );
   }
-  const parsed = tool.argsSchema.safeParse(decision.args);
+  if (decodeError) {
+    return failTool(
+      db,
+      toolStep.id,
+      toolCall.id,
+      "invalid_args",
+      `Arguments for ${toolName} are not valid JSON: ${decodeError}`,
+    );
+  }
+  const parsed = tool.argsSchema.safeParse(decodedArgs);
   if (!parsed.success) {
     return failTool(
       db,

--- a/src/lib/model-gateway.ts
+++ b/src/lib/model-gateway.ts
@@ -282,6 +282,12 @@ function generationModel(providerName: string, model: string): LanguageModel {
     });
     return provider(model);
   }
+  if (providerName !== "deepseek") {
+    throw new ModelGatewayError(
+      "config_error",
+      `Unsupported generation provider: ${providerName}. Set SOURCECADO_GENERATION_PROVIDER to "anthropic" or "deepseek".`,
+    );
+  }
   requireEnv("DEEPSEEK_API_KEY");
   return deepseek(model);
 }

--- a/src/lib/model-gateway.ts
+++ b/src/lib/model-gateway.ts
@@ -397,7 +397,7 @@ function resolveModel(input: CallModelInput): string {
   if (process.env.SOURCECADO_GENERATION_MODEL?.trim()) {
     return process.env.SOURCECADO_GENERATION_MODEL;
   }
-  return resolveProviderName(input) === "anthropic" ? "claude-opus-4-8" : "deepseek-chat";
+  return resolveProviderName(input) === "anthropic" ? "claude-sonnet-4-6" : "deepseek-chat";
 }
 
 function toProviderRequest(

--- a/src/lib/model-gateway.ts
+++ b/src/lib/model-gateway.ts
@@ -1,6 +1,8 @@
 import { createHash } from "node:crypto";
+import { createAnthropic } from "@ai-sdk/anthropic";
 import { deepseek } from "@ai-sdk/deepseek";
 import { openai } from "@ai-sdk/openai";
+import type { LanguageModel } from "ai";
 import { embed, embedMany, generateObject, generateText } from "ai";
 import type postgres from "postgres";
 import type { z } from "zod";
@@ -255,18 +257,44 @@ async function executeProvider(
     return input.provider(request);
   }
 
-  return executeDefaultProvider(input, model);
+  return executeDefaultProvider(input, providerName, model);
+}
+
+// Resolve the AI SDK language model for text/object generation. Embeddings stay
+// on OpenAI. Keeps the gateway's single provider abstraction (ADR-0004) uniform
+// across deepseek/anthropic without leaking provider details to callers.
+// @ai-sdk/anthropic expects a base URL that includes the `/v1` segment and posts
+// to `${baseURL}/messages`. Some environments export ANTHROPIC_BASE_URL as the
+// bare host (the official SDK's convention, which appends /v1 itself), which 404s
+// here. Normalize: honor a configured base but ensure it carries a version path.
+export function resolveAnthropicBaseUrl(raw?: string): string {
+  const configured = raw?.trim();
+  if (!configured) return "https://api.anthropic.com/v1";
+  const trimmed = configured.replace(/\/+$/, "");
+  return /\/v\d+$/.test(trimmed) ? trimmed : `${trimmed}/v1`;
+}
+
+function generationModel(providerName: string, model: string): LanguageModel {
+  if (providerName === "anthropic") {
+    requireEnv("ANTHROPIC_API_KEY");
+    const provider = createAnthropic({
+      baseURL: resolveAnthropicBaseUrl(process.env.ANTHROPIC_BASE_URL),
+    });
+    return provider(model);
+  }
+  requireEnv("DEEPSEEK_API_KEY");
+  return deepseek(model);
 }
 
 async function executeDefaultProvider(
   input: CallModelInput,
+  providerName: string,
   model: string,
 ): Promise<ModelGatewayProviderResult> {
   switch (input.kind) {
     case "generate_text": {
-      requireEnv("DEEPSEEK_API_KEY");
       const result = await generateText({
-        model: deepseek(model),
+        model: generationModel(providerName, model),
         prompt: input.prompt,
         system: input.system,
       });
@@ -277,9 +305,8 @@ async function executeDefaultProvider(
       };
     }
     case "generate_object": {
-      requireEnv("DEEPSEEK_API_KEY");
       const result = await generateObject({
-        model: deepseek(model),
+        model: generationModel(providerName, model),
         prompt: input.prompt,
         system: input.system,
         schema: input.schema,
@@ -354,7 +381,10 @@ function resolveProviderName(input: CallModelInput): string {
   if (input.providerName?.trim()) {
     return input.providerName;
   }
-  return input.kind === "embed" || input.kind === "embed_many" ? "openai" : "deepseek";
+  if (input.kind === "embed" || input.kind === "embed_many") {
+    return "openai";
+  }
+  return process.env.SOURCECADO_GENERATION_PROVIDER?.trim() || "deepseek";
 }
 
 function resolveModel(input: CallModelInput): string {
@@ -364,7 +394,10 @@ function resolveModel(input: CallModelInput): string {
   if (input.kind === "embed" || input.kind === "embed_many") {
     return process.env.SOURCECADO_EMBEDDING_MODEL || "text-embedding-3-small";
   }
-  return process.env.SOURCECADO_GENERATION_MODEL || "deepseek-chat";
+  if (process.env.SOURCECADO_GENERATION_MODEL?.trim()) {
+    return process.env.SOURCECADO_GENERATION_MODEL;
+  }
+  return resolveProviderName(input) === "anthropic" ? "claude-opus-4-8" : "deepseek-chat";
 }
 
 function toProviderRequest(

--- a/src/lib/tools/echo.ts
+++ b/src/lib/tools/echo.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+import type { Tool } from "./types";
+
+export const echoArgsSchema = z.object({ text: z.string() });
+export type EchoArgs = z.infer<typeof echoArgsSchema>;
+
+export const echoTool: Tool<EchoArgs, { echoed: string }> = {
+  name: "echo",
+  description: "Echo back the provided text. A reference tool for the harness.",
+  permissionClass: "read",
+  argsSchema: echoArgsSchema,
+  async execute(args) {
+    return { echoed: args.text };
+  },
+};

--- a/src/lib/tools/registry.ts
+++ b/src/lib/tools/registry.ts
@@ -1,0 +1,31 @@
+import type { PermissionClass, Tool } from "./types";
+
+export interface ToolRegistry {
+  register(tool: Tool): void;
+  get(name: string): Tool | undefined;
+  list(allowed: Set<PermissionClass>): Tool[];
+}
+
+export function createToolRegistry(tools: Tool[] = []): ToolRegistry {
+  const byName = new Map<string, Tool>();
+
+  const registry: ToolRegistry = {
+    register(tool) {
+      if (byName.has(tool.name)) {
+        throw new Error(`Tool "${tool.name}" is already registered.`);
+      }
+      byName.set(tool.name, tool);
+    },
+    get(name) {
+      return byName.get(name);
+    },
+    list(allowed) {
+      return [...byName.values()].filter((tool) => allowed.has(tool.permissionClass));
+    },
+  };
+
+  for (const tool of tools) {
+    registry.register(tool);
+  }
+  return registry;
+}

--- a/src/lib/tools/types.ts
+++ b/src/lib/tools/types.ts
@@ -1,0 +1,35 @@
+import type postgres from "postgres";
+import type { z } from "zod";
+
+export type Sql = postgres.Sql;
+
+export type PermissionClass =
+  | "read"
+  | "enrich"
+  | "reason"
+  | "draft"
+  | "write_internal"
+  | "admin";
+
+export const PERMISSION_CLASSES: readonly PermissionClass[] = [
+  "read",
+  "enrich",
+  "reason",
+  "draft",
+  "write_internal",
+  "admin",
+];
+
+export interface ToolContext {
+  db: Sql;
+  runId: number;
+  parentStepId: number;
+}
+
+export interface Tool<TArgs = unknown, TResult = unknown> {
+  name: string;
+  description: string;
+  permissionClass: PermissionClass;
+  argsSchema: z.ZodType<TArgs>;
+  execute(args: TArgs, ctx: ToolContext): Promise<TResult>;
+}

--- a/tests/agent-prompt.test.ts
+++ b/tests/agent-prompt.test.ts
@@ -1,0 +1,16 @@
+import { buildAgentSystemPrompt } from "@/lib/harness";
+import { echoTool } from "@/lib/tools/echo";
+
+describe("buildAgentSystemPrompt", () => {
+  it("lists each tool with its name, class, and args JSON schema", () => {
+    const prompt = buildAgentSystemPrompt([echoTool]);
+    expect(prompt).toContain("echo (read):");
+    // The model needs the tool's argument shape, not just its name/description.
+    expect(prompt).toContain("args JSON schema:");
+    expect(prompt).toContain('"text"');
+  });
+
+  it("handles an empty tool set", () => {
+    expect(buildAgentSystemPrompt([])).toContain("(none)");
+  });
+});

--- a/tests/agent-route.test.ts
+++ b/tests/agent-route.test.ts
@@ -1,0 +1,40 @@
+import { vi } from "vitest";
+
+const { runAgentMock } = vi.hoisted(() => ({ runAgentMock: vi.fn() }));
+vi.mock("@/lib/harness", () => ({ runAgent: runAgentMock }));
+
+import { POST } from "@/app/api/agent/route";
+
+function postRequest(body: unknown): Request {
+  return new Request("http://localhost/api/agent", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/agent", () => {
+  beforeEach(() => {
+    runAgentMock.mockReset();
+  });
+
+  it("returns 400 when question is missing", async () => {
+    const res = await POST(postRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("runs the agent and returns the run id on success", async () => {
+    runAgentMock.mockResolvedValue({ runId: 7, status: "succeeded", answer: "hi", steps: 2 });
+    const res = await POST(postRequest({ question: "echo hi" }));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ runId: 7, status: "succeeded" });
+    expect(runAgentMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 500 when the run fails", async () => {
+    runAgentMock.mockResolvedValue({ runId: 9, status: "failed", steps: 8 });
+    const res = await POST(postRequest({ question: "loop" }));
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toMatchObject({ runId: 9, status: "failed" });
+  });
+});

--- a/tests/agent-route.test.ts
+++ b/tests/agent-route.test.ts
@@ -37,4 +37,11 @@ describe("POST /api/agent", () => {
     expect(res.status).toBe(500);
     await expect(res.json()).resolves.toMatchObject({ runId: 9, status: "failed" });
   });
+
+  it("returns structured JSON error when runAgent throws (e.g. DB init failure)", async () => {
+    runAgentMock.mockRejectedValue(new Error("DB connection refused"));
+    const res = await POST(postRequest({ question: "anything" }));
+    expect(res.status).toBe(500);
+    await expect(res.json()).resolves.toMatchObject({ error: "DB connection refused" });
+  });
 });

--- a/tests/anthropic-base-url.test.ts
+++ b/tests/anthropic-base-url.test.ts
@@ -1,0 +1,20 @@
+import { resolveAnthropicBaseUrl } from "@/lib/model-gateway";
+
+describe("resolveAnthropicBaseUrl", () => {
+  it("defaults to the versioned Anthropic API base", () => {
+    expect(resolveAnthropicBaseUrl(undefined)).toBe("https://api.anthropic.com/v1");
+    expect(resolveAnthropicBaseUrl("  ")).toBe("https://api.anthropic.com/v1");
+  });
+
+  it("appends /v1 to a bare host (the official-SDK convention that 404s here)", () => {
+    expect(resolveAnthropicBaseUrl("https://api.anthropic.com")).toBe("https://api.anthropic.com/v1");
+    expect(resolveAnthropicBaseUrl("https://api.anthropic.com/")).toBe("https://api.anthropic.com/v1");
+  });
+
+  it("keeps a base that already has a version segment", () => {
+    expect(resolveAnthropicBaseUrl("https://api.anthropic.com/v1")).toBe("https://api.anthropic.com/v1");
+    expect(resolveAnthropicBaseUrl("https://proxy.internal/anthropic/v2")).toBe(
+      "https://proxy.internal/anthropic/v2",
+    );
+  });
+});

--- a/tests/components/ChatClient.test.tsx
+++ b/tests/components/ChatClient.test.tsx
@@ -15,6 +15,20 @@ describe("ChatClient", () => {
     expect(screen.getByRole("button", { name: /run/i })).toBeInTheDocument();
   });
 
+  it("shows an accessible alert when the request fails", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: async () => ({ error: "DB connection failed" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ChatClient />);
+    fireEvent.change(screen.getByLabelText("Question"), { target: { value: "will fail" } });
+    fireEvent.click(screen.getByRole("button", { name: /run/i }));
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
+    expect(screen.getByRole("alert")).toHaveTextContent("DB connection failed");
+  });
+
   it("posts the question and shows the run result with a trace link", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       json: async () => ({ runId: 42, status: "succeeded", answer: "Echoed hello", steps: 2 }),

--- a/tests/components/ChatClient.test.tsx
+++ b/tests/components/ChatClient.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { ChatClient } from "@/app/chat/ChatClient";
+
+describe("ChatClient", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the question input and run button", () => {
+    render(<ChatClient />);
+    expect(screen.getByLabelText("Question")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /run/i })).toBeInTheDocument();
+  });
+
+  it("posts the question and shows the run result with a trace link", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: async () => ({ runId: 42, status: "succeeded", answer: "Echoed hello", steps: 2 }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<ChatClient />);
+    fireEvent.change(screen.getByLabelText("Question"), { target: { value: "echo hello" } });
+    fireEvent.click(screen.getByRole("button", { name: /run/i }));
+
+    await waitFor(() => expect(screen.getByText(/Run #42/)).toBeInTheDocument());
+    expect(screen.getByText("Echoed hello")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /view trace/i })).toHaveAttribute("href", "/runs/42");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/agent",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});

--- a/tests/echo-tool.test.ts
+++ b/tests/echo-tool.test.ts
@@ -1,0 +1,17 @@
+import { getDb } from "@/lib/db";
+import { echoTool } from "@/lib/tools/echo";
+
+describe("echoTool", () => {
+  it("echoes the provided text", async () => {
+    const result = await echoTool.execute(
+      { text: "hello" },
+      { db: getDb(), runId: 0, parentStepId: 0 },
+    );
+    expect(result).toEqual({ echoed: "hello" });
+  });
+
+  it("is a read-class tool named echo", () => {
+    expect(echoTool.name).toBe("echo");
+    expect(echoTool.permissionClass).toBe("read");
+  });
+});

--- a/tests/harness.test.ts
+++ b/tests/harness.test.ts
@@ -29,6 +29,30 @@ describe("runAgent", () => {
     await closeDb();
   });
 
+  it("returns a failed result instead of throwing when the DB init fails (startRun throws)", async () => {
+    const brokenDb = new Proxy(getDb(), {
+      get(target, prop) {
+        const original = Reflect.get(target, prop) as unknown;
+        // Intercept the tagged-template SQL calls (db`...`) by returning a
+        // function that always rejects, simulating a DB connection failure.
+        if (typeof original === "function") {
+          return (...args: unknown[]) => {
+            // The first template-tagged call is startRun's INSERT; reject it.
+            throw new Error("DB connection refused");
+          };
+        }
+        return original;
+      },
+    }) as typeof getDb extends () => infer R ? R : never;
+
+    const registry = createToolRegistry([echoTool]);
+    const result = await runAgent({ question: "any", registry, db: brokenDb });
+
+    expect(result.status).toBe("failed");
+    expect(result.runId).toBe(0); // no DB record was created
+    expect(result.steps).toBe(0);
+  });
+
   it("runs a multi-step loop (tool then final) and traces it fully", async () => {
     const db = getDb();
     const registry = createToolRegistry([echoTool]);

--- a/tests/harness.test.ts
+++ b/tests/harness.test.ts
@@ -34,7 +34,7 @@ describe("runAgent", () => {
     const registry = createToolRegistry([echoTool]);
     const provider = vi
       .fn<ModelGatewayProvider>()
-      .mockResolvedValueOnce({ object: { action: "tool", tool: "echo", args: { text: "hello" } } })
+      .mockResolvedValueOnce({ object: { action: "tool", tool: "echo", args: '{"text":"hello"}' } })
       .mockResolvedValueOnce({ object: { action: "final", answer: "Echoed hello" } });
 
     const result = await runAgent({
@@ -78,7 +78,7 @@ describe("runAgent", () => {
     const registry = createToolRegistry([echoTool, adminTool]);
     const provider = vi
       .fn<ModelGatewayProvider>()
-      .mockResolvedValueOnce({ object: { action: "tool", tool: "danger", args: {} } })
+      .mockResolvedValueOnce({ object: { action: "tool", tool: "danger", args: "{}" } })
       .mockResolvedValueOnce({ object: { action: "final", answer: "could not use danger" } });
 
     const result = await runAgent({ question: "do danger", registry, allowedClasses: ALLOWED, provider });
@@ -98,7 +98,7 @@ describe("runAgent", () => {
     const registry = createToolRegistry([echoTool]);
     const provider = vi
       .fn<ModelGatewayProvider>()
-      .mockResolvedValue({ object: { action: "tool", tool: "echo", args: { text: "again" } } });
+      .mockResolvedValue({ object: { action: "tool", tool: "echo", args: '{"text":"again"}' } });
 
     const result = await runAgent({
       question: "loop forever",
@@ -130,7 +130,7 @@ describe("runAgent", () => {
     const registry = createToolRegistry([boomTool]);
     const provider = vi
       .fn<ModelGatewayProvider>()
-      .mockResolvedValueOnce({ object: { action: "tool", tool: "boom", args: {} } })
+      .mockResolvedValueOnce({ object: { action: "tool", tool: "boom", args: "{}" } })
       .mockResolvedValueOnce({ object: { action: "final", answer: "recovered" } });
 
     const result = await runAgent({ question: "x", registry, allowedClasses: ALLOWED, provider });
@@ -146,7 +146,7 @@ describe("runAgent", () => {
     const registry = createToolRegistry([echoTool]); // echo requires { text: string }
     const provider = vi
       .fn<ModelGatewayProvider>()
-      .mockResolvedValueOnce({ object: { action: "tool", tool: "echo", args: { wrong: 1 } } })
+      .mockResolvedValueOnce({ object: { action: "tool", tool: "echo", args: '{"wrong":1}' } })
       .mockResolvedValueOnce({ object: { action: "final", answer: "ok" } });
 
     const result = await runAgent({ question: "x", registry, allowedClasses: ALLOWED, provider });

--- a/tests/harness.test.ts
+++ b/tests/harness.test.ts
@@ -1,0 +1,159 @@
+import { vi } from "vitest";
+import { z } from "zod";
+import { closeDb, getDb } from "@/lib/db";
+import { getRunTrace } from "@/lib/ledger";
+import { runMigrations } from "@/lib/migrate";
+import type { ModelGatewayProvider } from "@/lib/model-gateway";
+import { runAgent } from "@/lib/harness";
+import { createToolRegistry } from "@/lib/tools/registry";
+import { echoTool } from "@/lib/tools/echo";
+import type { Tool } from "@/lib/tools/types";
+
+async function resetLedgerTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS tool_calls CASCADE`;
+  await db`DROP TABLE IF EXISTS model_calls CASCADE`;
+  await db`DROP TABLE IF EXISTS run_steps CASCADE`;
+  await db`DROP TABLE IF EXISTS runs CASCADE`;
+  await db`DROP TABLE IF EXISTS schema_migrations CASCADE`;
+  await runMigrations(db);
+}
+
+const ALLOWED = new Set<Tool["permissionClass"]>(["read", "reason"]);
+
+describe("runAgent", () => {
+  beforeEach(async () => {
+    await resetLedgerTables();
+  });
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("runs a multi-step loop (tool then final) and traces it fully", async () => {
+    const db = getDb();
+    const registry = createToolRegistry([echoTool]);
+    const provider = vi
+      .fn<ModelGatewayProvider>()
+      .mockResolvedValueOnce({ object: { action: "tool", tool: "echo", args: { text: "hello" } } })
+      .mockResolvedValueOnce({ object: { action: "final", answer: "Echoed hello" } });
+
+    const result = await runAgent({
+      question: "echo hello",
+      registry,
+      allowedClasses: ALLOWED,
+      provider,
+    });
+
+    expect(result.status).toBe("succeeded");
+    expect(result.answer).toBe("Echoed hello");
+    expect(provider).toHaveBeenCalledTimes(2);
+
+    const trace = await getRunTrace(db, result.runId);
+    expect(trace?.status).toBe("succeeded");
+    const agentStep = trace?.steps[0];
+    expect(agentStep?.stepKind).toBe("agent");
+
+    // Each callModel(trace) creates a child "model" step holding the model call.
+    const modelSteps = agentStep?.children.filter((s) => s.stepKind === "model") ?? [];
+    expect(modelSteps).toHaveLength(2);
+    expect(modelSteps[0]?.modelCalls).toHaveLength(1);
+
+    const toolStep = agentStep?.children.find((s) => s.stepKind === "tool" && s.name === "echo");
+    expect(toolStep?.toolCalls[0]).toMatchObject({
+      toolName: "echo",
+      status: "succeeded",
+      result: { echoed: "hello" },
+    });
+  });
+
+  it("refuses and logs a tool whose class is not in the allowed set", async () => {
+    const db = getDb();
+    const adminTool: Tool = {
+      name: "danger",
+      description: "admin-only action",
+      permissionClass: "admin",
+      argsSchema: z.object({}),
+      execute: async () => ({ ok: true }),
+    };
+    const registry = createToolRegistry([echoTool, adminTool]);
+    const provider = vi
+      .fn<ModelGatewayProvider>()
+      .mockResolvedValueOnce({ object: { action: "tool", tool: "danger", args: {} } })
+      .mockResolvedValueOnce({ object: { action: "final", answer: "could not use danger" } });
+
+    const result = await runAgent({ question: "do danger", registry, allowedClasses: ALLOWED, provider });
+
+    expect(result.status).toBe("succeeded"); // refusal is not a run failure
+    const trace = await getRunTrace(db, result.runId);
+    const toolStep = trace?.steps[0]?.children.find((s) => s.name === "danger");
+    expect(toolStep?.toolCalls[0]).toMatchObject({
+      toolName: "danger",
+      status: "failed",
+      errorType: "permission_denied",
+    });
+  });
+
+  it("fails the run when maxSteps is exceeded", async () => {
+    const db = getDb();
+    const registry = createToolRegistry([echoTool]);
+    const provider = vi
+      .fn<ModelGatewayProvider>()
+      .mockResolvedValue({ object: { action: "tool", tool: "echo", args: { text: "again" } } });
+
+    const result = await runAgent({
+      question: "loop forever",
+      registry,
+      allowedClasses: ALLOWED,
+      maxSteps: 3,
+      provider,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.steps).toBe(3);
+    expect(provider).toHaveBeenCalledTimes(3);
+    const trace = await getRunTrace(db, result.runId);
+    expect(trace?.status).toBe("failed");
+    expect(trace?.errorType).toBe("max_steps_exceeded");
+  });
+
+  it("feeds a tool execution error back and lets the model recover", async () => {
+    const db = getDb();
+    const boomTool: Tool = {
+      name: "boom",
+      description: "always throws",
+      permissionClass: "read",
+      argsSchema: z.object({}),
+      execute: async () => {
+        throw new Error("kaboom");
+      },
+    };
+    const registry = createToolRegistry([boomTool]);
+    const provider = vi
+      .fn<ModelGatewayProvider>()
+      .mockResolvedValueOnce({ object: { action: "tool", tool: "boom", args: {} } })
+      .mockResolvedValueOnce({ object: { action: "final", answer: "recovered" } });
+
+    const result = await runAgent({ question: "x", registry, allowedClasses: ALLOWED, provider });
+
+    expect(result.status).toBe("succeeded");
+    const trace = await getRunTrace(db, result.runId);
+    const toolStep = trace?.steps[0]?.children.find((s) => s.name === "boom");
+    expect(toolStep?.toolCalls[0]).toMatchObject({ status: "failed", errorType: "tool_error" });
+  });
+
+  it("feeds invalid tool args back and lets the model recover", async () => {
+    const db = getDb();
+    const registry = createToolRegistry([echoTool]); // echo requires { text: string }
+    const provider = vi
+      .fn<ModelGatewayProvider>()
+      .mockResolvedValueOnce({ object: { action: "tool", tool: "echo", args: { wrong: 1 } } })
+      .mockResolvedValueOnce({ object: { action: "final", answer: "ok" } });
+
+    const result = await runAgent({ question: "x", registry, allowedClasses: ALLOWED, provider });
+
+    expect(result.status).toBe("succeeded");
+    const trace = await getRunTrace(db, result.runId);
+    const toolStep = trace?.steps[0]?.children.find((s) => s.name === "echo");
+    expect(toolStep?.toolCalls[0]).toMatchObject({ status: "failed", errorType: "invalid_args" });
+  });
+});

--- a/tests/model-gateway-anthropic.test.ts
+++ b/tests/model-gateway-anthropic.test.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+import { callModel, ModelGatewayError } from "@/lib/model-gateway";
+
+async function resetLedgerTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS tool_calls CASCADE`;
+  await db`DROP TABLE IF EXISTS model_calls CASCADE`;
+  await db`DROP TABLE IF EXISTS run_steps CASCADE`;
+  await db`DROP TABLE IF EXISTS runs CASCADE`;
+  await db`DROP TABLE IF EXISTS schema_migrations CASCADE`;
+  await runMigrations(db);
+}
+
+describe("callModel() generation provider routing", () => {
+  const savedProvider = process.env.SOURCECADO_GENERATION_PROVIDER;
+  const savedModel = process.env.SOURCECADO_GENERATION_MODEL;
+  const savedKey = process.env.ANTHROPIC_API_KEY;
+
+  beforeEach(async () => {
+    await resetLedgerTables();
+  });
+
+  afterEach(async () => {
+    restore("SOURCECADO_GENERATION_PROVIDER", savedProvider);
+    restore("SOURCECADO_GENERATION_MODEL", savedModel);
+    restore("ANTHROPIC_API_KEY", savedKey);
+    await closeDb();
+  });
+
+  function restore(name: string, value: string | undefined) {
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
+  }
+
+  it("routes generation to Anthropic and requires ANTHROPIC_API_KEY", async () => {
+    process.env.SOURCECADO_GENERATION_PROVIDER = "anthropic";
+    delete process.env.SOURCECADO_GENERATION_MODEL;
+    delete process.env.ANTHROPIC_API_KEY;
+
+    const error = await callModel(getDb(), {
+      kind: "generate_object",
+      taskName: "routing_probe",
+      promptVersion: "1",
+      prompt: "hi",
+      schema: z.object({ ok: z.boolean() }),
+    }).catch((e) => e);
+
+    expect(error).toBeInstanceOf(ModelGatewayError);
+    expect((error as ModelGatewayError).code).toBe("missing_config");
+    expect((error as Error).message).toMatch(/ANTHROPIC_API_KEY/);
+  });
+});

--- a/tests/model-gateway-anthropic.test.ts
+++ b/tests/model-gateway-anthropic.test.ts
@@ -34,6 +34,21 @@ describe("callModel() generation provider routing", () => {
     else process.env[name] = value;
   }
 
+  it("throws config_error for an unknown generation provider instead of silently using DeepSeek", async () => {
+    process.env.SOURCECADO_GENERATION_PROVIDER = "bogus-provider";
+
+    const error = await callModel(getDb(), {
+      kind: "generate_text",
+      taskName: "unknown_provider_probe",
+      promptVersion: "1",
+      prompt: "hi",
+    }).catch((e) => e);
+
+    expect(error).toBeInstanceOf(ModelGatewayError);
+    expect((error as ModelGatewayError).code).toBe("config_error");
+    expect((error as Error).message).toMatch(/bogus-provider/);
+  });
+
   it("routes generation to Anthropic and requires ANTHROPIC_API_KEY", async () => {
     process.env.SOURCECADO_GENERATION_PROVIDER = "anthropic";
     delete process.env.SOURCECADO_GENERATION_MODEL;

--- a/tests/tool-registry.test.ts
+++ b/tests/tool-registry.test.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+import { createToolRegistry } from "@/lib/tools/registry";
+import type { Tool } from "@/lib/tools/types";
+
+function fakeTool(name: string, permissionClass: Tool["permissionClass"]): Tool {
+  return {
+    name,
+    description: `${name} tool`,
+    permissionClass,
+    argsSchema: z.object({}),
+    execute: async () => ({ ok: true }),
+  };
+}
+
+describe("createToolRegistry", () => {
+  it("registers and retrieves tools by name", () => {
+    const registry = createToolRegistry([fakeTool("a", "read")]);
+    expect(registry.get("a")?.name).toBe("a");
+    expect(registry.get("missing")).toBeUndefined();
+  });
+
+  it("throws on duplicate tool name", () => {
+    const registry = createToolRegistry([fakeTool("a", "read")]);
+    expect(() => registry.register(fakeTool("a", "read"))).toThrow(/already registered/);
+  });
+
+  it("lists only tools whose class is in the allowed set", () => {
+    const registry = createToolRegistry([
+      fakeTool("r", "read"),
+      fakeTool("d", "draft"),
+      fakeTool("a", "admin"),
+    ]);
+    const names = registry
+      .list(new Set(["read", "draft"]))
+      .map((t) => t.name)
+      .sort();
+    expect(names).toEqual(["d", "r"]);
+  });
+});


### PR DESCRIPTION
## F5 — Agent Harness ReAct loop (Foundation cluster, final slice)

Closes the Foundation cluster: a permission-gated ReAct tool-use loop that runs a multi-step agent through the F3 Model Gateway and writes the full trace to the F4 Run Ledger.

Design: `docs/superpowers/specs/2026-06-23-f5-agent-harness-react-loop-design.md`
Plan: `docs/superpowers/plans/2026-06-23-f5-agent-harness-react-loop.md`

### What's in it
- **Tool contract + permission-aware registry** (`src/lib/tools/`) — 6 permission classes, allowed-set per run, `allow|deny` only (no interactive `ask` tier — runs are headless).
- **`echo` reference tool** (class `read`).
- **`runAgent()` ReAct loop** (`src/lib/harness.ts`) — structured-output decisions via the gateway; tool error / permission refusal / invalid args become observations fed back to the model; step cap (8); full Run Ledger tracing. Loop guardrails validated against Claude Code's `query.ts` orchestration.
- **`POST /api/agent`** thin trigger; trace renders in the existing `/runs/[id]` inspector.

### Pulled a slice of A6 forward (so it's usable end-to-end now)
- **Anthropic generation provider** in the gateway behind ADR-0004 (`@ai-sdk/anthropic`; DeepSeek stays default, embeddings stay OpenAI; selected via `SOURCECADO_GENERATION_PROVIDER`, model default `claude-sonnet-4-6`). Normalizes a bare `ANTHROPIC_BASE_URL` to include `/v1`.
- **Minimal Research Chat UI** (`/chat`) → `POST /api/agent` → answer + run-inspector link, on `src/components/ui` primitives.
- Agent decision carries tool args as a **JSON string** (Anthropic structured output won't fill free-form objects); system prompt lists each tool's args JSON schema.

### Verification
- Full suite **156 passed** (1 todo) against live Postgres; lint + production build clean.
- Verified live end-to-end against `claude-sonnet-4-6`: echo loop succeeds in 2 steps, traced in the ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a chat experience to submit questions, trigger an agent run, and display status plus a trace link to the run details.
  * Introduced an agent harness with tool use, permission gating, and step-by-step run tracing.
  * Added support for Anthropic-based generation.
* **Bug Fixes**
  * Improved API request validation and error responses for failed agent runs.
* **Tests**
  * Added/expanded coverage for the agent prompt, agent route, tool registry, harness behavior, and UI component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes the Foundation cluster by adding a permission-gated ReAct tool-use loop (`runAgent`), an Anthropic generation provider behind `SOURCECADO_GENERATION_PROVIDER`, and a minimal Research Chat UI at `/chat` that submits questions to `POST /api/agent` and links the resulting trace.

- **Agent harness (`src/lib/harness.ts`)**: a structured-output decision loop capped at 8 steps; tool errors, permission refusals, and invalid args are fed back as observations; every step is written to the Run Ledger.
- **Model gateway (`src/lib/model-gateway.ts`)**: Anthropic added as an opt-in generation provider alongside DeepSeek; `resolveAnthropicBaseUrl` normalises bare hosts to include `/v1`; embeddings remain on OpenAI.
- **One real defect found**: `startRun` and `startRunStep` are called before the `try/catch` in `runAgent`, so a DB failure during ledger initialisation propagates as an unhandled rejection — the route handler has no error boundary, so the API contract breaks for that failure class.

<h3>Confidence Score: 3/5</h3>

Safe to merge for non-critical deployments; a DB outage at run start produces an unstructured 500 instead of a clean error response.

The harness, registry, and gateway additions are well-tested and logically sound. The one concrete defect — startRun/startRunStep sitting outside the try/catch — means that any DB failure before the loop begins escapes runAgent as an unhandled rejection. The /api/agent route handler has no catch of its own, so the API silently breaks for that failure class at runtime. Everything else (tool dispatch, permission checks, Anthropic base-URL normalisation, the chat UI) is straightforward and covered by tests.

src/lib/harness.ts needs the ledger initialisation calls wrapped in (or moved inside) the try/catch; src/lib/model-gateway.ts has a minor redundant call worth cleaning up.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/harness.ts | Core ReAct loop with comprehensive tracing; ledger initialization calls (startRun, startRunStep) are placed before the try/catch block, leaving DB errors during run setup as unhandled exceptions. |
| src/lib/model-gateway.ts | Adds Anthropic provider support and base-URL normalization; resolveModel calls resolveProviderName independently instead of reusing the already-resolved name from callModel. |
| src/app/api/agent/route.ts | Thin trigger endpoint; no try/catch around runAgent, so an unhandled exception (e.g., DB failure in ledger init) escapes as a framework-level 500 rather than a structured JSON error. |
| src/lib/tools/registry.ts | Clean permission-filtered registry with duplicate-name guard; looks correct. |
| src/lib/tools/types.ts | Defines PermissionClass, ToolContext, and the generic Tool interface; well-typed and complete. |
| src/lib/tools/echo.ts | Reference echo tool; minimal and correct. |
| src/app/chat/ChatClient.tsx | Minimal Research Chat UI; uses data.error check but not res.ok, so an unstructured server error and a normal failed-run 500 are handled by the same code path. |
| tests/harness.test.ts | Good coverage of happy path, permission denial, max-steps, tool errors, and invalid args; all run against live Postgres via the provider mock pattern. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User (Browser)
    participant C as ChatClient
    participant R as POST /api/agent
    participant H as runAgent (harness)
    participant L as Run Ledger (DB)
    participant G as Model Gateway
    participant M as LLM (Anthropic/DeepSeek)
    participant T as Tool Registry

    U->>C: submit question
    C->>R: "POST { question }"
    R->>H: "runAgent({ question, registry })"
    H->>L: startRun() ← outside try/catch
    H->>L: startRunStep(agent) ← outside try/catch
    loop ReAct loop (max 8 steps)
        H->>G: callModel(decide)
        G->>M: generateObject(agentDecisionSchema)
        M-->>G: "{ action, tool?, args?, answer? }"
        G->>L: record model_call
        G-->>H: AgentDecision
        alt "action == tool"
            H->>T: registry.get(toolName)
            H->>L: startRunStep(tool) + startToolCall
            alt permitted and valid args
                H->>T: tool.execute(args)
                T-->>H: result
                H->>L: finishToolCall + finishRunStep
                H->>H: append observation to transcript
            else denied or invalid
                H->>L: failToolCall + failRunStep
                H->>H: append error observation
            end
        else "action == final"
            H->>L: finishRunStep + finishRun
            H-->>R: "{ runId, status:succeeded, answer, steps }"
        end
    end
    H->>L: failRun (max_steps_exceeded)
    H-->>R: "{ runId, status:failed, steps }"
    R-->>C: JSON response (200 or 500)
    C-->>U: render result + trace link
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User (Browser)
    participant C as ChatClient
    participant R as POST /api/agent
    participant H as runAgent (harness)
    participant L as Run Ledger (DB)
    participant G as Model Gateway
    participant M as LLM (Anthropic/DeepSeek)
    participant T as Tool Registry

    U->>C: submit question
    C->>R: "POST { question }"
    R->>H: "runAgent({ question, registry })"
    H->>L: startRun() ← outside try/catch
    H->>L: startRunStep(agent) ← outside try/catch
    loop ReAct loop (max 8 steps)
        H->>G: callModel(decide)
        G->>M: generateObject(agentDecisionSchema)
        M-->>G: "{ action, tool?, args?, answer? }"
        G->>L: record model_call
        G-->>H: AgentDecision
        alt "action == tool"
            H->>T: registry.get(toolName)
            H->>L: startRunStep(tool) + startToolCall
            alt permitted and valid args
                H->>T: tool.execute(args)
                T-->>H: result
                H->>L: finishToolCall + finishRunStep
                H->>H: append observation to transcript
            else denied or invalid
                H->>L: failToolCall + failRunStep
                H->>H: append error observation
            end
        else "action == final"
            H->>L: finishRunStep + finishRun
            H-->>R: "{ runId, status:succeeded, answer, steps }"
        end
    end
    H->>L: failRun (max_steps_exceeded)
    H-->>R: "{ runId, status:failed, steps }"
    R-->>C: JSON response (200 or 500)
    C-->>U: render result + trace link
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore(f5): default Anthropic generation ..."](https://github.com/fisherxz/sourcecado/commit/f21e06655c33f95c1f823f69a78e2bb035cd733f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39725626)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->