### PR TITLE
feat(A): cited sourcing memory answer — Postgres/pgvector memory engine + search_memory tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ prove-and-plain-english-skills.zip
 .env
 .env.local
 .env.*.local
+
+# isolated worktrees
+.claude/worktrees/

--- a/docs/superpowers/plans/2026-06-08-sourcecado-autonomous-sourcing-os-weekly-timeline.md
+++ b/docs/superpowers/plans/2026-06-08-sourcecado-autonomous-sourcing-os-weekly-timeline.md
@@ -9,6 +9,39 @@ Status: Scoped for a 2-person team at ~5 hrs/week each (~70-100 person-hours tot
 > `superpowers:executing-plans` or `superpowers:subagent-driven-development`
 > to execute it.
 
+## Progress (updated 2026-06-25)
+
+FLOOR tier is substantially delivered. **Feature A — Cited Sourcing Memory Answer**
+(branch `feat/a-memory-impl`, off `feat/a-cited-memory-answer`) is built, principal-reviewed
+(merge risk LOW), and proven end-to-end on real data; 258 tests pass.
+
+- [x] **Memory model ported to Postgres/pgvector** — `source_records`, `memory_chunks`
+      (`vector(1536)` + hnsw cosine), `semantic_facts` lifecycle
+      (accepted/candidate/conflicted/stale), `extraction_runs` cache, `source_permissions`
+      (ADR-0001 default-deny). Migration `002_memory.sql`. (Deferred per design: the
+      entities/relationships/alias graph — unread by the answer path.)
+- [x] **Query the brain** — `search_memory` tool returns `{intent, acceptedFacts, gapFacts,
+      chunks}`; the model synthesizes the **Answer/Evidence/Gaps/Next-Action** cited answer
+      with a deterministic citation post-check. Asking in `/chat` runs the agent loop and
+      renders a 4-section cited answer with knowledge gaps, fully traced in the Run Ledger
+      (`/runs/[id]`). Verified live on 3 complex queries (claude-sonnet-4-6).
+- [x] **Add/correct notes** — `add_memory_note` tool writes a note that is immediately
+      retrievable; corrections are superseding notes (no destructive edit).
+- [x] **Ingest + refresh pipeline** — `npm run ingest <dir>` (md/txt/csv/eml → chunks +
+      pgvector embeddings, real OpenAI `text-embedding-3-small` or offline hash fallback) and
+      `npm run refresh` (extractor per chunk → `semantic_facts`, cached).
+- [x] **Agent runtime** — the small custom tool-use loop (F5 harness) is the runtime; this
+      feature registers `search_memory` into it (per the "own the runtime" decision).
+
+Remaining FLOOR work before the floor is fully shipped:
+- [ ] Load the **real Drive notes** corpus (this milestone used a representative demo corpus).
+- [ ] **Auto-write-back**: agent run outputs flowing back into memory automatically (the
+      `add_memory_note` primitive exists; the run→memory wiring is not yet automatic).
+- [ ] Thin web-app polish for query + note management (current surface is `/chat` + `/runs/[id]`).
+
+Infra note: local Postgres is the Dockerized `pgvector/pgvector:pg16` (`docker compose up -d`);
+the hosted Supabase target in Stack Decision is unchanged for later.
+
 ## Why This Was Rescoped
 
 The earlier design doc (`docs/superpowers/specs/2026-06-08-sourcecado-autonomous-sourcing-os-design.md`)

--- a/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
+++ b/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
@@ -114,39 +114,39 @@ build on these primitives instead of restyling. See
 - [x] FD.7 /styleguide catalog page (~1h) · AFK
 
 ## F3 — Model Gateway with usage logging
-Type: AFK · Blocked by: F2
+Type: AFK · Blocked by: F2 · Done: 2026-06-23 (PR #7 stack)
 
 **What to build:** The single `callModel()` entry point (ADR-0004). Records named model
 task, prompt/version name, usage, and errors to a `model_calls` table. Returns a real
 provider response.
 
 **Acceptance criteria:**
-- [ ] All model calls in the codebase go through the gateway (lint/grep check)
-- [ ] A call writes a `model_calls` row with task name, prompt/version, tokens, status
-- [ ] Provider error is captured, not thrown raw, and recorded
+- [x] All model calls in the codebase go through the gateway (lint/grep check)
+- [x] A call writes a `model_calls` row with task name, prompt/version, tokens, status
+- [x] Provider error is captured, not thrown raw, and recorded
 
 **Tasks:**
-- [ ] F3.1 `model_calls` migration (task name, prompt/version, usage, status, error) (~1h) · AFK
-- [ ] F3.2 `callModel()` with named tasks + prompt/version naming (~1.5h) · AFK
-- [ ] F3.3 Structured-output parse helper + error capture + usage counters (~1.5h) · AFK
+- [x] F3.1 `model_calls` migration (task name, prompt/version, usage, status, error) (~1h) · AFK
+- [x] F3.2 `callModel()` with named tasks + prompt/version naming (~1.5h) · AFK
+- [x] F3.3 Structured-output parse helper + error capture + usage counters (~1.5h) · AFK
 
 ## F4 — Run Ledger spine
-Type: AFK · Blocked by: F2
+Type: AFK · Blocked by: F2 · Done: 2026-06-23 (PR #7 stack)
 
 **What to build:** The Run Ledger tables and write path (ADR-0002): `runs`,
 `run_steps`, `tool_calls`, plus linkage to `model_calls`. A run inspector view renders
 the trace for one run.
 
 **Acceptance criteria:**
-- [ ] Starting a run creates a `runs` row; each step/tool/model call is recorded
-- [ ] Final run status (success/error) is persisted
-- [ ] Run inspector renders the full trace (steps, tool calls, model calls, usage) for a run id
+- [x] Starting a run creates a `runs` row; each step/tool/model call is recorded
+- [x] Final run status (success/error) is persisted
+- [x] Run inspector renders the full trace (steps, tool calls, model calls, usage) for a run id (`/runs/[id]`, gated by `SOURCECADO_ENABLE_RUN_INSPECTOR`)
 
 **Tasks:**
-- [ ] F4.1 `runs` + `run_steps` + `tool_calls` migrations (~1.5h) · AFK
-- [ ] F4.2 Run create + step/tool/model logging write path (~1.5h) · AFK
-- [ ] F4.3 Run status + error capture on the run (~1h) · AFK
-- [ ] F4.4 Run inspector view (read-only trace render) (~1.5h) · AFK (build with src/components/ui primitives)
+- [x] F4.1 `runs` + `run_steps` + `tool_calls` migrations (~1.5h) · AFK
+- [x] F4.2 Run create + step/tool/model logging write path (~1.5h) · AFK
+- [x] F4.3 Run status + error capture on the run (~1h) · AFK
+- [x] F4.4 Run inspector view (read-only trace render) (~1.5h) · AFK (build with src/components/ui primitives)
 
 ## F5 — Agent Harness ReAct loop
 Type: AFK · Blocked by: F3, F4 · Done: 2026-06-23
@@ -178,118 +178,135 @@ Ledger, and you can inspect it. Nothing sourcing-specific yet — the spine work
 Port the existing SQLite memory brain (`src/`) into the hosted app and expose it through
 Research Chat. **Highest-risk reuse in the project** — isolated here with a parity test.
 
+> **Status: core delivered (2026-06-25).** Implemented per the reframed design
+> `docs/superpowers/specs/2026-06-25-feature-a-cited-memory-answer-design.md` on branch
+> `feat/a-memory-impl` → **PR #8**. Principal-reviewed (merge risk LOW), 258 tests pass,
+> proven live on 3 complex queries (claude-sonnet-4-6). **Reframe vs this breakdown:** the
+> A3 parity-test gate was **cut** (decision #6 — build/run/validate instead) and the model
+> now synthesizes the prose (no `answer.ts` prose port); the in-app import UI (A4) and the
+> memory-management page (A7.2) are **deferred** to later UI slices — the CLI `npm run
+> ingest`/`refresh` and the `add_memory_note` tool cover those paths for now.
+
 ## A1 — Memory schema + ingest ported to Postgres/pgvector
-Type: AFK · Blocked by: F2
+Type: AFK · Blocked by: F2 · Done: 2026-06-25 (PR #8)
 
 **What to build:** Port `source_records` and `memory_chunks` to Postgres with a pgvector
 embedding column, plus the ingest + chunking path from `src/ingest.ts` / `src/chunk.ts`.
 Carry ADR-0001 permission metadata at the source and chunk level.
 
 **Acceptance criteria:**
-- [ ] Source records and chunks persist in Postgres with permission/source metadata
-- [ ] Ingesting a sample file produces chunks with citations
-- [ ] Embedding column is pgvector, not a text blob
+- [x] Source records and chunks persist in Postgres with permission/source metadata (migration `002_memory.sql` + `source_permissions`)
+- [x] Ingesting a sample file produces chunks with citations (`sourceId#chunk-N` / `#row-N`)
+- [x] Embedding column is pgvector, not a text blob (`vector(1536)` + hnsw cosine index)
 
 **Tasks:**
-- [ ] A1.1 `source_records` + `memory_chunks` migration with pgvector + permission cols (~1.5h) · AFK
-- [ ] A1.2 Port ingest (source record creation, content hashing, dedupe) (~2h) · AFK
-- [ ] A1.3 Port chunking + citation construction (~1.5h) · AFK
+- [x] A1.1 `source_records` + `memory_chunks` migration with pgvector + permission cols (~1.5h) · AFK
+- [x] A1.2 Port ingest (source record creation, content hashing, dedupe) (~2h) · AFK — `src/lib/memory/ingest.ts` + `scripts/ingest.ts`
+- [x] A1.3 Port chunking + citation construction (~1.5h) · AFK — `src/lib/memory/chunk.ts`
 
 ## A2 — Embeddings + cited retrieval ported
-Type: AFK · Blocked by: A1
+Type: AFK · Blocked by: A1 · Done: 2026-06-25 (PR #8)
 
 **What to build:** Replace the in-process text-blob cosine (`src/embeddings.ts`) with
 pgvector similarity search, and port the cited-retrieval path. Permission filter applies
 before retrieval (ADR-0001).
 
 **Acceptance criteria:**
-- [ ] Retrieval uses pgvector similarity, filtered by the caller's allowed sources
-- [ ] Retrieved chunks carry citations
-- [ ] A restricted source never surfaces to a caller without access
+- [x] Retrieval uses pgvector similarity, filtered by the caller's allowed sources (cosine gated by lexical, permission filter in SQL WHERE)
+- [x] Retrieved chunks carry citations
+- [x] A restricted source never surfaces to a caller without access (proven by test)
 
 **Tasks:**
-- [ ] A2.1 Embedding generation through the Model Gateway → pgvector column (~2h) · AFK
-- [ ] A2.2 pgvector similarity query with pre-retrieval permission filter (~2h) · AFK
+- [x] A2.1 Embedding generation through the Model Gateway → pgvector column (~2h) · AFK — `src/lib/memory/embed.ts` (pluggable 1536-dim, gateway or hash fallback)
+- [x] A2.2 pgvector similarity query with pre-retrieval permission filter (~2h) · AFK — `src/lib/memory/retrieve.ts` + `permissions.ts`
 
-## A3 — Answer logic ported with parity test
-Type: HITL · Blocked by: A2
+## A3 — Answer logic ported — REFRAMED (parity gate cut)
+Type: ~~HITL~~ AFK · Blocked by: A2 · Done: 2026-06-25 (PR #8)
 
 **What to build:** Port the intent classification + accepted/gap fact logic from
-`src/answer.ts` (420 LOC). Gate the port behind a **parity test** that runs the same
-question set against the old SQLite engine and the new Postgres engine and compares
-answers. HITL because a human signs off on acceptable parity deltas.
+`src/answer.ts` (420 LOC). ~~Gate the port behind a parity test.~~ **Reframed (2026-06-25
+spec, decision #6):** port the retrieval/ranking/fact-lifecycle behind `search_memory` and
+let the **model synthesize** the prose (the deterministic `answer.ts` templates are the one
+part NOT ported). **No parity harness/gate** — build, run on real data, validate. A
+deterministic citation post-check replaces the prose-parity concern.
 
 **Acceptance criteria:**
-- [ ] Cited Sourcing Memory Answer produced from Postgres with intent + gaps
-- [ ] Parity test compares SQLite vs Postgres answers on a fixed question set
-- [ ] Human-reviewed parity report: deltas are explained and accepted
+- [x] Cited Sourcing Memory Answer produced from Postgres with intent + gaps (model writes Answer/Evidence/Gaps/Next-Action from the tool bundle)
+- [x] ~~Parity test compares SQLite vs Postgres answers~~ → **cut**; replaced by a citation post-check (cited ids must exist in the tool result) + live validation on 3 complex queries
+- [x] ~~Human-reviewed parity report~~ → **cut** (no parity gate); principal review covered correctness instead
 
 **Tasks:**
-- [ ] A3.1 Port intent classification + fact selection (~2h) · AFK
-- [ ] A3.2 Port gap-fact handling + no-memory/no-relevant-memory paths (~1.5h) · AFK
-- [ ] A3.3 Parity harness: question set + SQLite-vs-Postgres diff report (~2h) · AFK
-- [ ] A3.4 Parity review gate + log accepted deltas (~1h) · HITL
+- [x] A3.1 Port intent classification + fact selection (~2h) · AFK — `src/lib/memory/rank.ts` (questionIntent/factIntentScore/rankRows) + `retrieve.ts`
+- [x] A3.2 Port gap-fact handling + no-memory/no-relevant-memory paths (~1.5h) · AFK — `gapFacts` in `retrieve.ts` + refuse-on-empty in `MEMORY_INSTRUCTIONS`
+- [x] ~~A3.3 Parity harness~~ — **cut** (decision #6)
+- [x] ~~A3.4 Parity review gate~~ — **cut** (decision #6); citation post-check (`src/lib/memory/citations.ts`) is the deterministic guard
 
-## A4 — File/export memory import path
+## A4 — File/export memory import path — DEFERRED (in-app UI)
 Type: AFK · Blocked by: A1
 
 **What to build:** App-side file/export import (roadmap: ingestion is file/export only).
 Imported sources become source records with citations.
 
+> **Deferred (2026-06-25):** the in-app import UI is out of Feature A's reframed scope. The
+> ingest path itself is done via the CLI (`npm run ingest <dir>`, A1.2) with per-file
+> success/skip reasons; only the app upload endpoint + UI remain for a later UI slice.
+
 **Acceptance criteria:**
-- [ ] A user can import a file/export from the app and see it become source records
-- [ ] Import surfaces per-file success/skip with reasons (no silent skips)
+- [ ] A user can import a file/export from the app and see it become source records (CLI only for now)
+- [x] Import surfaces per-file success/skip with reasons (no silent skips) — done in `ingestFolder`
 
 **Tasks:**
-- [ ] A4.1 Import endpoint + source-record creation from upload (~2h) · AFK
-- [ ] A4.2 Import result UI with per-file status/skip reasons (~1.5h) · AFK (build with src/components/ui primitives)
+- [ ] A4.1 Import endpoint + source-record creation from upload (~2h) · AFK — deferred (CLI ingest exists)
+- [ ] A4.2 Import result UI with per-file status/skip reasons (~1.5h) · AFK — deferred
 
 ## A5 — search_memory tool
-Type: AFK · Blocked by: A2, F5
+Type: AFK · Blocked by: A2, F5 · Done: 2026-06-25 (PR #8)
 
 **What to build:** A `search_memory` tool (class `read`) that wraps cited retrieval and
 plugs into the harness registry, replacing the echo tool for memory questions.
 
 **Acceptance criteria:**
-- [ ] `search_memory` returns cited chunks/facts to the loop
-- [ ] Tool call + result recorded in the Run Ledger
+- [x] `search_memory` returns cited chunks/facts to the loop (`{intent, acceptedFacts, gapFacts, chunks}`)
+- [x] Tool call + result recorded in the Run Ledger
 
 **Tasks:**
-- [ ] A5.1 `search_memory` tool wrapping retrieval + register it (~1.5h) · AFK
+- [x] A5.1 `search_memory` tool wrapping retrieval + register it (~1.5h) · AFK — `src/lib/tools/search-memory.ts` + `memoryRegistry()`
 
 ## A6 — Research Chat answers from memory
-Type: HITL · Blocked by: A3, A5, F1
+Type: HITL · Blocked by: A3, A5, F1 · Core done: 2026-06-25 (PR #8); design review pending
 
 **What to build:** Minimal Research Chat UI that triggers an agent run, shows run
 status/result inline, and renders the cited answer with gaps. HITL for one chat-layout
 design review.
 
 **Acceptance criteria:**
-- [ ] A Sourcing Director asks a question and gets a cited answer in chat
-- [ ] Run status shows while the run executes; result renders with citations + gaps
-- [ ] A link opens the run inspector for that answer
+- [x] A Sourcing Director asks a question and gets a cited answer in chat (reused `/chat` + memory run config; verified live)
+- [x] Run status shows while the run executes; result renders with citations + gaps
+- [x] A link opens the run inspector for that answer (`/runs/[id]`)
 
 **Tasks:**
-- [ ] A6.1 Research Chat UI: message list + input + run trigger (~2h) · AFK (build with src/components/ui primitives)
-- [ ] A6.2 Inline run status + cited answer + gaps render (~1.5h) · AFK
-- [ ] A6.3 Verify Research Chat matches DESIGN.md + uses src/components/ui primitives (~1h) · HITL
+- [x] A6.1 Research Chat UI: message list + input + run trigger (~2h) · AFK — reused the F5 `/chat` (ChatClient) against the memory config
+- [x] A6.2 Inline run status + cited answer + gaps render (~1.5h) · AFK — 4-section answer + `invalidCitations` from `/api/agent`
+- [ ] A6.3 Verify Research Chat matches DESIGN.md + uses src/components/ui primitives (~1h) · HITL — **pending** (design review not yet done)
 
 ## A7 — Memory management page (add/correct)
-Type: AFK · Blocked by: A3
+Type: AFK · Blocked by: A3 · A7.1 done: 2026-06-25 (PR #8); A7.2 page deferred
 
 **What to build:** Memory management page to add a memory note and correct existing
 memory (the memory-correction path from `src/`).
 
 **Acceptance criteria:**
-- [ ] A user can add a memory note from the app; it becomes retrievable
-- [ ] A user can correct memory; corrections affect future answers
+- [x] A user can add a memory note; it becomes retrievable (`add_memory_note` tool — immediately searchable)
+- [x] A user can correct memory; corrections affect future answers (superseding note, no destructive edit)
+- [ ] …from a dedicated **app page** — deferred (tool exists; management UI is a later slice)
 
 **Tasks:**
-- [ ] A7.1 `add_memory_note` tool + write path (~1.5h) · AFK
-- [ ] A7.2 Memory management page: list + add + correct (~2h) · AFK (build with src/components/ui primitives)
+- [x] A7.1 `add_memory_note` tool + write path (~1.5h) · AFK — `src/lib/tools/add-memory-note.ts` + `src/lib/memory/notes.ts`
+- [ ] A7.2 Memory management page: list + add + correct (~2h) · AFK — **deferred** to a later UI slice
 
-**FEATURE A DEMO:** import sourcing notes, ask a question in chat, get a cited answer
-with gaps, inspect the run, and correct memory.
+**FEATURE A DEMO:** ~~import sourcing notes~~ (CLI `npm run ingest`), ask a question in chat,
+get a cited answer with gaps, inspect the run, and correct memory (`add_memory_note`). ✅
+Demonstrated live 2026-06-25 on 3 complex queries.
 
 ---
 

--- a/docs/superpowers/specs/2026-06-25-feature-a-cited-memory-answer-design.md
+++ b/docs/superpowers/specs/2026-06-25-feature-a-cited-memory-answer-design.md
@@ -1,272 +1,244 @@
-# Feature A (reframed) — Cited Sourcing Memory Answer: Design
+# Feature A — Cited Sourcing Memory Answer: Design
 
-Date: 2026-06-25
+Date: 2026-06-25 (revised after a grill-me reconciliation of the Claude Code
+architecture with our local memory brain)
 Status: Approved for implementation
-Feature: A (Cited Sourcing Memory Answer) from
-`docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md`
-Blocked by: F2 (Postgres+pgvector), F3 (gateway embeddings), F5 (agent harness) — F5 in
-review on PR #7.
-Branch: `feat/a-cited-memory-answer` (off `feat/f5-agent-harness`; rebase onto `main`
-after F5 merges).
+Feature: A from `docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md`
+Blocked by: F2 (Postgres+pgvector), F3 (gateway embeddings), F5 (agent harness) — F5 on PR #7.
+Branch: `feat/a-cited-memory-answer` (off `feat/f5-agent-harness`; rebase onto `main` after F5 merges).
 
 ## Purpose
 
-Let a Sourcing Director ask a question in chat and get a **cited answer with knowledge
-gaps**, synthesized from imported sourcing notes held in Postgres/pgvector. This is the
-first tier-1 measurable outcome: an answer a director can verify against sources, fully
-traced in the Run Ledger.
+A Sourcing Director asks a question in chat and gets a **cited answer with knowledge
+gaps**, synthesized from imported sourcing notes in Postgres/pgvector — the first tier-1
+measurable outcome, fully traced in the Run Ledger.
 
-## The reframe (why this differs from the original A1–A7 plan)
+## The reconciliation (the core architectural decision)
 
-The original plan ported the legacy SQLite engine (`src/answer.ts`, ~420 LOC of regex
-intent classification + deterministic synthesis) and gated it behind a strict
-SQLite-vs-Postgres parity test, including the semantic fact graph
-(`entities`/`relationships`/`semantic_facts`/`extraction_runs`).
+We have a **mature local memory brain** (SQLite): chunking, embeddings, hybrid retrieval
+(cosine gated by lexical), intent-aware fact ranking, and a `semantic_facts` lifecycle
+(accepted / candidate / conflicted / stale) fed by an extraction pipeline with caching,
+confidence-based acceptance, and conflict/staleness detection. **Claude Code** teaches a
+different lesson: the agent reasons, tools fetch context on demand, and grounding lives in
+tool results in the transcript — synthesis is the model's job, not a deterministic
+template.
 
-A systematic read of the Claude Code production agent (leaked source) plus the internal
-fact that we just built the F5 harness reshaped this:
+These reconcile cleanly by **splitting the brain at the synthesis seam**:
 
-- **Claude Code grounds answers via agent-callable search tools + tool results in the
-  transcript, not a precomputed RAG monolith** (`memdir/findRelevantMemories.ts`,
-  `query.ts` tool_result handling). It has no `answer.ts`-style retrieve-and-synthesize
-  function.
-- Porting `answer.ts` as-is would create a non-agentic path that **bypasses the F5
-  harness** — incoherent with what we just shipped.
+- The mature engine becomes the **retrieval + ranking + fact-lifecycle layer behind one
+  tool** (`search_memory`). Nothing valuable is thrown away.
+- The **model becomes the synthesizer** — it writes the cited answer from the tool's
+  structured result. The deterministic prose templates (`answerLines`, `gapLines`, …) are
+  the *only* part not ported; the model replaces them.
 
-Therefore Feature A is reframed:
+This keeps 100% of the retrieval/ranking/fact engineering, makes the F5 loop meaningful,
+and grounds answers in tool results exactly as Claude Code does.
 
-1. **Memory is a tool the agent calls** (`search_memory`), not a monolithic function.
-2. **The model synthesizes the cited answer** (intent, gaps, refusal) from retrieved
-   chunks — `answer.ts`'s deterministic synthesis is NOT ported.
-3. **pgvector retrieval is kept** — semantic recall over notes is our legitimate
-   difference from Claude Code's grep-over-code (it greps exact strings; we need
-   semantic recall over prose).
-4. **Strict parity → an answer eval.** Non-deterministic synthesis can't be diffed
-   against the old engine; instead we assert structural properties (every claim cites a
-   retrieved chunk, gaps surface, refusal on empty, no permission leak).
-5. **The semantic fact graph is deferred** — answer from retrieved chunks; "knowledge
-   gaps" are agent-identified from retrieval coverage.
-6. **Memory add/correct is folded into A** so the learn-loop is closeable from the first
-   feature (Claude Code wires feedback early, not as an end-stage add-on).
+## Decisions (locked during brainstorming + grill-me)
 
-## Decisions (locked during brainstorming)
+1. **Brain↔agent boundary (B):** the brain is exposed as tools that return *structured*
+   results; the model synthesizes prose. Not an opaque "answer" tool, not raw primitives.
+2. **One bundled tool:** `search_memory(query, limit?)` returns
+   `{ intent, acceptedFacts[], gapFacts[], chunks[] }` — it runs `questionIntent` +
+   `loadFacts` + `loadGapFacts` + `retrieveRelevantChunks` internally (intent classified
+   inside the tool). Plus `add_memory_note` (class `write_internal`) for writes.
+3. **Fact model scope:** port `semantic_facts` + its full lifecycle + extraction. **Defer**
+   `entities` / `relationships` / `entity_aliases` — the answer path never reads them
+   (verified: `answer.ts` reads only `source_records`, `memory_chunks`, `semantic_facts`).
+4. **Extraction:** faithful **two-phase batch** — `npm run ingest` then `npm run refresh`.
+   Port `extraction_runs` caching; the LLM extractor routes through the gateway (Anthropic).
+   The extractor needs a **concrete candidate Zod schema** (not `z.array(z.unknown())`) so
+   Anthropic structured output populates it (the `args:{}` lesson from F5).
+5. **Synthesis contract:** the memory-run system prompt requires the **four-section format**
+   (Answer / Evidence / Gaps / Next Action), **strict citation grounding** (cite only
+   citation ids present in the tool result; never invent), **fact-first / chunk-fallback**,
+   **always surface gaps**, **refuse on empty** ("no relevant memory" / "no indexed memory
+   yet"). A cheap deterministic **post-check** drops/flags any cited id not in the tool
+   result.
+6. **No parity gate.** We build the ported system, test the mechanical pieces, run it on
+   real data, and ship if it works. No SQLite-vs-Postgres parity harness, no elaborate eval.
+7. **Embeddings = pgvector(1536), pluggable provider.** Real OpenAI `text-embedding-3-small`
+   when `OPENAI_API_KEY` is set, else a deterministic 1536-dim hash fallback. Same column;
+   set the key later to upgrade with no migration.
+8. **Permissions (ADR-0001) = carry + filter, single default actor for v1.** Build the
+   `source_permissions` column and filter-before-retrieval in SQL; seed one default actor
+   with read on all imported sources. Multi-user management UI deferred.
 
-- **Scope = the cited-answer core**: ingest + pgvector retrieval + `search_memory` tool +
-  agentic answer in chat + memory add/correct. Import UI (A4.2) and the fact graph are
-  out.
-- **Embeddings = pgvector(1536) with a pluggable provider.** The column is `vector(1536)`.
-  Generation goes through the Model Gateway: real OpenAI `text-embedding-3-small` when
-  `OPENAI_API_KEY` is set, else a deterministic 1536-dim hash fallback (offline,
-  reproducible, weak semantics). Same column either way — setting the key later upgrades
-  to real semantic search with no migration.
-- **Permissions (ADR-0001) = carry + filter, single default actor for v1.** The
-  `source_permissions` column and filter-before-retrieval in SQL are built; a default
-  actor seeded with read access to all imported sources. Multi-user permission
-  management UI is deferred.
-- **Ingestion = CLI for v1.** `npm run ingest <dir>` ports the legacy `ingestFolder` to
-  Postgres. In-app upload UI deferred to A4.
-- **Synthesis is agentic.** No port of `answer.ts`; the run's system prompt instructs the
-  model to answer only from retrieved chunks, cite every claim, list gaps, and refuse
-  when retrieval is empty.
+### What we port vs. don't
+
+- **Port:** `chunk` (chunkText/chunkCsv + citations), `ingest` (sources+chunks+embeddings,
+  dedup), `embed`→pgvector, `refresh`→`semantic_facts` lifecycle (extraction cache,
+  confidence accept at 0.75, `markConflictsAndStaleFacts`, `restoreStaleFacts`), retrieval
+  (`retrieveRelevantChunks` hybrid cosine∧lexical) + ranking (`rankRows`, `factIntentScore`,
+  `questionIntent`, `loadFacts`, `loadGapFacts`).
+- **Don't port:** deterministic prose templates (model synthesizes), `entities`/
+  `relationships`/`entity_aliases` graph (unread by the answer), parity harness.
+- **Reuse:** `src/extractors/{llm,csv}.ts` (already gateway-routed), `src/lib/harness.ts`
+  (+ `instructions` param), gateway, ledger, `/chat`, `/runs/[id]`.
 
 ## Module structure
 
-Greenfield unless marked. The legacy `src/` SQLite engine is kept untouched as the eval
-oracle and chunk/heuristic reference.
-
 ```
-src/lib/memory/schema.ts        SourceRecord, MemoryChunk, RetrievedChunk types
-src/lib/memory/embed.ts         embedText(text): Promise<number[]> — gateway or hash fallback
-src/lib/memory/chunk.ts         port of legacy chunkText/chunkCsv + citation construction
-src/lib/memory/ingest.ts        ingestFolder -> Postgres (source_records + memory_chunks)
-src/lib/memory/retrieve.ts      searchMemory() — pgvector cosine + pre-retrieval permission filter
-src/lib/memory/notes.ts         addMemoryNote() write path
+src/lib/memory/chunk.ts        port chunkText/chunkCsv + citationForChunk
+src/lib/memory/embed.ts        embedText(): pgvector(1536), gateway-or-hash fallback
+src/lib/memory/ingest.ts       ingestFolder -> source_records + memory_chunks
+src/lib/memory/extract.ts      refresh.ts port -> semantic_facts (cache, accept, conflict/stale)
+src/lib/memory/retrieve.ts     searchMemory() -> { intent, acceptedFacts, gapFacts, chunks }
+src/lib/memory/notes.ts        addMemoryNote() write/correct path
+src/lib/memory/answer-config.ts MEMORY_INSTRUCTIONS + memoryRegistry()
 src/lib/tools/search-memory.ts  search_memory tool (class read)
 src/lib/tools/add-memory-note.ts add_memory_note tool (class write_internal)
-src/lib/memory/answer-config.ts the memory-run system prompt + allowed tool set
-src/migrations/003_memory.sql   source_records + memory_chunks + source_permissions
-scripts/ingest.ts               CLI entry: npm run ingest <dir>
-REUSE: src/lib/model-gateway.ts (callModel embed), src/lib/harness.ts (runAgent),
-       src/lib/ledger.ts, src/app/chat (ChatClient), src/app/runs/[id]
+src/migrations/003_memory.sql   source_records, memory_chunks, semantic_facts, extraction_runs, source_permissions
+scripts/ingest.ts               npm run ingest <dir>
+scripts/refresh.ts              npm run refresh
 ```
 
 ## Components
 
 ### Schema (migration 003)
 
-```sql
-CREATE TABLE source_records (
-  id            BIGSERIAL PRIMARY KEY,
-  source_id     TEXT NOT NULL UNIQUE,           -- deterministic slug
-  path          TEXT,
-  title         TEXT NOT NULL,
-  source_type   TEXT NOT NULL,                  -- markdown | text | csv | email
-  content_hash  TEXT NOT NULL,                  -- sha256(raw_text), dedupe key
-  raw_text      TEXT NOT NULL,
-  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
-  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
-);
-
-CREATE TABLE memory_chunks (
-  id               BIGSERIAL PRIMARY KEY,
-  source_record_id BIGINT NOT NULL REFERENCES source_records(id) ON DELETE CASCADE,
-  chunk_index      INTEGER NOT NULL,
-  text             TEXT NOT NULL,
-  chunk_hash       TEXT NOT NULL,
-  embedding        vector(1536),                -- pgvector; pluggable provider
-  citation         TEXT NOT NULL,               -- source-id#chunk-N / #row-N
-  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
-  UNIQUE (source_record_id, chunk_index)
-);
-CREATE INDEX memory_chunks_embedding_idx ON memory_chunks
-  USING hnsw (embedding vector_cosine_ops);
-
-CREATE TABLE source_permissions (
-  id             BIGSERIAL PRIMARY KEY,
-  principal_type TEXT NOT NULL,                 -- user | oauth_client | test_client
-  principal_id   TEXT NOT NULL,
-  source_id      TEXT NOT NULL,
-  access         TEXT NOT NULL DEFAULT 'read',
-  created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
-  UNIQUE (principal_type, principal_id, source_id)
-);
-```
+- `source_records`: id, source_id (unique slug), path, title, source_type, content_hash,
+  raw_text, timestamps.
+- `memory_chunks`: id, source_record_id FK CASCADE, chunk_index, text, chunk_hash,
+  `embedding vector(1536)`, citation, timestamps; UNIQUE(source_record_id, chunk_index);
+  hnsw cosine index.
+- `semantic_facts`: id, subject, predicate, object, source_record_id FK, source_chunk_id FK,
+  confidence REAL, status TEXT CHECK in ('candidate','accepted','conflicted','stale'),
+  created_at; index on (source_record_id, status).
+- `extraction_runs`: id, source_chunk_id FK, cache_key UNIQUE, chunk_hash, extractor_type,
+  extractor_version, prompt_hash, schema_version, model_name, raw_output,
+  parsed_candidates_json, status, error, created_at.
+- `source_permissions`: principal_type, principal_id, source_id, access, UNIQUE(triple).
 
 ### Embeddings (`embed.ts`)
 
-`embedText(text: string): Promise<number[]>` returns a length-1536 vector.
-- If `process.env.OPENAI_API_KEY?.trim()`: `callModel({ kind: "embed",
-  model: "text-embedding-3-small" })` (logged in `model_calls`).
-- Else: deterministic hash — tokenize, sha256 each token, index mod 1536, increment,
-  L2-normalize (the legacy 64-dim approach widened to 1536). No network, reproducible.
-A `usesRealEmbeddings(): boolean` helper surfaces which path is active (for the import
-report and tests).
+`embedText(text): Promise<number[1536]>`. `OPENAI_API_KEY` set → `callModel({kind:"embed",
+model:"text-embedding-3-small"})` (logged in `model_calls`); else deterministic hash into
+1536 dims (legacy approach widened), L2-normalized, offline, reproducible.
+`usesRealEmbeddings()` surfaces the active path.
 
 ### Ingestion (`ingest.ts` + `scripts/ingest.ts`)
 
-Port of `src/ingest.ts`: walk supported files (.md/.txt/.csv/.eml) → `chunk` →
-`embedText` each chunk → upsert `source_records` (preserve source_id on conflict, dedupe
-by content_hash) → replace `memory_chunks` with citations
-(`citationForChunk` → `source-id#chunk-N`, 1-indexed; CSV → `#row-N`). Returns
-`{ processed, skipped, skippedFiles[] }` with per-file reasons (no silent skips). Seeds
-the default actor's `source_permissions` for every ingested source.
+Port `ingestFolder`: walk .md/.txt/.csv/.eml → `chunk` → `embedText` per chunk → upsert
+`source_records` (dedup by content_hash, preserve source_id) → replace `memory_chunks` with
+citations (`source-id#chunk-N`, CSV `#row-N`, 1-indexed). Per-file skip reasons reported; no
+orphan rows; seed default-actor `source_permissions` per source.
 
-### Retrieval (`retrieve.ts`) — ADR-0001 enforced
+### Extraction (`extract.ts` + `scripts/refresh.ts`)
 
-```ts
-searchMemory(db, {
-  query: string;
-  actor: { principalType: string; principalId: string };
-  limit?: number;            // default 6
-}): Promise<RetrievedChunk[]>   // { text, citation, sourceId, score }
-```
-1. Resolve the actor's allowed `source_id`s from `source_permissions` (default-deny).
-2. Embed the query via `embedText`.
-3. **Single SQL query** that filters to allowed sources in the WHERE clause AND ranks by
-   `embedding <=> $queryVec` (cosine). Permission filter is applied before ranking — a
-   restricted source can never surface even if it would rank higher.
-4. Return top-K chunks with citations. Empty allowed-set → empty result (not an error).
+Port `refreshMemory` for `semantic_facts` only: load chunks → per chunk run extractor
+(`createCsvExtractor` for csv, else `createLlmExtractor` via gateway) → cache by `cache_key`
+in `extraction_runs` (reuse on hit) → rebuild `semantic_facts` from `semantic_fact`
+candidates (confidence ≥ 0.75 → `accepted`, else `candidate`; dedup) → `restoreStaleFacts`
+(prior accepted facts that vanish become `stale`) → `markConflictsAndStaleFacts`
+(same subject+predicate, >1 distinct object → `conflicted`; orphaned chunk → `stale`).
+Entity/relationship candidate kinds are ignored in v1. The LLM extractor gets a concrete
+candidate Zod schema so Anthropic structured output populates it.
+
+### Retrieval (`retrieve.ts`) — the bundled tool's engine, ADR-0001 enforced
+
+`searchMemory(db, { query, actor, limit? })` → `{ intent, acceptedFacts, gapFacts, chunks }`:
+1. `intent = questionIntent(query)` (ported regex classifier).
+2. Resolve actor's allowed source_ids (default-deny).
+3. `acceptedFacts` = `loadFacts` (semantic_facts status='accepted', permission-filtered in
+   SQL, ranked by `rankRows`/`factIntentScore`, ≤6).
+4. `gapFacts` = `loadGapFacts` (candidate/conflicted/stale, ≤6).
+5. `chunks` = `retrieveRelevantChunks` — pgvector cosine **gated by lexical match**,
+   permission-filtered, top-3, each with citation.
+Permission filter is applied in the SQL WHERE before ranking — a restricted source never
+surfaces even if it would rank higher.
 
 ### `search_memory` tool + agentic answer
 
-- `search_memory` (class `read`): `argsSchema { query: string, limit?: number }`;
-  `execute` calls `searchMemory` with the run's actor and returns
-  `{ chunks: [{ citation, text, sourceId }] }`. Recorded as a tool_call in the ledger.
-- **Harness change:** `RunAgentInput` gains an optional `instructions?: string`.
-  `buildAgentSystemPrompt(tools, instructions?)` appends it after the tool catalog, so a
-  run can carry task guidance without forking the harness. The echo run passes nothing
-  (unchanged behavior); the memory run passes the memory instructions below.
-- `answer-config.ts` exports `MEMORY_INSTRUCTIONS` — *"Answer only from search_memory
-  results. Cite every claim with its citation id in brackets. If retrieved coverage is
-  thin or conflicting, list it under Knowledge Gaps. If search_memory returns nothing,
-  say there is no relevant memory. Never invent sources."* — and
-  `memoryRegistry()` = `createToolRegistry([searchMemoryTool])`.
-- **Route:** `/api/agent` runs the memory config by default
-  (`registry: memoryRegistry()`, `allowedClasses: {read}`, `instructions:
-  MEMORY_INSTRUCTIONS`), replacing the echo placeholder. The existing `/chat` renders the
-  cited answer + the run-inspector link unchanged.
+- `search_memory` (class `read`): args `{ query, limit? }` → returns the bundle above;
+  recorded as a tool_call in the ledger.
+- `answer-config.ts`: `MEMORY_INSTRUCTIONS` (the Q5 contract) + `memoryRegistry()` =
+  `createToolRegistry([searchMemoryTool])`.
+- **Harness change:** `RunAgentInput` gains optional `instructions?: string`;
+  `buildAgentSystemPrompt(tools, instructions?)` appends it. Echo run unchanged; memory run
+  passes `MEMORY_INSTRUCTIONS`.
+- **Route:** `/api/agent` runs the memory config by default (`memoryRegistry()`,
+  `allowedClasses:{read}`, `instructions: MEMORY_INSTRUCTIONS`), replacing the echo
+  placeholder. Existing `/chat` + `/runs/[id]` render unchanged. A post-check drops any
+  cited id not present in the tool result.
 
-### Memory add/correct (`notes.ts` + `add_memory_note` tool)
+### Memory add/correct (`notes.ts` + `add_memory_note`)
 
-`addMemoryNote(db, { title, text, actor })` writes a `source_record` (source_type
-`note`) + chunk(s) (embedded, cited), grants the actor read, and returns the source_id —
-immediately retrievable. **Correction = add a superseding note** (no destructive edit in
-v1). Exposed as `add_memory_note` tool (class `write_internal`) so an agent run can write
-back, and callable directly from a future memory page.
+`addMemoryNote(db, { title, text, actor })` writes a `source_record` (type `note`) + chunk(s)
+(embedded, cited), grants the actor read, returns source_id — retrievable immediately.
+Correction = add a superseding note (no destructive edit in v1). Exposed as `add_memory_note`
+(class `write_internal`).
 
 ## Data flow
 
 ```
-npm run ingest ./notes
-  -> ingestFolder -> per file: chunk -> embedText -> source_records + memory_chunks (+perms)
+npm run ingest ./notes -> source_records + memory_chunks (+embeddings, +perms)
+npm run refresh         -> extractor per chunk (cached) -> semantic_facts (accept/conflict/stale)
 
-POST /api/agent { question }   (memory run config)
-  -> runAgent(allowed={read}, tools={search_memory})
-       loop: callModel(generate_object decision)
-         -> search_memory(query) -> retrieve.searchMemory (permission-filtered pgvector)
-              -> cited chunks back into the loop (tool_call logged)
-         -> model writes final cited answer + gaps
+POST /api/agent { question }   (memory config)
+  -> runAgent(allowed={read}, tools={search_memory}, instructions=MEMORY_INSTRUCTIONS)
+       loop: callModel(decision)
+         -> search_memory(query) -> retrieve.searchMemory (permission-filtered)
+              -> { intent, acceptedFacts, gapFacts, chunks } back into the loop (logged)
+         -> model writes the 4-section cited answer; post-check validates citations
   -> { runId, answer }
-GET /runs/[id] -> existing inspector renders the trace (search_memory tool calls + answer)
+GET /runs/[id] -> existing inspector renders the trace
 ```
 
 ## Error handling
 
-- Empty allowed-set or no matching chunks → the tool returns an empty result; the model
-  answers "no relevant memory" (not a run failure).
-- Embedding provider error (real path) → surfaces as a `ModelGatewayError`; the run fails
-  and is inspectable (consistent with F5).
-- Ingest per-file failures → recorded with a reason and reported; never silently skipped;
-  never leaves orphan source/chunk rows.
+- Empty allowed-set / no matches → tool returns empty bundle → model answers
+  "no relevant memory" (not a failure).
+- Embedding provider error (real path) → `ModelGatewayError`, run fails, inspectable.
+- Extraction per-chunk failure → recorded in `extraction_runs` with status='failed'; refresh
+  continues; reported in the run summary.
+- Ingest per-file failure → reason recorded, reported, no orphan rows, no silent skips.
 
-## Testing
+## Testing (lean — no parity, no elaborate eval)
 
-Live Postgres, same harness as F3/F4/F5. Reset tables + run migrations in `beforeEach`.
-
-- `tests/memory-ingest.test.ts`: ingest writes source_records + chunks with citations and
-  a 1536-dim embedding; CSV → `#row-N`; per-file skip reasons; no orphan rows.
-- `tests/memory-embed.test.ts`: hash fallback is deterministic and length-1536, L2-norm ~1;
-  `usesRealEmbeddings()` reflects env.
-- `tests/memory-retrieve.test.ts`: pgvector ranking returns cited chunks; **a restricted
-  source never surfaces even when it lexically/semantically matches** (ported from
-  `read-service.test.ts`); empty allowed-set → empty.
-- `tests/search-memory-tool.test.ts`: tool returns cited chunks and logs a tool_call.
-- `tests/memory-answer-eval.test.ts` (the parity replacement): seed corpus + fixed
-  question set, mock provider returning canned cited answers; assert structural
-  properties — every cited id exists in the retrieved set, gaps surface on thin coverage,
-  "no relevant memory" on empty, restricted content never leaks. A separate opt-in live
-  run (real Anthropic) is manual, not in CI.
-- The legacy SQLite suite (`tests/answer.test.ts`, `read-service.test.ts`, etc.) stays
-  green, untouched, as the reference oracle.
+Live Postgres, reset + migrate in `beforeEach`, mock provider where a model is involved.
+- `memory-ingest`: writes records/chunks with citations + 1536-dim embedding; CSV `#row-N`;
+  dedup by content_hash; per-file skip reasons; no orphans.
+- `memory-embed`: hash fallback deterministic, length-1536, L2-norm ~1; `usesRealEmbeddings()`.
+- `memory-extract`: extraction populates `semantic_facts` (accept vs candidate at 0.75);
+  conflict detection (same subject+predicate, 2 objects → conflicted); stale on orphaned
+  chunk; cache reuse on unchanged chunk.
+- `memory-retrieve`: bundle shape; permission filter — **restricted source never surfaces**
+  even when it lexically/semantically matches; empty allowed-set → empty.
+- `search-memory-tool`: returns the bundle, logs a tool_call.
+- `memory-answer`: with a mock provider returning a canned cited answer, assert the
+  post-check passes valid citations and flags an invented one; refuse-on-empty path.
+Real-run validation (ingest a real corpus, ask in `/chat`, eyeball the cited answer) is the
+final check.
 
 ## Deferred (YAGNI)
 
-- Semantic fact graph: `entities`, `relationships`, `semantic_facts`, `extraction_runs`
-  and the LLM extraction pipeline.
-- Multi-user permission management UI.
-- In-app file upload UI (A4.2) — CLI ingest covers v1.
-- Live Drive/Gmail/Notion sync.
+`entities`/`relationships`/`entity_aliases` graph; deterministic prose templates; parity
+harness; multi-user permission UI; in-app upload UI (A4.2); live Drive/Gmail/Notion sync.
 
 ## Acceptance criteria
 
-- [ ] `npm run ingest <dir>` loads notes into Postgres as source_records + memory_chunks
-      with pgvector embeddings and citations; per-file status reported.
-- [ ] `search_memory` returns permission-filtered, cited chunks and logs a tool call.
+- [ ] `npm run ingest <dir>` loads notes as source_records + memory_chunks with pgvector
+      embeddings + citations; per-file status reported.
+- [ ] `npm run refresh` populates `semantic_facts` with accept/candidate split, conflict and
+      stale marking, and reuses cached extractions on unchanged chunks.
+- [ ] `search_memory` returns `{ intent, acceptedFacts, gapFacts, chunks }`,
+      permission-filtered, cited, logged as a tool call.
 - [ ] A restricted source never surfaces to an actor without access (SQL-level filter).
-- [ ] Asking a question in `/chat` runs the harness, calls `search_memory`, and renders a
-      cited answer with knowledge gaps; "no relevant memory" when retrieval is empty.
-- [ ] `add_memory_note` writes a retrievable note; a correction note supersedes prior
-      content in future answers.
-- [ ] The full run (search_memory tool calls, model calls, answer, status) appears in the
-      run inspector.
-- [ ] Answer eval passes on the seed question set; legacy SQLite suite stays green.
+- [ ] Asking in `/chat` runs the harness, calls `search_memory`, and renders a 4-section
+      cited answer with gaps; cited ids are validated against the tool result; "no relevant
+      memory" when empty.
+- [ ] `add_memory_note` writes a retrievable note; a correction note supersedes prior content.
+- [ ] The full run appears in the run inspector.
 
 ## Maps to original plan slices
 
-- A1 (schema+ingest) → migration 003 + `ingest.ts`/`chunk.ts` + CLI.
-- A2 (embeddings + retrieval) → `embed.ts` (pluggable 1536) + `retrieve.ts` (permission-filtered pgvector).
-- A3 (answer + parity) → **reframed**: agentic answer via prompt + answer eval (no `answer.ts` port, no strict parity).
-- A5 (search_memory tool) → `search-memory.ts`, registered into the harness — **the center of A**.
-- A6 (Research Chat from memory) → reuse existing `/chat` + memory run config.
-- A7 (add/correct) → `notes.ts` + `add_memory_note` — **folded into A**.
-- A4 (import UI), fact graph → **deferred**.
+- A1 → migration 003 + `chunk.ts`/`ingest.ts` + `scripts/ingest.ts`.
+- A2 → `embed.ts` (pluggable 1536) + `retrieve.ts` (permission-filtered hybrid pgvector).
+- A3 → **reframed**: faithful port of retrieval/ranking/fact-lifecycle behind `search_memory`
+  + agentic synthesis with citation post-check. No `answer.ts` prose port, **no parity gate**.
+- (extraction) → `extract.ts` + `scripts/refresh.ts` (the `refresh.ts` port; `semantic_facts` only).
+- A5 → `search-memory.ts` registered into the harness — the center of A.
+- A6 → reuse `/chat` + memory run config.
+- A7 → `notes.ts` + `add_memory_note` — folded in.
+- A4 (import UI), entity/relationship graph, prose templates → deferred.

--- a/docs/superpowers/specs/2026-06-25-feature-a-cited-memory-answer-design.md
+++ b/docs/superpowers/specs/2026-06-25-feature-a-cited-memory-answer-design.md
@@ -1,0 +1,272 @@
+# Feature A (reframed) — Cited Sourcing Memory Answer: Design
+
+Date: 2026-06-25
+Status: Approved for implementation
+Feature: A (Cited Sourcing Memory Answer) from
+`docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md`
+Blocked by: F2 (Postgres+pgvector), F3 (gateway embeddings), F5 (agent harness) — F5 in
+review on PR #7.
+Branch: `feat/a-cited-memory-answer` (off `feat/f5-agent-harness`; rebase onto `main`
+after F5 merges).
+
+## Purpose
+
+Let a Sourcing Director ask a question in chat and get a **cited answer with knowledge
+gaps**, synthesized from imported sourcing notes held in Postgres/pgvector. This is the
+first tier-1 measurable outcome: an answer a director can verify against sources, fully
+traced in the Run Ledger.
+
+## The reframe (why this differs from the original A1–A7 plan)
+
+The original plan ported the legacy SQLite engine (`src/answer.ts`, ~420 LOC of regex
+intent classification + deterministic synthesis) and gated it behind a strict
+SQLite-vs-Postgres parity test, including the semantic fact graph
+(`entities`/`relationships`/`semantic_facts`/`extraction_runs`).
+
+A systematic read of the Claude Code production agent (leaked source) plus the internal
+fact that we just built the F5 harness reshaped this:
+
+- **Claude Code grounds answers via agent-callable search tools + tool results in the
+  transcript, not a precomputed RAG monolith** (`memdir/findRelevantMemories.ts`,
+  `query.ts` tool_result handling). It has no `answer.ts`-style retrieve-and-synthesize
+  function.
+- Porting `answer.ts` as-is would create a non-agentic path that **bypasses the F5
+  harness** — incoherent with what we just shipped.
+
+Therefore Feature A is reframed:
+
+1. **Memory is a tool the agent calls** (`search_memory`), not a monolithic function.
+2. **The model synthesizes the cited answer** (intent, gaps, refusal) from retrieved
+   chunks — `answer.ts`'s deterministic synthesis is NOT ported.
+3. **pgvector retrieval is kept** — semantic recall over notes is our legitimate
+   difference from Claude Code's grep-over-code (it greps exact strings; we need
+   semantic recall over prose).
+4. **Strict parity → an answer eval.** Non-deterministic synthesis can't be diffed
+   against the old engine; instead we assert structural properties (every claim cites a
+   retrieved chunk, gaps surface, refusal on empty, no permission leak).
+5. **The semantic fact graph is deferred** — answer from retrieved chunks; "knowledge
+   gaps" are agent-identified from retrieval coverage.
+6. **Memory add/correct is folded into A** so the learn-loop is closeable from the first
+   feature (Claude Code wires feedback early, not as an end-stage add-on).
+
+## Decisions (locked during brainstorming)
+
+- **Scope = the cited-answer core**: ingest + pgvector retrieval + `search_memory` tool +
+  agentic answer in chat + memory add/correct. Import UI (A4.2) and the fact graph are
+  out.
+- **Embeddings = pgvector(1536) with a pluggable provider.** The column is `vector(1536)`.
+  Generation goes through the Model Gateway: real OpenAI `text-embedding-3-small` when
+  `OPENAI_API_KEY` is set, else a deterministic 1536-dim hash fallback (offline,
+  reproducible, weak semantics). Same column either way — setting the key later upgrades
+  to real semantic search with no migration.
+- **Permissions (ADR-0001) = carry + filter, single default actor for v1.** The
+  `source_permissions` column and filter-before-retrieval in SQL are built; a default
+  actor seeded with read access to all imported sources. Multi-user permission
+  management UI is deferred.
+- **Ingestion = CLI for v1.** `npm run ingest <dir>` ports the legacy `ingestFolder` to
+  Postgres. In-app upload UI deferred to A4.
+- **Synthesis is agentic.** No port of `answer.ts`; the run's system prompt instructs the
+  model to answer only from retrieved chunks, cite every claim, list gaps, and refuse
+  when retrieval is empty.
+
+## Module structure
+
+Greenfield unless marked. The legacy `src/` SQLite engine is kept untouched as the eval
+oracle and chunk/heuristic reference.
+
+```
+src/lib/memory/schema.ts        SourceRecord, MemoryChunk, RetrievedChunk types
+src/lib/memory/embed.ts         embedText(text): Promise<number[]> — gateway or hash fallback
+src/lib/memory/chunk.ts         port of legacy chunkText/chunkCsv + citation construction
+src/lib/memory/ingest.ts        ingestFolder -> Postgres (source_records + memory_chunks)
+src/lib/memory/retrieve.ts      searchMemory() — pgvector cosine + pre-retrieval permission filter
+src/lib/memory/notes.ts         addMemoryNote() write path
+src/lib/tools/search-memory.ts  search_memory tool (class read)
+src/lib/tools/add-memory-note.ts add_memory_note tool (class write_internal)
+src/lib/memory/answer-config.ts the memory-run system prompt + allowed tool set
+src/migrations/003_memory.sql   source_records + memory_chunks + source_permissions
+scripts/ingest.ts               CLI entry: npm run ingest <dir>
+REUSE: src/lib/model-gateway.ts (callModel embed), src/lib/harness.ts (runAgent),
+       src/lib/ledger.ts, src/app/chat (ChatClient), src/app/runs/[id]
+```
+
+## Components
+
+### Schema (migration 003)
+
+```sql
+CREATE TABLE source_records (
+  id            BIGSERIAL PRIMARY KEY,
+  source_id     TEXT NOT NULL UNIQUE,           -- deterministic slug
+  path          TEXT,
+  title         TEXT NOT NULL,
+  source_type   TEXT NOT NULL,                  -- markdown | text | csv | email
+  content_hash  TEXT NOT NULL,                  -- sha256(raw_text), dedupe key
+  raw_text      TEXT NOT NULL,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE memory_chunks (
+  id               BIGSERIAL PRIMARY KEY,
+  source_record_id BIGINT NOT NULL REFERENCES source_records(id) ON DELETE CASCADE,
+  chunk_index      INTEGER NOT NULL,
+  text             TEXT NOT NULL,
+  chunk_hash       TEXT NOT NULL,
+  embedding        vector(1536),                -- pgvector; pluggable provider
+  citation         TEXT NOT NULL,               -- source-id#chunk-N / #row-N
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (source_record_id, chunk_index)
+);
+CREATE INDEX memory_chunks_embedding_idx ON memory_chunks
+  USING hnsw (embedding vector_cosine_ops);
+
+CREATE TABLE source_permissions (
+  id             BIGSERIAL PRIMARY KEY,
+  principal_type TEXT NOT NULL,                 -- user | oauth_client | test_client
+  principal_id   TEXT NOT NULL,
+  source_id      TEXT NOT NULL,
+  access         TEXT NOT NULL DEFAULT 'read',
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (principal_type, principal_id, source_id)
+);
+```
+
+### Embeddings (`embed.ts`)
+
+`embedText(text: string): Promise<number[]>` returns a length-1536 vector.
+- If `process.env.OPENAI_API_KEY?.trim()`: `callModel({ kind: "embed",
+  model: "text-embedding-3-small" })` (logged in `model_calls`).
+- Else: deterministic hash — tokenize, sha256 each token, index mod 1536, increment,
+  L2-normalize (the legacy 64-dim approach widened to 1536). No network, reproducible.
+A `usesRealEmbeddings(): boolean` helper surfaces which path is active (for the import
+report and tests).
+
+### Ingestion (`ingest.ts` + `scripts/ingest.ts`)
+
+Port of `src/ingest.ts`: walk supported files (.md/.txt/.csv/.eml) → `chunk` →
+`embedText` each chunk → upsert `source_records` (preserve source_id on conflict, dedupe
+by content_hash) → replace `memory_chunks` with citations
+(`citationForChunk` → `source-id#chunk-N`, 1-indexed; CSV → `#row-N`). Returns
+`{ processed, skipped, skippedFiles[] }` with per-file reasons (no silent skips). Seeds
+the default actor's `source_permissions` for every ingested source.
+
+### Retrieval (`retrieve.ts`) — ADR-0001 enforced
+
+```ts
+searchMemory(db, {
+  query: string;
+  actor: { principalType: string; principalId: string };
+  limit?: number;            // default 6
+}): Promise<RetrievedChunk[]>   // { text, citation, sourceId, score }
+```
+1. Resolve the actor's allowed `source_id`s from `source_permissions` (default-deny).
+2. Embed the query via `embedText`.
+3. **Single SQL query** that filters to allowed sources in the WHERE clause AND ranks by
+   `embedding <=> $queryVec` (cosine). Permission filter is applied before ranking — a
+   restricted source can never surface even if it would rank higher.
+4. Return top-K chunks with citations. Empty allowed-set → empty result (not an error).
+
+### `search_memory` tool + agentic answer
+
+- `search_memory` (class `read`): `argsSchema { query: string, limit?: number }`;
+  `execute` calls `searchMemory` with the run's actor and returns
+  `{ chunks: [{ citation, text, sourceId }] }`. Recorded as a tool_call in the ledger.
+- **Harness change:** `RunAgentInput` gains an optional `instructions?: string`.
+  `buildAgentSystemPrompt(tools, instructions?)` appends it after the tool catalog, so a
+  run can carry task guidance without forking the harness. The echo run passes nothing
+  (unchanged behavior); the memory run passes the memory instructions below.
+- `answer-config.ts` exports `MEMORY_INSTRUCTIONS` — *"Answer only from search_memory
+  results. Cite every claim with its citation id in brackets. If retrieved coverage is
+  thin or conflicting, list it under Knowledge Gaps. If search_memory returns nothing,
+  say there is no relevant memory. Never invent sources."* — and
+  `memoryRegistry()` = `createToolRegistry([searchMemoryTool])`.
+- **Route:** `/api/agent` runs the memory config by default
+  (`registry: memoryRegistry()`, `allowedClasses: {read}`, `instructions:
+  MEMORY_INSTRUCTIONS`), replacing the echo placeholder. The existing `/chat` renders the
+  cited answer + the run-inspector link unchanged.
+
+### Memory add/correct (`notes.ts` + `add_memory_note` tool)
+
+`addMemoryNote(db, { title, text, actor })` writes a `source_record` (source_type
+`note`) + chunk(s) (embedded, cited), grants the actor read, and returns the source_id —
+immediately retrievable. **Correction = add a superseding note** (no destructive edit in
+v1). Exposed as `add_memory_note` tool (class `write_internal`) so an agent run can write
+back, and callable directly from a future memory page.
+
+## Data flow
+
+```
+npm run ingest ./notes
+  -> ingestFolder -> per file: chunk -> embedText -> source_records + memory_chunks (+perms)
+
+POST /api/agent { question }   (memory run config)
+  -> runAgent(allowed={read}, tools={search_memory})
+       loop: callModel(generate_object decision)
+         -> search_memory(query) -> retrieve.searchMemory (permission-filtered pgvector)
+              -> cited chunks back into the loop (tool_call logged)
+         -> model writes final cited answer + gaps
+  -> { runId, answer }
+GET /runs/[id] -> existing inspector renders the trace (search_memory tool calls + answer)
+```
+
+## Error handling
+
+- Empty allowed-set or no matching chunks → the tool returns an empty result; the model
+  answers "no relevant memory" (not a run failure).
+- Embedding provider error (real path) → surfaces as a `ModelGatewayError`; the run fails
+  and is inspectable (consistent with F5).
+- Ingest per-file failures → recorded with a reason and reported; never silently skipped;
+  never leaves orphan source/chunk rows.
+
+## Testing
+
+Live Postgres, same harness as F3/F4/F5. Reset tables + run migrations in `beforeEach`.
+
+- `tests/memory-ingest.test.ts`: ingest writes source_records + chunks with citations and
+  a 1536-dim embedding; CSV → `#row-N`; per-file skip reasons; no orphan rows.
+- `tests/memory-embed.test.ts`: hash fallback is deterministic and length-1536, L2-norm ~1;
+  `usesRealEmbeddings()` reflects env.
+- `tests/memory-retrieve.test.ts`: pgvector ranking returns cited chunks; **a restricted
+  source never surfaces even when it lexically/semantically matches** (ported from
+  `read-service.test.ts`); empty allowed-set → empty.
+- `tests/search-memory-tool.test.ts`: tool returns cited chunks and logs a tool_call.
+- `tests/memory-answer-eval.test.ts` (the parity replacement): seed corpus + fixed
+  question set, mock provider returning canned cited answers; assert structural
+  properties — every cited id exists in the retrieved set, gaps surface on thin coverage,
+  "no relevant memory" on empty, restricted content never leaks. A separate opt-in live
+  run (real Anthropic) is manual, not in CI.
+- The legacy SQLite suite (`tests/answer.test.ts`, `read-service.test.ts`, etc.) stays
+  green, untouched, as the reference oracle.
+
+## Deferred (YAGNI)
+
+- Semantic fact graph: `entities`, `relationships`, `semantic_facts`, `extraction_runs`
+  and the LLM extraction pipeline.
+- Multi-user permission management UI.
+- In-app file upload UI (A4.2) — CLI ingest covers v1.
+- Live Drive/Gmail/Notion sync.
+
+## Acceptance criteria
+
+- [ ] `npm run ingest <dir>` loads notes into Postgres as source_records + memory_chunks
+      with pgvector embeddings and citations; per-file status reported.
+- [ ] `search_memory` returns permission-filtered, cited chunks and logs a tool call.
+- [ ] A restricted source never surfaces to an actor without access (SQL-level filter).
+- [ ] Asking a question in `/chat` runs the harness, calls `search_memory`, and renders a
+      cited answer with knowledge gaps; "no relevant memory" when retrieval is empty.
+- [ ] `add_memory_note` writes a retrievable note; a correction note supersedes prior
+      content in future answers.
+- [ ] The full run (search_memory tool calls, model calls, answer, status) appears in the
+      run inspector.
+- [ ] Answer eval passes on the seed question set; legacy SQLite suite stays green.
+
+## Maps to original plan slices
+
+- A1 (schema+ingest) → migration 003 + `ingest.ts`/`chunk.ts` + CLI.
+- A2 (embeddings + retrieval) → `embed.ts` (pluggable 1536) + `retrieve.ts` (permission-filtered pgvector).
+- A3 (answer + parity) → **reframed**: agentic answer via prompt + answer eval (no `answer.ts` port, no strict parity).
+- A5 (search_memory tool) → `search-memory.ts`, registered into the harness — **the center of A**.
+- A6 (Research Chat from memory) → reuse existing `/chat` + memory run config.
+- A7 (add/correct) → `notes.ts` + `add_memory_note` — **folded into A**.
+- A4 (import UI), fact graph → **deferred**.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "vitest run",
     "migrate": "tsx scripts/migrate.ts",
     "ingest": "tsx scripts/ingest.ts",
-    "stress": "tsx scripts/stress.ts"
+    "stress": "tsx scripts/stress.ts",
+    "refresh": "tsx scripts/refresh.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.85",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint",
     "test": "vitest run",
     "migrate": "tsx scripts/migrate.ts",
+    "ingest": "tsx scripts/ingest.ts",
     "stress": "tsx scripts/stress.ts"
   },
   "dependencies": {

--- a/scripts/ingest.ts
+++ b/scripts/ingest.ts
@@ -1,0 +1,31 @@
+import { closeDb, getDb } from "../src/lib/db.js";
+import { ingestFolder } from "../src/lib/memory/ingest.js";
+
+async function main(): Promise<void> {
+  const folderPath = process.argv[2];
+  if (!folderPath) {
+    process.stderr.write("Usage: tsx scripts/ingest.ts <dir>\n");
+    process.exit(1);
+  }
+
+  const db = getDb();
+  try {
+    const result = await ingestFolder(db, folderPath);
+    const summary = `Ingested ${result.processed} source file${result.processed === 1 ? "" : "s"}; skipped ${result.skipped}.`;
+    process.stdout.write(summary + "\n");
+
+    if (result.skippedFiles.length > 0) {
+      process.stdout.write("\nSkipped files:\n");
+      for (const skipped of result.skippedFiles) {
+        process.stdout.write(`  - ${skipped.path} [${skipped.category}]: ${skipped.reason}\n`);
+      }
+    }
+  } finally {
+    await closeDb();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/refresh.ts
+++ b/scripts/refresh.ts
@@ -1,0 +1,20 @@
+import { closeDb, getDb } from "../src/lib/db.js";
+import { refreshMemory } from "../src/lib/memory/extract.js";
+
+async function main(): Promise<void> {
+  const db = getDb();
+  try {
+    const result = await refreshMemory(db);
+    process.stdout.write(
+      `Refresh complete: ${result.chunksProcessed} chunk(s) processed, ` +
+        `${result.extracted} extracted, ${result.reused} reused, ${result.failed} failed.\n`
+    );
+  } finally {
+    await closeDb();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/agent/route.ts
+++ b/src/app/api/agent/route.ts
@@ -1,26 +1,9 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { runAgent } from "@/lib/harness";
-import { getRunTrace, type RunTrace, type RunStepTrace } from "@/lib/ledger";
-import { collectAllowedCitations, checkCitations } from "@/lib/memory/citations";
+import { getRunTrace } from "@/lib/ledger";
+import { verifyAnswerCitations } from "@/lib/memory/citations";
 import { memoryRegistry, MEMORY_INSTRUCTIONS } from "@/lib/memory/answer-config";
-import type { MemoryBundle } from "@/lib/memory/retrieve";
-
-function collectBundlesFromTrace(trace: RunTrace): MemoryBundle[] {
-  const bundles: MemoryBundle[] = [];
-  function walk(steps: RunStepTrace[]) {
-    for (const step of steps) {
-      for (const tc of step.toolCalls) {
-        if (tc.toolName === "search_memory" && tc.status === "succeeded" && tc.result) {
-          bundles.push(tc.result as MemoryBundle);
-        }
-      }
-      walk(step.children);
-    }
-  }
-  walk(trace.steps);
-  return bundles;
-}
 
 export async function POST(request: Request) {
   const body = await request.json().catch(() => null);
@@ -44,13 +27,9 @@ export async function POST(request: Request) {
 
   if (result.status === "succeeded" && answer !== undefined) {
     const trace = await getRunTrace(db, result.runId);
-    if (trace) {
-      const bundles = collectBundlesFromTrace(trace);
-      const allowed = collectAllowedCitations(bundles);
-      const checked = checkCitations(answer, allowed);
-      answer = checked.sanitizedAnswer;
-      invalidCitations = checked.invalid;
-    }
+    const checked = verifyAnswerCitations(trace, answer);
+    answer = checked.answer;
+    invalidCitations = checked.invalidCitations;
   }
 
   return NextResponse.json(

--- a/src/app/api/agent/route.ts
+++ b/src/app/api/agent/route.ts
@@ -1,7 +1,26 @@
 import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
 import { runAgent } from "@/lib/harness";
-import { echoTool } from "@/lib/tools/echo";
-import { createToolRegistry } from "@/lib/tools/registry";
+import { getRunTrace, type RunTrace, type RunStepTrace } from "@/lib/ledger";
+import { collectAllowedCitations, checkCitations } from "@/lib/memory/citations";
+import { memoryRegistry, MEMORY_INSTRUCTIONS } from "@/lib/memory/answer-config";
+import type { MemoryBundle } from "@/lib/memory/retrieve";
+
+function collectBundlesFromTrace(trace: RunTrace): MemoryBundle[] {
+  const bundles: MemoryBundle[] = [];
+  function walk(steps: RunStepTrace[]) {
+    for (const step of steps) {
+      for (const tc of step.toolCalls) {
+        if (tc.toolName === "search_memory" && tc.status === "succeeded" && tc.result) {
+          bundles.push(tc.result as MemoryBundle);
+        }
+      }
+      walk(step.children);
+    }
+  }
+  walk(trace.steps);
+  return bundles;
+}
 
 export async function POST(request: Request) {
   const body = await request.json().catch(() => null);
@@ -10,7 +29,32 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "question is required" }, { status: 400 });
   }
 
-  const registry = createToolRegistry([echoTool]);
-  const result = await runAgent({ question, registry });
-  return NextResponse.json(result, { status: result.status === "succeeded" ? 200 : 500 });
+  const db = getDb();
+  const registry = memoryRegistry();
+  const result = await runAgent({
+    question,
+    registry,
+    allowedClasses: new Set(["read"]),
+    instructions: MEMORY_INSTRUCTIONS,
+    db,
+  });
+
+  let answer = result.answer;
+  let invalidCitations: string[] = [];
+
+  if (result.status === "succeeded" && answer !== undefined) {
+    const trace = await getRunTrace(db, result.runId);
+    if (trace) {
+      const bundles = collectBundlesFromTrace(trace);
+      const allowed = collectAllowedCitations(bundles);
+      const checked = checkCitations(answer, allowed);
+      answer = checked.sanitizedAnswer;
+      invalidCitations = checked.invalid;
+    }
+  }
+
+  return NextResponse.json(
+    { runId: result.runId, status: result.status, answer, steps: result.steps, invalidCitations },
+    { status: result.status === "succeeded" ? 200 : 500 }
+  );
 }

--- a/src/extractors/llm.ts
+++ b/src/extractors/llm.ts
@@ -39,7 +39,9 @@ export interface LlmExtractorConfig {
 }
 
 export function createLlmExtractor(config: LlmExtractorConfig = {}): Extractor {
-  const model = config.model ?? process.env.SOURCECADO_GENERATION_MODEL ?? "deepseek-chat";
+  const generationProvider = process.env.SOURCECADO_GENERATION_PROVIDER?.trim() || "deepseek";
+  const defaultModel = generationProvider === "anthropic" ? "claude-sonnet-4-6" : "deepseek-chat";
+  const model = (config.model ?? process.env.SOURCECADO_GENERATION_MODEL?.trim()) || defaultModel;
 
   // If an explicit apiKey is supplied via config, propagate it to the environment
   // so the Model Gateway can pick it up at call time via requireEnv.

--- a/src/extractors/llm.ts
+++ b/src/extractors/llm.ts
@@ -206,7 +206,7 @@ function createModelGatewayProvider(): LlmProvider {
       schema: candidateResponseSchema(),
       schemaName: "sourcyavo_memory_candidates",
       // providerName omitted: gateway resolves via SOURCECADO_GENERATION_PROVIDER env
-      // (defaults to "anthropic" → claude-sonnet-4-6, or "deepseek" if set)
+      // (defaults to "deepseek" unless SOURCECADO_GENERATION_PROVIDER overrides it)
       model: request.model
     });
     return JSON.stringify(result.object);

--- a/src/extractors/llm.ts
+++ b/src/extractors/llm.ts
@@ -39,20 +39,10 @@ export interface LlmExtractorConfig {
 }
 
 export function createLlmExtractor(config: LlmExtractorConfig = {}): Extractor {
-  const apiKey = config.apiKey ?? process.env.DEEPSEEK_API_KEY ?? "";
   const model = config.model ?? process.env.SOURCECADO_GENERATION_MODEL ?? "deepseek-chat";
 
-  if (!config.provider && !apiKey.trim()) {
-    throw new ExtractionError(
-      "missing_config",
-      "DEEPSEEK_API_KEY is required for unstructured LLM extraction."
-    );
-  }
-
-  // The Model Gateway's default DeepSeek provider reads DEEPSEEK_API_KEY from
-  // the environment. Honor an explicitly supplied config.apiKey by populating
-  // the env when it isn't already set, so a configured key actually takes
-  // effect instead of passing validation here and failing at call time.
+  // If an explicit apiKey is supplied via config, propagate it to the environment
+  // so the Model Gateway can pick it up at call time via requireEnv.
   if (!config.provider && config.apiKey?.trim() && !process.env.DEEPSEEK_API_KEY?.trim()) {
     process.env.DEEPSEEK_API_KEY = config.apiKey;
   }
@@ -202,7 +192,7 @@ function buildSystemPrompt(): string {
 
 function createModelGatewayProvider(): LlmProvider {
   return async (request) => {
-    const result = await callModel<{ candidates: unknown[] }>(getDb(), {
+    const result = await callModel(getDb(), {
       kind: "generate_object",
       taskName: "extract_memory_candidates",
       promptVersion: request.schemaVersion,
@@ -215,16 +205,28 @@ function createModelGatewayProvider(): LlmProvider {
       system: request.systemPrompt,
       schema: candidateResponseSchema(),
       schemaName: "sourcyavo_memory_candidates",
-      providerName: "deepseek",
+      // providerName omitted: gateway resolves via SOURCECADO_GENERATION_PROVIDER env
+      // (defaults to "anthropic" → claude-sonnet-4-6, or "deepseek" if set)
       model: request.model
     });
     return JSON.stringify(result.object);
   };
 }
 
-function candidateResponseSchema(): z.ZodType<{ candidates: unknown[] }> {
+function candidateResponseSchema() {
   return z.object({
-    candidates: z.array(z.unknown())
+    candidates: z.array(
+      z.object({
+        kind: z.enum(["entity", "relationship", "semantic_fact"]),
+        subject: z.string().optional(),
+        predicate: z.string().optional(),
+        object: z.string().optional(),
+        entityType: z.enum(ENTITY_TYPES).optional(),
+        relationshipType: z.enum(RELATIONSHIP_TYPES).optional(),
+        confidence: z.number(),
+        evidenceText: z.string(),
+      })
+    ),
   });
 }
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -6,7 +6,7 @@ export function getDb(): postgres.Sql {
   if (!_db) {
     const url = process.env.DATABASE_URL;
     if (!url) throw new Error("DATABASE_URL is not set");
-    _db = postgres(url);
+    _db = postgres(url, { onnotice: () => {} });
   }
   return _db;
 }

--- a/src/lib/harness.ts
+++ b/src/lib/harness.ts
@@ -42,6 +42,7 @@ export interface RunAgentInput {
   maxSteps?: number;
   provider?: ModelGatewayProvider;
   db?: Sql;
+  instructions?: string;
 }
 
 export interface RunAgentResult {
@@ -84,6 +85,7 @@ export async function runAgent(input: RunAgentInput): Promise<RunAgentResult> {
         allowed,
         transcript,
         provider: input.provider,
+        instructions: input.instructions,
       });
 
       if (decision.action === "final") {
@@ -137,6 +139,7 @@ interface DecideOptions {
   allowed: Set<PermissionClass>;
   transcript: string[];
   provider?: ModelGatewayProvider;
+  instructions?: string;
 }
 
 async function decide(db: Sql, opts: DecideOptions): Promise<AgentDecision> {
@@ -145,7 +148,7 @@ async function decide(db: Sql, opts: DecideOptions): Promise<AgentDecision> {
     kind: "generate_object",
     taskName: "agent_react_decide",
     promptVersion: "1",
-    system: buildAgentSystemPrompt(tools),
+    system: buildAgentSystemPrompt(tools, opts.instructions),
     prompt: buildUserPrompt(opts.question, opts.transcript),
     schema: agentDecisionSchema,
     schemaName: "agent_decision",
@@ -158,7 +161,7 @@ async function decide(db: Sql, opts: DecideOptions): Promise<AgentDecision> {
   return result.object;
 }
 
-export function buildAgentSystemPrompt(tools: Tool[]): string {
+export function buildAgentSystemPrompt(tools: Tool[], instructions?: string): string {
   const catalog = tools
     .map((tool) => {
       let schema = "{}";
@@ -170,14 +173,18 @@ export function buildAgentSystemPrompt(tools: Tool[]): string {
       return `- ${tool.name} (${tool.permissionClass}): ${tool.description}\n  args JSON schema: ${schema}`;
     })
     .join("\n");
-  return [
+  const parts = [
     "You are a sourcing agent. Decide the next action.",
     "Either call one tool, or give a final answer.",
     "Respond with a decision object: {action:'tool', tool, args} or {action:'final', answer}.",
     "When calling a tool, set `args` to a JSON object STRING matching that tool's args JSON schema exactly (e.g. \"{\\\"text\\\":\\\"hi\\\"}\").",
     "Available tools:",
     catalog || "(none)",
-  ].join("\n");
+  ];
+  if (instructions) {
+    parts.push("", instructions);
+  }
+  return parts.join("\n");
 }
 
 function buildUserPrompt(question: string, transcript: string[]): string {

--- a/src/lib/memory/actor.ts
+++ b/src/lib/memory/actor.ts
@@ -1,0 +1,9 @@
+export interface MemoryActor {
+  actorType: "user" | "oauth_client" | "test_client";
+  actorId: string;
+}
+
+export const DEFAULT_ACTOR: MemoryActor = {
+  actorType: "test_client",
+  actorId: "default",
+};

--- a/src/lib/memory/actor.ts
+++ b/src/lib/memory/actor.ts
@@ -3,6 +3,7 @@ export interface MemoryActor {
   actorId: string;
 }
 
+// v1 single-tenant sentinel. Replace with a real actor when per-user auth ships.
 export const DEFAULT_ACTOR: MemoryActor = {
   actorType: "test_client",
   actorId: "default",

--- a/src/lib/memory/answer-config.ts
+++ b/src/lib/memory/answer-config.ts
@@ -1,0 +1,34 @@
+import { createToolRegistry } from "../tools/registry";
+import type { ToolRegistry } from "../tools/registry";
+import { searchMemoryTool } from "../tools/search-memory";
+
+export const MEMORY_INSTRUCTIONS = `## Memory Answer Contract
+
+You are a memory-grounded sourcing assistant. Follow these rules strictly:
+
+1. **Call search_memory first.** Before answering any question, call search_memory to retrieve
+   relevant sourcing memory. Never answer from prior training knowledge alone.
+
+2. **Four-section format.** Your final answer MUST use exactly these four sections in this order:
+   Answer: <direct answer to the question, citing sources>
+   Evidence: <the acceptedFacts and chunks that support the answer>
+   Gaps: <candidate, conflicted, or stale facts from gapFacts; if none, write "None">
+   Next Action: <what to do next based on memory gaps>
+
+3. **Strict citation grounding.** Only cite ids that appear in the search_memory result
+   (the citation fields of acceptedFacts, gapFacts, or chunks). NEVER invent a citation id.
+   Format citations inline as: sourceId#chunk-N or sourceId#row-N.
+
+4. **Fact-first, chunk-fallback.** Prefer acceptedFacts for the Answer and Evidence sections.
+   If acceptedFacts is empty, fall back to chunks.
+
+5. **Always surface gaps.** List candidate, conflicted, and stale facts from gapFacts in the
+   Gaps section. Do not omit them.
+
+6. **Refuse on empty.** If the search_memory result is entirely empty (no facts, no chunks),
+   reply with "no relevant memory" (when sources exist but nothing matched) or
+   "no indexed memory yet" (when memory is empty). This is a valid answer, not an error.`;
+
+export function memoryRegistry(): ToolRegistry {
+  return createToolRegistry([searchMemoryTool]);
+}

--- a/src/lib/memory/chunk-store.ts
+++ b/src/lib/memory/chunk-store.ts
@@ -1,0 +1,52 @@
+import type postgres from "postgres";
+import type { MemoryActor } from "./actor";
+import { citationForChunk, type TextChunk } from "./chunk";
+import { toVectorLiteral } from "./embed";
+
+type Sql = postgres.Sql;
+
+/**
+ * Shared transaction helper: DELETE old chunks for a source record, INSERT the
+ * new chunks with embeddings, and seed the read permission grant.
+ *
+ * `tx` must be a postgres transaction handle (inside a `db.begin` callback).
+ * `chunks` and `embeddings` must be positionally aligned.
+ */
+export async function writeChunksAndGrant(
+  tx: Sql,
+  args: {
+    sourceRecordId: string;
+    sourceId: string;
+    sourceType: string;
+    chunks: TextChunk[];
+    embeddings: number[][];
+    actor: MemoryActor;
+  }
+): Promise<void> {
+  const { sourceRecordId, sourceId, sourceType, chunks, embeddings, actor } = args;
+
+  await tx`DELETE FROM memory_chunks WHERE source_record_id = ${sourceRecordId}`;
+
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i];
+    const vectorLiteral = toVectorLiteral(embeddings[i]);
+    const citation = citationForChunk(sourceId, sourceType, chunk);
+    await tx`
+      INSERT INTO memory_chunks (source_record_id, chunk_index, text, chunk_hash, embedding, citation)
+      VALUES (
+        ${sourceRecordId},
+        ${chunk.chunkIndex},
+        ${chunk.text},
+        ${chunk.chunkHash},
+        ${vectorLiteral}::vector,
+        ${citation}
+      )
+    `;
+  }
+
+  await tx`
+    INSERT INTO source_permissions (principal_type, principal_id, source_id, access)
+    VALUES (${actor.actorType}, ${actor.actorId}, ${sourceId}, 'read')
+    ON CONFLICT (principal_type, principal_id, source_id) DO NOTHING
+  `;
+}

--- a/src/lib/memory/chunk.ts
+++ b/src/lib/memory/chunk.ts
@@ -1,0 +1,110 @@
+// Faithful port of src/chunk.ts + the citationForChunk helper from src/ingest.ts.
+// No DB calls — pure text processing.
+import { createHash } from "node:crypto";
+import { parseCsvRecords, serializeCsvRecord } from "../../csv.js";
+import { IngestError } from "../../ingest-error.js";
+
+export interface TextChunk {
+  chunkIndex: number;
+  text: string;
+  chunkHash: string;
+}
+
+const MAX_CHUNK_CHARACTERS = 1_000;
+
+export function chunkText(text: string): TextChunk[] {
+  const paragraphs = text
+    .split(/\n{2,}/)
+    .map((paragraph) => paragraph.trim())
+    .filter(Boolean);
+  const chunks: string[] = [];
+
+  for (const paragraph of paragraphs.length > 0 ? paragraphs : [text.trim()]) {
+    if (paragraph.length <= MAX_CHUNK_CHARACTERS) {
+      chunks.push(paragraph);
+      continue;
+    }
+
+    chunks.push(...splitLongText(paragraph));
+  }
+
+  if (chunks.length === 0) {
+    throw new IngestError("parse-error", "No chunks created");
+  }
+
+  return chunks.map((chunk, index) => ({
+    chunkIndex: index,
+    text: chunk,
+    chunkHash: sha256(chunk),
+  }));
+}
+
+export function chunkCsvRows(text: string): TextChunk[] {
+  const [headers, ...rows] = parseCsvRecords(text);
+  if (!headers) {
+    throw new IngestError("parse-error", "CSV file has no header row");
+  }
+
+  const dataRows = rows.filter((row) => row.some((value) => value.trim()));
+  if (dataRows.length === 0) {
+    throw new IngestError("parse-error", "CSV file has no data rows");
+  }
+
+  return dataRows.map((row, index) => {
+    const chunk = [serializeCsvRecord(headers), serializeCsvRecord(row)].join("\n");
+    return {
+      chunkIndex: index,
+      text: chunk,
+      chunkHash: sha256(chunk),
+    };
+  });
+}
+
+export function sha256(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+export function citationForChunk(sourceId: string, sourceType: string, chunk: TextChunk): string {
+  const anchor = sourceType === "csv" ? "row" : "chunk";
+  return `${sourceId}#${anchor}-${chunk.chunkIndex + 1}`;
+}
+
+function splitLongText(text: string): string[] {
+  const words = text.split(/\s+/).filter(Boolean);
+  const chunks: string[] = [];
+  let current = "";
+
+  for (const word of words) {
+    if (!current) {
+      current = word;
+      continue;
+    }
+
+    const candidate = `${current} ${word}`;
+    if (candidate.length > MAX_CHUNK_CHARACTERS) {
+      chunks.push(current);
+      current = word;
+    } else {
+      current = candidate;
+    }
+  }
+
+  if (current) {
+    chunks.push(current);
+  }
+
+  return chunks.flatMap((chunk) => splitOversizedToken(chunk));
+}
+
+function splitOversizedToken(text: string): string[] {
+  if (text.length <= MAX_CHUNK_CHARACTERS) {
+    return [text];
+  }
+
+  const chunks: string[] = [];
+  for (let index = 0; index < text.length; index += MAX_CHUNK_CHARACTERS) {
+    chunks.push(text.slice(index, index + MAX_CHUNK_CHARACTERS));
+  }
+
+  return chunks;
+}

--- a/src/lib/memory/chunk.ts
+++ b/src/lib/memory/chunk.ts
@@ -108,3 +108,21 @@ function splitOversizedToken(text: string): string[] {
 
   return chunks;
 }
+
+// Ported from src/db.ts (legacy SQLite). Kept here so the Postgres memory
+// stack does not pull in better-sqlite3 via that module's import side-effects.
+// Deterministic slug: lowercase, non-alphanumeric runs collapse to '-', path
+// separators are preserved. Windows backslash is normalised to '/' first.
+export function slugifySourceId(relativeLabel: string): string {
+  return relativeLabel
+    .replace(/\\/g, "/")
+    .toLowerCase()
+    .split("/")
+    .map((segment) =>
+      segment
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+    )
+    .filter((segment) => segment.length > 0)
+    .join("/");
+}

--- a/src/lib/memory/citations.ts
+++ b/src/lib/memory/citations.ts
@@ -1,7 +1,7 @@
 import type { RunTrace, RunStepTrace } from "../ledger";
 import type { MemoryBundle } from "./retrieve";
 
-const CITATION_PATTERN = "[A-Za-z0-9._-]+#(?:chunk|row)-\\d+";
+const CITATION_PATTERN = "[A-Za-z0-9._/-]+#(?:chunk|row)-\\d+";
 
 /** Walk a run trace and collect every MemoryBundle from search_memory tool calls. */
 export function collectBundlesFromTrace(trace: RunTrace | null): MemoryBundle[] {

--- a/src/lib/memory/citations.ts
+++ b/src/lib/memory/citations.ts
@@ -1,6 +1,25 @@
+import type { RunTrace, RunStepTrace } from "../ledger";
 import type { MemoryBundle } from "./retrieve";
 
 const CITATION_PATTERN = "[A-Za-z0-9._-]+#(?:chunk|row)-\\d+";
+
+/** Walk a run trace and collect every MemoryBundle from search_memory tool calls. */
+export function collectBundlesFromTrace(trace: RunTrace | null): MemoryBundle[] {
+  if (!trace) return [];
+  const bundles: MemoryBundle[] = [];
+  function walk(steps: RunStepTrace[]) {
+    for (const step of steps) {
+      for (const tc of step.toolCalls) {
+        if (tc.toolName === "search_memory" && tc.status === "succeeded" && tc.result) {
+          bundles.push(tc.result as MemoryBundle);
+        }
+      }
+      walk(step.children);
+    }
+  }
+  walk(trace.steps);
+  return bundles;
+}
 
 /** Collect every citation id the search_memory tool actually returned for a run. */
 export function collectAllowedCitations(bundles: MemoryBundle[]): Set<string> {
@@ -37,4 +56,19 @@ export function checkCitations(
   );
 
   return { invalid, sanitizedAnswer };
+}
+
+/**
+ * Full citation post-check pipeline: walk the trace → collect allowed citations
+ * → strip any citation tokens the agent invented. Returns the sanitized answer
+ * and the list of invalid citation ids.
+ */
+export function verifyAnswerCitations(
+  trace: RunTrace | null,
+  answer: string
+): { answer: string; invalidCitations: string[] } {
+  const bundles = collectBundlesFromTrace(trace);
+  const allowed = collectAllowedCitations(bundles);
+  const { sanitizedAnswer, invalid } = checkCitations(answer, allowed);
+  return { answer: sanitizedAnswer, invalidCitations: invalid };
 }

--- a/src/lib/memory/citations.ts
+++ b/src/lib/memory/citations.ts
@@ -1,0 +1,40 @@
+import type { MemoryBundle } from "./retrieve";
+
+const CITATION_PATTERN = "[A-Za-z0-9._-]+#(?:chunk|row)-\\d+";
+
+/** Collect every citation id the search_memory tool actually returned for a run. */
+export function collectAllowedCitations(bundles: MemoryBundle[]): Set<string> {
+  const allowed = new Set<string>();
+  for (const bundle of bundles) {
+    for (const fact of bundle.acceptedFacts) {
+      if (fact.citation) allowed.add(fact.citation);
+    }
+    for (const fact of bundle.gapFacts) {
+      if (fact.citation) allowed.add(fact.citation);
+    }
+    for (const chunk of bundle.chunks) {
+      allowed.add(chunk.citation);
+    }
+  }
+  return allowed;
+}
+
+/**
+ * Find citation-like tokens in the answer and split into valid / invalid
+ * against the allowed set. Invalid tokens are replaced in sanitizedAnswer.
+ */
+export function checkCitations(
+  answer: string,
+  allowed: Set<string>
+): { invalid: string[]; sanitizedAnswer: string } {
+  const cited = answer.match(new RegExp(CITATION_PATTERN, "g")) ?? [];
+  const invalid = cited.filter((id) => !allowed.has(id));
+  const invalidSet = new Set(invalid);
+
+  const sanitizedAnswer = answer.replace(
+    new RegExp(CITATION_PATTERN, "g"),
+    (match) => (invalidSet.has(match) ? "[unverified citation removed]" : match)
+  );
+
+  return { invalid, sanitizedAnswer };
+}

--- a/src/lib/memory/citations.ts
+++ b/src/lib/memory/citations.ts
@@ -28,8 +28,8 @@ export function checkCitations(
   allowed: Set<string>
 ): { invalid: string[]; sanitizedAnswer: string } {
   const cited = answer.match(new RegExp(CITATION_PATTERN, "g")) ?? [];
-  const invalid = cited.filter((id) => !allowed.has(id));
-  const invalidSet = new Set(invalid);
+  const invalidSet = new Set(cited.filter((id) => !allowed.has(id)));
+  const invalid = [...invalidSet];
 
   const sanitizedAnswer = answer.replace(
     new RegExp(CITATION_PATTERN, "g"),

--- a/src/lib/memory/embed.ts
+++ b/src/lib/memory/embed.ts
@@ -1,0 +1,45 @@
+import { createHash } from "node:crypto";
+import { callModel } from "../model-gateway";
+import type { Sql } from "../tools/types";
+
+export const MEMORY_EMBEDDING_DIMENSIONS = 1536;
+
+export function usesRealEmbeddings(): boolean {
+  return !!(process.env.OPENAI_API_KEY?.trim());
+}
+
+export function toVectorLiteral(vec: number[]): string {
+  return `[${vec.join(",")}]`;
+}
+
+export async function embedText(db: Sql, text: string): Promise<number[]> {
+  if (usesRealEmbeddings()) {
+    const result = await callModel(db, {
+      kind: "embed",
+      taskName: "embed_memory_text",
+      promptVersion: "1",
+      value: text,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return result.embedding!;
+  }
+  return fallbackEmbed(text);
+}
+
+function fallbackEmbed(text: string): number[] {
+  const vector = Array.from({ length: MEMORY_EMBEDDING_DIMENSIONS }, () => 0);
+  const tokens = text.toLowerCase().match(/[a-z0-9]+/g) ?? [];
+
+  for (const token of tokens) {
+    const hash = createHash("sha256").update(token).digest();
+    const index = hash.readUInt32BE(0) % MEMORY_EMBEDDING_DIMENSIONS;
+    vector[index] += 1;
+  }
+
+  const magnitude = Math.sqrt(vector.reduce((sum, value) => sum + value * value, 0));
+  if (magnitude === 0) {
+    return vector;
+  }
+
+  return vector.map((value) => value / magnitude);
+}

--- a/src/lib/memory/extract.ts
+++ b/src/lib/memory/extract.ts
@@ -1,0 +1,401 @@
+/**
+ * extract.ts — async Postgres port of the semantic_facts lifecycle from src/refresh.ts.
+ *
+ * Scope: semantic_facts ONLY (no entities / relationships / entity_aliases — those tables
+ * do not exist in this stack).  Entity and relationship candidates from extractors are
+ * silently skipped.
+ */
+
+import type postgres from "postgres";
+import { createCsvExtractor } from "../../extractors/csv.js";
+import { createLlmExtractor, LLM_SCHEMA_VERSION } from "../../extractors/llm.js";
+import type { ExtractionInput, Extractor } from "../../extractors/types.js";
+import type { ExtractedCandidate, SourceType } from "../../types.js";
+import { sha256 } from "./chunk.js";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const ACCEPTED_CONFIDENCE_THRESHOLD = 0.75;
+const DEFAULT_PROMPT_HASH = "none";
+const DEFAULT_SCHEMA_VERSION = "1";
+const DEFAULT_MODEL_NAME = "local";
+
+// ---------------------------------------------------------------------------
+// Public interfaces
+// ---------------------------------------------------------------------------
+
+export interface RefreshMemoryOptions {
+  /** Per-source-type extractor override, checked before selectExtractor. */
+  extractorsBySourceType?: Partial<Record<SourceType, Extractor>>;
+  /** Custom extractor selector, used when no per-type override matches. */
+  selectExtractor?: (input: ExtractionInput) => Extractor;
+  /** Override metadata (promptHash / schemaVersion / modelName) per extractor type. */
+  metadataByExtractorType?: Partial<Record<string, Partial<ExtractionMetadata>>>;
+}
+
+export interface RefreshMemoryResult {
+  chunksProcessed: number;
+  extracted: number;
+  reused: number;
+  failed: number;
+}
+
+// ---------------------------------------------------------------------------
+// Private types
+// ---------------------------------------------------------------------------
+
+interface ExtractionMetadata {
+  promptHash: string;
+  schemaVersion: string;
+  modelName: string;
+}
+
+// Postgres BIGSERIAL IDs come back as strings from postgres.js
+interface SourceChunkRow {
+  chunk_id: string;
+  source_record_id: string;
+  source_path: string;
+  source_type: SourceType;
+  text: string;
+  chunk_hash: string;
+}
+
+interface ExtractionRunRow {
+  parsed_candidates_json: unknown | null;
+}
+
+interface ExistingFactSnapshot {
+  subject: string;
+  predicate: string;
+  object: string;
+  source_record_id: string | null;
+  source_chunk_id: string | null;
+  confidence: number;
+}
+
+type Sql = postgres.Sql;
+
+// ---------------------------------------------------------------------------
+// Public: refreshMemory
+// ---------------------------------------------------------------------------
+
+export async function refreshMemory(
+  db: Sql,
+  options: RefreshMemoryOptions = {}
+): Promise<RefreshMemoryResult> {
+  const chunks = await loadSourceChunks(db);
+  const result: RefreshMemoryResult = {
+    chunksProcessed: chunks.length,
+    extracted: 0,
+    reused: 0,
+    failed: 0,
+  };
+
+  const candidateBatches: Array<{ chunk: SourceChunkRow; candidates: ExtractedCandidate[] }> = [];
+
+  for (const chunk of chunks) {
+    const input = toExtractionInput(chunk);
+    const extractor = pickExtractor(input, options);
+    const metadata = metadataForExtractor(extractor, options);
+    const cacheKey = buildCacheKey(chunk.chunk_hash, extractor, metadata);
+    const cached = await loadCachedRun(db, cacheKey);
+
+    if (cached && cached.parsed_candidates_json !== null && cached.parsed_candidates_json !== undefined) {
+      const cachedCandidates = Array.isArray(cached.parsed_candidates_json)
+        ? (cached.parsed_candidates_json as ExtractedCandidate[])
+        : [];
+      candidateBatches.push({ chunk, candidates: cachedCandidates });
+      await db`UPDATE extraction_runs SET source_chunk_id = ${chunk.chunk_id} WHERE cache_key = ${cacheKey}`;
+      result.reused += 1;
+      continue;
+    }
+
+    try {
+      const candidates = await extractor.extract(input);
+      await recordExtractionRun(db, { chunk, extractor, metadata, cacheKey, candidates, status: "succeeded", error: null });
+      candidateBatches.push({ chunk, candidates });
+      result.extracted += 1;
+    } catch (error) {
+      await recordExtractionRun(db, { chunk, extractor, metadata, cacheKey, candidates: [], status: "failed", error: errorMessage(error) });
+      result.failed += 1;
+    }
+  }
+
+  await rebuildDerivedMemory(db, candidateBatches);
+  await markConflictsAndStaleFacts(db);
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Public: normalizeMemoryKey
+// ---------------------------------------------------------------------------
+
+export function normalizeMemoryKey(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/['"]/g, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\s/g, "-");
+}
+
+// ---------------------------------------------------------------------------
+// Public: markConflictsAndStaleFacts
+// ---------------------------------------------------------------------------
+
+export async function markConflictsAndStaleFacts(db: Sql): Promise<void> {
+  // Find non-candidate subject+predicate groups with more than one distinct object
+  const groups = await db<{ subject_key: string; predicate_key: string }[]>`
+    SELECT subject_key, predicate_key
+    FROM (
+      SELECT
+        lower(trim(subject))   AS subject_key,
+        lower(trim(predicate)) AS predicate_key,
+        count(distinct lower(trim(object))) AS object_count
+      FROM semantic_facts
+      WHERE status != 'candidate'
+      GROUP BY lower(trim(subject)), lower(trim(predicate))
+    ) g
+    WHERE g.object_count > 1
+  `;
+
+  for (const group of groups) {
+    await db`
+      UPDATE semantic_facts
+      SET status = 'conflicted'
+      WHERE lower(trim(subject))   = ${group.subject_key}
+        AND lower(trim(predicate)) = ${group.predicate_key}
+        AND status != 'candidate'
+    `;
+  }
+
+  // Mark facts stale when their source_chunk_id points to a missing chunk.
+  // In normal operation ON DELETE SET NULL handles this, but this guards against
+  // orphaned rows produced by TRUNCATE or other non-cascading deletions.
+  await db`
+    UPDATE semantic_facts
+    SET status = 'stale'
+    WHERE source_chunk_id IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM memory_chunks WHERE memory_chunks.id = semantic_facts.source_chunk_id
+      )
+  `;
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+async function loadSourceChunks(db: Sql): Promise<SourceChunkRow[]> {
+  return db<SourceChunkRow[]>`
+    SELECT
+      memory_chunks.id          AS chunk_id,
+      source_records.id         AS source_record_id,
+      source_records.path       AS source_path,
+      source_records.source_type AS source_type,
+      memory_chunks.text        AS text,
+      memory_chunks.chunk_hash  AS chunk_hash
+    FROM memory_chunks
+    JOIN source_records ON source_records.id = memory_chunks.source_record_id
+    ORDER BY source_records.id, memory_chunks.chunk_index
+  `;
+}
+
+function toExtractionInput(chunk: SourceChunkRow): ExtractionInput {
+  return {
+    sourceId: chunk.source_record_id,
+    sourcePath: chunk.source_path,
+    sourceType: chunk.source_type,
+    content: chunk.text,
+  };
+}
+
+function pickExtractor(input: ExtractionInput, options: RefreshMemoryOptions): Extractor {
+  const injected = options.extractorsBySourceType?.[input.sourceType];
+  if (injected) return injected;
+  if (options.selectExtractor) return options.selectExtractor(input);
+  if (input.sourceType === "csv") return createCsvExtractor();
+  return createLlmExtractor();
+}
+
+function metadataForExtractor(extractor: Extractor, options: RefreshMemoryOptions): ExtractionMetadata {
+  const provided = options.metadataByExtractorType?.[extractor.type] ?? {};
+  const defaults =
+    extractor.type === "llm"
+      ? {
+          promptHash: sha256("sourcyavo-llm-extractor-v1"),
+          schemaVersion: LLM_SCHEMA_VERSION,
+          modelName: process.env.SOURCECADO_GENERATION_MODEL || "deepseek-chat",
+        }
+      : {
+          promptHash: DEFAULT_PROMPT_HASH,
+          schemaVersion: DEFAULT_SCHEMA_VERSION,
+          modelName: extractor.type === "mock" ? "mock" : DEFAULT_MODEL_NAME,
+        };
+
+  return {
+    promptHash: provided.promptHash ?? extractor.promptHash ?? defaults.promptHash,
+    schemaVersion: provided.schemaVersion ?? extractor.schemaVersion ?? defaults.schemaVersion,
+    modelName: provided.modelName ?? extractor.modelName ?? defaults.modelName,
+  };
+}
+
+function buildCacheKey(chunkHash: string, extractor: Extractor, metadata: ExtractionMetadata): string {
+  return [
+    chunkHash,
+    extractor.type,
+    extractor.version,
+    metadata.promptHash,
+    metadata.schemaVersion,
+    metadata.modelName,
+  ].join(":");
+}
+
+async function loadCachedRun(db: Sql, cacheKey: string): Promise<ExtractionRunRow | undefined> {
+  const [row] = await db<ExtractionRunRow[]>`
+    SELECT parsed_candidates_json
+    FROM extraction_runs
+    WHERE cache_key = ${cacheKey} AND status = 'succeeded'
+  `;
+  return row;
+}
+
+async function recordExtractionRun(
+  db: Sql,
+  run: {
+    chunk: SourceChunkRow;
+    extractor: Extractor;
+    metadata: ExtractionMetadata;
+    cacheKey: string;
+    candidates: ExtractedCandidate[];
+    status: "succeeded" | "failed";
+    error: string | null;
+  }
+): Promise<void> {
+  const rawOutput = JSON.stringify(run.candidates);
+  const parsedCandidates = run.status === "succeeded" ? run.candidates : [];
+
+  await db`
+    INSERT INTO extraction_runs (
+      source_chunk_id, cache_key, chunk_hash, extractor_type, extractor_version,
+      prompt_hash, schema_version, model_name, raw_output, parsed_candidates_json, status, error
+    ) VALUES (
+      ${run.chunk.chunk_id},
+      ${run.cacheKey},
+      ${run.chunk.chunk_hash},
+      ${run.extractor.type},
+      ${run.extractor.version},
+      ${run.metadata.promptHash},
+      ${run.metadata.schemaVersion},
+      ${run.metadata.modelName},
+      ${rawOutput},
+      ${db.json(parsedCandidates as postgres.JSONValue)},
+      ${run.status},
+      ${run.error}
+    )
+    ON CONFLICT (cache_key) DO UPDATE SET
+      source_chunk_id        = EXCLUDED.source_chunk_id,
+      raw_output             = EXCLUDED.raw_output,
+      parsed_candidates_json = EXCLUDED.parsed_candidates_json,
+      status                 = EXCLUDED.status,
+      error                  = EXCLUDED.error
+  `;
+}
+
+async function rebuildDerivedMemory(
+  db: Sql,
+  batches: Array<{ chunk: SourceChunkRow; candidates: ExtractedCandidate[] }>
+): Promise<void> {
+  await db.begin(async (tx) => {
+    const previousFacts = await snapshotAcceptedFacts(tx);
+    await tx`DELETE FROM semantic_facts`;
+
+    const seenFacts = new Set<string>();
+
+    for (const batch of batches) {
+      for (const candidate of batch.candidates) {
+        // Only semantic_facts are supported in this stack.
+        if (candidate.kind !== "semantic_fact") continue;
+        if (candidate.subject && candidate.predicate && candidate.object) {
+          await insertSemanticFact(tx, candidate, batch.chunk, seenFacts);
+        }
+      }
+    }
+
+    await restoreStaleFacts(tx, previousFacts, seenFacts);
+  });
+}
+
+async function snapshotAcceptedFacts(db: Sql): Promise<ExistingFactSnapshot[]> {
+  return db<ExistingFactSnapshot[]>`
+    SELECT subject, predicate, object, source_record_id, source_chunk_id, confidence
+    FROM semantic_facts
+    WHERE status = 'accepted'
+  `;
+}
+
+async function restoreStaleFacts(
+  db: Sql,
+  previousFacts: ExistingFactSnapshot[],
+  seenFacts: Set<string>
+): Promise<void> {
+  for (const fact of previousFacts) {
+    const key = [
+      normalizeMemoryKey(fact.subject),
+      normalizeMemoryKey(fact.predicate),
+      normalizeMemoryKey(fact.object),
+      fact.source_record_id,
+      fact.source_chunk_id,
+    ].join(":");
+
+    if (seenFacts.has(key)) continue;
+
+    await db`
+      INSERT INTO semantic_facts
+        (subject, predicate, object, source_record_id, source_chunk_id, confidence, status)
+      VALUES
+        (${fact.subject}, ${fact.predicate}, ${fact.object},
+         ${fact.source_record_id}, ${fact.source_chunk_id}, ${fact.confidence}, 'stale')
+    `;
+  }
+}
+
+async function insertSemanticFact(
+  db: Sql,
+  candidate: ExtractedCandidate,
+  chunk: SourceChunkRow,
+  seen: Set<string>
+): Promise<void> {
+  const subject = candidate.subject ?? "";
+  const predicate = candidate.predicate ?? "";
+  const object = candidate.object ?? "";
+  const key = [
+    normalizeMemoryKey(subject),
+    normalizeMemoryKey(predicate),
+    normalizeMemoryKey(object),
+    chunk.source_record_id,
+    chunk.chunk_id,
+  ].join(":");
+
+  if (seen.has(key)) return;
+  seen.add(key);
+
+  const status = candidate.confidence >= ACCEPTED_CONFIDENCE_THRESHOLD ? "accepted" : "candidate";
+
+  await db`
+    INSERT INTO semantic_facts
+      (subject, predicate, object, source_record_id, source_chunk_id, confidence, status)
+    VALUES
+      (${subject.trim()}, ${predicate.trim()}, ${object.trim()},
+       ${chunk.source_record_id}, ${chunk.chunk_id}, ${candidate.confidence}, ${status})
+  `;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/lib/memory/extract.ts
+++ b/src/lib/memory/extract.ts
@@ -175,8 +175,13 @@ export async function markConflictsAndStaleFacts(db: Sql): Promise<void> {
   }
 
   // Mark facts stale when their source_chunk_id points to a missing chunk.
-  // In normal operation ON DELETE SET NULL handles this, but this guards against
-  // orphaned rows produced by TRUNCATE or other non-cascading deletions.
+  // NOTE: under the `source_chunk_id … ON DELETE SET NULL` FK, deleting a chunk
+  // nulls this column, so `source_chunk_id IS NOT NULL AND NOT EXISTS(chunk)` can
+  // never fire through a normal application DELETE. This branch is UNREACHABLE in
+  // normal operation and exists as defensive-only SQL — the only way to reach it
+  // is by bypassing the FK (DDL / session_replication_role); the covering test
+  // manufactures such an orphan via DDL. Task 5: do not treat this as live orphan
+  // protection.
   await db`
     UPDATE semantic_facts
     SET status = 'stale'
@@ -298,6 +303,9 @@ async function recordExtractionRun(
       ${run.status},
       ${run.error}
     )
+    -- On a repeated failure, this overwrites the prior failure row, so the error
+    -- column reflects only the most recent attempt. Acceptable: failed runs are
+    -- never cache-hit (loadCachedRun filters status = succeeded), so they re-run.
     ON CONFLICT (cache_key) DO UPDATE SET
       source_chunk_id        = EXCLUDED.source_chunk_id,
       raw_output             = EXCLUDED.raw_output,
@@ -345,6 +353,10 @@ async function restoreStaleFacts(
   seenFacts: Set<string>
 ): Promise<void> {
   for (const fact of previousFacts) {
+    // If the prior accepted fact's chunk was deleted, its snapshot source_chunk_id
+    // is null, so this key can never match a fresh-extraction key (which carries a
+    // live numeric chunk id) — the fact is therefore always restored as stale, which
+    // is the intended behavior.
     const key = [
       normalizeMemoryKey(fact.subject),
       normalizeMemoryKey(fact.predicate),

--- a/src/lib/memory/extract.ts
+++ b/src/lib/memory/extract.ts
@@ -11,7 +11,7 @@ import { createCsvExtractor } from "../../extractors/csv.js";
 import { createLlmExtractor, LLM_SCHEMA_VERSION } from "../../extractors/llm.js";
 import type { ExtractionInput, Extractor } from "../../extractors/types.js";
 import type { ExtractedCandidate, SourceType } from "../../types.js";
-import { sha256 } from "./chunk.js";
+import { sha256 } from "./chunk";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -230,12 +230,16 @@ function pickExtractor(input: ExtractionInput, options: RefreshMemoryOptions): E
 
 function metadataForExtractor(extractor: Extractor, options: RefreshMemoryOptions): ExtractionMetadata {
   const provided = options.metadataByExtractorType?.[extractor.type] ?? {};
+  const generationProvider = process.env.SOURCECADO_GENERATION_PROVIDER?.trim() || "deepseek";
+  const generationModel =
+    process.env.SOURCECADO_GENERATION_MODEL?.trim() ||
+    (generationProvider === "anthropic" ? "claude-sonnet-4-6" : "deepseek-chat");
   const defaults =
     extractor.type === "llm"
       ? {
           promptHash: sha256("sourcyavo-llm-extractor-v1"),
           schemaVersion: LLM_SCHEMA_VERSION,
-          modelName: process.env.SOURCECADO_GENERATION_MODEL || "deepseek-chat",
+          modelName: generationModel,
         }
       : {
           promptHash: DEFAULT_PROMPT_HASH,

--- a/src/lib/memory/ingest.ts
+++ b/src/lib/memory/ingest.ts
@@ -1,11 +1,10 @@
 import { readFile, readdir } from "node:fs/promises";
 import { join, relative, resolve, sep } from "node:path";
 import type postgres from "postgres";
-import { slugifySourceId } from "../../db.js";
 import { isSupportedSourcePath, parseSourceFile } from "../../frontmatter.js";
 import { IngestError, classifyIngestError, type IngestErrorCategory } from "../../ingest-error.js";
 import { DEFAULT_ACTOR, type MemoryActor } from "./actor.js";
-import { chunkCsvRows, chunkText, citationForChunk, sha256, type TextChunk } from "./chunk.js";
+import { chunkCsvRows, chunkText, citationForChunk, sha256, slugifySourceId, type TextChunk } from "./chunk.js";
 import { embedText, toVectorLiteral } from "./embed.js";
 
 export type MemorySkipCategory = IngestErrorCategory | "unchanged";
@@ -76,7 +75,7 @@ async function ingestFile(
 
   const contentHash = sha256(parsed.rawText);
   const relativeLabel = sourceLabel(rootFolder, filePath);
-  const sourceId = parsed.sourceId ?? slugifySourceId(relativeLabel);
+  const sourceId = slugifySourceId(parsed.sourceId ?? relativeLabel);
 
   // Dedup: skip if the stored row already has the same content hash
   const [existing] = await db<{ content_hash: string }[]>`

--- a/src/lib/memory/ingest.ts
+++ b/src/lib/memory/ingest.ts
@@ -1,0 +1,182 @@
+import { readFile, readdir } from "node:fs/promises";
+import { join, relative, resolve, sep } from "node:path";
+import type postgres from "postgres";
+import { slugifySourceId } from "../../db.js";
+import { isSupportedSourcePath, parseSourceFile } from "../../frontmatter.js";
+import { IngestError, classifyIngestError, type IngestErrorCategory } from "../../ingest-error.js";
+import { DEFAULT_ACTOR, type MemoryActor } from "./actor.js";
+import { chunkCsvRows, chunkText, citationForChunk, sha256, type TextChunk } from "./chunk.js";
+import { embedText, toVectorLiteral } from "./embed.js";
+
+export type MemorySkipCategory = IngestErrorCategory | "unchanged";
+
+export interface MemorySkippedFile {
+  path: string;
+  category: MemorySkipCategory;
+  reason: string;
+}
+
+export interface MemoryIngestResult {
+  processed: number;
+  skipped: number;
+  skippedFiles: MemorySkippedFile[];
+}
+
+type Sql = postgres.Sql;
+
+// Internal signal for dedup skip — not an IngestError.
+class UnchangedSkip {
+  readonly message = "File content unchanged";
+}
+
+export async function ingestFolder(
+  db: Sql,
+  folderPath: string,
+  actor: MemoryActor = DEFAULT_ACTOR
+): Promise<MemoryIngestResult> {
+  const folder = resolve(folderPath);
+  const result: MemoryIngestResult = { processed: 0, skipped: 0, skippedFiles: [] };
+
+  for (const filePath of await walkFiles(folder)) {
+    if (!isSupportedSourcePath(filePath)) {
+      recordSkip(result, filePath, new IngestError("unsupported-type", `Unsupported file extension: ${filePath}`));
+      continue;
+    }
+
+    try {
+      await ingestFile(db, filePath, folder, actor);
+      result.processed += 1;
+    } catch (error) {
+      recordSkip(result, filePath, error);
+    }
+  }
+
+  return result;
+}
+
+async function ingestFile(
+  db: Sql,
+  filePath: string,
+  rootFolder: string,
+  actor: MemoryActor
+): Promise<void> {
+  // Read
+  let content: string;
+  try {
+    content = await readFile(filePath, "utf8");
+  } catch (err) {
+    throw new IngestError("unreadable", `Failed to read file: ${errorMessage(err)}`);
+  }
+
+  // Parse (throws IngestError on empty / parse failures)
+  const parsed = parseSourceFile(filePath, content);
+
+  // Chunk (throws IngestError on parse failures)
+  const chunks = chunkSourceText(parsed.sourceType, parsed.rawText);
+
+  const contentHash = sha256(parsed.rawText);
+  const relativeLabel = sourceLabel(rootFolder, filePath);
+  const sourceId = parsed.sourceId ?? slugifySourceId(relativeLabel);
+
+  // Dedup: skip if the stored row already has the same content hash
+  const [existing] = await db<{ content_hash: string }[]>`
+    SELECT content_hash FROM source_records WHERE path = ${filePath}
+  `;
+  if (existing && existing.content_hash === contentHash) {
+    throw new UnchangedSkip();
+  }
+
+  // Compute embeddings outside the transaction so model_calls tracking
+  // (when OPENAI_API_KEY is set) is not rolled back on a chunk insert failure.
+  const embeddings = await Promise.all(chunks.map((chunk) => embedText(db, chunk.text)));
+
+  // Atomically: upsert source_record + replace chunks + seed permission
+  await db.begin(async (tx) => {
+    const [source] = await tx<{ id: string; source_id: string }[]>`
+      INSERT INTO source_records (source_id, path, title, source_type, content_hash, raw_text)
+      VALUES (${sourceId}, ${filePath}, ${parsed.title}, ${parsed.sourceType}, ${contentHash}, ${parsed.rawText})
+      ON CONFLICT (path) DO UPDATE SET
+        title        = EXCLUDED.title,
+        source_type  = EXCLUDED.source_type,
+        content_hash = EXCLUDED.content_hash,
+        raw_text     = EXCLUDED.raw_text,
+        updated_at   = now()
+      RETURNING id, source_id
+    `;
+
+    const effectiveSourceId = source.source_id;
+    const sourceRecordId = source.id;
+
+    await tx`DELETE FROM memory_chunks WHERE source_record_id = ${sourceRecordId}`;
+
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i];
+      const vectorLiteral = toVectorLiteral(embeddings[i]);
+      const citation = citationForChunk(effectiveSourceId, parsed.sourceType, chunk);
+      await tx`
+        INSERT INTO memory_chunks (source_record_id, chunk_index, text, chunk_hash, embedding, citation)
+        VALUES (
+          ${sourceRecordId},
+          ${chunk.chunkIndex},
+          ${chunk.text},
+          ${chunk.chunkHash},
+          ${vectorLiteral}::vector,
+          ${citation}
+        )
+      `;
+    }
+
+    await tx`
+      INSERT INTO source_permissions (principal_type, principal_id, source_id, access)
+      VALUES (${actor.actorType}, ${actor.actorId}, ${effectiveSourceId}, 'read')
+      ON CONFLICT (principal_type, principal_id, source_id) DO NOTHING
+    `;
+  });
+}
+
+async function walkFiles(folder: string): Promise<string[]> {
+  const entries = (await readdir(folder, { withFileTypes: true })).sort((a, b) =>
+    a.name.localeCompare(b.name)
+  );
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.name === ".sourcyavo") {
+      continue;
+    }
+
+    const entryPath = join(folder, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await walkFiles(entryPath)));
+    } else {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+function chunkSourceText(sourceType: string, rawText: string): TextChunk[] {
+  return sourceType === "csv" ? chunkCsvRows(rawText) : chunkText(rawText);
+}
+
+function sourceLabel(rootFolder: string, filePath: string): string {
+  const label = relative(rootFolder, filePath) || filePath;
+  return label.split(sep).join("/");
+}
+
+function recordSkip(result: MemoryIngestResult, filePath: string, error: unknown): void {
+  if (error instanceof UnchangedSkip) {
+    result.skipped += 1;
+    result.skippedFiles.push({ path: filePath, category: "unchanged", reason: error.message });
+    return;
+  }
+  const category = classifyIngestError(error);
+  const reason = errorMessage(error);
+  result.skipped += 1;
+  result.skippedFiles.push({ path: filePath, category, reason });
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/lib/memory/ingest.ts
+++ b/src/lib/memory/ingest.ts
@@ -3,9 +3,10 @@ import { join, relative, resolve, sep } from "node:path";
 import type postgres from "postgres";
 import { isSupportedSourcePath, parseSourceFile } from "../../frontmatter.js";
 import { IngestError, classifyIngestError, type IngestErrorCategory } from "../../ingest-error.js";
-import { DEFAULT_ACTOR, type MemoryActor } from "./actor.js";
-import { chunkCsvRows, chunkText, citationForChunk, sha256, slugifySourceId, type TextChunk } from "./chunk.js";
-import { embedText, toVectorLiteral } from "./embed.js";
+import { DEFAULT_ACTOR, type MemoryActor } from "./actor";
+import { chunkCsvRows, chunkText, sha256, slugifySourceId, type TextChunk } from "./chunk";
+import { writeChunksAndGrant } from "./chunk-store";
+import { embedText } from "./embed";
 
 export type MemorySkipCategory = IngestErrorCategory | "unchanged";
 
@@ -106,30 +107,14 @@ async function ingestFile(
     const effectiveSourceId = source.source_id;
     const sourceRecordId = source.id;
 
-    await tx`DELETE FROM memory_chunks WHERE source_record_id = ${sourceRecordId}`;
-
-    for (let i = 0; i < chunks.length; i++) {
-      const chunk = chunks[i];
-      const vectorLiteral = toVectorLiteral(embeddings[i]);
-      const citation = citationForChunk(effectiveSourceId, parsed.sourceType, chunk);
-      await tx`
-        INSERT INTO memory_chunks (source_record_id, chunk_index, text, chunk_hash, embedding, citation)
-        VALUES (
-          ${sourceRecordId},
-          ${chunk.chunkIndex},
-          ${chunk.text},
-          ${chunk.chunkHash},
-          ${vectorLiteral}::vector,
-          ${citation}
-        )
-      `;
-    }
-
-    await tx`
-      INSERT INTO source_permissions (principal_type, principal_id, source_id, access)
-      VALUES (${actor.actorType}, ${actor.actorId}, ${effectiveSourceId}, 'read')
-      ON CONFLICT (principal_type, principal_id, source_id) DO NOTHING
-    `;
+    await writeChunksAndGrant(tx, {
+      sourceRecordId,
+      sourceId: effectiveSourceId,
+      sourceType: parsed.sourceType,
+      chunks,
+      embeddings,
+      actor,
+    });
   });
 }
 

--- a/src/lib/memory/notes.ts
+++ b/src/lib/memory/notes.ts
@@ -1,7 +1,6 @@
 import type postgres from "postgres";
-import { slugifySourceId } from "../../db.js";
 import { DEFAULT_ACTOR, type MemoryActor } from "./actor.js";
-import { chunkText, citationForChunk, sha256 } from "./chunk.js";
+import { chunkText, citationForChunk, sha256, slugifySourceId } from "./chunk.js";
 import { embedText, toVectorLiteral } from "./embed.js";
 
 type Sql = postgres.Sql;

--- a/src/lib/memory/notes.ts
+++ b/src/lib/memory/notes.ts
@@ -1,7 +1,8 @@
 import type postgres from "postgres";
-import { DEFAULT_ACTOR, type MemoryActor } from "./actor.js";
-import { chunkText, citationForChunk, sha256, slugifySourceId } from "./chunk.js";
-import { embedText, toVectorLiteral } from "./embed.js";
+import { DEFAULT_ACTOR, type MemoryActor } from "./actor";
+import { chunkText, sha256, slugifySourceId } from "./chunk";
+import { writeChunksAndGrant } from "./chunk-store";
+import { embedText } from "./embed";
 
 type Sql = postgres.Sql;
 
@@ -38,30 +39,14 @@ export async function addMemoryNote(
     const effectiveSourceId = source.source_id;
 
     // Replace chunks to stay idempotent on re-add (same dedup pattern as ingest.ts).
-    await tx`DELETE FROM memory_chunks WHERE source_record_id = ${sourceRecordId}`;
-
-    for (let i = 0; i < chunks.length; i++) {
-      const chunk = chunks[i];
-      const vectorLiteral = toVectorLiteral(embeddings[i]);
-      const citation = citationForChunk(effectiveSourceId, "note", chunk);
-      await tx`
-        INSERT INTO memory_chunks (source_record_id, chunk_index, text, chunk_hash, embedding, citation)
-        VALUES (
-          ${sourceRecordId},
-          ${chunk.chunkIndex},
-          ${chunk.text},
-          ${chunk.chunkHash},
-          ${vectorLiteral}::vector,
-          ${citation}
-        )
-      `;
-    }
-
-    await tx`
-      INSERT INTO source_permissions (principal_type, principal_id, source_id, access)
-      VALUES (${actor.actorType}, ${actor.actorId}, ${effectiveSourceId}, 'read')
-      ON CONFLICT (principal_type, principal_id, source_id) DO NOTHING
-    `;
+    await writeChunksAndGrant(tx, {
+      sourceRecordId,
+      sourceId: effectiveSourceId,
+      sourceType: "note",
+      chunks,
+      embeddings,
+      actor,
+    });
   });
 
   return { sourceId };

--- a/src/lib/memory/notes.ts
+++ b/src/lib/memory/notes.ts
@@ -1,0 +1,69 @@
+import type postgres from "postgres";
+import { slugifySourceId } from "../../db.js";
+import { DEFAULT_ACTOR, type MemoryActor } from "./actor.js";
+import { chunkText, citationForChunk, sha256 } from "./chunk.js";
+import { embedText, toVectorLiteral } from "./embed.js";
+
+type Sql = postgres.Sql;
+
+export async function addMemoryNote(
+  db: Sql,
+  args: { title: string; text: string; actor?: MemoryActor }
+): Promise<{ sourceId: string }> {
+  const { title, text, actor = DEFAULT_ACTOR } = args;
+
+  const titleSlug = slugifySourceId(title);
+  const sourceId = `note-${titleSlug}-${sha256(text).slice(0, 8)}`;
+  const path = `note://${sourceId}`;
+  const contentHash = sha256(text);
+
+  const chunks = chunkText(text);
+
+  // Embed outside the transaction so model_calls tracking is not rolled back
+  // on a chunk insert failure (mirrors the pattern in ingest.ts).
+  const embeddings = await Promise.all(chunks.map((chunk) => embedText(db, chunk.text)));
+
+  await db.begin(async (tx) => {
+    const [source] = await tx<{ id: string; source_id: string }[]>`
+      INSERT INTO source_records (source_id, path, title, source_type, content_hash, raw_text)
+      VALUES (${sourceId}, ${path}, ${title}, 'note', ${contentHash}, ${text})
+      ON CONFLICT (path) DO UPDATE SET
+        title        = EXCLUDED.title,
+        content_hash = EXCLUDED.content_hash,
+        raw_text     = EXCLUDED.raw_text,
+        updated_at   = now()
+      RETURNING id, source_id
+    `;
+
+    const sourceRecordId = source.id;
+    const effectiveSourceId = source.source_id;
+
+    // Replace chunks to stay idempotent on re-add (same dedup pattern as ingest.ts).
+    await tx`DELETE FROM memory_chunks WHERE source_record_id = ${sourceRecordId}`;
+
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i];
+      const vectorLiteral = toVectorLiteral(embeddings[i]);
+      const citation = citationForChunk(effectiveSourceId, "note", chunk);
+      await tx`
+        INSERT INTO memory_chunks (source_record_id, chunk_index, text, chunk_hash, embedding, citation)
+        VALUES (
+          ${sourceRecordId},
+          ${chunk.chunkIndex},
+          ${chunk.text},
+          ${chunk.chunkHash},
+          ${vectorLiteral}::vector,
+          ${citation}
+        )
+      `;
+    }
+
+    await tx`
+      INSERT INTO source_permissions (principal_type, principal_id, source_id, access)
+      VALUES (${actor.actorType}, ${actor.actorId}, ${effectiveSourceId}, 'read')
+      ON CONFLICT (principal_type, principal_id, source_id) DO NOTHING
+    `;
+  });
+
+  return { sourceId };
+}

--- a/src/lib/memory/permissions.ts
+++ b/src/lib/memory/permissions.ts
@@ -1,0 +1,16 @@
+import type { Sql } from "../tools/types";
+import type { MemoryActor } from "./actor";
+
+// Default-deny: returns only source_ids explicitly granted 'read' to this actor.
+// No rows → [] (caller must not fetch restricted data).
+export async function resolveAllowedSourceIds(db: Sql, actor: MemoryActor): Promise<string[]> {
+  const rows = await db<{ source_id: string }[]>`
+    SELECT source_id
+    FROM source_permissions
+    WHERE principal_type = ${actor.actorType}
+      AND principal_id = ${actor.actorId}
+      AND access = 'read'
+    ORDER BY source_id
+  `;
+  return rows.map((r) => r.source_id);
+}

--- a/src/lib/memory/rank.ts
+++ b/src/lib/memory/rank.ts
@@ -1,0 +1,170 @@
+// Pure ranking and intent helpers — no DB calls, no side effects.
+// Ported verbatim from src/answer.ts (legacy); prose/answer functions not included.
+
+export type QuestionIntent =
+  | "follow_up"
+  | "responded"
+  | "no_response"
+  | "worked_with"
+  | "uncertainty"
+  | "generic";
+
+// Structural shape required by factIntentScore and rankRows.
+interface FactRow {
+  subject: string;
+  predicate: string;
+  object: string;
+}
+
+// ---------------------------------------------------------------------------
+// Exported pure functions
+// ---------------------------------------------------------------------------
+
+export function asksForUncertainty(question: string): boolean {
+  return /\b(uncertain|gap|gaps|conflict|conflicted|candidate|stale|missing)\b/i.test(question);
+}
+
+export function questionIntent(question: string): QuestionIntent {
+  if (asksForUncertainty(question)) {
+    return "uncertainty";
+  }
+  if (/\b(worked with|work with|partnered|collaborated|sponsored|client project)\b/i.test(question)) {
+    return "worked_with";
+  }
+  if (
+    /\b(did not respond|didn't respond|no response|not respond|ghosted|did not reply|no reply)\b/i.test(
+      question
+    )
+  ) {
+    return "no_response";
+  }
+  if (/\b(responded|replied|reply|in discussion)\b/i.test(question)) {
+    return "responded";
+  }
+  if (/\b(follow[- ]?up|needs follow|need follow)\b/i.test(question)) {
+    return "follow_up";
+  }
+  return "generic";
+}
+
+export function meaningfulQuestionTerms(question: string): string[] {
+  const terms = new Set(question.toLowerCase().match(/[a-z0-9]+/g) ?? []);
+  const stopWords = new Set([
+    "a",
+    "an",
+    "and",
+    "for",
+    "happened",
+    "is",
+    "needs",
+    "the",
+    "to",
+    "what",
+    "who",
+    "with",
+  ]);
+  return Array.from(terms).filter((term) => term.length > 2 && !stopWords.has(term));
+}
+
+export function lexicalScore(text: string, question: string): number {
+  const meaningfulTerms = meaningfulQuestionTerms(question);
+  const normalizedText = text.toLowerCase();
+  return meaningfulTerms.reduce(
+    (score, term) => score + (normalizedText.includes(term) ? 1 : 0),
+    0
+  );
+}
+
+export function factIntentScore(fact: FactRow, intent: QuestionIntent): number {
+  const predicate = fact.predicate.toLowerCase();
+  const object = fact.object.toLowerCase();
+  const text = `${predicate} ${object}`;
+
+  if (intent === "follow_up") {
+    return isFollowUpFact(fact) ? 2 : 0;
+  }
+  if (intent === "responded") {
+    if (predicate === "status" && /\b(responded|replied|in discussion|locked in)\b/.test(object)) {
+      return 3;
+    }
+    return /\b(responded|replied|locked in)\b/.test(text) ? 2 : 0;
+  }
+  if (intent === "no_response") {
+    if (
+      predicate === "status" &&
+      /\b(ghosted|rejected|no response|no reply|declined)\b/.test(object)
+    ) {
+      return 3;
+    }
+    return /\b(ghosted|no response|no reply|not respond|did not respond|declined)\b/.test(text)
+      ? 2
+      : 0;
+  }
+  if (intent === "worked_with") {
+    if (predicate === "codeology_owner" || predicate === "interest") {
+      return 0;
+    }
+    if (predicate === "status" && /\b(locked in)\b/.test(object)) {
+      return 3;
+    }
+    return /\b(worked with|partnered|collaborated|sponsored|sponsor|sow)\b/.test(text) ? 2 : 0;
+  }
+  return 0;
+}
+
+export function rankRows<T>(
+  rows: T[],
+  question: string,
+  intent: QuestionIntent,
+  getText: (row: T) => string
+): T[] {
+  const meaningfulTerms = meaningfulQuestionTerms(question);
+  return rows
+    .map((row, index) => {
+      const score = lexicalScore(getText(row), question);
+      const intentScore = isFactRow(row) ? factIntentScore(row, intent) : 0;
+      return { row, score, intentScore, index };
+    })
+    .filter(({ score, intentScore }) =>
+      intentRequiresSemanticMatch(intent)
+        ? intentScore > 0
+        : meaningfulTerms.length === 0 || score > 0 || intentScore > 0
+    )
+    .sort(
+      (left, right) =>
+        right.intentScore - left.intentScore ||
+        right.score - left.score ||
+        left.index - right.index
+    )
+    .map(({ row }) => row);
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function isFollowUpFact(fact: FactRow): boolean {
+  return (
+    fact.predicate === "needs_follow_up" ||
+    fact.predicate === "reason" ||
+    fact.object.toLowerCase().includes("follow")
+  );
+}
+
+function isFactRow(row: unknown): row is FactRow {
+  return (
+    typeof row === "object" &&
+    row !== null &&
+    "subject" in row &&
+    "predicate" in row &&
+    "object" in row
+  );
+}
+
+function isStrictIntent(intent: QuestionIntent): boolean {
+  return intent === "responded" || intent === "no_response" || intent === "worked_with";
+}
+
+function intentRequiresSemanticMatch(intent: QuestionIntent): boolean {
+  return isStrictIntent(intent);
+}

--- a/src/lib/memory/retrieve.ts
+++ b/src/lib/memory/retrieve.ts
@@ -1,0 +1,165 @@
+import type { Sql } from "../tools/types";
+import { DEFAULT_ACTOR, type MemoryActor } from "./actor";
+import { embedText, toVectorLiteral } from "./embed";
+import { resolveAllowedSourceIds } from "./permissions";
+import {
+  asksForUncertainty,
+  lexicalScore,
+  questionIntent,
+  rankRows,
+  type QuestionIntent,
+} from "./rank";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface MemoryFact {
+  subject: string;
+  predicate: string;
+  object: string;
+  confidence: number;
+  status: string;
+  citation: string | null;
+}
+
+export interface MemoryChunk {
+  text: string;
+  citation: string;
+  score: number;
+}
+
+export interface MemoryBundle {
+  intent: QuestionIntent;
+  acceptedFacts: MemoryFact[];
+  gapFacts: MemoryFact[];
+  chunks: MemoryChunk[];
+}
+
+// ---------------------------------------------------------------------------
+// searchMemory — permission-filtered hybrid retrieval
+// ---------------------------------------------------------------------------
+
+export async function searchMemory(
+  db: Sql,
+  args: { query: string; actor?: MemoryActor; limit?: number }
+): Promise<MemoryBundle> {
+  const { query, actor = DEFAULT_ACTOR, limit = 6 } = args;
+
+  const intent = questionIntent(query);
+  const allowed = await resolveAllowedSourceIds(db, actor);
+
+  // Default-deny: empty allowlist → no data returned immediately.
+  if (allowed.length === 0) {
+    return { intent, acceptedFacts: [], gapFacts: [], chunks: [] };
+  }
+
+  const [acceptedFacts, gapFacts, chunks] = await Promise.all([
+    loadAcceptedFacts(db, query, intent, allowed, limit),
+    loadGapFacts(db, query, allowed),
+    loadChunks(db, query, allowed),
+  ]);
+
+  return { intent, acceptedFacts, gapFacts, chunks };
+}
+
+// ---------------------------------------------------------------------------
+// Internal query helpers — permission filter is always in SQL WHERE
+// ---------------------------------------------------------------------------
+
+async function loadAcceptedFacts(
+  db: Sql,
+  query: string,
+  intent: QuestionIntent,
+  allowed: string[],
+  limit: number
+): Promise<MemoryFact[]> {
+  // sr.source_id = ANY(${allowed}) is the permission gate — enforced in SQL,
+  // never in JS, so a restricted source is never a ranking candidate.
+  const rows = await db<MemoryFact[]>`
+    SELECT
+      sf.subject,
+      sf.predicate,
+      sf.object,
+      sf.confidence,
+      sf.status,
+      mc.citation
+    FROM semantic_facts sf
+    JOIN source_records sr ON sr.id = sf.source_record_id
+    LEFT JOIN memory_chunks mc ON mc.id = sf.source_chunk_id
+    WHERE sf.status = 'accepted'
+      AND sr.source_id = ANY(${allowed})
+    ORDER BY sf.confidence DESC, sf.subject
+  `;
+
+  const ranked = rankRows(
+    rows,
+    query,
+    intent,
+    (r) => `${r.subject} ${r.predicate} ${r.object}`
+  );
+  return ranked.slice(0, limit);
+}
+
+async function loadGapFacts(db: Sql, query: string, allowed: string[]): Promise<MemoryFact[]> {
+  const rows = await db<MemoryFact[]>`
+    SELECT
+      sf.subject,
+      sf.predicate,
+      sf.object,
+      sf.confidence,
+      sf.status,
+      mc.citation
+    FROM semantic_facts sf
+    JOIN source_records sr ON sr.id = sf.source_record_id
+    LEFT JOIN memory_chunks mc ON mc.id = sf.source_chunk_id
+    WHERE sf.status IN ('candidate', 'conflicted', 'stale')
+      AND sr.source_id = ANY(${allowed})
+    ORDER BY sf.status, sf.subject
+  `;
+
+  if (asksForUncertainty(query)) {
+    return rows.slice(0, 6);
+  }
+
+  return rankRows(
+    rows,
+    query,
+    "generic",
+    (r) => `${r.subject} ${r.predicate} ${r.object}`
+  ).slice(0, 6);
+}
+
+interface RawChunkRow {
+  text: string;
+  citation: string;
+  score: number;
+}
+
+async function loadChunks(db: Sql, query: string, allowed: string[]): Promise<MemoryChunk[]> {
+  const qvec = await embedText(db, query);
+  const qvecLiteral = toVectorLiteral(qvec);
+
+  // Fetch top-10 candidates by cosine distance; permission filter is in SQL WHERE.
+  // The ${qvecLiteral}::vector cast sends the vector literal as a bound parameter,
+  // letting pgvector handle cosine arithmetic entirely in the database.
+  const rows = await db<RawChunkRow[]>`
+    SELECT
+      mc.text,
+      mc.citation,
+      (1 - (mc.embedding <=> ${qvecLiteral}::vector))::float8 AS score
+    FROM memory_chunks mc
+    JOIN source_records sr ON sr.id = mc.source_record_id
+    WHERE sr.source_id = ANY(${allowed})
+      AND mc.embedding IS NOT NULL
+    ORDER BY mc.embedding <=> ${qvecLiteral}::vector ASC
+    LIMIT 10
+  `;
+
+  // JS post-filter: require both semantic overlap (score > 0) and at least one
+  // meaningful query term in the text (lexical gate).
+  return rows
+    .filter((r) => r.score > 0 && lexicalScore(r.text, query) > 0)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 3);
+}

--- a/src/lib/tools/add-memory-note.ts
+++ b/src/lib/tools/add-memory-note.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+import { addMemoryNote } from "../memory/notes";
+import type { Tool } from "./types";
+
+export const addMemoryNoteTool: Tool<{ title: string; text: string }, { sourceId: string }> = {
+  name: "add_memory_note",
+  description: "Record a sourcing memory note (or a correction). Becomes immediately searchable.",
+  permissionClass: "write_internal",
+  argsSchema: z.object({ title: z.string().min(1), text: z.string().min(1) }),
+  async execute(args, ctx) {
+    return addMemoryNote(ctx.db, { title: args.title, text: args.text });
+  },
+};

--- a/src/lib/tools/search-memory.ts
+++ b/src/lib/tools/search-memory.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+import { searchMemory, type MemoryBundle } from "../memory/retrieve";
+import type { Tool } from "./types";
+
+export const searchMemoryTool: Tool<{ query: string; limit?: number }, MemoryBundle> = {
+  name: "search_memory",
+  description:
+    "Search sourcing memory. Returns { intent, acceptedFacts, gapFacts, chunks } with citations. Use this to ground every answer.",
+  permissionClass: "read",
+  argsSchema: z.object({
+    query: z.string().min(1),
+    limit: z.number().int().positive().optional(),
+  }),
+  async execute(args, ctx) {
+    return searchMemory(ctx.db, { query: args.query, limit: args.limit });
+  },
+};

--- a/src/migrations/002_memory.sql
+++ b/src/migrations/002_memory.sql
@@ -1,0 +1,71 @@
+-- 002_memory.sql — Feature A memory schema (source records, chunks, semantic facts, extraction cache, permissions).
+
+CREATE TABLE IF NOT EXISTS source_records (
+  id             BIGSERIAL PRIMARY KEY,
+  source_id      TEXT NOT NULL UNIQUE,
+  path           TEXT NOT NULL UNIQUE,
+  title          TEXT,
+  source_type    TEXT NOT NULL CHECK (source_type IN ('markdown', 'text', 'csv', 'email', 'note')),
+  content_hash   TEXT NOT NULL,
+  raw_text       TEXT,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS memory_chunks (
+  id               BIGSERIAL PRIMARY KEY,
+  source_record_id BIGINT NOT NULL REFERENCES source_records(id) ON DELETE CASCADE,
+  chunk_index      INTEGER NOT NULL,
+  text             TEXT NOT NULL,
+  chunk_hash       TEXT NOT NULL,
+  embedding        vector(1536),
+  citation         TEXT NOT NULL,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (source_record_id, chunk_index)
+);
+
+CREATE TABLE IF NOT EXISTS semantic_facts (
+  id               BIGSERIAL PRIMARY KEY,
+  subject          TEXT NOT NULL,
+  predicate        TEXT NOT NULL,
+  object           TEXT NOT NULL,
+  source_record_id BIGINT REFERENCES source_records(id) ON DELETE SET NULL,
+  source_chunk_id  BIGINT REFERENCES memory_chunks(id) ON DELETE SET NULL,
+  confidence       REAL NOT NULL,
+  status           TEXT NOT NULL CHECK (status IN ('candidate', 'accepted', 'conflicted', 'stale')),
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS extraction_runs (
+  id                     BIGSERIAL PRIMARY KEY,
+  source_chunk_id        BIGINT REFERENCES memory_chunks(id) ON DELETE SET NULL,
+  cache_key              TEXT NOT NULL UNIQUE,
+  chunk_hash             TEXT NOT NULL,
+  extractor_type         TEXT NOT NULL,
+  extractor_version      TEXT NOT NULL,
+  prompt_hash            TEXT NOT NULL,
+  schema_version         TEXT NOT NULL,
+  model_name             TEXT NOT NULL,
+  raw_output             TEXT,
+  parsed_candidates_json JSONB,
+  status                 TEXT NOT NULL CHECK (status IN ('succeeded', 'failed')),
+  error                  TEXT,
+  created_at             TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS source_permissions (
+  id             BIGSERIAL PRIMARY KEY,
+  principal_type TEXT NOT NULL CHECK (principal_type IN ('user', 'oauth_client', 'test_client')),
+  principal_id   TEXT NOT NULL,
+  source_id      TEXT NOT NULL,
+  access         TEXT NOT NULL CHECK (access IN ('read')),
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (principal_type, principal_id, source_id)
+);
+
+CREATE INDEX IF NOT EXISTS source_records_source_id_idx ON source_records(source_id);
+
+CREATE INDEX IF NOT EXISTS memory_chunks_source_record_idx ON memory_chunks(source_record_id);
+CREATE INDEX IF NOT EXISTS memory_chunks_embedding_idx ON memory_chunks USING hnsw (embedding vector_cosine_ops);
+
+CREATE INDEX IF NOT EXISTS semantic_facts_source_status_idx ON semantic_facts(source_record_id, status);

--- a/tests/agent-prompt.test.ts
+++ b/tests/agent-prompt.test.ts
@@ -13,4 +13,12 @@ describe("buildAgentSystemPrompt", () => {
   it("handles an empty tool set", () => {
     expect(buildAgentSystemPrompt([])).toContain("(none)");
   });
+
+  it("appends the instructions string after the tool catalog", () => {
+    const instructions = "INSTRUCTIONS_MARKER: ground every answer.";
+    const prompt = buildAgentSystemPrompt([echoTool], instructions);
+    expect(prompt).toContain(instructions);
+    // The instructions block comes after the tool catalog entry.
+    expect(prompt.indexOf(instructions)).toBeGreaterThan(prompt.indexOf("echo (read):"));
+  });
 });

--- a/tests/agent-route.test.ts
+++ b/tests/agent-route.test.ts
@@ -1,7 +1,12 @@
 import { vi } from "vitest";
 
-const { runAgentMock } = vi.hoisted(() => ({ runAgentMock: vi.fn() }));
+const { runAgentMock, getRunTraceMock } = vi.hoisted(() => ({
+  runAgentMock: vi.fn(),
+  getRunTraceMock: vi.fn(),
+}));
 vi.mock("@/lib/harness", () => ({ runAgent: runAgentMock }));
+vi.mock("@/lib/ledger", () => ({ getRunTrace: getRunTraceMock }));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue({}) }));
 
 import { POST } from "@/app/api/agent/route";
 
@@ -16,6 +21,7 @@ function postRequest(body: unknown): Request {
 describe("POST /api/agent", () => {
   beforeEach(() => {
     runAgentMock.mockReset();
+    getRunTraceMock.mockResolvedValue(null); // no trace → skip citation check
   });
 
   it("returns 400 when question is missing", async () => {
@@ -36,5 +42,12 @@ describe("POST /api/agent", () => {
     const res = await POST(postRequest({ question: "loop" }));
     expect(res.status).toBe(500);
     await expect(res.json()).resolves.toMatchObject({ runId: 9, status: "failed" });
+  });
+
+  it("returns invalidCitations in the response body", async () => {
+    runAgentMock.mockResolvedValue({ runId: 7, status: "succeeded", answer: "hi", steps: 1 });
+    const res = await POST(postRequest({ question: "echo hi" }));
+    const body = await res.json();
+    expect(Array.isArray(body.invalidCitations)).toBe(true);
   });
 });

--- a/tests/agent-route.test.ts
+++ b/tests/agent-route.test.ts
@@ -50,4 +50,45 @@ describe("POST /api/agent", () => {
     const body = await res.json();
     expect(Array.isArray(body.invalidCitations)).toBe(true);
   });
+
+  it("flags an invented citation while leaving a valid one unflagged", async () => {
+    // Final answer cites a valid id (from the bundle) AND an invented one.
+    runAgentMock.mockResolvedValue({
+      runId: 11,
+      status: "succeeded",
+      answer: "Answer: see real-src#chunk-1 and ghost#chunk-7",
+      steps: 2,
+    });
+    // Override the shared null mock: return a trace whose search_memory tool
+    // call produced a bundle containing only the valid citation.
+    getRunTraceMock.mockResolvedValue({
+      steps: [
+        {
+          children: [],
+          toolCalls: [
+            {
+              toolName: "search_memory",
+              status: "succeeded",
+              result: {
+                intent: "generic",
+                acceptedFacts: [],
+                gapFacts: [],
+                chunks: [{ text: "t", citation: "real-src#chunk-1", score: 0.9 }],
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const res = await POST(postRequest({ question: "who responded?" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.invalidCitations).toContain("ghost#chunk-7");
+    expect(body.invalidCitations).not.toContain("real-src#chunk-1");
+    // Invalid token is sanitized out; the valid one survives.
+    expect(body.answer).toContain("real-src#chunk-1");
+    expect(body.answer).not.toContain("ghost#chunk-7");
+  });
 });

--- a/tests/extractors.test.ts
+++ b/tests/extractors.test.ts
@@ -318,4 +318,71 @@ describe("LLM extractor", () => {
     expect(source).not.toContain("https://api.openai.com/v1/responses");
     expect(source).toContain("callModel");
   });
+
+  describe("provider-aware model default", () => {
+    function withEnv(overrides: Record<string, string | undefined>, fn: () => void) {
+      const saved: Record<string, string | undefined> = {};
+      for (const key of Object.keys(overrides)) {
+        saved[key] = process.env[key];
+        if (overrides[key] === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = overrides[key];
+        }
+      }
+      try {
+        fn();
+      } finally {
+        for (const key of Object.keys(saved)) {
+          if (saved[key] === undefined) delete process.env[key];
+          else process.env[key] = saved[key];
+        }
+      }
+    }
+
+    it("uses claude-sonnet-4-6 when provider is anthropic and no model env is set", () => {
+      withEnv(
+        { SOURCECADO_GENERATION_PROVIDER: "anthropic", SOURCECADO_GENERATION_MODEL: undefined },
+        () => {
+          expect(createLlmExtractor().modelName).toBe("claude-sonnet-4-6");
+        }
+      );
+    });
+
+    it("uses deepseek-chat when provider is unset and no model env is set", () => {
+      withEnv(
+        { SOURCECADO_GENERATION_PROVIDER: undefined, SOURCECADO_GENERATION_MODEL: undefined },
+        () => {
+          expect(createLlmExtractor().modelName).toBe("deepseek-chat");
+        }
+      );
+    });
+
+    it("uses deepseek-chat when provider is 'deepseek' and no model env is set", () => {
+      withEnv(
+        { SOURCECADO_GENERATION_PROVIDER: "deepseek", SOURCECADO_GENERATION_MODEL: undefined },
+        () => {
+          expect(createLlmExtractor().modelName).toBe("deepseek-chat");
+        }
+      );
+    });
+
+    it("explicit config.model wins over provider-aware default", () => {
+      withEnv(
+        { SOURCECADO_GENERATION_PROVIDER: "anthropic", SOURCECADO_GENERATION_MODEL: undefined },
+        () => {
+          expect(createLlmExtractor({ model: "claude-haiku-4-5" }).modelName).toBe("claude-haiku-4-5");
+        }
+      );
+    });
+
+    it("SOURCECADO_GENERATION_MODEL wins over provider-aware default", () => {
+      withEnv(
+        { SOURCECADO_GENERATION_PROVIDER: "anthropic", SOURCECADO_GENERATION_MODEL: "claude-opus-4-5" },
+        () => {
+          expect(createLlmExtractor().modelName).toBe("claude-opus-4-5");
+        }
+      );
+    });
+  });
 });

--- a/tests/extractors.test.ts
+++ b/tests/extractors.test.ts
@@ -293,10 +293,24 @@ describe("LLM extractor", () => {
     });
   });
 
-  it("requires model config when creating an unstructured LLM extractor", () => {
-    expect(() => createLlmExtractor({ apiKey: "", model: "test-model" })).toThrow(
-      /DEEPSEEK_API_KEY/
-    );
+  it("can be constructed without a key; provider error surfaces at call time", async () => {
+    // Construction no longer throws — the gateway's requireEnv validates the
+    // active provider's key at call time, not at construction.
+    const extractor = createLlmExtractor({ model: "test-model" });
+    expect(extractor).toBeDefined();
+
+    // A provider that rejects simulates what happens when requireEnv fires at runtime.
+    const failingProvider: LlmProvider = async () => {
+      throw new Error("DEEPSEEK_API_KEY is required for Model Gateway provider calls.");
+    };
+    const extractorWithBadProvider = createLlmExtractor({
+      model: "test-model",
+      provider: failingProvider,
+    });
+    await expect(extractorWithBadProvider.extract(input)).rejects.toMatchObject({
+      name: "ExtractionError",
+      code: "provider_error",
+    });
   });
 
   it("does not use the legacy OpenAI Responses API provider", () => {

--- a/tests/memory-answer.test.ts
+++ b/tests/memory-answer.test.ts
@@ -4,7 +4,7 @@ import { getRunTrace } from "@/lib/ledger";
 import { runMigrations } from "@/lib/migrate";
 import type { ModelGatewayProvider } from "@/lib/model-gateway";
 import { runAgent } from "@/lib/harness";
-import { collectAllowedCitations, checkCitations } from "@/lib/memory/citations";
+import { collectAllowedCitations, checkCitations, collectBundlesFromTrace } from "@/lib/memory/citations";
 import { memoryRegistry } from "@/lib/memory/answer-config";
 import { DEFAULT_ACTOR, type MemoryActor } from "@/lib/memory/actor";
 import { embedText, toVectorLiteral } from "@/lib/memory/embed";
@@ -86,28 +86,6 @@ async function insertFact(
   `;
 }
 
-// ---------------------------------------------------------------------------
-// Helper: extract MemoryBundles from search_memory tool calls in a run trace
-// ---------------------------------------------------------------------------
-
-function collectBundlesFromRun(
-  trace: Awaited<ReturnType<typeof getRunTrace>>
-): MemoryBundle[] {
-  if (!trace) return [];
-  const bundles: MemoryBundle[] = [];
-  function walk(steps: typeof trace.steps) {
-    for (const step of steps) {
-      for (const tc of step.toolCalls) {
-        if (tc.toolName === "search_memory" && tc.status === "succeeded" && tc.result) {
-          bundles.push(tc.result as MemoryBundle);
-        }
-      }
-      walk(step.children);
-    }
-  }
-  walk(trace.steps);
-  return bundles;
-}
 
 // ---------------------------------------------------------------------------
 // Pure unit tests — collectAllowedCitations
@@ -284,7 +262,7 @@ describe("search_memory agentic flow (mock provider + postgres)", () => {
     // Verify tool call is recorded in the ledger
     const trace = await getRunTrace(db, result.runId);
     expect(trace).not.toBeNull();
-    const bundles = collectBundlesFromRun(trace);
+    const bundles = collectBundlesFromTrace(trace);
     expect(bundles).toHaveLength(1);
 
     // Citation post-check: the real citation is allowed
@@ -330,7 +308,7 @@ describe("search_memory agentic flow (mock provider + postgres)", () => {
     expect(result.status).toBe("succeeded");
 
     const trace = await getRunTrace(db, result.runId);
-    const bundles = collectBundlesFromRun(trace);
+    const bundles = collectBundlesFromTrace(trace);
     const allowed = collectAllowedCitations(bundles);
 
     const { invalid } = checkCitations(result.answer!, allowed);
@@ -362,7 +340,7 @@ describe("search_memory agentic flow (mock provider + postgres)", () => {
     expect(result.answer).toBe("no relevant memory");
 
     const trace = await getRunTrace(db, result.runId);
-    const bundles = collectBundlesFromRun(trace);
+    const bundles = collectBundlesFromTrace(trace);
     const allowed = collectAllowedCitations(bundles);
     expect(allowed.size).toBe(0);
 

--- a/tests/memory-answer.test.ts
+++ b/tests/memory-answer.test.ts
@@ -191,6 +191,23 @@ describe("checkCitations", () => {
     const { invalid } = checkCitations("see ghost#row-5 for details", new Set());
     expect(invalid).toContain("ghost#row-5");
   });
+
+  it("matches nested-path source IDs containing '/'", () => {
+    const allowed = new Set(["alice/outreach-md#chunk-1"]);
+    const answer = "See alice/outreach-md#chunk-1 for context.";
+    const { invalid, sanitizedAnswer } = checkCitations(answer, allowed);
+    expect(invalid).toHaveLength(0);
+    expect(sanitizedAnswer).toContain("alice/outreach-md#chunk-1");
+  });
+
+  it("rejects truncated last-segment of nested citation when full path is required", () => {
+    // Guard: regex must NOT match the bare last segment as a valid citation
+    const allowed = new Set(["alice/outreach-md#chunk-1"]);
+    const answer = "See outreach-md#chunk-1 for context.";
+    const { invalid } = checkCitations(answer, allowed);
+    // "outreach-md#chunk-1" is not in allowed — should be flagged
+    expect(invalid).toContain("outreach-md#chunk-1");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/memory-answer.test.ts
+++ b/tests/memory-answer.test.ts
@@ -1,0 +1,372 @@
+import { vi } from "vitest";
+import { closeDb, getDb } from "@/lib/db";
+import { getRunTrace } from "@/lib/ledger";
+import { runMigrations } from "@/lib/migrate";
+import type { ModelGatewayProvider } from "@/lib/model-gateway";
+import { runAgent } from "@/lib/harness";
+import { collectAllowedCitations, checkCitations } from "@/lib/memory/citations";
+import { memoryRegistry } from "@/lib/memory/answer-config";
+import { DEFAULT_ACTOR, type MemoryActor } from "@/lib/memory/actor";
+import { embedText, toVectorLiteral } from "@/lib/memory/embed";
+import type { MemoryBundle } from "@/lib/memory/retrieve";
+
+type Db = ReturnType<typeof getDb>;
+
+// ---------------------------------------------------------------------------
+// DB helpers (mirrors memory-retrieve.test.ts pattern)
+// ---------------------------------------------------------------------------
+
+async function resetAllTables(db: Db): Promise<void> {
+  await db`DROP TABLE IF EXISTS source_permissions CASCADE`;
+  await db`DROP TABLE IF EXISTS extraction_runs CASCADE`;
+  await db`DROP TABLE IF EXISTS semantic_facts CASCADE`;
+  await db`DROP TABLE IF EXISTS memory_chunks CASCADE`;
+  await db`DROP TABLE IF EXISTS source_records CASCADE`;
+  await db`DROP TABLE IF EXISTS tool_calls CASCADE`;
+  await db`DROP TABLE IF EXISTS model_calls CASCADE`;
+  await db`DROP TABLE IF EXISTS run_steps CASCADE`;
+  await db`DROP TABLE IF EXISTS runs CASCADE`;
+  await db`DROP TABLE IF EXISTS schema_migrations CASCADE`;
+  await runMigrations(db);
+}
+
+async function insertSource(db: Db, sourceId: string): Promise<string> {
+  const [row] = await db<{ id: string }[]>`
+    INSERT INTO source_records (source_id, path, source_type, content_hash)
+    VALUES (${sourceId}, ${"/test/" + sourceId}, 'markdown', ${"hash-" + sourceId})
+    RETURNING id
+  `;
+  return row.id;
+}
+
+async function grantRead(db: Db, actor: MemoryActor, sourceId: string): Promise<void> {
+  await db`
+    INSERT INTO source_permissions (principal_type, principal_id, source_id, access)
+    VALUES (${actor.actorType}, ${actor.actorId}, ${sourceId}, 'read')
+  `;
+}
+
+async function insertChunk(
+  db: Db,
+  opts: { sourceRecordId: string; text: string; citation: string; chunkIndex?: number }
+): Promise<string> {
+  const vec = await embedText(db, opts.text);
+  const vecLiteral = toVectorLiteral(vec);
+  const [row] = await db<{ id: string }[]>`
+    INSERT INTO memory_chunks (source_record_id, chunk_index, text, chunk_hash, embedding, citation)
+    VALUES (
+      ${opts.sourceRecordId}, ${opts.chunkIndex ?? 0}, ${opts.text},
+      ${"chunk-hash-" + opts.citation}, ${vecLiteral}::vector, ${opts.citation}
+    )
+    RETURNING id
+  `;
+  return row.id;
+}
+
+async function insertFact(
+  db: Db,
+  opts: {
+    subject: string;
+    predicate: string;
+    object: string;
+    status: string;
+    sourceRecordId: string;
+    sourceChunkId?: string | null;
+    confidence?: number;
+  }
+): Promise<void> {
+  await db`
+    INSERT INTO semantic_facts
+      (subject, predicate, object, source_record_id, source_chunk_id, confidence, status)
+    VALUES (
+      ${opts.subject}, ${opts.predicate}, ${opts.object},
+      ${opts.sourceRecordId}, ${opts.sourceChunkId ?? null},
+      ${opts.confidence ?? 0.9}, ${opts.status}
+    )
+  `;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: extract MemoryBundles from search_memory tool calls in a run trace
+// ---------------------------------------------------------------------------
+
+function collectBundlesFromRun(
+  trace: Awaited<ReturnType<typeof getRunTrace>>
+): MemoryBundle[] {
+  if (!trace) return [];
+  const bundles: MemoryBundle[] = [];
+  function walk(steps: typeof trace.steps) {
+    for (const step of steps) {
+      for (const tc of step.toolCalls) {
+        if (tc.toolName === "search_memory" && tc.status === "succeeded" && tc.result) {
+          bundles.push(tc.result as MemoryBundle);
+        }
+      }
+      walk(step.children);
+    }
+  }
+  walk(trace.steps);
+  return bundles;
+}
+
+// ---------------------------------------------------------------------------
+// Pure unit tests — collectAllowedCitations
+// ---------------------------------------------------------------------------
+
+describe("collectAllowedCitations", () => {
+  it("unions citations from acceptedFacts, gapFacts, and chunks", () => {
+    const bundle: MemoryBundle = {
+      intent: "generic",
+      acceptedFacts: [
+        { subject: "A", predicate: "p", object: "o", confidence: 0.9, status: "accepted", citation: "src1#chunk-1" },
+      ],
+      gapFacts: [
+        { subject: "B", predicate: "p", object: "o", confidence: 0.5, status: "candidate", citation: "src1#chunk-2" },
+      ],
+      chunks: [{ text: "t", citation: "src1#chunk-3", score: 0.8 }],
+    };
+    const allowed = collectAllowedCitations([bundle]);
+    expect(allowed.has("src1#chunk-1")).toBe(true);
+    expect(allowed.has("src1#chunk-2")).toBe(true);
+    expect(allowed.has("src1#chunk-3")).toBe(true);
+    expect(allowed.size).toBe(3);
+  });
+
+  it("skips null citations in facts", () => {
+    const bundle: MemoryBundle = {
+      intent: "generic",
+      acceptedFacts: [
+        { subject: "A", predicate: "p", object: "o", confidence: 0.9, status: "accepted", citation: null },
+      ],
+      gapFacts: [],
+      chunks: [],
+    };
+    const allowed = collectAllowedCitations([bundle]);
+    expect(allowed.size).toBe(0);
+  });
+
+  it("unions across multiple bundles", () => {
+    const b1: MemoryBundle = {
+      intent: "generic",
+      acceptedFacts: [],
+      gapFacts: [],
+      chunks: [{ text: "t", citation: "src1#chunk-1", score: 0.8 }],
+    };
+    const b2: MemoryBundle = {
+      intent: "generic",
+      acceptedFacts: [],
+      gapFacts: [],
+      chunks: [{ text: "t", citation: "src2#chunk-1", score: 0.8 }],
+    };
+    const allowed = collectAllowedCitations([b1, b2]);
+    expect(allowed.has("src1#chunk-1")).toBe(true);
+    expect(allowed.has("src2#chunk-1")).toBe(true);
+    expect(allowed.size).toBe(2);
+  });
+
+  it("returns empty set for empty bundles array", () => {
+    expect(collectAllowedCitations([])).toEqual(new Set());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pure unit tests — checkCitations
+// ---------------------------------------------------------------------------
+
+describe("checkCitations", () => {
+  it("returns no invalid when all cited ids are in allowed set", () => {
+    const allowed = new Set(["src1#chunk-1", "src1#row-2"]);
+    const answer = "Found data src1#chunk-1 and also src1#row-2.";
+    const { invalid, sanitizedAnswer } = checkCitations(answer, allowed);
+    expect(invalid).toHaveLength(0);
+    expect(sanitizedAnswer).toContain("src1#chunk-1");
+    expect(sanitizedAnswer).toContain("src1#row-2");
+  });
+
+  it("flags invented citation id and replaces it in sanitizedAnswer", () => {
+    const allowed = new Set(["src1#chunk-1"]);
+    const answer = "Found src1#chunk-1 but invented ghost#chunk-7 is wrong.";
+    const { invalid, sanitizedAnswer } = checkCitations(answer, allowed);
+    expect(invalid).toContain("ghost#chunk-7");
+    expect(invalid).toHaveLength(1);
+    expect(sanitizedAnswer).not.toContain("ghost#chunk-7");
+    expect(sanitizedAnswer).toContain("src1#chunk-1");
+    expect(sanitizedAnswer).toContain("[unverified citation removed]");
+  });
+
+  it("leaves valid citations untouched when removing invalid ones", () => {
+    const allowed = new Set(["real#chunk-1"]);
+    const answer = "Valid: real#chunk-1. Invalid: bad#row-99.";
+    const { invalid, sanitizedAnswer } = checkCitations(answer, allowed);
+    expect(invalid).toContain("bad#row-99");
+    expect(sanitizedAnswer).toContain("real#chunk-1");
+    expect(sanitizedAnswer).not.toContain("bad#row-99");
+  });
+
+  it("returns empty invalid and unchanged answer when no citations present", () => {
+    const { invalid, sanitizedAnswer } = checkCitations("no memory found", new Set());
+    expect(invalid).toHaveLength(0);
+    expect(sanitizedAnswer).toBe("no memory found");
+  });
+
+  it("flags all cited ids when allowed set is empty", () => {
+    const { invalid } = checkCitations("see ghost#row-5 for details", new Set());
+    expect(invalid).toContain("ghost#row-5");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests — agentic flow with mock provider + real Postgres
+// ---------------------------------------------------------------------------
+
+describe("search_memory agentic flow (mock provider + postgres)", () => {
+  let savedApiKey: string | undefined;
+
+  beforeEach(async () => {
+    savedApiKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY; // force offline hash embedding
+    const db = getDb();
+    await resetAllTables(db);
+  });
+
+  afterEach(async () => {
+    if (savedApiKey !== undefined) {
+      process.env.OPENAI_API_KEY = savedApiKey;
+    } else {
+      delete process.env.OPENAI_API_KEY;
+    }
+    await closeDb();
+  });
+
+  it("tool ran and real citation from bundle validates (no invalid)", async () => {
+    const db = getDb();
+    const srcId = await insertSource(db, "src-answer-test");
+    await grantRead(db, DEFAULT_ACTOR, "src-answer-test");
+    const chunkId = await insertChunk(db, {
+      sourceRecordId: srcId,
+      text: "Alice responded to sourcing outreach",
+      citation: "src-answer-test#chunk-1",
+    });
+    await insertFact(db, {
+      subject: "Alice",
+      predicate: "status",
+      object: "responded",
+      status: "accepted",
+      sourceRecordId: srcId,
+      sourceChunkId: chunkId,
+    });
+
+    const provider = vi
+      .fn<ModelGatewayProvider>()
+      .mockResolvedValueOnce({
+        object: { action: "tool", tool: "search_memory", args: '{"query":"who responded"}' },
+      })
+      .mockResolvedValueOnce({
+        object: {
+          action: "final",
+          answer:
+            "Answer: Alice responded src-answer-test#chunk-1\nEvidence: src-answer-test#chunk-1\nGaps: None\nNext Action: Follow up",
+        },
+      });
+
+    const registry = memoryRegistry();
+    const result = await runAgent({
+      question: "who responded?",
+      registry,
+      allowedClasses: new Set(["read"]),
+      provider,
+      db,
+    });
+
+    expect(result.status).toBe("succeeded");
+    expect(provider).toHaveBeenCalledTimes(2);
+
+    // Verify tool call is recorded in the ledger
+    const trace = await getRunTrace(db, result.runId);
+    expect(trace).not.toBeNull();
+    const bundles = collectBundlesFromRun(trace);
+    expect(bundles).toHaveLength(1);
+
+    // Citation post-check: the real citation is allowed
+    const allowed = collectAllowedCitations(bundles);
+    expect(allowed.has("src-answer-test#chunk-1")).toBe(true);
+
+    const { invalid } = checkCitations(result.answer!, allowed);
+    expect(invalid).toHaveLength(0);
+  });
+
+  it("invented citation is flagged in post-check", async () => {
+    const db = getDb();
+    const srcId = await insertSource(db, "src-invent-test");
+    await grantRead(db, DEFAULT_ACTOR, "src-invent-test");
+    await insertChunk(db, {
+      sourceRecordId: srcId,
+      text: "Bob responded to sourcing outreach",
+      citation: "src-invent-test#chunk-1",
+    });
+
+    const provider = vi
+      .fn<ModelGatewayProvider>()
+      .mockResolvedValueOnce({
+        object: { action: "tool", tool: "search_memory", args: '{"query":"who responded"}' },
+      })
+      .mockResolvedValueOnce({
+        object: {
+          action: "final",
+          answer:
+            "Answer: Bob responded src-invent-test#chunk-1 and ghost#chunk-99\nEvidence: src-invent-test#chunk-1\nGaps: None\nNext Action: None",
+        },
+      });
+
+    const registry = memoryRegistry();
+    const result = await runAgent({
+      question: "who responded?",
+      registry,
+      allowedClasses: new Set(["read"]),
+      provider,
+      db,
+    });
+
+    expect(result.status).toBe("succeeded");
+
+    const trace = await getRunTrace(db, result.runId);
+    const bundles = collectBundlesFromRun(trace);
+    const allowed = collectAllowedCitations(bundles);
+
+    const { invalid } = checkCitations(result.answer!, allowed);
+    expect(invalid).toContain("ghost#chunk-99");
+  });
+
+  it("refuse-on-empty: empty memory → flow completes as succeeded, no invalid citations", async () => {
+    // No data seeded — memory is empty, so search_memory returns empty bundle
+    const provider = vi
+      .fn<ModelGatewayProvider>()
+      .mockResolvedValueOnce({
+        object: { action: "tool", tool: "search_memory", args: '{"query":"who responded"}' },
+      })
+      .mockResolvedValueOnce({
+        object: { action: "final", answer: "no relevant memory" },
+      });
+
+    const db = getDb();
+    const registry = memoryRegistry();
+    const result = await runAgent({
+      question: "who responded?",
+      registry,
+      allowedClasses: new Set(["read"]),
+      provider,
+      db,
+    });
+
+    expect(result.status).toBe("succeeded");
+    expect(result.answer).toBe("no relevant memory");
+
+    const trace = await getRunTrace(db, result.runId);
+    const bundles = collectBundlesFromRun(trace);
+    const allowed = collectAllowedCitations(bundles);
+    expect(allowed.size).toBe(0);
+
+    const { invalid } = checkCitations(result.answer!, allowed);
+    expect(invalid).toHaveLength(0);
+  });
+});

--- a/tests/memory-embed.test.ts
+++ b/tests/memory-embed.test.ts
@@ -1,0 +1,173 @@
+import {
+  embedText,
+  MEMORY_EMBEDDING_DIMENSIONS,
+  toVectorLiteral,
+  usesRealEmbeddings,
+} from "@/lib/memory/embed";
+import type { Sql } from "@/lib/tools/types";
+
+// Placeholder db — not used in fallback path; real path uses callModel
+const fakeDb = {} as Sql;
+
+// ---------------------------------------------------------------------------
+// MEMORY_EMBEDDING_DIMENSIONS
+// ---------------------------------------------------------------------------
+
+describe("MEMORY_EMBEDDING_DIMENSIONS", () => {
+  it("is 1536", () => {
+    expect(MEMORY_EMBEDDING_DIMENSIONS).toBe(1536);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// toVectorLiteral
+// ---------------------------------------------------------------------------
+
+describe("toVectorLiteral()", () => {
+  it("formats a two-element vector for pgvector", () => {
+    expect(toVectorLiteral([0.5, -0.25])).toBe("[0.5,-0.25]");
+  });
+
+  it("handles an empty vector", () => {
+    expect(toVectorLiteral([])).toBe("[]");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// usesRealEmbeddings()
+// ---------------------------------------------------------------------------
+
+describe("usesRealEmbeddings()", () => {
+  const saveRestore = () => {
+    const saved = process.env.OPENAI_API_KEY;
+    return () => {
+      if (saved === undefined) {
+        delete process.env.OPENAI_API_KEY;
+      } else {
+        process.env.OPENAI_API_KEY = saved;
+      }
+    };
+  };
+
+  it("returns true when OPENAI_API_KEY is a non-empty string", () => {
+    const restore = saveRestore();
+    process.env.OPENAI_API_KEY = "sk-test";
+    try {
+      expect(usesRealEmbeddings()).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  it("returns false when OPENAI_API_KEY is unset", () => {
+    const restore = saveRestore();
+    delete process.env.OPENAI_API_KEY;
+    try {
+      expect(usesRealEmbeddings()).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  it("returns false when OPENAI_API_KEY is an empty string", () => {
+    const restore = saveRestore();
+    process.env.OPENAI_API_KEY = "";
+    try {
+      expect(usesRealEmbeddings()).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  it("returns false when OPENAI_API_KEY is whitespace only", () => {
+    const restore = saveRestore();
+    process.env.OPENAI_API_KEY = "   ";
+    try {
+      expect(usesRealEmbeddings()).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// embedText() — fallback path (OPENAI_API_KEY unset)
+// ---------------------------------------------------------------------------
+
+describe("embedText() fallback path", () => {
+  let savedKey: string | undefined;
+
+  beforeEach(() => {
+    savedKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  afterEach(() => {
+    if (savedKey !== undefined) {
+      process.env.OPENAI_API_KEY = savedKey;
+    }
+  });
+
+  it("returns a vector of exactly 1536 dimensions", async () => {
+    const vec = await embedText(fakeDb, "hello world");
+    expect(vec).toHaveLength(1536);
+  });
+
+  it("is deterministic: same input → identical vector", async () => {
+    const vec1 = await embedText(fakeDb, "deterministic test phrase");
+    const vec2 = await embedText(fakeDb, "deterministic test phrase");
+    expect(vec1).toEqual(vec2);
+  });
+
+  it("is L2-normalized: magnitude ≈ 1 for non-empty text", async () => {
+    const vec = await embedText(fakeDb, "some meaningful text for normalization");
+    const mag = Math.sqrt(vec.reduce((sum, v) => sum + v * v, 0));
+    expect(mag).toBeCloseTo(1, 6);
+  });
+
+  it("returns a zero vector for empty string (no tokens)", async () => {
+    const vec = await embedText(fakeDb, "");
+    expect(vec).toHaveLength(1536);
+    expect(vec.every((v) => v === 0)).toBe(true);
+  });
+
+  it("returns a zero vector for text with no alphanumeric tokens", async () => {
+    const vec = await embedText(fakeDb, "!!! ??? --- ###");
+    expect(vec).toHaveLength(1536);
+    expect(vec.every((v) => v === 0)).toBe(true);
+  });
+
+  it("has no NaN values", async () => {
+    const empty = await embedText(fakeDb, "");
+    const nonEmpty = await embedText(fakeDb, "no nan values");
+    expect(empty.every((v) => !Number.isNaN(v))).toBe(true);
+    expect(nonEmpty.every((v) => !Number.isNaN(v))).toBe(true);
+  });
+
+  it("produces different vectors for different inputs", async () => {
+    const vec1 = await embedText(fakeDb, "apple orange banana");
+    const vec2 = await embedText(fakeDb, "quantum physics relativity");
+    expect(vec1).not.toEqual(vec2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// embedText() — real path branch selection (no network call)
+// ---------------------------------------------------------------------------
+
+describe("embedText() real path branch selection", () => {
+  it("usesRealEmbeddings() is true when OPENAI_API_KEY is set, confirming real path selection", () => {
+    const saved = process.env.OPENAI_API_KEY;
+    process.env.OPENAI_API_KEY = "sk-fake-key-for-branch-test";
+    try {
+      // The function reads OPENAI_API_KEY at call time — presence means real path
+      expect(usesRealEmbeddings()).toBe(true);
+    } finally {
+      if (saved === undefined) {
+        delete process.env.OPENAI_API_KEY;
+      } else {
+        process.env.OPENAI_API_KEY = saved;
+      }
+    }
+  });
+});

--- a/tests/memory-extract.test.ts
+++ b/tests/memory-extract.test.ts
@@ -1,0 +1,370 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+import {
+  markConflictsAndStaleFacts,
+  normalizeMemoryKey,
+  refreshMemory,
+} from "@/lib/memory/extract";
+import { createMockExtractor } from "@/extractors/mock";
+import type { ExtractionInput } from "@/extractors/types";
+import type { ExtractedCandidate } from "@/types";
+
+type Db = ReturnType<typeof getDb>;
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+async function resetMemoryTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS source_permissions CASCADE`;
+  await db`DROP TABLE IF EXISTS extraction_runs CASCADE`;
+  await db`DROP TABLE IF EXISTS semantic_facts CASCADE`;
+  await db`DROP TABLE IF EXISTS memory_chunks CASCADE`;
+  await db`DROP TABLE IF EXISTS source_records CASCADE`;
+  await db`DROP TABLE IF EXISTS schema_migrations CASCADE`;
+  await runMigrations(db);
+}
+
+async function insertSource(
+  db: Db,
+  opts: { sourceId: string; path: string; contentHash?: string; sourceType?: string }
+): Promise<string> {
+  const [row] = await db<{ id: string }[]>`
+    INSERT INTO source_records (source_id, path, source_type, content_hash)
+    VALUES (
+      ${opts.sourceId},
+      ${opts.path},
+      ${opts.sourceType ?? "markdown"},
+      ${opts.contentHash ?? "hash-" + opts.sourceId}
+    )
+    RETURNING id
+  `;
+  return row.id;
+}
+
+async function insertChunk(
+  db: Db,
+  opts: { sourceRecordId: string; text: string; chunkHash: string; citation: string; chunkIndex?: number }
+): Promise<string> {
+  const [row] = await db<{ id: string }[]>`
+    INSERT INTO memory_chunks (source_record_id, chunk_index, text, chunk_hash, citation)
+    VALUES (
+      ${opts.sourceRecordId},
+      ${opts.chunkIndex ?? 0},
+      ${opts.text},
+      ${opts.chunkHash},
+      ${opts.citation}
+    )
+    RETURNING id
+  `;
+  return row.id;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("refreshMemory (postgres)", () => {
+  beforeEach(async () => {
+    await resetMemoryTables();
+  });
+
+  afterEach(async () => {
+    await closeDb();
+  });
+
+  // -------------------------------------------------------------------------
+  // accept vs candidate threshold
+  // -------------------------------------------------------------------------
+
+  it("inserts 'accepted' for confidence >= 0.75, 'candidate' for < 0.75", async () => {
+    const db = getDb();
+    const srcId = await insertSource(db, { sourceId: "src-threshold", path: "/threshold.md" });
+    await insertChunk(db, {
+      sourceRecordId: srcId,
+      text: "Threshold test.",
+      chunkHash: "ch-threshold",
+      citation: "src-threshold#chunk-1",
+    });
+
+    const candidates: ExtractedCandidate[] = [
+      { kind: "semantic_fact", subject: "Alice", predicate: "works_at", object: "Acme", confidence: 0.8, evidenceText: "e1" },
+      { kind: "semantic_fact", subject: "Bob", predicate: "role", object: "Engineer", confidence: 0.7, evidenceText: "e2" },
+    ];
+    const result = await refreshMemory(db, { selectExtractor: () => createMockExtractor(candidates) });
+
+    expect(result.chunksProcessed).toBe(1);
+    expect(result.extracted).toBe(1);
+
+    const facts = await db<{ subject: string; status: string }[]>`
+      SELECT subject, status FROM semantic_facts ORDER BY subject
+    `;
+    expect(facts).toHaveLength(2);
+    expect(facts.find((f) => f.subject === "Alice")?.status).toBe("accepted");
+    expect(facts.find((f) => f.subject === "Bob")?.status).toBe("candidate");
+  });
+
+  it("treats confidence exactly at 0.75 as 'accepted'", async () => {
+    const db = getDb();
+    const srcId = await insertSource(db, { sourceId: "src-exact", path: "/exact.md" });
+    await insertChunk(db, {
+      sourceRecordId: srcId,
+      text: "Boundary test.",
+      chunkHash: "ch-exact",
+      citation: "src-exact#chunk-1",
+    });
+
+    const candidates: ExtractedCandidate[] = [
+      { kind: "semantic_fact", subject: "Carol", predicate: "skill", object: "TypeScript", confidence: 0.75, evidenceText: "e" },
+    ];
+    await refreshMemory(db, { selectExtractor: () => createMockExtractor(candidates) });
+
+    const [fact] = await db<{ status: string }[]>`SELECT status FROM semantic_facts WHERE subject = 'Carol'`;
+    expect(fact.status).toBe("accepted");
+  });
+
+  // -------------------------------------------------------------------------
+  // conflict detection
+  // -------------------------------------------------------------------------
+
+  it("marks both facts 'conflicted' when same subject+predicate has different objects", async () => {
+    const db = getDb();
+    const src1 = await insertSource(db, { sourceId: "src-c1", path: "/c1.md", contentHash: "h1" });
+    const src2 = await insertSource(db, { sourceId: "src-c2", path: "/c2.md", contentHash: "h2" });
+    const chunk1Id = await insertChunk(db, {
+      sourceRecordId: src1,
+      text: "Alice at Acme.",
+      chunkHash: "ch-c1",
+      citation: "src-c1#chunk-1",
+    });
+    await insertChunk(db, {
+      sourceRecordId: src2,
+      text: "Alice at BetaCorp.",
+      chunkHash: "ch-c2",
+      citation: "src-c2#chunk-1",
+    });
+
+    const ext1 = createMockExtractor([
+      { kind: "semantic_fact", subject: "Alice", predicate: "works_at", object: "Acme", confidence: 0.9, evidenceText: "e1" },
+    ]);
+    const ext2 = createMockExtractor([
+      { kind: "semantic_fact", subject: "Alice", predicate: "works_at", object: "BetaCorp", confidence: 0.85, evidenceText: "e2" },
+    ]);
+
+    await refreshMemory(db, {
+      selectExtractor: (input: ExtractionInput) =>
+        input.sourcePath.includes("c1.md") ? ext1 : ext2,
+    });
+
+    const facts = await db<{ object: string; status: string }[]>`
+      SELECT object, status FROM semantic_facts
+      WHERE subject = 'Alice' AND predicate = 'works_at'
+      ORDER BY object
+    `;
+    expect(facts).toHaveLength(2);
+    expect(facts.every((f) => f.status === "conflicted")).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // stale — vanished accepted fact
+  // -------------------------------------------------------------------------
+
+  it("restores a vanished accepted fact as 'stale' on the second refresh", async () => {
+    const db = getDb();
+    const srcId = await insertSource(db, { sourceId: "src-stale", path: "/stale.md" });
+    await insertChunk(db, {
+      sourceRecordId: srcId,
+      text: "Alice at Acme.",
+      chunkHash: "ch-stale",
+      citation: "src-stale#chunk-1",
+    });
+
+    const ext1 = createMockExtractor([
+      { kind: "semantic_fact", subject: "Alice", predicate: "works_at", object: "Acme", confidence: 0.9, evidenceText: "e1" },
+    ]);
+    await refreshMemory(db, { selectExtractor: () => ext1 });
+
+    const [firstFact] = await db<{ status: string }[]>`SELECT status FROM semantic_facts WHERE subject = 'Alice'`;
+    expect(firstFact.status).toBe("accepted");
+
+    // Clear extraction cache so the second run re-extracts (doesn't reuse ext1's cached candidates).
+    await db`DELETE FROM extraction_runs`;
+
+    // Second refresh: only Bob is extracted — Alice vanishes.
+    const ext2 = createMockExtractor([
+      { kind: "semantic_fact", subject: "Bob", predicate: "role", object: "CTO", confidence: 0.9, evidenceText: "e2" },
+    ]);
+    await refreshMemory(db, { selectExtractor: () => ext2 });
+
+    const [staleFact] = await db<{ status: string }[]>`SELECT status FROM semantic_facts WHERE subject = 'Alice'`;
+    expect(staleFact.status).toBe("stale");
+
+    const [bobFact] = await db<{ status: string }[]>`SELECT status FROM semantic_facts WHERE subject = 'Bob'`;
+    expect(bobFact.status).toBe("accepted");
+  });
+
+  // -------------------------------------------------------------------------
+  // stale — orphaned source_chunk_id
+  // -------------------------------------------------------------------------
+
+  it("marks a fact 'stale' when its source_chunk_id points to a missing chunk", async () => {
+    const db = getDb();
+    const srcId = await insertSource(db, { sourceId: "src-orphan", path: "/orphan.md" });
+
+    // Temporarily drop the FK so we can insert an orphaned source_chunk_id.
+    // In production, ON DELETE SET NULL prevents this; this test exercises the
+    // defensive markConflictsAndStaleFacts query.
+    await db`ALTER TABLE semantic_facts DROP CONSTRAINT IF EXISTS semantic_facts_source_chunk_id_fkey`;
+    await db`
+      INSERT INTO semantic_facts (subject, predicate, object, source_record_id, source_chunk_id, confidence, status)
+      VALUES ('Charlie', 'role', 'Designer', ${srcId}, 999999, 0.9, 'accepted')
+    `;
+    await db`
+      ALTER TABLE semantic_facts
+      ADD CONSTRAINT semantic_facts_source_chunk_id_fkey
+      FOREIGN KEY (source_chunk_id) REFERENCES memory_chunks(id) ON DELETE SET NULL NOT VALID
+    `;
+
+    await markConflictsAndStaleFacts(db);
+
+    const [fact] = await db<{ status: string }[]>`
+      SELECT status FROM semantic_facts WHERE subject = 'Charlie'
+    `;
+    expect(fact.status).toBe("stale");
+  });
+
+  // -------------------------------------------------------------------------
+  // cache reuse
+  // -------------------------------------------------------------------------
+
+  it("reuses extraction_runs cache on second refresh of unchanged chunks", async () => {
+    const db = getDb();
+    const srcId = await insertSource(db, { sourceId: "src-cache", path: "/cache.md" });
+    await insertChunk(db, {
+      sourceRecordId: srcId,
+      text: "Cache test.",
+      chunkHash: "ch-cache",
+      citation: "src-cache#chunk-1",
+    });
+
+    let callCount = 0;
+    const countingExtractor = createMockExtractor(async (_input: ExtractionInput) => {
+      callCount++;
+      return [
+        { kind: "semantic_fact" as const, subject: "Alice", predicate: "works_at", object: "Acme", confidence: 0.9, evidenceText: "e1" },
+      ];
+    });
+
+    const result1 = await refreshMemory(db, { selectExtractor: () => countingExtractor });
+    expect(result1.extracted).toBe(1);
+    expect(result1.reused).toBe(0);
+    expect(callCount).toBe(1);
+
+    const result2 = await refreshMemory(db, { selectExtractor: () => countingExtractor });
+    expect(result2.extracted).toBe(0);
+    expect(result2.reused).toBe(1);
+    expect(callCount).toBe(1); // extractor not called again
+  });
+
+  // -------------------------------------------------------------------------
+  // failed extraction
+  // -------------------------------------------------------------------------
+
+  it("continues and increments failed when extractor throws", async () => {
+    const db = getDb();
+    const srcId = await insertSource(db, { sourceId: "src-fail", path: "/fail.md" });
+    await insertChunk(db, {
+      sourceRecordId: srcId,
+      text: "Will fail.",
+      chunkHash: "ch-fail",
+      citation: "src-fail#chunk-1",
+    });
+
+    const failingExtractor = {
+      type: "mock",
+      version: "1",
+      async extract(_input: ExtractionInput): Promise<ExtractedCandidate[]> {
+        throw new Error("test extraction failure");
+      },
+    };
+
+    const result = await refreshMemory(db, { selectExtractor: () => failingExtractor });
+    expect(result.failed).toBe(1);
+    expect(result.extracted).toBe(0);
+
+    const [runRow] = await db<{ status: string; error: string }[]>`
+      SELECT status, error FROM extraction_runs
+    `;
+    expect(runRow.status).toBe("failed");
+    expect(runRow.error).toContain("test extraction failure");
+  });
+
+  // -------------------------------------------------------------------------
+  // entity / relationship candidates are ignored
+  // -------------------------------------------------------------------------
+
+  it("skips entity and relationship candidates, only inserts semantic_facts", async () => {
+    const db = getDb();
+    const srcId = await insertSource(db, { sourceId: "src-kinds", path: "/kinds.md" });
+    await insertChunk(db, {
+      sourceRecordId: srcId,
+      text: "Mixed kinds.",
+      chunkHash: "ch-kinds",
+      citation: "src-kinds#chunk-1",
+    });
+
+    const candidates: ExtractedCandidate[] = [
+      { kind: "entity", subject: "Alice", entityType: "person", confidence: 0.9, evidenceText: "e" },
+      { kind: "relationship", subject: "Alice", object: "Acme", relationshipType: "works_at", confidence: 0.9, evidenceText: "e" },
+      { kind: "semantic_fact", subject: "Alice", predicate: "email", object: "alice@acme.com", confidence: 0.95, evidenceText: "e" },
+    ];
+
+    await refreshMemory(db, { selectExtractor: () => createMockExtractor(candidates) });
+
+    const facts = await db<{ subject: string; predicate: string }[]>`
+      SELECT subject, predicate FROM semantic_facts
+    `;
+    expect(facts).toHaveLength(1);
+    expect(facts[0].predicate).toBe("email");
+  });
+
+  // -------------------------------------------------------------------------
+  // dedup within a single refresh
+  // -------------------------------------------------------------------------
+
+  it("deduplicates identical semantic_facts from the same chunk", async () => {
+    const db = getDb();
+    const srcId = await insertSource(db, { sourceId: "src-dedup", path: "/dedup.md" });
+    await insertChunk(db, {
+      sourceRecordId: srcId,
+      text: "Dedup test.",
+      chunkHash: "ch-dedup",
+      citation: "src-dedup#chunk-1",
+    });
+
+    const candidates: ExtractedCandidate[] = [
+      { kind: "semantic_fact", subject: "Alice", predicate: "works_at", object: "Acme", confidence: 0.9, evidenceText: "e1" },
+      { kind: "semantic_fact", subject: "Alice", predicate: "works_at", object: "Acme", confidence: 0.85, evidenceText: "e2" },
+    ];
+
+    await refreshMemory(db, { selectExtractor: () => createMockExtractor(candidates) });
+
+    const [{ n }] = await db<{ n: number }[]>`SELECT count(*)::int AS n FROM semantic_facts`;
+    expect(n).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// normalizeMemoryKey unit tests
+// ---------------------------------------------------------------------------
+
+describe("normalizeMemoryKey", () => {
+  it("normalizes strings for dedup key comparison", () => {
+    expect(normalizeMemoryKey("  Alice Smith  ")).toBe("alice-smith");
+    expect(normalizeMemoryKey("Acme Corp.")).toBe("acme-corp");
+    expect(normalizeMemoryKey("AI Safety")).toBe("ai-safety");
+    expect(normalizeMemoryKey("'quoted'")).toBe("quoted");
+  });
+});

--- a/tests/memory-ingest.test.ts
+++ b/tests/memory-ingest.test.ts
@@ -216,6 +216,35 @@ describe("memory ingestFolder (postgres)", () => {
     expect(sources.every((s) => !s.path.includes("image.png"))).toBe(true);
   });
 
+  it("frontmatter source_id with spaces/punctuation is slugified before storage so citations match the citation regex", async () => {
+    const db = getDb();
+    const dir = makeTempDir();
+    // source_id with spaces and punctuation — would break the citation regex if stored as-is
+    writeFileSync(
+      join(dir, "note.md"),
+      "---\ntitle: My Source\nsource_id: My Src: 2026\n---\nContent about sourcing candidates."
+    );
+
+    const result = await ingestFolder(db, dir);
+    expect(result.processed).toBe(1);
+
+    const [record] = await db<{ source_id: string }[]>`
+      SELECT source_id FROM source_records LIMIT 1
+    `;
+    // source_id must conform to the citation charset
+    expect(record.source_id).toMatch(/^[A-Za-z0-9._/-]+$/);
+
+    const chunks = await db<{ citation: string }[]>`
+      SELECT citation FROM memory_chunks ORDER BY chunk_index
+    `;
+    expect(chunks.length).toBeGreaterThan(0);
+    // Every stored citation must match the citation token pattern
+    const citationPattern = /^[A-Za-z0-9._-]+#(?:chunk|row)-\d+$/;
+    for (const chunk of chunks) {
+      expect(chunk.citation).toMatch(citationPattern);
+    }
+  });
+
   it("empty file is reported in skippedFiles with no orphan rows", async () => {
     const db = getDb();
     const dir = makeTempDir();

--- a/tests/memory-ingest.test.ts
+++ b/tests/memory-ingest.test.ts
@@ -1,0 +1,235 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+import { DEFAULT_ACTOR } from "@/lib/memory/actor";
+import { ingestFolder } from "@/lib/memory/ingest";
+
+async function resetMemoryTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS source_permissions CASCADE`;
+  await db`DROP TABLE IF EXISTS extraction_runs CASCADE`;
+  await db`DROP TABLE IF EXISTS semantic_facts CASCADE`;
+  await db`DROP TABLE IF EXISTS memory_chunks CASCADE`;
+  await db`DROP TABLE IF EXISTS source_records CASCADE`;
+  await db`DROP TABLE IF EXISTS schema_migrations CASCADE`;
+  await runMigrations(db);
+}
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "memory-ingest-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("memory ingestFolder (postgres)", () => {
+  let savedApiKey: string | undefined;
+
+  beforeEach(async () => {
+    // Unset OPENAI_API_KEY so embedText uses the deterministic hash fallback
+    savedApiKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    await resetMemoryTables();
+  });
+
+  afterEach(async () => {
+    if (savedApiKey !== undefined) {
+      process.env.OPENAI_API_KEY = savedApiKey;
+    } else {
+      delete process.env.OPENAI_API_KEY;
+    }
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    await closeDb();
+  });
+
+  it("writes source_records + memory_chunks with 1536-dim embeddings and non-empty citations", async () => {
+    const db = getDb();
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "note.md"), "---\ntitle: Test Note\n---\nContent about sourcing.");
+    writeFileSync(join(dir, "contacts.csv"), "name,status\nJane,contacted\n");
+
+    const result = await ingestFolder(db, dir);
+
+    expect(result.processed).toBe(2);
+    expect(result.skipped).toBe(0);
+    expect(result.skippedFiles).toHaveLength(0);
+
+    const sources = await db<{ id: string; source_type: string }[]>`
+      SELECT id, source_type FROM source_records ORDER BY id
+    `;
+    expect(sources).toHaveLength(2);
+
+    const chunks = await db<{ citation: string }[]>`
+      SELECT citation FROM memory_chunks ORDER BY id
+    `;
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+    expect(chunks.every((c) => c.citation.length > 0)).toBe(true);
+
+    const dims = await db<{ d: number }[]>`
+      SELECT vector_dims(embedding) AS d FROM memory_chunks LIMIT 1
+    `;
+    expect(dims[0].d).toBe(1536);
+  });
+
+  it("md/txt chunk citation ends with #chunk-1 (1-indexed); csv row citation ends with #row-1", async () => {
+    const db = getDb();
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "note.txt"), "Simple sourcing note.");
+    writeFileSync(join(dir, "data.csv"), "name,status\nJane,contacted\n");
+
+    await ingestFolder(db, dir);
+
+    const chunks = await db<{ citation: string }[]>`
+      SELECT mc.citation
+      FROM memory_chunks mc
+      JOIN source_records sr ON sr.id = mc.source_record_id
+      WHERE mc.chunk_index = 0
+      ORDER BY mc.id
+    `;
+
+    const txtCitation = chunks.find((c) => c.citation.includes("#chunk-"));
+    const csvCitation = chunks.find((c) => c.citation.includes("#row-"));
+
+    expect(txtCitation?.citation).toMatch(/#chunk-1$/);
+    expect(csvCitation?.citation).toMatch(/#row-1$/);
+  });
+
+  it("dedup: second run on unchanged folder skips all files and does not duplicate chunks", async () => {
+    const db = getDb();
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "note.txt"), "Content to be deduplicated.");
+
+    const firstResult = await ingestFolder(db, dir);
+    expect(firstResult.processed).toBe(1);
+    expect(firstResult.skipped).toBe(0);
+
+    const [{ n: countBefore }] = await db<{ n: number }[]>`
+      SELECT count(*)::int AS n FROM memory_chunks
+    `;
+
+    const secondResult = await ingestFolder(db, dir);
+    expect(secondResult.skipped).toBe(1);
+    expect(secondResult.processed).toBe(0);
+    expect(secondResult.skippedFiles[0].reason).toMatch(/unchanged/i);
+
+    const [{ n: countAfter }] = await db<{ n: number }[]>`
+      SELECT count(*)::int AS n FROM memory_chunks
+    `;
+    expect(countAfter).toBe(countBefore);
+  });
+
+  it("content change replaces chunks: old text gone, new present, no orphan rows", async () => {
+    const db = getDb();
+    const dir = makeTempDir();
+    const file = join(dir, "note.txt");
+    writeFileSync(file, "Original content for sourcing.");
+
+    await ingestFolder(db, dir);
+
+    const [oldChunk] = await db<{ text: string }[]>`SELECT text FROM memory_chunks LIMIT 1`;
+    expect(oldChunk.text).toContain("Original content");
+
+    writeFileSync(file, "New content after an update.");
+    await ingestFolder(db, dir);
+
+    const chunks = await db<{ text: string }[]>`SELECT text FROM memory_chunks`;
+    expect(chunks.some((c) => c.text.includes("Original content"))).toBe(false);
+    expect(chunks.some((c) => c.text.includes("New content"))).toBe(true);
+
+    const [{ n: orphans }] = await db<{ n: number }[]>`
+      SELECT count(*)::int AS n
+      FROM memory_chunks mc
+      LEFT JOIN source_records sr ON sr.id = mc.source_record_id
+      WHERE sr.id IS NULL
+    `;
+    expect(orphans).toBe(0);
+  });
+
+  it("grants DEFAULT_ACTOR read permission on each ingested source_id", async () => {
+    const db = getDb();
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "note.txt"), "Sourcing note.");
+    writeFileSync(join(dir, "data.csv"), "name,status\nJane,contacted\n");
+
+    await ingestFolder(db, dir);
+
+    const perms = await db<{
+      principal_type: string;
+      principal_id: string;
+      access: string;
+    }[]>`
+      SELECT principal_type, principal_id, access FROM source_permissions ORDER BY source_id
+    `;
+    expect(perms).toHaveLength(2);
+    expect(perms.every((p) => p.principal_type === DEFAULT_ACTOR.actorType)).toBe(true);
+    expect(perms.every((p) => p.principal_id === DEFAULT_ACTOR.actorId)).toBe(true);
+    expect(perms.every((p) => p.access === "read")).toBe(true);
+  });
+
+  it("re-ingesting after permission is manually seeded preserves the existing permission row", async () => {
+    const db = getDb();
+    const dir = makeTempDir();
+    const file = join(dir, "note.txt");
+    writeFileSync(file, "Sourcing note.");
+
+    await ingestFolder(db, dir);
+
+    const [{ source_id }] = await db<{ source_id: string }[]>`
+      SELECT source_id FROM source_records LIMIT 1
+    `;
+    await db`
+      INSERT INTO source_permissions (principal_type, principal_id, source_id, access)
+      VALUES ('user', 'alice', ${source_id}, 'read')
+      ON CONFLICT DO NOTHING
+    `;
+
+    writeFileSync(file, "Updated sourcing note.");
+    await ingestFolder(db, dir);
+
+    const perms = await db<{ principal_id: string }[]>`
+      SELECT principal_id FROM source_permissions WHERE principal_id = 'alice'
+    `;
+    expect(perms).toHaveLength(1);
+  });
+
+  it("unsupported file is in skippedFiles with a reason; no orphan source_records row", async () => {
+    const db = getDb();
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "ok.txt"), "Good content.");
+    writeFileSync(join(dir, "image.png"), "binary data");
+
+    const result = await ingestFolder(db, dir);
+
+    expect(result.processed).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(result.skippedFiles).toHaveLength(1);
+    expect(result.skippedFiles[0].path).toContain("image.png");
+    expect(result.skippedFiles[0].reason.length).toBeGreaterThan(0);
+
+    const sources = await db<{ path: string }[]>`SELECT path FROM source_records`;
+    expect(sources.every((s) => !s.path.includes("image.png"))).toBe(true);
+  });
+
+  it("empty file is reported in skippedFiles with no orphan rows", async () => {
+    const db = getDb();
+    const dir = makeTempDir();
+    writeFileSync(join(dir, "empty.md"), "   \n\t");
+
+    const result = await ingestFolder(db, dir);
+
+    expect(result.processed).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.skippedFiles[0].reason).toMatch(/empty/i);
+
+    const [{ n }] = await db<{ n: number }[]>`
+      SELECT count(*)::int AS n FROM source_records
+    `;
+    expect(n).toBe(0);
+  });
+});

--- a/tests/memory-migrate.test.ts
+++ b/tests/memory-migrate.test.ts
@@ -1,0 +1,112 @@
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+
+async function resetMemoryTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS source_permissions CASCADE`;
+  await db`DROP TABLE IF EXISTS extraction_runs CASCADE`;
+  await db`DROP TABLE IF EXISTS semantic_facts CASCADE`;
+  await db`DROP TABLE IF EXISTS memory_chunks CASCADE`;
+  await db`DROP TABLE IF EXISTS source_records CASCADE`;
+  await db`DROP TABLE IF EXISTS schema_migrations CASCADE`;
+  await runMigrations(db);
+}
+
+describe("002 memory schema migration", () => {
+  beforeEach(async () => {
+    await resetMemoryTables();
+  });
+
+  afterEach(async () => {
+    await closeDb();
+  });
+
+  it("creates all 5 memory tables", async () => {
+    const db = getDb();
+    const result = await db<{ table_name: string }[]>`
+      SELECT table_name
+      FROM information_schema.tables
+      WHERE table_schema = 'public'
+        AND table_name IN (
+          'source_records',
+          'memory_chunks',
+          'semantic_facts',
+          'extraction_runs',
+          'source_permissions'
+        )
+      ORDER BY table_name
+    `;
+    const names = result.map((r) => r.table_name).sort();
+    expect(names).toEqual([
+      "extraction_runs",
+      "memory_chunks",
+      "semantic_facts",
+      "source_permissions",
+      "source_records",
+    ]);
+  });
+
+  it("memory_chunks.embedding has udt_name = vector", async () => {
+    const db = getDb();
+    const result = await db<{ udt_name: string }[]>`
+      SELECT udt_name
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'memory_chunks'
+        AND column_name = 'embedding'
+    `;
+    expect(result).toHaveLength(1);
+    expect(result[0].udt_name).toBe("vector");
+  });
+
+  it("memory_chunks_embedding_idx hnsw index exists", async () => {
+    const db = getDb();
+    const result = await db<{ indexname: string }[]>`
+      SELECT indexname
+      FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND tablename = 'memory_chunks'
+        AND indexname = 'memory_chunks_embedding_idx'
+    `;
+    expect(result).toHaveLength(1);
+    expect(result[0].indexname).toBe("memory_chunks_embedding_idx");
+  });
+
+  it("memory_chunks has unique constraint on (source_record_id, chunk_index)", async () => {
+    const db = getDb();
+    const result = await db<{ constraint_name: string }[]>`
+      SELECT tc.constraint_name
+      FROM information_schema.table_constraints tc
+      JOIN information_schema.key_column_usage kcu
+        ON kcu.constraint_name = tc.constraint_name
+        AND kcu.table_schema = tc.table_schema
+        AND kcu.table_name = tc.table_name
+      WHERE tc.table_schema = 'public'
+        AND tc.table_name = 'memory_chunks'
+        AND tc.constraint_type = 'UNIQUE'
+        AND kcu.column_name IN ('source_record_id', 'chunk_index')
+      GROUP BY tc.constraint_name
+      HAVING count(*) = 2
+    `;
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("source_permissions has unique constraint on (principal_type, principal_id, source_id)", async () => {
+    const db = getDb();
+    const result = await db<{ constraint_name: string }[]>`
+      SELECT tc.constraint_name
+      FROM information_schema.table_constraints tc
+      JOIN information_schema.key_column_usage kcu
+        ON kcu.constraint_name = tc.constraint_name
+        AND kcu.table_schema = tc.table_schema
+        AND kcu.table_name = tc.table_name
+      WHERE tc.table_schema = 'public'
+        AND tc.table_name = 'source_permissions'
+        AND tc.constraint_type = 'UNIQUE'
+        AND kcu.column_name IN ('principal_type', 'principal_id', 'source_id')
+      GROUP BY tc.constraint_name
+      HAVING count(*) = 3
+    `;
+    expect(result.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/tests/memory-notes.test.ts
+++ b/tests/memory-notes.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+import { DEFAULT_ACTOR } from "@/lib/memory/actor";
+import { addMemoryNote } from "@/lib/memory/notes";
+import { searchMemory } from "@/lib/memory/retrieve";
+import { addMemoryNoteTool } from "@/lib/tools/add-memory-note";
+
+async function resetMemoryTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS source_permissions CASCADE`;
+  await db`DROP TABLE IF EXISTS extraction_runs CASCADE`;
+  await db`DROP TABLE IF EXISTS semantic_facts CASCADE`;
+  await db`DROP TABLE IF EXISTS memory_chunks CASCADE`;
+  await db`DROP TABLE IF EXISTS source_records CASCADE`;
+  await db`DROP TABLE IF EXISTS schema_migrations CASCADE`;
+  await runMigrations(db);
+}
+
+describe("addMemoryNote (postgres)", () => {
+  let savedApiKey: string | undefined;
+
+  beforeEach(async () => {
+    savedApiKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    await resetMemoryTables();
+  });
+
+  afterEach(async () => {
+    if (savedApiKey !== undefined) {
+      process.env.OPENAI_API_KEY = savedApiKey;
+    } else {
+      delete process.env.OPENAI_API_KEY;
+    }
+    await closeDb();
+  });
+
+  it("writes a source_records row with source_type='note' and returns { sourceId }", async () => {
+    const db = getDb();
+    const { sourceId } = await addMemoryNote(db, {
+      title: "Sourcing Note",
+      text: "Alice responded to outreach.",
+    });
+
+    expect(typeof sourceId).toBe("string");
+    expect(sourceId.length).toBeGreaterThan(0);
+
+    const [row] = await db<{ source_type: string; path: string; title: string }[]>`
+      SELECT source_type, path, title FROM source_records WHERE source_id = ${sourceId}
+    `;
+    expect(row).toBeDefined();
+    expect(row.source_type).toBe("note");
+    expect(row.path).toBe(`note://${sourceId}`);
+    expect(row.title).toBe("Sourcing Note");
+  });
+
+  it("writes memory_chunks with 1536-dim embedding and #chunk-1 citation", async () => {
+    const db = getDb();
+    const { sourceId } = await addMemoryNote(db, {
+      title: "Test Note",
+      text: "Alice responded to outreach.",
+    });
+
+    const chunks = await db<{ citation: string; embedding_dims: number }[]>`
+      SELECT mc.citation, vector_dims(mc.embedding) AS embedding_dims
+      FROM memory_chunks mc
+      JOIN source_records sr ON sr.id = mc.source_record_id
+      WHERE sr.source_id = ${sourceId}
+      ORDER BY mc.chunk_index
+    `;
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks[0].citation).toBe(`${sourceId}#chunk-1`);
+    expect(chunks[0].embedding_dims).toBe(1536);
+  });
+
+  it("grants DEFAULT_ACTOR read permission on the source", async () => {
+    const db = getDb();
+    const { sourceId } = await addMemoryNote(db, {
+      title: "Perm Note",
+      text: "Some sourcing content.",
+    });
+
+    const [perm] = await db<{ principal_type: string; principal_id: string; access: string }[]>`
+      SELECT principal_type, principal_id, access
+      FROM source_permissions
+      WHERE source_id = ${sourceId}
+    `;
+    expect(perm).toBeDefined();
+    expect(perm.principal_type).toBe(DEFAULT_ACTOR.actorType);
+    expect(perm.principal_id).toBe(DEFAULT_ACTOR.actorId);
+    expect(perm.access).toBe("read");
+  });
+
+  it("is immediately retrievable via searchMemory", async () => {
+    const db = getDb();
+    const text = "Apollo sourcing pipeline candidates outreach contact";
+    const { sourceId } = await addMemoryNote(db, { title: "Pipeline Note", text });
+
+    const bundle = await searchMemory(db, {
+      query: "Apollo sourcing pipeline candidates",
+    });
+
+    const found = bundle.chunks.some((c) => c.citation.startsWith(sourceId));
+    expect(found).toBe(true);
+  });
+
+  it("correction: same title, new text → distinct sourceId; corrected content retrievable", async () => {
+    const db = getDb();
+    const title = "Sourcing Strategy";
+    const { sourceId: id1 } = await addMemoryNote(db, {
+      title,
+      text: "Original outreach plan for pipeline candidates overview.",
+    });
+    const { sourceId: id2 } = await addMemoryNote(db, {
+      title,
+      text: "Updated outreach strategy candidates silicon valley recruiting.",
+    });
+
+    expect(id1).not.toBe(id2);
+
+    const records = await db<{ source_id: string }[]>`
+      SELECT source_id FROM source_records WHERE source_id = ANY(${[id1, id2]})
+    `;
+    expect(records).toHaveLength(2);
+
+    const bundle = await searchMemory(db, {
+      query: "Updated outreach strategy silicon valley recruiting",
+    });
+    const found = bundle.chunks.some((c) => c.citation.startsWith(id2));
+    expect(found).toBe(true);
+  });
+
+  it("idempotent: adding identical note twice does not duplicate memory_chunks", async () => {
+    const db = getDb();
+    const args = { title: "Idempotent Note", text: "Unique sourcing content for dedup test." };
+
+    await addMemoryNote(db, args);
+    const [{ n: countAfterFirst }] = await db<{ n: number }[]>`
+      SELECT count(*)::int AS n FROM memory_chunks
+    `;
+
+    await addMemoryNote(db, args);
+    const [{ n: countAfterSecond }] = await db<{ n: number }[]>`
+      SELECT count(*)::int AS n FROM memory_chunks
+    `;
+
+    expect(countAfterSecond).toBe(countAfterFirst);
+  });
+});
+
+describe("addMemoryNoteTool", () => {
+  it("has name 'add_memory_note' and permissionClass 'write_internal'", () => {
+    expect(addMemoryNoteTool.name).toBe("add_memory_note");
+    expect(addMemoryNoteTool.permissionClass).toBe("write_internal");
+  });
+
+  it("argsSchema rejects empty title", () => {
+    const result = addMemoryNoteTool.argsSchema.safeParse({ title: "", text: "hello" });
+    expect(result.success).toBe(false);
+  });
+
+  it("argsSchema rejects empty text", () => {
+    const result = addMemoryNoteTool.argsSchema.safeParse({ title: "My Note", text: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("argsSchema accepts valid title and text", () => {
+    const result = addMemoryNoteTool.argsSchema.safeParse({
+      title: "My Note",
+      text: "Some content.",
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/tests/memory-retrieve.test.ts
+++ b/tests/memory-retrieve.test.ts
@@ -1,0 +1,565 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+import { DEFAULT_ACTOR, type MemoryActor } from "@/lib/memory/actor";
+import { embedText, toVectorLiteral } from "@/lib/memory/embed";
+import {
+  asksForUncertainty,
+  factIntentScore,
+  lexicalScore,
+  meaningfulQuestionTerms,
+  questionIntent,
+  rankRows,
+} from "@/lib/memory/rank";
+import { resolveAllowedSourceIds } from "@/lib/memory/permissions";
+import { searchMemory } from "@/lib/memory/retrieve";
+
+type Db = ReturnType<typeof getDb>;
+
+// ---------------------------------------------------------------------------
+// DB helpers
+// ---------------------------------------------------------------------------
+
+async function resetMemoryTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS source_permissions CASCADE`;
+  await db`DROP TABLE IF EXISTS extraction_runs CASCADE`;
+  await db`DROP TABLE IF EXISTS semantic_facts CASCADE`;
+  await db`DROP TABLE IF EXISTS memory_chunks CASCADE`;
+  await db`DROP TABLE IF EXISTS source_records CASCADE`;
+  await db`DROP TABLE IF EXISTS schema_migrations CASCADE`;
+  await runMigrations(db);
+}
+
+async function insertSource(db: Db, sourceId: string): Promise<string> {
+  const [row] = await db<{ id: string }[]>`
+    INSERT INTO source_records (source_id, path, source_type, content_hash)
+    VALUES (
+      ${sourceId},
+      ${"/test/" + sourceId + ".md"},
+      'markdown',
+      ${"hash-" + sourceId}
+    )
+    RETURNING id
+  `;
+  return row.id;
+}
+
+async function grantRead(db: Db, actor: MemoryActor, sourceId: string): Promise<void> {
+  await db`
+    INSERT INTO source_permissions (principal_type, principal_id, source_id, access)
+    VALUES (${actor.actorType}, ${actor.actorId}, ${sourceId}, 'read')
+  `;
+}
+
+async function insertChunk(
+  db: Db,
+  opts: { sourceRecordId: string; text: string; citation: string; chunkIndex?: number }
+): Promise<string> {
+  const vec = await embedText(db, opts.text);
+  const vecLiteral = toVectorLiteral(vec);
+  const [row] = await db<{ id: string }[]>`
+    INSERT INTO memory_chunks (source_record_id, chunk_index, text, chunk_hash, embedding, citation)
+    VALUES (
+      ${opts.sourceRecordId},
+      ${opts.chunkIndex ?? 0},
+      ${opts.text},
+      ${"chunk-hash-" + opts.citation},
+      ${vecLiteral}::vector,
+      ${opts.citation}
+    )
+    RETURNING id
+  `;
+  return row.id;
+}
+
+async function insertFact(
+  db: Db,
+  opts: {
+    subject: string;
+    predicate: string;
+    object: string;
+    status: string;
+    sourceRecordId: string;
+    sourceChunkId?: string | null;
+    confidence?: number;
+  }
+): Promise<void> {
+  await db`
+    INSERT INTO semantic_facts
+      (subject, predicate, object, source_record_id, source_chunk_id, confidence, status)
+    VALUES (
+      ${opts.subject},
+      ${opts.predicate},
+      ${opts.object},
+      ${opts.sourceRecordId},
+      ${opts.sourceChunkId ?? null},
+      ${opts.confidence ?? 0.9},
+      ${opts.status}
+    )
+  `;
+}
+
+// ---------------------------------------------------------------------------
+// Pure rank.ts unit tests
+// ---------------------------------------------------------------------------
+
+describe("questionIntent()", () => {
+  it('classifies uncertainty phrases → "uncertainty"', () => {
+    expect(questionIntent("what are the gaps?")).toBe("uncertainty");
+    expect(questionIntent("any conflict here?")).toBe("uncertainty");
+    expect(questionIntent("show stale facts")).toBe("uncertainty");
+    expect(questionIntent("what is missing?")).toBe("uncertainty");
+  });
+
+  it('classifies collaboration phrases → "worked_with"', () => {
+    expect(questionIntent("who worked with us before?")).toBe("worked_with");
+    expect(questionIntent("who sponsored our project?")).toBe("worked_with");
+    expect(questionIntent("who collaborated on this?")).toBe("worked_with");
+  });
+
+  it('classifies ghosted/no-reply phrases → "no_response"', () => {
+    expect(questionIntent("who did not respond?")).toBe("no_response");
+    expect(questionIntent("who ghosted us?")).toBe("no_response");
+    expect(questionIntent("who gave no reply?")).toBe("no_response");
+  });
+
+  it('classifies response phrases → "responded"', () => {
+    expect(questionIntent("who responded?")).toBe("responded");
+    expect(questionIntent("who replied to us?")).toBe("responded");
+    expect(questionIntent("who is in discussion?")).toBe("responded");
+  });
+
+  it('classifies follow-up phrases → "follow_up"', () => {
+    expect(questionIntent("who needs follow-up?")).toBe("follow_up");
+    expect(questionIntent("who needs followup?")).toBe("follow_up");
+    expect(questionIntent("need follow up on this")).toBe("follow_up");
+  });
+
+  it('classifies general questions → "generic"', () => {
+    expect(questionIntent("who are our contacts?")).toBe("generic");
+    expect(questionIntent("list everyone")).toBe("generic");
+    expect(questionIntent("show me AI safety leads")).toBe("generic");
+  });
+});
+
+describe("asksForUncertainty()", () => {
+  it("returns true for uncertainty keywords", () => {
+    expect(asksForUncertainty("what are the gaps?")).toBe(true);
+    expect(asksForUncertainty("show conflicted facts")).toBe(true);
+    expect(asksForUncertainty("any candidate entries?")).toBe(true);
+    expect(asksForUncertainty("stale records?")).toBe(true);
+    expect(asksForUncertainty("missing info?")).toBe(true);
+  });
+
+  it("returns false for non-uncertainty phrases", () => {
+    expect(asksForUncertainty("who responded?")).toBe(false);
+    expect(asksForUncertainty("who needs follow-up?")).toBe(false);
+    expect(asksForUncertainty("who worked with us?")).toBe(false);
+  });
+});
+
+describe("meaningfulQuestionTerms()", () => {
+  it("filters out stop words", () => {
+    const terms = meaningfulQuestionTerms("what is the status");
+    expect(terms).not.toContain("what");
+    expect(terms).not.toContain("is");
+    expect(terms).not.toContain("the");
+    expect(terms).toContain("status");
+  });
+
+  it("filters out terms with length ≤ 2", () => {
+    const terms = meaningfulQuestionTerms("is it ok");
+    expect(terms).not.toContain("it");
+    expect(terms).not.toContain("is");
+    expect(terms).not.toContain("ok");
+  });
+
+  it("returns empty array for all-stop-word query", () => {
+    expect(meaningfulQuestionTerms("what is the")).toHaveLength(0);
+  });
+
+  it("lowercases before matching", () => {
+    const terms = meaningfulQuestionTerms("Who RESPONDED today");
+    expect(terms).toContain("responded");
+    expect(terms).toContain("today");
+    expect(terms).not.toContain("who");
+  });
+});
+
+describe("lexicalScore()", () => {
+  it("returns 0 when no meaningful query terms appear in text", () => {
+    expect(lexicalScore("apple orange banana", "quantum physics relativity")).toBe(0);
+  });
+
+  it("counts matching meaningful terms (case-insensitive)", () => {
+    // "follow" is the only meaningful term in "who needs follow up"
+    expect(lexicalScore("alice follow up contact", "who needs follow up")).toBe(1);
+    expect(lexicalScore("ALICE RESPONDED today", "who responded today")).toBeGreaterThan(0);
+  });
+
+  it("returns 0 for text that shares only stop words with the query", () => {
+    expect(lexicalScore("what is the thing", "what is the answer")).toBe(0);
+  });
+
+  it("accumulates score across multiple matching terms", () => {
+    const score1 = lexicalScore("alice responded outreach", "responded outreach contact");
+    const score2 = lexicalScore("alice responded", "responded outreach contact");
+    expect(score1).toBeGreaterThan(score2);
+  });
+});
+
+describe("factIntentScore()", () => {
+  const makeFact = (predicate: string, object: string) => ({
+    subject: "Alice",
+    predicate,
+    object,
+    confidence: 0.9,
+    status: "accepted",
+    citation: null,
+  });
+
+  it('returns 2 for follow_up intent on needs_follow_up predicate', () => {
+    expect(factIntentScore(makeFact("needs_follow_up", "yes"), "follow_up")).toBe(2);
+  });
+
+  it('returns 2 for follow_up intent on reason predicate', () => {
+    expect(factIntentScore(makeFact("reason", "needs intro"), "follow_up")).toBe(2);
+  });
+
+  it('returns 3 for responded intent on status=responded', () => {
+    expect(factIntentScore(makeFact("status", "responded"), "responded")).toBe(3);
+  });
+
+  it('returns 3 for no_response intent on status=ghosted', () => {
+    expect(factIntentScore(makeFact("status", "ghosted"), "no_response")).toBe(3);
+  });
+
+  it('returns 3 for worked_with intent on status=locked in', () => {
+    expect(factIntentScore(makeFact("status", "locked in"), "worked_with")).toBe(3);
+  });
+
+  it('returns 0 for codeology_owner predicate on worked_with intent', () => {
+    expect(factIntentScore(makeFact("codeology_owner", "Rohan"), "worked_with")).toBe(0);
+  });
+
+  it('returns 0 for interest predicate on worked_with intent', () => {
+    expect(factIntentScore(makeFact("interest", "Client project"), "worked_with")).toBe(0);
+  });
+
+  it('returns 0 for generic intent on any fact', () => {
+    expect(factIntentScore(makeFact("status", "responded"), "generic")).toBe(0);
+    expect(factIntentScore(makeFact("needs_follow_up", "yes"), "generic")).toBe(0);
+  });
+});
+
+describe("rankRows()", () => {
+  const facts = [
+    { subject: "Alice", predicate: "status", object: "responded", confidence: 0.9, status: "accepted", citation: null },
+    { subject: "Bob", predicate: "needs_follow_up", object: "yes", confidence: 0.8, status: "accepted", citation: null },
+    { subject: "Carol", predicate: "domain", object: "robotics design", confidence: 0.7, status: "accepted", citation: null },
+  ];
+  const getText = (f: typeof facts[0]) => `${f.subject} ${f.predicate} ${f.object}`;
+
+  it("filters to only intent-matching rows on strict intents (responded)", () => {
+    const result = rankRows(facts, "who responded?", "responded", getText);
+    expect(result.some((f) => f.subject === "Alice")).toBe(true);
+    // Bob and Carol have no responded signal
+    expect(result.some((f) => f.subject === "Bob")).toBe(false);
+    expect(result.some((f) => f.subject === "Carol")).toBe(false);
+  });
+
+  it("includes lexically-matching rows on generic intent", () => {
+    const result = rankRows(facts, "robotics domain", "generic", getText);
+    expect(result.some((f) => f.subject === "Carol")).toBe(true);
+  });
+
+  it("returns all rows when no meaningful terms and generic intent", () => {
+    const result = rankRows(facts, "what is the", "generic", getText);
+    expect(result).toHaveLength(facts.length);
+  });
+
+  it("sorts by intentScore DESC then lexicalScore DESC then stable index", () => {
+    const result = rankRows(facts, "who responded?", "responded", getText);
+    // Alice has the highest intentScore (responded), so she comes first
+    expect(result[0]?.subject).toBe("Alice");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAllowedSourceIds — live Postgres
+// ---------------------------------------------------------------------------
+
+describe("resolveAllowedSourceIds (postgres)", () => {
+  beforeEach(async () => {
+    await resetMemoryTables();
+  });
+
+  afterEach(async () => {
+    await closeDb();
+  });
+
+  it("returns source_ids granted to the actor", async () => {
+    const db = getDb();
+    await insertSource(db, "src-perm-a");
+    await insertSource(db, "src-perm-b");
+    await grantRead(db, DEFAULT_ACTOR, "src-perm-a");
+
+    const allowed = await resolveAllowedSourceIds(db, DEFAULT_ACTOR);
+    expect(allowed).toContain("src-perm-a");
+    expect(allowed).not.toContain("src-perm-b");
+  });
+
+  it("returns [] for an actor with no permissions (default-deny)", async () => {
+    const db = getDb();
+    await insertSource(db, "src-no-perm");
+    const noPermsActor: MemoryActor = { actorType: "test_client", actorId: "ghost" };
+    const allowed = await resolveAllowedSourceIds(db, noPermsActor);
+    expect(allowed).toHaveLength(0);
+  });
+
+  it("returns [] when there are no sources at all", async () => {
+    const db = getDb();
+    const allowed = await resolveAllowedSourceIds(db, DEFAULT_ACTOR);
+    expect(allowed).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// searchMemory — live Postgres integration tests
+// ---------------------------------------------------------------------------
+
+describe("searchMemory (postgres)", () => {
+  let savedApiKey: string | undefined;
+
+  beforeEach(async () => {
+    savedApiKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY; // force offline hash embedding
+    await resetMemoryTables();
+  });
+
+  afterEach(async () => {
+    if (savedApiKey !== undefined) {
+      process.env.OPENAI_API_KEY = savedApiKey;
+    } else {
+      delete process.env.OPENAI_API_KEY;
+    }
+    await closeDb();
+  });
+
+  it("returns correct bundle shape with expected field types", async () => {
+    const db = getDb();
+    const srcId = await insertSource(db, "src-shape");
+    await grantRead(db, DEFAULT_ACTOR, "src-shape");
+    const chunkId = await insertChunk(db, {
+      sourceRecordId: srcId,
+      text: "Alice responded to sourcing outreach",
+      citation: "src-shape#chunk-1",
+    });
+    await insertFact(db, {
+      subject: "Alice",
+      predicate: "status",
+      object: "responded",
+      status: "accepted",
+      sourceRecordId: srcId,
+      sourceChunkId: chunkId,
+    });
+
+    const bundle = await searchMemory(db, { query: "who responded", actor: DEFAULT_ACTOR });
+
+    expect(bundle).toHaveProperty("intent");
+    expect(bundle).toHaveProperty("acceptedFacts");
+    expect(bundle).toHaveProperty("gapFacts");
+    expect(bundle).toHaveProperty("chunks");
+    expect(Array.isArray(bundle.acceptedFacts)).toBe(true);
+    expect(Array.isArray(bundle.gapFacts)).toBe(true);
+    expect(Array.isArray(bundle.chunks)).toBe(true);
+    expect(bundle.intent).toBe("responded");
+
+    expect(bundle.acceptedFacts.length).toBeGreaterThan(0);
+    const fact = bundle.acceptedFacts[0];
+    expect(typeof fact.subject).toBe("string");
+    expect(typeof fact.predicate).toBe("string");
+    expect(typeof fact.object).toBe("string");
+    expect(typeof fact.confidence).toBe("number");
+    expect(typeof fact.status).toBe("string");
+    // citation may be string or null
+    expect(fact.citation === null || typeof fact.citation === "string").toBe(true);
+  });
+
+  it("THE acceptance test: restricted source never surfaces in any bundle field", async () => {
+    const db = getDb();
+    const query = "who responded to sourcing outreach";
+
+    // Source A — granted to DEFAULT_ACTOR
+    const srcAId = await insertSource(db, "src-allowed");
+    await grantRead(db, DEFAULT_ACTOR, "src-allowed");
+    const chunkAId = await insertChunk(db, {
+      sourceRecordId: srcAId,
+      text: "Alice responded to sourcing outreach contact",
+      citation: "src-allowed#chunk-1",
+    });
+    await insertFact(db, {
+      subject: "Alice",
+      predicate: "status",
+      object: "responded",
+      status: "accepted",
+      sourceRecordId: srcAId,
+      sourceChunkId: chunkAId,
+    });
+
+    // Source B — NOT granted (no source_permissions row); text overlaps with query
+    const srcBId = await insertSource(db, "src-restricted");
+    // intentionally no grantRead
+    const chunkBId = await insertChunk(db, {
+      sourceRecordId: srcBId,
+      text: "Bob responded to sourcing outreach contact",
+      citation: "src-restricted#chunk-1",
+    });
+    await insertFact(db, {
+      subject: "Bob",
+      predicate: "status",
+      object: "responded",
+      status: "accepted",
+      sourceRecordId: srcBId,
+      sourceChunkId: chunkBId,
+    });
+
+    const bundle = await searchMemory(db, { query, actor: DEFAULT_ACTOR });
+
+    // Alice (allowed) appears in acceptedFacts
+    expect(bundle.acceptedFacts.some((f) => f.subject === "Alice")).toBe(true);
+
+    // Bob (restricted) must NOT appear anywhere
+    expect(bundle.acceptedFacts.some((f) => f.subject === "Bob")).toBe(false);
+    expect(bundle.gapFacts.some((f) => f.subject === "Bob")).toBe(false);
+    expect(bundle.chunks.some((c) => c.citation.includes("src-restricted"))).toBe(false);
+  });
+
+  it("empty allowed-set → empty bundle with correct intent (default-deny)", async () => {
+    const db = getDb();
+    // Insert a source but don't grant the test actor permission
+    const srcId = await insertSource(db, "src-no-perm-test");
+    await insertFact(db, {
+      subject: "Alice",
+      predicate: "status",
+      object: "responded",
+      status: "accepted",
+      sourceRecordId: srcId,
+    });
+
+    const noPermActor: MemoryActor = { actorType: "test_client", actorId: "no-perms-actor" };
+    const bundle = await searchMemory(db, { query: "who responded?", actor: noPermActor });
+
+    expect(bundle.intent).toBe("responded");
+    expect(bundle.acceptedFacts).toHaveLength(0);
+    expect(bundle.gapFacts).toHaveLength(0);
+    expect(bundle.chunks).toHaveLength(0);
+  });
+
+  it("candidate/conflicted/stale facts appear in gapFacts only, not acceptedFacts", async () => {
+    const db = getDb();
+    const srcId = await insertSource(db, "src-gaps");
+    await grantRead(db, DEFAULT_ACTOR, "src-gaps");
+
+    await insertFact(db, {
+      subject: "Noor",
+      predicate: "status",
+      object: "maybe interested",
+      status: "candidate",
+      sourceRecordId: srcId,
+    });
+    await insertFact(db, {
+      subject: "Maya",
+      predicate: "status",
+      object: "contacted",
+      status: "conflicted",
+      sourceRecordId: srcId,
+    });
+    await insertFact(db, {
+      subject: "Leo",
+      predicate: "status",
+      object: "old data",
+      status: "stale",
+      sourceRecordId: srcId,
+    });
+
+    // Use uncertainty query so rankRows doesn't filter gapFacts by lexical match
+    const bundle = await searchMemory(db, { query: "what gaps or conflicts exist?", actor: DEFAULT_ACTOR });
+
+    expect(bundle.gapFacts.some((f) => f.subject === "Noor")).toBe(true);
+    expect(bundle.gapFacts.some((f) => f.subject === "Maya")).toBe(true);
+    expect(bundle.gapFacts.some((f) => f.subject === "Leo")).toBe(true);
+    expect(bundle.acceptedFacts.some((f) => f.subject === "Noor")).toBe(false);
+    expect(bundle.acceptedFacts.some((f) => f.subject === "Maya")).toBe(false);
+    expect(bundle.acceptedFacts.some((f) => f.subject === "Leo")).toBe(false);
+  });
+
+  it("lexical gate: chunk with no matching query terms is excluded from chunks", async () => {
+    const db = getDb();
+    const srcId = await insertSource(db, "src-lexical");
+    await grantRead(db, DEFAULT_ACTOR, "src-lexical");
+
+    // This chunk has "follow" — the only meaningful term in "who needs follow up"
+    await insertChunk(db, {
+      sourceRecordId: srcId,
+      text: "alice needs follow up from sourcing team",
+      citation: "src-lexical#chunk-1",
+      chunkIndex: 0,
+    });
+
+    // This chunk shares no meaningful query terms (zxqy/irrelevant won't match "follow")
+    await insertChunk(db, {
+      sourceRecordId: srcId,
+      text: "zxqy irrelevant xywz unrelated data only",
+      citation: "src-lexical#chunk-2",
+      chunkIndex: 1,
+    });
+
+    const bundle = await searchMemory(db, { query: "who needs follow up", actor: DEFAULT_ACTOR });
+
+    // Matching chunk appears
+    expect(bundle.chunks.some((c) => c.citation === "src-lexical#chunk-1")).toBe(true);
+    // Non-matching chunk is excluded by lexical gate
+    expect(bundle.chunks.some((c) => c.citation === "src-lexical#chunk-2")).toBe(false);
+  });
+
+  it("each chunk carries a string citation and a numeric score > 0", async () => {
+    const db = getDb();
+    const srcId = await insertSource(db, "src-chunk-shape");
+    await grantRead(db, DEFAULT_ACTOR, "src-chunk-shape");
+    await insertChunk(db, {
+      sourceRecordId: srcId,
+      text: "Alice responded to our sourcing outreach",
+      citation: "src-chunk-shape#chunk-1",
+    });
+
+    const bundle = await searchMemory(db, { query: "responded sourcing outreach", actor: DEFAULT_ACTOR });
+
+    expect(bundle.chunks.length).toBeGreaterThan(0);
+    for (const chunk of bundle.chunks) {
+      expect(typeof chunk.text).toBe("string");
+      expect(typeof chunk.citation).toBe("string");
+      expect(chunk.citation.length).toBeGreaterThan(0);
+      expect(typeof chunk.score).toBe("number");
+      expect(chunk.score).toBeGreaterThan(0);
+    }
+  });
+
+  it("uses DEFAULT_ACTOR when actor is omitted", async () => {
+    const db = getDb();
+    const srcId = await insertSource(db, "src-default-actor");
+    await grantRead(db, DEFAULT_ACTOR, "src-default-actor");
+    await insertFact(db, {
+      subject: "Alice",
+      predicate: "status",
+      object: "responded",
+      status: "accepted",
+      sourceRecordId: srcId,
+    });
+
+    // No actor arg → should use DEFAULT_ACTOR
+    const bundle = await searchMemory(db, { query: "who responded" });
+    expect(bundle.acceptedFacts.some((f) => f.subject === "Alice")).toBe(true);
+  });
+});

--- a/tests/refresh.test.ts
+++ b/tests/refresh.test.ts
@@ -79,7 +79,11 @@ describe("refreshMemory", () => {
     db.close();
   });
 
-  it("returns a clear missing-config error when unstructured sources need LLM extraction", async () => {
+  it("records a failed extraction when unstructured sources need LLM extraction without config", async () => {
+    // The construction-time guard was removed from createLlmExtractor so the gateway can
+    // validate the active provider's key at call time (supporting non-DeepSeek providers via
+    // SOURCECADO_GENERATION_PROVIDER). Without a key, extraction now fails gracefully (failed: 1)
+    // rather than throwing from the extractor selection step.
     const previousKey = process.env.DEEPSEEK_API_KEY;
     const previousModel = process.env.SOURCECADO_GENERATION_MODEL;
     delete process.env.DEEPSEEK_API_KEY;
@@ -91,7 +95,9 @@ describe("refreshMemory", () => {
     ingestFolder(db, dir);
 
     try {
-      await expect(refreshMemory(db)).rejects.toThrow(/DEEPSEEK_API_KEY/);
+      const result = await refreshMemory(db);
+      expect(result.extracted).toBe(0);
+      expect(result.failed).toBeGreaterThan(0);
     } finally {
       restoreEnv("DEEPSEEK_API_KEY", previousKey);
       restoreEnv("SOURCECADO_GENERATION_MODEL", previousModel);


### PR DESCRIPTION
## Feature A — Cited Sourcing Memory Answer

A Sourcing Director asks a question in `/chat` and gets a **4-section cited answer with
knowledge gaps**, synthesized from imported sourcing notes in Postgres/pgvector and fully
traced in the Run Ledger. This is the first tier-1 measurable outcome and the FLOOR-tier
"query the brain" capability.

Spec: `docs/superpowers/specs/2026-06-25-feature-a-cited-memory-answer-design.md`

### What's in this PR
- **Postgres/pgvector memory engine** (`src/lib/memory/*`): chunking, pluggable 1536-dim
  embeddings (real OpenAI `text-embedding-3-small` or offline hash fallback), ingestion,
  the `semantic_facts` lifecycle (accept ≥0.75 / candidate / conflicted / stale) with an
  `extraction_runs` cache, and permission-filtered hybrid retrieval (pgvector cosine gated
  by lexical match). Migration `002_memory.sql`.
- **`search_memory` tool** (class `read`) → `{intent, acceptedFacts, gapFacts, chunks}`;
  the model synthesizes the Answer/Evidence/Gaps/Next-Action answer; a deterministic
  citation post-check (`verifyAnswerCitations`) flags any cited id not present in the tool
  result. Harness gains an optional `instructions` passthrough; `/api/agent` runs the memory
  config (`allowedClasses: {read}`).
- **`add_memory_note` tool** (class `write_internal`): immediately-retrievable notes;
  corrections are superseding notes (no destructive edit).
- **Scripts**: `npm run ingest <dir>` and `npm run refresh`.
- **ADR-0001 permissions**: default-deny, carry+filter in SQL before ranking; a restricted
  source never surfaces (proven by test).

### Deliberately deferred (YAGNI, per spec)
entities/relationships/alias graph; deterministic prose templates (the model synthesizes);
parity harness; multi-user permission UI; in-app upload UI; live Drive/Gmail/Notion sync.

### Testing
- **258 tests pass** (live Postgres, mocked model provider). Coverage includes the
  restricted-source isolation, citation valid/invented at the route, refuse-on-empty, and
  the extraction accept/conflict/stale + cache-reuse paths.
- **Built via subagent-driven development** (7 tasks, each task-reviewed with fix loops) and
  **principal-reviewed** (adversarial pre-merge across correctness/security, architecture,
  tests/CI — **merge risk LOW**; all findings applied in `cb057fa`).
- **Live e2e**: ingested a representative corpus (real OpenAI embeddings) → `refresh` →
  68 accepted facts + 6 conflicted gaps → 3 complex queries to live `/api/agent` on
  claude-sonnet-4-6 → all returned 4-section cited answers with valid citations
  (`invalidCitations: []`), knowledge gaps surfaced, full Run Ledger traces.

### Notes
- Stacked on `feat/f5-agent-harness` (PR #7) via the design branch
  `feat/a-cited-memory-answer`; rebase onto `main` after F5 merges.
- Local Postgres is Dockerized `pgvector/pgvector:pg16` (`docker compose up -d`; `npm run migrate`).
- Follow-ups ticketed in review: extract a shared `writeChunksAndGrant` (ingest/notes dup),
  normalize `.js` import extensions, and fix the extractor sending `deepseek-chat` regardless
  of provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers the Feature A \"Cited Sourcing Memory Answer\" milestone: a Postgres/pgvector memory engine (chunking, 1536-dim embeddings, `semantic_facts` lifecycle, permission-filtered hybrid retrieval) wired into a `search_memory` tool and a citation post-check that strips invented citation IDs from model answers.

- **Memory engine** (`src/lib/memory/*`): ingestion, extraction + caching (`extraction_runs`), hybrid retrieval (pgvector cosine gated by lexical match), and a default-deny permission layer all sit in SQL.
- **Agent integration**: `/api/agent` now runs the memory registry with `MEMORY_INSTRUCTIONS`, calls `verifyAnswerCitations` after each succeeded run, and returns `invalidCitations` alongside the sanitized answer.
- **`CITATION_PATTERN` in `citations.ts` does not include `/`**, so citations from any source ingested via a nested folder are mis-extracted as only the last path segment, flagged invalid, and silently stripped — one-character fix needed before any real corpus with subdirectories is used.
- **`markConflictsAndStaleFacts` runs outside the `rebuildDerivedMemory` transaction**, creating a brief window after each refresh where conflicted facts appear as accepted to concurrent queries.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is for any real corpus with subdirectories; the citation regex bug will strip valid citations from every answer citing a nested source, and the conflict-marking window means refresh produces a brief period of incorrect fact states.

The citation pattern missing `/` activates the moment `npm run ingest` is pointed at a folder with subdirectories, breaking the core cited-answer feature silently. The conflict-marking gap is less acute but real. The rest — permission-gated SQL queries, pgvector retrieval, extraction cache, migration — is well-structured and thoroughly tested.

`src/lib/memory/citations.ts` (citation regex fix required) and `src/lib/memory/extract.ts` (transaction boundary for conflict marking).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/memory/citations.ts | Citation post-check: CITATION_PATTERN excludes `/`, mis-extracting citations from nested source paths and silently stripping valid ones from every answer. |
| src/lib/memory/extract.ts | Semantic-facts lifecycle: markConflictsAndStaleFacts runs outside the rebuildDerivedMemory transaction, leaving a window where conflicted facts appear as accepted. |
| src/lib/memory/retrieve.ts | Permission-filtered hybrid retrieval with pgvector cosine search; SQL permission gate is correct, parameterized queries safe. |
| src/lib/memory/ingest.ts | File ingestion with dedup, chunking, embedding, and atomic upsert; embeddings computed outside the transaction by design. |
| src/migrations/002_memory.sql | Adds source_records, memory_chunks (pgvector hnsw), semantic_facts, extraction_runs, and source_permissions with appropriate FK cascades. |
| src/app/api/agent/route.ts | Agent route wired to memory registry with citation post-check; all requests share DEFAULT_ACTOR. |
| src/lib/memory/actor.ts | DEFAULT_ACTOR uses actorType test_client, which is the production default for both ingestion and search. |
| src/extractors/llm.ts | Removes early DEEPSEEK_API_KEY validation; provider errors now surface at call time rather than construction. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Route as /api/agent
    participant Harness as runAgent
    participant Model as Model Gateway
    participant Tool as search_memory tool
    participant DB as Postgres/pgvector
    participant Citations as verifyAnswerCitations

    Client->>Route: "POST { question }"
    Route->>Harness: "runAgent({ question, registry, allowedClasses })"
    loop ReAct steps
        Harness->>Model: decide(question, transcript)
        Model-->>Harness: "{ action: tool, tool: search_memory }"
        Harness->>Tool: execute(args, ctx)
        Tool->>DB: resolveAllowedSourceIds
        DB-->>Tool: allowed source_ids[]
        Tool->>DB: loadAcceptedFacts + loadGapFacts + loadChunks
        DB-->>Tool: MemoryBundle
        Tool-->>Harness: "{ intent, acceptedFacts, gapFacts, chunks }"
        Harness->>Model: decide with tool result
        Model-->>Harness: "{ action: final, answer }"
    end
    Harness-->>Route: "{ runId, status, answer }"
    Route->>DB: getRunTrace(runId)
    DB-->>Route: RunTrace
    Route->>Citations: verifyAnswerCitations(trace, answer)
    Citations-->>Route: "{ answer: sanitized, invalidCitations[] }"
    Route-->>Client: "{ runId, status, answer, invalidCitations }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Route as /api/agent
    participant Harness as runAgent
    participant Model as Model Gateway
    participant Tool as search_memory tool
    participant DB as Postgres/pgvector
    participant Citations as verifyAnswerCitations

    Client->>Route: "POST { question }"
    Route->>Harness: "runAgent({ question, registry, allowedClasses })"
    loop ReAct steps
        Harness->>Model: decide(question, transcript)
        Model-->>Harness: "{ action: tool, tool: search_memory }"
        Harness->>Tool: execute(args, ctx)
        Tool->>DB: resolveAllowedSourceIds
        DB-->>Tool: allowed source_ids[]
        Tool->>DB: loadAcceptedFacts + loadGapFacts + loadChunks
        DB-->>Tool: MemoryBundle
        Tool-->>Harness: "{ intent, acceptedFacts, gapFacts, chunks }"
        Harness->>Model: decide with tool result
        Model-->>Harness: "{ action: final, answer }"
    end
    Harness-->>Route: "{ runId, status, answer }"
    Route->>DB: getRunTrace(runId)
    DB-->>Route: RunTrace
    Route->>Citations: verifyAnswerCitations(trace, answer)
    Citations-->>Route: "{ answer: sanitized, invalidCitations[] }"
    Route-->>Client: "{ runId, status, answer, invalidCitations }"
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/lib/memory/extract.ts`, line 780-784 ([link](https://github.com/fisherxz/sourcecado/blob/72ad04a38469e13d62e567948a9a9db93af065dc/src/lib/memory/extract.ts#L780-L784)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Conflict marking runs outside the `rebuildDerivedMemory` transaction**

   After `rebuildDerivedMemory` commits its transaction, all freshly re-inserted facts have status `accepted` or `candidate`. `markConflictsAndStaleFacts` then runs as a separate set of queries to flip some of those accepted facts to `conflicted`. Any `searchMemory` query that executes between the transaction commit and the completion of `markConflictsAndStaleFacts` will see conflicting facts as `accepted`, causing the model to present them as established facts rather than surfacing them in the Gaps section. Moving the `markConflictsAndStaleFacts` call inside the `db.begin` block in `rebuildDerivedMemory` (passing `tx` instead of `db`) would make the full lifecycle atomic.


2. `src/extractors/llm.ts`, line 189-208 ([link](https://github.com/fisherxz/sourcecado/blob/72ad04a38469e13d62e567948a9a9db93af065dc/src/extractors/llm.ts#L189-L208)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Early API-key validation removed — misconfiguration surfaces only at call time**

   The previous guard gave an immediate error at extractor construction when no key was available. The new code removes that guard, so a missing `DEEPSEEK_API_KEY` (or mismatched provider env) is silent until `extractor.extract()` is called during `refreshMemory`. For a long-running batch refresh over hundreds of chunks this means all chunks fail with a runtime error rather than one up-front configuration error — and the `extraction_runs` table accumulates failure rows for each chunk.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["docs(A): mark Feature A progress against..."](https://github.com/fisherxz/sourcecado/commit/72ad04a38469e13d62e567948a9a9db93af065dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39945375)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->