### PR TITLE
feat(A): import endpoint, multi-turn chat backend, and /memory management page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,9 +11,13 @@ POSTGRES_PASSWORD=sourcecado
 # Constructed from the above — used by the DB client
 DATABASE_URL=postgresql://sourcecado:sourcecado@localhost:5432/sourcecado
 
-# Model Gateway generation provider
+# Model Gateway generation provider (anthropic | deepseek)
+# NOTE: provider defaults to deepseek when unset, so set this to anthropic if you
+# only have an ANTHROPIC_API_KEY (a real sk-ant-api03 key, not an OAuth token).
+SOURCECADO_GENERATION_PROVIDER=anthropic
+SOURCECADO_GENERATION_MODEL=claude-sonnet-4-6
 DEEPSEEK_API_KEY=
-SOURCECADO_GENERATION_MODEL=deepseek-chat
+QWEN_API_KEY=
 
 # Model Gateway embedding provider
 OPENAI_API_KEY=
@@ -22,3 +26,4 @@ SOURCECADO_EMBEDDING_DIMENSIONS=1536
 
 # Local-only raw run payload inspector. Disabled in production even when true.
 SOURCECADO_ENABLE_RUN_INSPECTOR=
+ANTHROPIC_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,6 @@ DATABASE_URL=postgresql://sourcecado:sourcecado@localhost:5432/sourcecado
 SOURCECADO_GENERATION_PROVIDER=anthropic
 SOURCECADO_GENERATION_MODEL=claude-sonnet-4-6
 DEEPSEEK_API_KEY=
-QWEN_API_KEY=
 
 # Model Gateway embedding provider
 OPENAI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 .next/
 dist/
+*.tsbuildinfo
 .sourcyavo/
 *.db
 *.db-shm

--- a/src/app/api/agent/route.ts
+++ b/src/app/api/agent/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
-import { runAgent } from "@/lib/harness";
+import { runAgent, type ConversationTurn } from "@/lib/harness";
 import { getRunTrace } from "@/lib/ledger";
 import { verifyAnswerCitations } from "@/lib/memory/citations";
 import { memoryRegistry, MEMORY_INSTRUCTIONS } from "@/lib/memory/answer-config";
@@ -11,12 +11,14 @@ export async function POST(request: Request) {
   if (typeof question !== "string" || !question.trim()) {
     return NextResponse.json({ error: "question is required" }, { status: 400 });
   }
+  const history = parseHistory((body as { history?: unknown } | null)?.history);
 
   try {
     const db = getDb();
     const registry = memoryRegistry();
     const result = await runAgent({
       question,
+      history,
       registry,
       allowedClasses: new Set(["read"]),
       instructions: MEMORY_INSTRUCTIONS,
@@ -41,4 +43,18 @@ export async function POST(request: Request) {
     const message = err instanceof Error ? err.message : "agent run failed";
     return NextResponse.json({ error: message }, { status: 500 });
   }
+}
+
+// Accept only well-formed {role, content} turns; ignore anything malformed so a
+// bad client payload degrades to a single-turn run rather than a 500.
+function parseHistory(raw: unknown): ConversationTurn[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const turns = raw.filter(
+    (turn): turn is ConversationTurn =>
+      typeof turn === "object" &&
+      turn !== null &&
+      ((turn as ConversationTurn).role === "user" || (turn as ConversationTurn).role === "assistant") &&
+      typeof (turn as ConversationTurn).content === "string"
+  );
+  return turns.length ? turns : undefined;
 }

--- a/src/app/api/memory/import/route.ts
+++ b/src/app/api/memory/import/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { ingestFiles, type UploadFile } from "@/lib/memory/ingest";
+
+// AFK import: accept uploaded file(s) as multipart/form-data and turn them into
+// source records via the shared ingest core. Per-file outcomes (incl. skips with
+// reasons) come back in the IngestResult — one bad file never sinks the batch.
+// TODO: upload size/count limits before this is exposed beyond single-user/local.
+export async function POST(request: Request): Promise<Response> {
+  let form: FormData;
+  try {
+    form = await request.formData();
+  } catch {
+    return NextResponse.json(
+      { error: "expected multipart/form-data with file uploads" },
+      { status: 400 }
+    );
+  }
+
+  const uploads = form.getAll("files").filter((value): value is File => value instanceof File);
+  if (uploads.length === 0) {
+    return NextResponse.json({ error: "no files attached" }, { status: 400 });
+  }
+
+  const files: UploadFile[] = await Promise.all(
+    uploads.map(async (file) => ({
+      name: file.name,
+      bytes: new Uint8Array(await file.arrayBuffer()),
+    }))
+  );
+
+  try {
+    const result = await ingestFiles(getDb(), files);
+    return NextResponse.json(result, { status: 200 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "import failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/memory/note/route.ts
+++ b/src/app/api/memory/note/route.ts
@@ -16,7 +16,9 @@ export async function POST(request: Request): Promise<Response> {
     const result = await addMemoryNote(getDb(), { title, text });
     return NextResponse.json(result, { status: 200 });
   } catch (err) {
-    const message = err instanceof Error ? err.message : "failed to add note";
-    return NextResponse.json({ error: message }, { status: 500 });
+    // Log the real failure server-side; return a stable message so internal
+    // DB/embedding details never reach the browser.
+    console.error("failed to add note", err);
+    return NextResponse.json({ error: "failed to add note" }, { status: 500 });
   }
 }

--- a/src/app/api/memory/note/route.ts
+++ b/src/app/api/memory/note/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { addMemoryNote } from "@/lib/memory/notes";
+
+// Add a memory note (or a correction = a superseding note). Dedicated write path
+// — NOT the read-only /api/agent registry. Becomes immediately retrievable.
+export async function POST(request: Request): Promise<Response> {
+  const body = await request.json().catch(() => null);
+  const title = (body as { title?: unknown } | null)?.title;
+  const text = (body as { text?: unknown } | null)?.text;
+  if (typeof title !== "string" || !title.trim() || typeof text !== "string" || !text.trim()) {
+    return NextResponse.json({ error: "title and text are required" }, { status: 400 });
+  }
+
+  try {
+    const result = await addMemoryNote(getDb(), { title, text });
+    return NextResponse.json(result, { status: 200 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "failed to add note";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/memory/sources/[id]/archive/route.ts
+++ b/src/app/api/memory/sources/[id]/archive/route.ts
@@ -10,8 +10,23 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> }
 ): Promise<Response> {
   const { id } = await params;
-  const body = await request.json().catch(() => null);
-  const archived = (body as { archived?: unknown } | null)?.archived !== false;
+
+  // Default to archive only when the body is genuinely absent/empty. Malformed
+  // JSON is a client error, not an implicit "archive" — reject it with 400.
+  const raw = await request.text();
+  let archived = true;
+  if (raw.trim()) {
+    let body: unknown;
+    try {
+      body = JSON.parse(raw);
+    } catch {
+      return NextResponse.json({ error: "invalid request body" }, { status: 400 });
+    }
+    if (body === null || typeof body !== "object") {
+      return NextResponse.json({ error: "invalid request body" }, { status: 400 });
+    }
+    archived = (body as { archived?: unknown }).archived !== false;
+  }
 
   try {
     const result = await setSourceArchived(getDb(), { sourceId: id, archived });
@@ -20,7 +35,9 @@ export async function POST(
     }
     return NextResponse.json(result, { status: 200 });
   } catch (err) {
-    const message = err instanceof Error ? err.message : "archive failed";
-    return NextResponse.json({ error: message }, { status: 500 });
+    // Log the real failure server-side; return a stable message (same rule as
+    // the note route — internal DB details must not reach the browser).
+    console.error("archive failed", err);
+    return NextResponse.json({ error: "archive failed" }, { status: 500 });
   }
 }

--- a/src/app/api/memory/sources/[id]/archive/route.ts
+++ b/src/app/api/memory/sources/[id]/archive/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { setSourceArchived } from "@/lib/memory/sources";
+
+// Soft-archive (default) or un-archive a source. Body { archived?: boolean } —
+// omit or true to archive, false to restore. 404 if the source is unknown or
+// the actor isn't permitted (setSourceArchived returns null, default-deny).
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<Response> {
+  const { id } = await params;
+  const body = await request.json().catch(() => null);
+  const archived = (body as { archived?: unknown } | null)?.archived !== false;
+
+  try {
+    const result = await setSourceArchived(getDb(), { sourceId: id, archived });
+    if (!result) {
+      return NextResponse.json({ error: "source not found" }, { status: 404 });
+    }
+    return NextResponse.json(result, { status: 200 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "archive failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/memory/sources/route.ts
+++ b/src/app/api/memory/sources/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { listSources } from "@/lib/memory/sources";
+
+// Management list of the actor's sources (includes archived, flagged) for the
+// /memory Sources tab. Permission-filtered (default-deny) inside listSources.
+export async function GET(): Promise<Response> {
+  try {
+    const sources = await listSources(getDb());
+    return NextResponse.json({ sources });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "failed to list sources";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/memory/MemoryClient.tsx
+++ b/src/app/memory/MemoryClient.tsx
@@ -93,12 +93,19 @@ function SourcesTab() {
   async function toggleArchive(row: SourceItem) {
     setBusyId(row.sourceId);
     try {
-      await fetch(`/api/memory/sources/${row.sourceId}/archive`, {
+      const res = await fetch(`/api/memory/sources/${row.sourceId}/archive`, {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ archived: !row.archived }),
       });
+      const data = (await res.json()) as { error?: string };
+      if (!res.ok || data.error) {
+        throw new Error(data.error ?? "Failed to update source");
+      }
+      setError(null);
       await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update source");
     } finally {
       setBusyId(null);
     }

--- a/src/app/memory/MemoryClient.tsx
+++ b/src/app/memory/MemoryClient.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useCallback, useEffect, useState, type FormEvent } from "react";
+import { Button, Card, DataTable, EmptyState, Input, StatusPill, type Column } from "@/components/ui";
+
+interface SourceItem {
+  sourceId: string;
+  title: string | null;
+  sourceType: string;
+  updatedAt: string;
+  archived: boolean;
+}
+
+type Tab = "sources" | "note";
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime())
+    ? iso
+    : d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+}
+
+export function MemoryClient() {
+  const [tab, setTab] = useState<Tab>("sources");
+
+  return (
+    <div className="px-6 py-6">
+      <header className="mb-5">
+        <h1 className="text-xl font-semibold tracking-tight text-text">Memory</h1>
+        <p className="mt-1 text-[13px] text-muted">
+          Sources the agent can cite, and notes you add by hand. Archiving a wrong source retires it
+          from answers without deleting it.
+        </p>
+      </header>
+
+      <div className="mb-4 flex gap-1">
+        <TabButton active={tab === "sources"} onClick={() => setTab("sources")}>
+          Sources
+        </TabButton>
+        <TabButton active={tab === "note"} onClick={() => setTab("note")}>
+          Add note
+        </TabButton>
+      </div>
+
+      {tab === "sources" ? <SourcesTab /> : <AddNoteTab />}
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      className={`rounded-[6px] px-3 py-1.5 text-[13px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-accent-tint ${
+        active ? "bg-accent-tint text-accent-deep" : "text-muted hover:text-text"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function SourcesTab() {
+  const [sources, setSources] = useState<SourceItem[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch("/api/memory/sources");
+      const data = (await res.json()) as { sources?: SourceItem[]; error?: string };
+      if (data.error) setError(data.error);
+      else setSources(data.sources ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load sources");
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function toggleArchive(row: SourceItem) {
+    setBusyId(row.sourceId);
+    try {
+      await fetch(`/api/memory/sources/${row.sourceId}/archive`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ archived: !row.archived }),
+      });
+      await load();
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <div role="alert" className="text-[13px] text-text">
+          Error: {error}
+        </div>
+      </Card>
+    );
+  }
+  if (!sources) {
+    return <p className="text-[13px] text-muted">Loading…</p>;
+  }
+  if (sources.length === 0) {
+    return (
+      <EmptyState
+        title="No sources yet"
+        description="Import files or add a note to start building sourcing memory."
+      />
+    );
+  }
+
+  const columns: Column<SourceItem>[] = [
+    {
+      key: "title",
+      header: "Source",
+      render: (r) => (
+        <div className="flex flex-col py-1.5">
+          <span className="font-medium text-text">{r.title ?? r.sourceId}</span>
+          <span className="font-mono text-[11px] text-muted">{r.sourceId}</span>
+        </div>
+      ),
+    },
+    { key: "sourceType", header: "Type", render: (r) => <span className="text-muted">{r.sourceType}</span> },
+    {
+      key: "updatedAt",
+      header: "Updated",
+      render: (r) => (
+        <span className="font-mono tabular-nums text-[12px] text-muted">{formatDate(r.updatedAt)}</span>
+      ),
+    },
+    {
+      key: "status",
+      header: "Status",
+      render: (r) => (
+        <StatusPill tone={r.archived ? "warn" : "go"}>{r.archived ? "Archived" : "Active"}</StatusPill>
+      ),
+    },
+    {
+      key: "action",
+      header: "",
+      render: (r) => (
+        <Button variant="ghost" disabled={busyId === r.sourceId} onClick={() => toggleArchive(r)}>
+          {r.archived ? "Restore" : "Archive"}
+        </Button>
+      ),
+    },
+  ];
+
+  return (
+    <div className="overflow-hidden rounded-[8px] border border-border bg-surface">
+      <DataTable columns={columns} rows={sources} getRowId={(r) => r.sourceId} />
+    </div>
+  );
+}
+
+function AddNoteTab() {
+  const [title, setTitle] = useState("");
+  const [text, setText] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(event: FormEvent) {
+    event.preventDefault();
+    if (!title.trim() || !text.trim() || saving) return;
+    setSaving(true);
+    setError(null);
+    setSaved(null);
+    try {
+      const res = await fetch("/api/memory/note", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title, text }),
+      });
+      const data = (await res.json()) as { sourceId?: string; error?: string };
+      if (data.error) setError(data.error);
+      else {
+        setSaved(data.sourceId ?? null);
+        setTitle("");
+        setText("");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save note");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Card className="max-w-2xl">
+      <form onSubmit={onSubmit} className="flex flex-col gap-3">
+        <div>
+          <label htmlFor="note-title" className="mb-1 block text-[12px] font-medium text-muted">
+            Note title
+          </label>
+          <Input
+            id="note-title"
+            placeholder="e.g. Jordan Lee — went cold"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            disabled={saving}
+          />
+        </div>
+        <div>
+          <label htmlFor="note-text" className="mb-1 block text-[12px] font-medium text-muted">
+            Note text
+          </label>
+          <textarea
+            id="note-text"
+            rows={5}
+            placeholder="What did you learn? A correction supersedes prior info on the same subject."
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            disabled={saving}
+            className="w-full rounded-[6px] border border-border bg-canvas px-3 py-2 text-[13px] text-text outline-none placeholder:text-muted focus:border-accent focus:ring-[3px] focus:ring-accent-tint"
+          />
+        </div>
+        <div className="flex items-center gap-3">
+          <Button type="submit" disabled={saving || !title.trim() || !text.trim()}>
+            {saving ? "Saving…" : "Save note"}
+          </Button>
+          {saved && (
+            <span className="text-[13px] text-accent-deep">
+              Saved as <span className="font-mono">{saved}</span>
+            </span>
+          )}
+          {error && (
+            <span role="alert" className="text-[13px] text-neg-tx">
+              {error}
+            </span>
+          )}
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/src/app/memory/page.tsx
+++ b/src/app/memory/page.tsx
@@ -1,0 +1,5 @@
+import { MemoryClient } from "./MemoryClient";
+
+export default function MemoryPage() {
+  return <MemoryClient />;
+}

--- a/src/lib/harness.ts
+++ b/src/lib/harness.ts
@@ -35,6 +35,11 @@ export const agentDecisionSchema = z.discriminatedUnion("action", [
 ]);
 export type AgentDecision = z.infer<typeof agentDecisionSchema>;
 
+export interface ConversationTurn {
+  role: "user" | "assistant";
+  content: string;
+}
+
 export interface RunAgentInput {
   question: string;
   registry: ToolRegistry;
@@ -43,6 +48,9 @@ export interface RunAgentInput {
   provider?: ModelGatewayProvider;
   db?: Sql;
   instructions?: string;
+  // Prior conversation turns for multi-turn chat. Threaded into the user prompt
+  // (not the system prompt) and capped server-side in buildUserPrompt.
+  history?: ConversationTurn[];
 }
 
 export interface RunAgentResult {
@@ -88,6 +96,7 @@ export async function runAgent(input: RunAgentInput): Promise<RunAgentResult> {
         transcript,
         provider: input.provider,
         instructions: input.instructions,
+        history: input.history,
       });
 
       if (decision.action === "final") {
@@ -146,6 +155,7 @@ interface DecideOptions {
   transcript: string[];
   provider?: ModelGatewayProvider;
   instructions?: string;
+  history?: ConversationTurn[];
 }
 
 async function decide(db: Sql, opts: DecideOptions): Promise<AgentDecision> {
@@ -155,7 +165,7 @@ async function decide(db: Sql, opts: DecideOptions): Promise<AgentDecision> {
     taskName: "agent_react_decide",
     promptVersion: "1",
     system: buildAgentSystemPrompt(tools, opts.instructions),
-    prompt: buildUserPrompt(opts.question, opts.transcript),
+    prompt: buildUserPrompt(opts.question, opts.transcript, opts.history),
     schema: agentDecisionSchema,
     schemaName: "agent_decision",
     trace: { runId: opts.runId, parentStepId: opts.parentStepId },
@@ -193,11 +203,28 @@ export function buildAgentSystemPrompt(tools: Tool[], instructions?: string): st
   return parts.join("\n");
 }
 
-function buildUserPrompt(question: string, transcript: string[]): string {
-  const history = transcript.length
+// Multi-turn history is threaded into the USER prompt (never the system prompt,
+// which holds the tool catalog + MEMORY_INSTRUCTIONS). Capped server-side so a
+// long client conversation can't grow the prompt unbounded — a client cannot be
+// trusted to cap it.
+const MAX_HISTORY_TURNS = 12;
+const MAX_TURN_CHARS = 4000;
+
+export function buildUserPrompt(
+  question: string,
+  transcript: string[],
+  history: ConversationTurn[] = []
+): string {
+  const recent = history.slice(-MAX_HISTORY_TURNS);
+  const conversation = recent.length
+    ? `Conversation so far:\n${recent
+        .map((turn) => `${turn.role === "assistant" ? "Assistant" : "User"}: ${turn.content.slice(0, MAX_TURN_CHARS)}`)
+        .join("\n")}\n\n`
+    : "";
+  const observations = transcript.length
     ? `\n\nObservations so far:\n${transcript.join("\n")}`
     : "";
-  return `Question: ${question}${history}`;
+  return `${conversation}Question: ${question}${observations}`;
 }
 
 interface ExecuteToolOptions {

--- a/src/lib/memory/answer-config.ts
+++ b/src/lib/memory/answer-config.ts
@@ -6,8 +6,10 @@ export const MEMORY_INSTRUCTIONS = `## Memory Answer Contract
 
 You are a memory-grounded sourcing assistant. Follow these rules strictly:
 
-1. **Call search_memory first.** Before answering any question, call search_memory to retrieve
-   relevant sourcing memory. Never answer from prior training knowledge alone.
+1. **Call search_memory first — on every turn.** Before answering any question, call search_memory
+   to retrieve relevant sourcing memory. Never answer from prior training knowledge alone. On
+   follow-up turns in a conversation, call search_memory AGAIN before citing — never reuse a citation
+   from an earlier turn without re-retrieving it this turn (uncited prior-turn ids are dropped).
 
 2. **Four-section format.** Your final answer MUST use exactly these four sections in this order:
    Answer: <direct answer to the question, citing sources>

--- a/src/lib/memory/ingest.ts
+++ b/src/lib/memory/ingest.ts
@@ -8,9 +8,11 @@ import { chunkCsvRows, chunkText, sha256, slugifySourceId, type TextChunk } from
 import { writeChunksAndGrant } from "./chunk-store";
 import { embedText } from "./embed";
 
-export type MemorySkipCategory = IngestErrorCategory | "unchanged";
+export type MemorySkipCategory = IngestErrorCategory | "unchanged" | "duplicate";
 
 export interface MemorySkippedFile {
+  // The file's user-facing identity: the relative path for folder ingest,
+  // the original filename for uploads.
   path: string;
   category: MemorySkipCategory;
   reason: string;
@@ -22,11 +24,22 @@ export interface MemoryIngestResult {
   skippedFiles: MemorySkippedFile[];
 }
 
+export interface UploadFile {
+  name: string;
+  bytes: Uint8Array;
+}
+
 type Sql = postgres.Sql;
 
 // Internal signal for dedup skip — not an IngestError.
 class UnchangedSkip {
   readonly message = "File content unchanged";
+}
+
+// Internal signal for a friendly duplicate/collision skip — not an IngestError.
+// Surfaced instead of a raw Postgres UNIQUE error so the import UI stays readable.
+class DuplicateSkip {
+  constructor(readonly message: string) {}
 }
 
 export async function ingestFolder(
@@ -54,13 +67,59 @@ export async function ingestFolder(
   return result;
 }
 
+// Ingest in-memory uploaded files (no disk). Each upload gets a stable
+// filename identity: path = `upload://{name}`, name-derived source_id. So
+// re-uploading the same filename dedups/updates in place, and citations stay
+// clean. Two collisions become friendly per-file skips rather than DB errors:
+//   (a) the same filename twice in one batch (would silently overwrite)
+//   (b) different names that slugify to the same source_id (UNIQUE violation)
+export async function ingestFiles(
+  db: Sql,
+  files: UploadFile[],
+  actor: MemoryActor = DEFAULT_ACTOR
+): Promise<MemoryIngestResult> {
+  const result: MemoryIngestResult = { processed: 0, skipped: 0, skippedFiles: [] };
+  const seenPaths = new Set<string>();
+
+  for (const file of files) {
+    const storedPath = `upload://${file.name}`;
+
+    // Collision (a): same filename twice in one batch. Skip the later one
+    // rather than let ON CONFLICT (path) silently overwrite the first.
+    if (seenPaths.has(storedPath)) {
+      recordSkip(result, file.name, new DuplicateSkip("duplicate filename in this upload"));
+      continue;
+    }
+    seenPaths.add(storedPath);
+
+    if (!isSupportedSourcePath(file.name)) {
+      recordSkip(result, file.name, new IngestError("unsupported-type", `Unsupported file extension: ${file.name}`));
+      continue;
+    }
+
+    try {
+      await ingestParsedSource(db, {
+        parseName: file.name,
+        storedPath,
+        label: file.name,
+        content: new TextDecoder().decode(file.bytes),
+        actor,
+      });
+      result.processed += 1;
+    } catch (error) {
+      recordSkip(result, file.name, error);
+    }
+  }
+
+  return result;
+}
+
 async function ingestFile(
   db: Sql,
   filePath: string,
   rootFolder: string,
   actor: MemoryActor
 ): Promise<void> {
-  // Read
   let content: string;
   try {
     content = await readFile(filePath, "utf8");
@@ -68,22 +127,52 @@ async function ingestFile(
     throw new IngestError("unreadable", `Failed to read file: ${errorMessage(err)}`);
   }
 
+  await ingestParsedSource(db, {
+    parseName: filePath,
+    storedPath: filePath,
+    label: sourceLabel(rootFolder, filePath),
+    content,
+    actor,
+  });
+}
+
+// Shared core: parse → chunk → dedup → embed → atomically upsert the source
+// record, replace its chunks, and seed the read grant. The three names let
+// folder and upload callers map their own identity onto the same pipeline:
+//   parseName  — for parseSourceFile (extension/type + title)
+//   storedPath — source_records.path (dedup key + ON CONFLICT target)
+//   label      — slugifySourceId fallback when there is no frontmatter source_id
+async function ingestParsedSource(
+  db: Sql,
+  args: { parseName: string; storedPath: string; label: string; content: string; actor: MemoryActor }
+): Promise<void> {
+  const { parseName, storedPath, label, content, actor } = args;
+
   // Parse (throws IngestError on empty / parse failures)
-  const parsed = parseSourceFile(filePath, content);
+  const parsed = parseSourceFile(parseName, content);
 
   // Chunk (throws IngestError on parse failures)
   const chunks = chunkSourceText(parsed.sourceType, parsed.rawText);
 
   const contentHash = sha256(parsed.rawText);
-  const relativeLabel = sourceLabel(rootFolder, filePath);
-  const sourceId = slugifySourceId(parsed.sourceId ?? relativeLabel);
+  const sourceId = slugifySourceId(parsed.sourceId ?? label);
 
   // Dedup: skip if the stored row already has the same content hash
   const [existing] = await db<{ content_hash: string }[]>`
-    SELECT content_hash FROM source_records WHERE path = ${filePath}
+    SELECT content_hash FROM source_records WHERE path = ${storedPath}
   `;
   if (existing && existing.content_hash === contentHash) {
     throw new UnchangedSkip();
+  }
+
+  // Collision: a different source (different path) already claims this
+  // source_id. Surface a friendly skip instead of tripping the source_id
+  // UNIQUE constraint, which would throw a raw Postgres error.
+  const [collision] = await db<{ path: string }[]>`
+    SELECT path FROM source_records WHERE source_id = ${sourceId} AND path != ${storedPath} LIMIT 1
+  `;
+  if (collision) {
+    throw new DuplicateSkip(`a different source already uses id '${sourceId}'`);
   }
 
   // Compute embeddings outside the transaction so model_calls tracking
@@ -94,7 +183,7 @@ async function ingestFile(
   await db.begin(async (tx) => {
     const [source] = await tx<{ id: string; source_id: string }[]>`
       INSERT INTO source_records (source_id, path, title, source_type, content_hash, raw_text)
-      VALUES (${sourceId}, ${filePath}, ${parsed.title}, ${parsed.sourceType}, ${contentHash}, ${parsed.rawText})
+      VALUES (${sourceId}, ${storedPath}, ${parsed.title}, ${parsed.sourceType}, ${contentHash}, ${parsed.rawText})
       ON CONFLICT (path) DO UPDATE SET
         title        = EXCLUDED.title,
         source_type  = EXCLUDED.source_type,
@@ -149,16 +238,21 @@ function sourceLabel(rootFolder: string, filePath: string): string {
   return label.split(sep).join("/");
 }
 
-function recordSkip(result: MemoryIngestResult, filePath: string, error: unknown): void {
+function recordSkip(result: MemoryIngestResult, identifier: string, error: unknown): void {
   if (error instanceof UnchangedSkip) {
     result.skipped += 1;
-    result.skippedFiles.push({ path: filePath, category: "unchanged", reason: error.message });
+    result.skippedFiles.push({ path: identifier, category: "unchanged", reason: error.message });
+    return;
+  }
+  if (error instanceof DuplicateSkip) {
+    result.skipped += 1;
+    result.skippedFiles.push({ path: identifier, category: "duplicate", reason: error.message });
     return;
   }
   const category = classifyIngestError(error);
   const reason = errorMessage(error);
   result.skipped += 1;
-  result.skippedFiles.push({ path: filePath, category, reason });
+  result.skippedFiles.push({ path: identifier, category, reason });
 }
 
 function errorMessage(error: unknown): string {

--- a/src/lib/memory/ingest.ts
+++ b/src/lib/memory/ingest.ts
@@ -179,32 +179,52 @@ async function ingestParsedSource(
   // (when OPENAI_API_KEY is set) is not rolled back on a chunk insert failure.
   const embeddings = await Promise.all(chunks.map((chunk) => embedText(db, chunk.text)));
 
-  // Atomically: upsert source_record + replace chunks + seed permission
-  await db.begin(async (tx) => {
-    const [source] = await tx<{ id: string; source_id: string }[]>`
-      INSERT INTO source_records (source_id, path, title, source_type, content_hash, raw_text)
-      VALUES (${sourceId}, ${storedPath}, ${parsed.title}, ${parsed.sourceType}, ${contentHash}, ${parsed.rawText})
-      ON CONFLICT (path) DO UPDATE SET
-        title        = EXCLUDED.title,
-        source_type  = EXCLUDED.source_type,
-        content_hash = EXCLUDED.content_hash,
-        raw_text     = EXCLUDED.raw_text,
-        updated_at   = now()
-      RETURNING id, source_id
-    `;
+  // Atomically: upsert source_record + replace chunks + seed permission.
+  try {
+    await db.begin(async (tx) => {
+      const [source] = await tx<{ id: string; source_id: string }[]>`
+        INSERT INTO source_records (source_id, path, title, source_type, content_hash, raw_text)
+        VALUES (${sourceId}, ${storedPath}, ${parsed.title}, ${parsed.sourceType}, ${contentHash}, ${parsed.rawText})
+        ON CONFLICT (path) DO UPDATE SET
+          title        = EXCLUDED.title,
+          source_type  = EXCLUDED.source_type,
+          content_hash = EXCLUDED.content_hash,
+          raw_text     = EXCLUDED.raw_text,
+          updated_at   = now()
+        RETURNING id, source_id
+      `;
 
-    const effectiveSourceId = source.source_id;
-    const sourceRecordId = source.id;
+      const effectiveSourceId = source.source_id;
+      const sourceRecordId = source.id;
 
-    await writeChunksAndGrant(tx, {
-      sourceRecordId,
-      sourceId: effectiveSourceId,
-      sourceType: parsed.sourceType,
-      chunks,
-      embeddings,
-      actor,
+      await writeChunksAndGrant(tx, {
+        sourceRecordId,
+        sourceId: effectiveSourceId,
+        sourceType: parsed.sourceType,
+        chunks,
+        embeddings,
+        actor,
+      });
     });
-  });
+  } catch (error) {
+    // TOCTOU backstop: the collision pre-check above is non-atomic (embeddings
+    // are computed between it and this INSERT), so two concurrent ingests of
+    // different paths that slugify to the same source_id can both pass the check
+    // and race here. Path conflicts are absorbed by ON CONFLICT (path), and the
+    // chunk/permission writes can't trip a UNIQUE in this txn, so a unique
+    // violation reaching here is necessarily source_id — surface the same
+    // friendly skip the pre-check would, not a raw Postgres error.
+    if (isSourceIdConflict(error)) {
+      throw new DuplicateSkip(`a different source already uses id '${sourceId}'`);
+    }
+    throw error;
+  }
+}
+
+// A Postgres unique_violation (SQLSTATE 23505) on the source_id constraint.
+function isSourceIdConflict(error: unknown): boolean {
+  const e = error as { code?: string; constraint_name?: string } | null;
+  return e?.code === "23505" && (e.constraint_name == null || e.constraint_name.includes("source_id"));
 }
 
 async function walkFiles(folder: string): Promise<string[]> {

--- a/src/lib/memory/permissions.ts
+++ b/src/lib/memory/permissions.ts
@@ -3,14 +3,27 @@ import type { MemoryActor } from "./actor";
 
 // Default-deny: returns only source_ids explicitly granted 'read' to this actor.
 // No rows → [] (caller must not fetch restricted data).
-export async function resolveAllowedSourceIds(db: Sql, actor: MemoryActor): Promise<string[]> {
+//
+// Archived sources are excluded by default. The JOIN to source_records is the
+// single chokepoint that drops archived sources from EVERY retrieval path
+// (searchMemory's three loaders all gate on this allowlist). Management views
+// (the sources list, archive/un-archive) pass { includeArchived: true } so they
+// can still see and act on archived sources.
+export async function resolveAllowedSourceIds(
+  db: Sql,
+  actor: MemoryActor,
+  opts: { includeArchived?: boolean } = {}
+): Promise<string[]> {
+  const includeArchived = opts.includeArchived ?? false;
   const rows = await db<{ source_id: string }[]>`
-    SELECT source_id
-    FROM source_permissions
-    WHERE principal_type = ${actor.actorType}
-      AND principal_id = ${actor.actorId}
-      AND access = 'read'
-    ORDER BY source_id
+    SELECT sp.source_id
+    FROM source_permissions sp
+    JOIN source_records sr ON sr.source_id = sp.source_id
+    WHERE sp.principal_type = ${actor.actorType}
+      AND sp.principal_id = ${actor.actorId}
+      AND sp.access = 'read'
+      AND (${includeArchived} OR sr.archived_at IS NULL)
+    ORDER BY sp.source_id
   `;
   return rows.map((r) => r.source_id);
 }

--- a/src/lib/memory/sources.ts
+++ b/src/lib/memory/sources.ts
@@ -1,0 +1,66 @@
+import type { Sql } from "../tools/types";
+import { DEFAULT_ACTOR, type MemoryActor } from "./actor";
+import { resolveAllowedSourceIds } from "./permissions";
+
+export interface SourceListItem {
+  sourceId: string;
+  title: string | null;
+  sourceType: string;
+  updatedAt: string;
+  archived: boolean;
+}
+
+// Management list: the actor's permitted sources INCLUDING archived (so they can
+// be shown + un-archived). Active first, then archived; newest-updated first.
+export async function listSources(
+  db: Sql,
+  actor: MemoryActor = DEFAULT_ACTOR
+): Promise<SourceListItem[]> {
+  const allowed = await resolveAllowedSourceIds(db, actor, { includeArchived: true });
+  if (allowed.length === 0) return [];
+
+  const rows = await db<
+    {
+      source_id: string;
+      title: string | null;
+      source_type: string;
+      updated_at: Date;
+      archived_at: Date | null;
+    }[]
+  >`
+    SELECT source_id, title, source_type, updated_at, archived_at
+    FROM source_records
+    WHERE source_id = ANY(${allowed})
+    ORDER BY (archived_at IS NOT NULL), updated_at DESC
+  `;
+
+  return rows.map((r) => ({
+    sourceId: r.source_id,
+    title: r.title,
+    sourceType: r.source_type,
+    updatedAt: r.updated_at.toISOString(),
+    archived: r.archived_at != null,
+  }));
+}
+
+// Soft-archive / un-archive a source the actor is permitted to manage. Returns
+// null when the source is unknown or not permitted (default-deny).
+export async function setSourceArchived(
+  db: Sql,
+  args: { sourceId: string; archived: boolean; actor?: MemoryActor }
+): Promise<{ sourceId: string; archived: boolean } | null> {
+  const { sourceId, archived, actor = DEFAULT_ACTOR } = args;
+
+  const allowed = await resolveAllowedSourceIds(db, actor, { includeArchived: true });
+  if (!allowed.includes(sourceId)) return null;
+
+  const [row] = await db<{ source_id: string; archived_at: Date | null }[]>`
+    UPDATE source_records
+    SET archived_at = CASE WHEN ${archived} THEN now() ELSE NULL END,
+        updated_at = now()
+    WHERE source_id = ${sourceId}
+    RETURNING source_id, archived_at
+  `;
+  if (!row) return null;
+  return { sourceId: row.source_id, archived: row.archived_at != null };
+}

--- a/src/lib/nav.ts
+++ b/src/lib/nav.ts
@@ -2,4 +2,7 @@ import type { NavItem } from "@/components/ui";
 
 // Live routes only. Downstream slices append their entry here as pages land
 // (e.g. Contacts, Run Ledger, Drafts, Memory, Routines).
-export const NAV: NavItem[] = [{ label: "Research Chat", href: "/chat" }];
+export const NAV: NavItem[] = [
+  { label: "Research Chat", href: "/chat" },
+  { label: "Memory", href: "/memory" },
+];

--- a/src/migrations/003_archived.sql
+++ b/src/migrations/003_archived.sql
@@ -1,0 +1,9 @@
+-- 003_archived.sql — soft-archive for source records (A7.2 "correct/retire a source").
+-- Archiving is reversible and never deletes: a hard DELETE would orphan facts via
+-- semantic_facts.source_record_id ON DELETE SET NULL (accepted-but-citationless
+-- facts would keep surfacing). Retrieval excludes archived sources centrally in
+-- resolveAllowedSourceIds; management views pass includeArchived to still see them.
+
+ALTER TABLE source_records ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS source_records_archived_idx ON source_records(archived_at);

--- a/tests/agent-route-history.test.ts
+++ b/tests/agent-route-history.test.ts
@@ -1,0 +1,50 @@
+import { vi } from "vitest";
+
+const { runAgentMock, getRunTraceMock } = vi.hoisted(() => ({
+  runAgentMock: vi.fn(),
+  getRunTraceMock: vi.fn(),
+}));
+vi.mock("@/lib/harness", () => ({ runAgent: runAgentMock }));
+vi.mock("@/lib/ledger", () => ({ getRunTrace: getRunTraceMock }));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue({}) }));
+
+import { POST } from "@/app/api/agent/route";
+
+function post(body: unknown): Request {
+  return new Request("http://localhost/api/agent", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/agent — multi-turn history", () => {
+  beforeEach(() => {
+    runAgentMock.mockReset();
+    runAgentMock.mockResolvedValue({ runId: 1, status: "succeeded", answer: "ok", steps: 1 });
+    getRunTraceMock.mockResolvedValue(null);
+  });
+
+  it("forwards conversation history to runAgent", async () => {
+    const history = [
+      { role: "user", content: "Who is Acme?" },
+      { role: "assistant", content: "A fintech." },
+    ];
+    await POST(post({ question: "And funding?", history }));
+    expect(runAgentMock).toHaveBeenCalledTimes(1);
+    expect(runAgentMock.mock.calls[0][0]).toMatchObject({ history });
+  });
+
+  it("works without history (back-compat)", async () => {
+    const res = await POST(post({ question: "solo" }));
+    expect(res.status).toBe(200);
+    expect(runAgentMock.mock.calls[0][0].question).toBe("solo");
+  });
+
+  it("ignores a malformed history (not an array) instead of 500ing", async () => {
+    const res = await POST(post({ question: "q", history: "nope" }));
+    expect(res.status).toBe(200);
+    const arg = runAgentMock.mock.calls[0][0];
+    expect(arg.history === undefined || Array.isArray(arg.history)).toBe(true);
+  });
+});

--- a/tests/components/MemoryClient.test.tsx
+++ b/tests/components/MemoryClient.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryClient } from "@/app/memory/MemoryClient";
+
+const sourceRow = (over = {}) => ({
+  sourceId: "acme",
+  title: "Acme Robotics",
+  sourceType: "markdown",
+  updatedAt: "2026-06-25T00:00:00.000Z",
+  archived: false,
+  ...over,
+});
+
+describe("MemoryClient", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("lists sources from the API and flags archived ones", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ sources: [sourceRow(), sourceRow({ sourceId: "beta", title: null, sourceType: "csv", archived: true })] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<MemoryClient />);
+
+    await waitFor(() => expect(screen.getByText("Acme Robotics")).toBeInTheDocument());
+    expect(fetchMock).toHaveBeenCalledWith("/api/memory/sources");
+    expect(screen.getByText(/archived/i)).toBeInTheDocument();
+  });
+
+  it("shows an empty state when there are no sources", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ sources: [] }) }));
+    render(<MemoryClient />);
+    await waitFor(() => expect(screen.getByText(/no sources yet/i)).toBeInTheDocument());
+  });
+
+  it("archives a source via the archive endpoint", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ sources: [sourceRow()] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ sourceId: "acme", archived: true }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ sources: [sourceRow({ archived: true })] }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<MemoryClient />);
+    await waitFor(() => expect(screen.getByText("Acme Robotics")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: /^archive$/i }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/memory/sources/acme/archive",
+        expect.objectContaining({ method: "POST" })
+      )
+    );
+  });
+
+  it("adds a note via the note endpoint", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ sources: [] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ sourceId: "note-x" }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<MemoryClient />);
+    // let the initial sources fetch settle before switching tabs
+    await waitFor(() => expect(screen.getByText(/no sources yet/i)).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /add note/i }));
+    fireEvent.change(screen.getByLabelText(/note title/i), { target: { value: "Correction" } });
+    fireEvent.change(screen.getByLabelText(/note text/i), { target: { value: "Jordan went cold." } });
+    fireEvent.click(screen.getByRole("button", { name: /save note/i }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/memory/note",
+        expect.objectContaining({ method: "POST" })
+      )
+    );
+  });
+});

--- a/tests/harness-multiturn.test.ts
+++ b/tests/harness-multiturn.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { buildUserPrompt } from "@/lib/harness";
+import { MEMORY_INSTRUCTIONS } from "@/lib/memory/answer-config";
+
+describe("buildUserPrompt — multi-turn history", () => {
+  it("threads prior conversation turns into the prompt, before the current question", () => {
+    const prompt = buildUserPrompt("And their latest funding?", [], [
+      { role: "user", content: "Who is Acme?" },
+      { role: "assistant", content: "Acme is a fintech startup." },
+    ]);
+    expect(prompt).toContain("Who is Acme?");
+    expect(prompt).toContain("Acme is a fintech startup.");
+    expect(prompt).toContain("And their latest funding?");
+    expect(prompt.indexOf("Who is Acme?")).toBeLessThan(prompt.indexOf("And their latest funding?"));
+  });
+
+  it("works with no history (back-compat: a plain single-turn prompt)", () => {
+    const prompt = buildUserPrompt("Just this.", []);
+    expect(prompt).toContain("Just this.");
+    expect(prompt).not.toMatch(/Conversation so far/i);
+  });
+
+  it("caps history to the most recent turns server-side, dropping the oldest", () => {
+    const many = Array.from({ length: 50 }, (_, i) => ({
+      role: "user" as const,
+      content: `HISTMARK_${i}`,
+    }));
+    const prompt = buildUserPrompt("now", [], many);
+    expect(prompt).toContain("HISTMARK_49");
+    expect(prompt).not.toContain("HISTMARK_0");
+  });
+
+  it("caps a single very long turn so the prompt cannot grow unbounded", () => {
+    const huge = "x".repeat(20000);
+    const prompt = buildUserPrompt("now", [], [{ role: "user", content: huge }]);
+    expect(prompt.length).toBeLessThan(huge.length);
+  });
+
+  it("still includes intra-run observations alongside conversation history", () => {
+    const prompt = buildUserPrompt("q", ["Step 1: called search_memory -> ok"], [
+      { role: "user", content: "earlier turn" },
+    ]);
+    expect(prompt).toContain("earlier turn");
+    expect(prompt).toContain("Observations so far");
+    expect(prompt).toContain("Step 1: called search_memory");
+  });
+});
+
+describe("MEMORY_INSTRUCTIONS — multi-turn citation safety (N3)", () => {
+  it("requires calling search_memory every turn so prior-turn citations are not scrubbed", () => {
+    expect(MEMORY_INSTRUCTIONS).toMatch(/every turn|each turn|follow-up/i);
+  });
+});

--- a/tests/memory-archive.test.ts
+++ b/tests/memory-archive.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+import { DEFAULT_ACTOR } from "@/lib/memory/actor";
+import { resolveAllowedSourceIds } from "@/lib/memory/permissions";
+import { ingestFiles } from "@/lib/memory/ingest";
+import { searchMemory } from "@/lib/memory/retrieve";
+
+function bytes(text: string): Uint8Array {
+  return new TextEncoder().encode(text);
+}
+
+async function resetMemoryTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS source_permissions CASCADE`;
+  await db`DROP TABLE IF EXISTS extraction_runs CASCADE`;
+  await db`DROP TABLE IF EXISTS semantic_facts CASCADE`;
+  await db`DROP TABLE IF EXISTS memory_chunks CASCADE`;
+  await db`DROP TABLE IF EXISTS source_records CASCADE`;
+  await db`DROP TABLE IF EXISTS schema_migrations CASCADE`;
+  await runMigrations(db);
+}
+
+describe("memory archive (soft-archive + central filter)", () => {
+  let savedApiKey: string | undefined;
+
+  beforeEach(async () => {
+    savedApiKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    await resetMemoryTables();
+  });
+
+  afterEach(async () => {
+    if (savedApiKey !== undefined) process.env.OPENAI_API_KEY = savedApiKey;
+    else delete process.env.OPENAI_API_KEY;
+    await closeDb();
+  });
+
+  it("003 migration adds an archived_at column to source_records", async () => {
+    const db = getDb();
+    const [col] = await db<{ data_type: string }[]>`
+      SELECT data_type FROM information_schema.columns
+      WHERE table_name = 'source_records' AND column_name = 'archived_at'
+    `;
+    expect(col?.data_type).toMatch(/timestamp/i);
+  });
+
+  it("resolveAllowedSourceIds excludes archived sources by default; includeArchived returns them", async () => {
+    const db = getDb();
+    await ingestFiles(db, [{ name: "acme.md", bytes: bytes("# Acme\n\nAcme is a sourcing target.") }]);
+    const [{ source_id: sid }] = await db<{ source_id: string }[]>`SELECT source_id FROM source_records`;
+
+    expect(await resolveAllowedSourceIds(db, DEFAULT_ACTOR)).toContain(sid);
+
+    await db`UPDATE source_records SET archived_at = now() WHERE source_id = ${sid}`;
+
+    expect(await resolveAllowedSourceIds(db, DEFAULT_ACTOR)).not.toContain(sid);
+    expect(await resolveAllowedSourceIds(db, DEFAULT_ACTOR, { includeArchived: true })).toContain(sid);
+  });
+
+  it("searchMemory returns no chunks/facts for an archived source; un-archiving restores them", async () => {
+    const db = getDb();
+    await ingestFiles(db, [
+      { name: "acme.md", bytes: bytes("# Acme Robotics\n\nAcme Robotics is a Series B sourcing target in Boston.") },
+    ]);
+
+    const before = await searchMemory(db, { query: "Acme Robotics sourcing target" });
+    expect(before.chunks.length).toBeGreaterThan(0);
+
+    await db`UPDATE source_records SET archived_at = now()`;
+    const archived = await searchMemory(db, { query: "Acme Robotics sourcing target" });
+    expect(archived.chunks).toHaveLength(0);
+    expect(archived.acceptedFacts).toHaveLength(0);
+
+    await db`UPDATE source_records SET archived_at = NULL`;
+    const restored = await searchMemory(db, { query: "Acme Robotics sourcing target" });
+    expect(restored.chunks.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/memory-import-route.test.ts
+++ b/tests/memory-import-route.test.ts
@@ -1,0 +1,76 @@
+import { vi } from "vitest";
+
+const { ingestFilesMock } = vi.hoisted(() => ({ ingestFilesMock: vi.fn() }));
+vi.mock("@/lib/memory/ingest", () => ({ ingestFiles: ingestFilesMock }));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue({}) }));
+
+import { POST } from "@/app/api/memory/import/route";
+
+function bytes(text: string): Uint8Array {
+  return new TextEncoder().encode(text);
+}
+
+function importRequest(form: FormData): Request {
+  return new Request("http://localhost/api/memory/import", { method: "POST", body: form });
+}
+
+describe("POST /api/memory/import", () => {
+  beforeEach(() => {
+    ingestFilesMock.mockReset();
+    ingestFilesMock.mockResolvedValue({ processed: 2, skipped: 0, skippedFiles: [] });
+  });
+
+  it("accepts multipart uploads, calls ingestFiles with {name,bytes}, returns the result", async () => {
+    const form = new FormData();
+    form.append("files", new File([bytes("# Acme\n\nx")], "acme.md"));
+    form.append("files", new File([bytes("name,status\nJane,contacted\n")], "contacts.csv"));
+
+    const res = await POST(importRequest(form));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ processed: 2, skipped: 0 });
+
+    expect(ingestFilesMock).toHaveBeenCalledTimes(1);
+    const files = ingestFilesMock.mock.calls[0][1] as { name: string; bytes: Uint8Array }[];
+    expect(files.map((f) => f.name)).toEqual(["acme.md", "contacts.csv"]);
+    expect(files[0].bytes).toBeInstanceOf(Uint8Array);
+  });
+
+  it("returns 200 with the per-file skip list — one bad file does not sink the batch", async () => {
+    ingestFilesMock.mockResolvedValue({
+      processed: 1,
+      skipped: 1,
+      skippedFiles: [{ path: "image.png", category: "unsupported-type", reason: "Unsupported file extension: image.png" }],
+    });
+
+    const form = new FormData();
+    form.append("files", new File([bytes("ok")], "ok.txt"));
+    form.append("files", new File([bytes("x")], "image.png"));
+
+    const res = await POST(importRequest(form));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.skippedFiles[0].path).toBe("image.png");
+  });
+
+  it("returns 400 when the request is not multipart/form-data", async () => {
+    const res = await POST(
+      new Request("http://localhost/api/memory/import", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      })
+    );
+
+    expect(res.status).toBe(400);
+    expect(ingestFilesMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when no files are attached", async () => {
+    const res = await POST(importRequest(new FormData()));
+
+    expect(res.status).toBe(400);
+    expect(ingestFilesMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/memory-ingest-files.test.ts
+++ b/tests/memory-ingest-files.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+import { DEFAULT_ACTOR } from "@/lib/memory/actor";
+import { ingestFiles } from "@/lib/memory/ingest";
+
+function bytes(text: string): Uint8Array {
+  return new TextEncoder().encode(text);
+}
+
+async function resetMemoryTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS source_permissions CASCADE`;
+  await db`DROP TABLE IF EXISTS extraction_runs CASCADE`;
+  await db`DROP TABLE IF EXISTS semantic_facts CASCADE`;
+  await db`DROP TABLE IF EXISTS memory_chunks CASCADE`;
+  await db`DROP TABLE IF EXISTS source_records CASCADE`;
+  await db`DROP TABLE IF EXISTS schema_migrations CASCADE`;
+  await runMigrations(db);
+}
+
+describe("memory ingestFiles (in-memory uploads)", () => {
+  let savedApiKey: string | undefined;
+
+  beforeEach(async () => {
+    // Offline: hash-fallback embeddings (mirror memory-ingest.test.ts)
+    savedApiKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    await resetMemoryTables();
+  });
+
+  afterEach(async () => {
+    if (savedApiKey !== undefined) {
+      process.env.OPENAI_API_KEY = savedApiKey;
+    } else {
+      delete process.env.OPENAI_API_KEY;
+    }
+    await closeDb();
+  });
+
+  it("ingests uploaded files: writes source_records with upload:// path + chunks, grants DEFAULT_ACTOR read", async () => {
+    const db = getDb();
+
+    const result = await ingestFiles(db, [
+      { name: "acme.md", bytes: bytes("# Acme\n\nAcme is a sourcing target.") },
+      { name: "contacts.csv", bytes: bytes("name,status\nJane,contacted\n") },
+    ]);
+
+    expect(result.processed).toBe(2);
+    expect(result.skipped).toBe(0);
+
+    const sources = await db<{ path: string }[]>`
+      SELECT path FROM source_records ORDER BY path
+    `;
+    expect(sources.map((s) => s.path)).toEqual(["upload://acme.md", "upload://contacts.csv"]);
+
+    const [{ n: grants }] = await db<{ n: number }[]>`
+      SELECT count(*)::int AS n FROM source_permissions
+      WHERE principal_type = ${DEFAULT_ACTOR.actorType}
+        AND principal_id = ${DEFAULT_ACTOR.actorId}
+        AND access = 'read'
+    `;
+    expect(grants).toBe(2);
+
+    const chunks = await db<{ citation: string }[]>`SELECT citation FROM memory_chunks`;
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+    expect(chunks.every((c) => c.citation.length > 0)).toBe(true);
+  });
+
+  it("re-uploading the same filename with unchanged content is skipped (dedup); no duplicate chunks", async () => {
+    const db = getDb();
+    const content = "# Acme\n\nStable content.";
+
+    const first = await ingestFiles(db, [{ name: "acme.md", bytes: bytes(content) }]);
+    expect(first.processed).toBe(1);
+
+    const [{ n: before }] = await db<{ n: number }[]>`SELECT count(*)::int AS n FROM memory_chunks`;
+
+    const second = await ingestFiles(db, [{ name: "acme.md", bytes: bytes(content) }]);
+    expect(second.processed).toBe(0);
+    expect(second.skipped).toBe(1);
+    expect(second.skippedFiles[0].path).toBe("acme.md");
+    expect(second.skippedFiles[0].reason).toMatch(/unchanged/i);
+
+    const [{ n: after }] = await db<{ n: number }[]>`SELECT count(*)::int AS n FROM memory_chunks`;
+    expect(after).toBe(before);
+  });
+
+  it("re-uploading the same filename with changed content updates in place (same source_id, new chunks)", async () => {
+    const db = getDb();
+    await ingestFiles(db, [{ name: "acme.md", bytes: bytes("# Acme\n\nOld funding 5M.") }]);
+    const [{ source_id: firstId }] = await db<{ source_id: string }[]>`SELECT source_id FROM source_records`;
+
+    const result = await ingestFiles(db, [{ name: "acme.md", bytes: bytes("# Acme\n\nNew funding 10M.") }]);
+    expect(result.processed).toBe(1);
+
+    const recs = await db<{ source_id: string }[]>`SELECT source_id FROM source_records`;
+    expect(recs).toHaveLength(1); // updated in place, not duplicated
+    expect(recs[0].source_id).toBe(firstId);
+
+    const chunks = await db<{ text: string }[]>`SELECT text FROM memory_chunks`;
+    expect(chunks.some((c) => c.text.includes("New funding"))).toBe(true);
+    expect(chunks.some((c) => c.text.includes("Old funding"))).toBe(false);
+  });
+
+  it("collision (a): two files with the same name in one batch — second skipped, first NOT overwritten", async () => {
+    const db = getDb();
+
+    const result = await ingestFiles(db, [
+      { name: "notes.md", bytes: bytes("# Notes\n\nFirst file content.") },
+      { name: "notes.md", bytes: bytes("# Notes\n\nSecond file content.") },
+    ]);
+
+    expect(result.processed).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(result.skippedFiles[0].path).toBe("notes.md");
+    expect(result.skippedFiles[0].category).toBe("duplicate");
+    expect(result.skippedFiles[0].reason).toMatch(/duplicate filename/i);
+
+    const recs = await db<{ raw_text: string }[]>`SELECT raw_text FROM source_records`;
+    expect(recs).toHaveLength(1);
+    expect(recs[0].raw_text).toContain("First file content"); // first wins, no silent overwrite
+  });
+
+  it("collision (b): different names that slugify to the same source_id — friendly skip, not a raw DB error", async () => {
+    const db = getDb();
+
+    const result = await ingestFiles(db, [
+      { name: "Acme Corp.md", bytes: bytes("# Acme\n\nFirst.") },
+      { name: "acme-corp.md", bytes: bytes("# Acme\n\nSecond.") },
+    ]);
+
+    expect(result.processed).toBe(1);
+    expect(result.skipped).toBe(1);
+
+    const skip = result.skippedFiles[0];
+    expect(skip.category).toBe("duplicate");
+    expect(skip.reason).toMatch(/already uses id/i);
+    expect(skip.reason).not.toMatch(/duplicate key value|violates|23505/i); // not a leaked PG error
+  });
+
+  it("unsupported file type is skipped with a reason; writes no source_records row", async () => {
+    const db = getDb();
+
+    const result = await ingestFiles(db, [
+      { name: "ok.txt", bytes: bytes("Good content.") },
+      { name: "image.png", bytes: bytes("binary data") },
+    ]);
+
+    expect(result.processed).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(result.skippedFiles[0].path).toBe("image.png");
+    expect(result.skippedFiles[0].reason.length).toBeGreaterThan(0);
+
+    const recs = await db<{ path: string }[]>`SELECT path FROM source_records`;
+    expect(recs.every((r) => !r.path.includes("image.png"))).toBe(true);
+  });
+
+  it("empty file is skipped with an 'empty' reason and no orphan rows", async () => {
+    const db = getDb();
+
+    const result = await ingestFiles(db, [{ name: "empty.md", bytes: bytes("   \n\t") }]);
+
+    expect(result.processed).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.skippedFiles[0].reason).toMatch(/empty/i);
+
+    const [{ n }] = await db<{ n: number }[]>`SELECT count(*)::int AS n FROM source_records`;
+    expect(n).toBe(0);
+  });
+});

--- a/tests/memory-routes.test.ts
+++ b/tests/memory-routes.test.ts
@@ -1,0 +1,89 @@
+import { vi } from "vitest";
+
+const { listSourcesMock, setArchivedMock, addNoteMock } = vi.hoisted(() => ({
+  listSourcesMock: vi.fn(),
+  setArchivedMock: vi.fn(),
+  addNoteMock: vi.fn(),
+}));
+vi.mock("@/lib/memory/sources", () => ({
+  listSources: listSourcesMock,
+  setSourceArchived: setArchivedMock,
+}));
+vi.mock("@/lib/memory/notes", () => ({ addMemoryNote: addNoteMock }));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue({}) }));
+
+import { GET as getSources } from "@/app/api/memory/sources/route";
+import { POST as archive } from "@/app/api/memory/sources/[id]/archive/route";
+import { POST as addNote } from "@/app/api/memory/note/route";
+
+function jsonReq(url: string, body: unknown): Request {
+  return new Request(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("GET /api/memory/sources", () => {
+  beforeEach(() => listSourcesMock.mockReset());
+
+  it("returns the source list", async () => {
+    listSourcesMock.mockResolvedValue([
+      { sourceId: "acme", title: "Acme", sourceType: "markdown", updatedAt: "2026-06-25T00:00:00.000Z", archived: false },
+    ]);
+    const res = await getSources();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sources[0].sourceId).toBe("acme");
+  });
+});
+
+describe("POST /api/memory/sources/[id]/archive", () => {
+  beforeEach(() => setArchivedMock.mockReset());
+
+  const req = (body: unknown) => jsonReq("http://localhost/api/memory/sources/acme/archive", body);
+
+  it("archives a source and returns the new state", async () => {
+    setArchivedMock.mockResolvedValue({ sourceId: "acme", archived: true });
+    const res = await archive(req({ archived: true }), { params: Promise.resolve({ id: "acme" }) });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ sourceId: "acme", archived: true });
+    expect(setArchivedMock).toHaveBeenCalledWith(expect.anything(), { sourceId: "acme", archived: true });
+  });
+
+  it("defaults to archived=true when the body omits it", async () => {
+    setArchivedMock.mockResolvedValue({ sourceId: "acme", archived: true });
+    await archive(req({}), { params: Promise.resolve({ id: "acme" }) });
+    expect(setArchivedMock).toHaveBeenCalledWith(expect.anything(), { sourceId: "acme", archived: true });
+  });
+
+  it("un-archives when archived=false", async () => {
+    setArchivedMock.mockResolvedValue({ sourceId: "acme", archived: false });
+    await archive(req({ archived: false }), { params: Promise.resolve({ id: "acme" }) });
+    expect(setArchivedMock).toHaveBeenCalledWith(expect.anything(), { sourceId: "acme", archived: false });
+  });
+
+  it("returns 404 when the source is unknown/not permitted", async () => {
+    setArchivedMock.mockResolvedValue(null);
+    const res = await archive(req({ archived: true }), { params: Promise.resolve({ id: "ghost" }) });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /api/memory/note", () => {
+  beforeEach(() => addNoteMock.mockReset());
+
+  it("adds a note and returns its sourceId", async () => {
+    addNoteMock.mockResolvedValue({ sourceId: "note-abc" });
+    const res = await addNote(jsonReq("http://localhost/api/memory/note", { title: "T", text: "body" }));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ sourceId: "note-abc" });
+    expect(addNoteMock).toHaveBeenCalledWith(expect.anything(), { title: "T", text: "body" });
+  });
+
+  it("returns 400 when title or text is missing", async () => {
+    const res = await addNote(jsonReq("http://localhost/api/memory/note", { title: "only title" }));
+    expect(res.status).toBe(400);
+    expect(addNoteMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/memory-sources.test.ts
+++ b/tests/memory-sources.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+import { DEFAULT_ACTOR } from "@/lib/memory/actor";
+import { ingestFiles } from "@/lib/memory/ingest";
+import { searchMemory } from "@/lib/memory/retrieve";
+import { listSources, setSourceArchived } from "@/lib/memory/sources";
+
+function bytes(text: string): Uint8Array {
+  return new TextEncoder().encode(text);
+}
+
+async function resetMemoryTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS source_permissions CASCADE`;
+  await db`DROP TABLE IF EXISTS extraction_runs CASCADE`;
+  await db`DROP TABLE IF EXISTS semantic_facts CASCADE`;
+  await db`DROP TABLE IF EXISTS memory_chunks CASCADE`;
+  await db`DROP TABLE IF EXISTS source_records CASCADE`;
+  await db`DROP TABLE IF EXISTS schema_migrations CASCADE`;
+  await runMigrations(db);
+}
+
+describe("memory sources management (list + archive)", () => {
+  let savedApiKey: string | undefined;
+
+  beforeEach(async () => {
+    savedApiKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    await resetMemoryTables();
+  });
+
+  afterEach(async () => {
+    if (savedApiKey !== undefined) process.env.OPENAI_API_KEY = savedApiKey;
+    else delete process.env.OPENAI_API_KEY;
+    await closeDb();
+  });
+
+  it("listSources returns the actor's permitted sources including archived, with an archived flag", async () => {
+    const db = getDb();
+    await ingestFiles(db, [
+      { name: "acme.md", bytes: bytes("# Acme\n\nAcme is a sourcing target.") },
+      { name: "beta.md", bytes: bytes("# Beta\n\nBeta is a sourcing target.") },
+    ]);
+
+    const list = await listSources(db, DEFAULT_ACTOR);
+    expect(list).toHaveLength(2);
+    expect(list.every((s) => s.archived === false)).toBe(true);
+    expect(list.every((s) => s.sourceType === "markdown")).toBe(true);
+    expect(list.every((s) => typeof s.sourceId === "string" && s.sourceId.length > 0)).toBe(true);
+
+    const target = list[0].sourceId;
+    await setSourceArchived(db, { sourceId: target, archived: true });
+
+    const list2 = await listSources(db, DEFAULT_ACTOR);
+    expect(list2).toHaveLength(2); // management view still shows archived
+    expect(list2.find((s) => s.sourceId === target)?.archived).toBe(true);
+  });
+
+  it("setSourceArchived hides the source from searchMemory; un-archive restores it", async () => {
+    const db = getDb();
+    await ingestFiles(db, [
+      { name: "acme.md", bytes: bytes("# Acme Robotics\n\nAcme Robotics is a sourcing target in Boston.") },
+    ]);
+    const [{ source_id: sid }] = await db<{ source_id: string }[]>`SELECT source_id FROM source_records`;
+
+    const archived = await setSourceArchived(db, { sourceId: sid, archived: true });
+    expect(archived).toEqual({ sourceId: sid, archived: true });
+    expect((await searchMemory(db, { query: "Acme Robotics sourcing target" })).chunks).toHaveLength(0);
+
+    const restored = await setSourceArchived(db, { sourceId: sid, archived: false });
+    expect(restored).toEqual({ sourceId: sid, archived: false });
+    expect((await searchMemory(db, { query: "Acme Robotics sourcing target" })).chunks.length).toBeGreaterThan(0);
+  });
+
+  it("setSourceArchived returns null for a source the actor cannot access", async () => {
+    const db = getDb();
+    await ingestFiles(db, [{ name: "acme.md", bytes: bytes("# Acme\n\nAcme.") }]);
+    const res = await setSourceArchived(db, { sourceId: "no-such-source", archived: true });
+    expect(res).toBeNull();
+  });
+});


### PR DESCRIPTION
## Feature A — leftover UI slices (on top of the merged engine)

Builds the deferred Feature A slices on the cited-memory engine (PR #7 + #8, now on `main`).
Scoped via `/grill-me`, eng-reviewed against `origin/main`, TDD throughout.

### Shipped in this PR

**A4.1 — Import endpoint** (`POST /api/memory/import`)
- Refactored a shared `ingestFiles({name,bytes})` core out of `ingestFolder` so uploads ingest without a disk path.
- Filename identity: `path = upload://{name}`, name-derived `source_id` → re-upload dedups/updates in place, citations stay clean (`acme-md#chunk-1`).
- Both collisions become friendly per-file skips (never raw Postgres errors, never silent overwrite): duplicate filename in a batch, and different names that slugify to the same `source_id`.
- One bad file never sinks the batch (per-file skip, 200); 400 only for a malformed/empty request.

**A6.3 — Chat backend** (multi-turn + the "agent doesn't work" fix)
- Root cause of "agent doesn't work" was config, not code: provider defaulted to DeepSeek (no key) while a real Anthropic key sat unused. `.env.example` now documents `SOURCECADO_GENERATION_PROVIDER=anthropic`. **Proven live**: `POST /api/agent` → `200/succeeded`, multi-turn cited answer (turn 2 resolved "there" from history and surfaced a responded-vs-cold conflict as a Gap).
- `runAgent` + `/api/agent` accept optional conversation `history`, threaded into the user prompt (not the system prompt), **capped server-side** (12 turns / 4000 chars).
- `MEMORY_INSTRUCTIONS` now require re-calling `search_memory` every turn so the per-turn citation post-check never scrubs a valid prior-turn citation (eng-review N3).

**A7.2 — Memory management** (`/memory`)
- `003_archived.sql` adds `source_records.archived_at` (soft-archive; hard delete would orphan facts via `ON DELETE SET NULL`).
- Central archived filter: `resolveAllowedSourceIds` now JOINs `source_records` and excludes archived by default, with an `includeArchived` opt for management views (eng-review N1/N2). One chokepoint drops archived from all three `searchMemory` loaders.
- `listSources` (incl. archived, flagged) + `setSourceArchived` (default-deny auth); routes `GET /api/memory/sources`, `POST /api/memory/sources/[id]/archive`, `POST /api/memory/note` (dedicated write path, not the read-only agent).
- `/memory` page on the Warm Operator primitives: Sources table (Active/Archived pills, per-row Archive/Restore) + Add-note form.

### Deferred to a dedicated design session (UI-decision-heavy)
- **A4.2** — import result UI (the `/memory` Import tab).
- **A6.3 render** — the chat surface (multi-turn bubbles vs research-log cards, markdown vs styled-citations). The backend is done and proven; only the render is parked.

### Verification
- **307 tests green** (51 new across import core/route, multi-turn, archive, sources, routes, and the `/memory` component), 0 regressions; lint clean.
- `/memory` confirmed live via `/browse` (3 sources, archive actions, add-note form, zero console errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Memory area for viewing sources, archiving/restoring them, and creating notes.
  * Added support for importing files into Memory.
  * Research chat now supports multi-turn conversation history.

* **Bug Fixes**
  * Archived sources are excluded from retrieval/search by default and restored when unarchived.
  * Improved validation for chat history and Memory API requests (malformed data is handled safely).

* **Chores**
  * Updated example environment defaults for the generation provider and added a Memory link to navigation.
  * Ignored TypeScript incremental build artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up three deferred Feature A slices on top of the merged cited-memory engine: a `POST /api/memory/import` endpoint backed by a new `ingestFiles` core extracted from `ingestFolder`, multi-turn conversation history threaded into the agent harness with server-side capping, and a `/memory` management page for listing, archiving, and restoring sources plus adding notes.

- **Import endpoint & ingest refactor**: `ingestParsedSource` is cleanly extracted as a shared core; batch-level duplicate detection (same filename in one upload, and colliding `source_id` slugs) surfaces friendly skip messages instead of raw Postgres errors; per-file errors never abort the whole batch.
- **Multi-turn chat**: `buildUserPrompt` injects up to 12 prior turns (4 000 chars each) into the user prompt, not the system prompt; `parseHistory` on the route degrades malformed payloads to single-turn rather than erroring; `MEMORY_INSTRUCTIONS` now require `search_memory` on every turn so the per-turn citation post-check doesn't scrub valid prior-turn citations.
- **Memory management page & archive**: `resolveAllowedSourceIds` gains a single `includeArchived` chokepoint that drops archived sources from all three `searchMemory` loaders by default; `003_archived.sql` adds the nullable `archived_at` column idempotently; `listSources` / `setSourceArchived` provide the management API.

<h3>Confidence Score: 3/5</h3>

The backend (ingest core, archive logic, multi-turn harness) is solid and well-tested, but the new /memory UI has a functional defect in its archive/restore action that leaves users with no feedback when the operation fails.

The `toggleArchive` handler in `MemoryClient.tsx` never checks the HTTP response status and has no `catch` block. A 404 (source not permitted) or 500 from the server is silently swallowed — `load()` is still called, the list refreshes, and the row snaps back to its prior state with no error message shown. A network failure propagates as an unhandled promise rejection from the `onClick` callback. The `AddNoteTab.onSubmit` function in the same file shows the correct pattern, so this is an inconsistency rather than a missing pattern. The backend changes are well-structured, the migration is idempotent, and the archive filter is correctly centralized.

`src/app/memory/MemoryClient.tsx` — the `toggleArchive` function needs error handling aligned with how `AddNoteTab.onSubmit` already handles errors. `src/lib/memory/ingest.ts` — the source_id collision SELECT and INSERT are non-atomic across concurrent requests, though this is low risk for the current single-user scope.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/app/memory/MemoryClient.tsx | New memory management UI with Sources table and Add-note form; `toggleArchive` is missing error handling — HTTP errors are silently swallowed and network errors become unhandled promise rejections. |
| src/lib/memory/ingest.ts | Refactored to extract `ingestParsedSource` shared core; adds `ingestFiles` for in-memory uploads with batch-level duplicate detection; the cross-request source_id collision check is non-atomic (SELECT then INSERT in separate transactions), which can surface a raw Postgres error under concurrent load. |
| src/app/api/memory/import/route.ts | New import endpoint — clean multipart handling, good per-file error isolation; missing upload size/count limits (acknowledged TODO). |
| src/lib/memory/permissions.ts | Adds `includeArchived` opt to `resolveAllowedSourceIds`, which JOINs source_records to exclude archived sources centrally — a sound single-chokepoint design. |
| src/lib/memory/sources.ts | New `listSources` and `setSourceArchived` functions; correctly uses `includeArchived: true` for management views, permissioned via `resolveAllowedSourceIds`. |
| src/lib/harness.ts | Adds `ConversationTurn` type and threads `history` into `buildUserPrompt`; correctly capped server-side at 12 turns / 4000 chars per turn; change is well-isolated. |
| src/migrations/003_archived.sql | Adds `archived_at TIMESTAMPTZ` with `IF NOT EXISTS` guards; idempotent and non-destructive; index on `archived_at` is appropriate. |
| src/app/api/agent/route.ts | Adds multi-turn history via `parseHistory` — malformed payloads degrade gracefully to single-turn; clean and minimal change. |
| src/app/api/memory/sources/[id]/archive/route.ts | New archive/restore route; body parsing defaults `archived` to `true` on empty body, which is the expected default-archive behaviour; 404 on null from `setSourceArchived`. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as MemoryClient (browser)
    participant AgentAPI as POST /api/agent
    participant ImportAPI as POST /api/memory/import
    participant SourcesAPI as GET /api/memory/sources
    participant ArchiveAPI as POST /api/memory/sources/[id]/archive
    participant NoteAPI as POST /api/memory/note
    participant Harness as runAgent + buildUserPrompt
    participant Ingest as ingestFiles / ingestParsedSource
    participant Perms as resolveAllowedSourceIds
    participant DB as Postgres

    UI->>SourcesAPI: GET /api/memory/sources
    SourcesAPI->>Perms: resolveAllowedSourceIds(includeArchived:true)
    Perms->>DB: JOIN source_permissions + source_records
    DB-->>Perms: allowed source_ids (incl. archived)
    Perms-->>SourcesAPI: source_ids[]
    SourcesAPI->>DB: "SELECT source_records WHERE source_id = ANY(allowed)"
    DB-->>SourcesAPI: rows
    SourcesAPI-->>UI: sources

    UI->>ArchiveAPI: POST /api/memory/sources/[id]/archive archived
    ArchiveAPI->>Perms: resolveAllowedSourceIds(includeArchived:true)
    Perms-->>ArchiveAPI: allowed source_ids
    ArchiveAPI->>DB: UPDATE source_records SET archived_at
    DB-->>ArchiveAPI: updated row
    ArchiveAPI-->>UI: sourceId archived

    UI->>ImportAPI: POST multipart/form-data files[]
    ImportAPI->>Ingest: ingestFiles(db, name bytes)
    loop per file
        Ingest->>DB: SELECT content_hash dedup check
        Ingest->>DB: SELECT source_id collision check
        Ingest->>DB: BEGIN upsert source_records + chunks + grant
    end
    Ingest-->>ImportAPI: processed skipped skippedFiles
    ImportAPI-->>UI: IngestResult

    UI->>NoteAPI: POST /api/memory/note title text
    NoteAPI->>DB: addMemoryNote
    NoteAPI-->>UI: sourceId

    UI->>AgentAPI: POST question history[]
    AgentAPI->>Harness: runAgent question history
    Harness->>Harness: buildUserPrompt cap 12 turns 4000 chars each
    Harness->>Perms: resolveAllowedSourceIds excludes archived
    Perms-->>Harness: active source_ids only
    Harness->>DB: search_memory tool calls
    Harness-->>AgentAPI: answer runId status
    AgentAPI->>DB: verifyAnswerCitations
    AgentAPI-->>UI: answer invalidCitations
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as MemoryClient (browser)
    participant AgentAPI as POST /api/agent
    participant ImportAPI as POST /api/memory/import
    participant SourcesAPI as GET /api/memory/sources
    participant ArchiveAPI as POST /api/memory/sources/[id]/archive
    participant NoteAPI as POST /api/memory/note
    participant Harness as runAgent + buildUserPrompt
    participant Ingest as ingestFiles / ingestParsedSource
    participant Perms as resolveAllowedSourceIds
    participant DB as Postgres

    UI->>SourcesAPI: GET /api/memory/sources
    SourcesAPI->>Perms: resolveAllowedSourceIds(includeArchived:true)
    Perms->>DB: JOIN source_permissions + source_records
    DB-->>Perms: allowed source_ids (incl. archived)
    Perms-->>SourcesAPI: source_ids[]
    SourcesAPI->>DB: "SELECT source_records WHERE source_id = ANY(allowed)"
    DB-->>SourcesAPI: rows
    SourcesAPI-->>UI: sources

    UI->>ArchiveAPI: POST /api/memory/sources/[id]/archive archived
    ArchiveAPI->>Perms: resolveAllowedSourceIds(includeArchived:true)
    Perms-->>ArchiveAPI: allowed source_ids
    ArchiveAPI->>DB: UPDATE source_records SET archived_at
    DB-->>ArchiveAPI: updated row
    ArchiveAPI-->>UI: sourceId archived

    UI->>ImportAPI: POST multipart/form-data files[]
    ImportAPI->>Ingest: ingestFiles(db, name bytes)
    loop per file
        Ingest->>DB: SELECT content_hash dedup check
        Ingest->>DB: SELECT source_id collision check
        Ingest->>DB: BEGIN upsert source_records + chunks + grant
    end
    Ingest-->>ImportAPI: processed skipped skippedFiles
    ImportAPI-->>UI: IngestResult

    UI->>NoteAPI: POST /api/memory/note title text
    NoteAPI->>DB: addMemoryNote
    NoteAPI-->>UI: sourceId

    UI->>AgentAPI: POST question history[]
    AgentAPI->>Harness: runAgent question history
    Harness->>Harness: buildUserPrompt cap 12 turns 4000 chars each
    Harness->>Perms: resolveAllowedSourceIds excludes archived
    Perms-->>Harness: active source_ids only
    Harness->>DB: search_memory tool calls
    Harness-->>AgentAPI: answer runId status
    AgentAPI->>DB: verifyAnswerCitations
    AgentAPI-->>UI: answer invalidCitations
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/app/api/memory/import/route.ts`, line 97-127 ([link](https://github.com/fisherxz/sourcecado/blob/4e866c2b605c10e1a57060776fd1626408557f3f/src/app/api/memory/import/route.ts#L97-L127)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **No upload size or count limits**

   The endpoint reads every `File` in the multipart body with `file.arrayBuffer()` before any size check, so a client can exhaust server memory by posting a single large file or a large number of files. The inline TODO already notes this; flagging it here so it surfaces in the review trail before the endpoint is exposed beyond the single-user local context.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["chore: document SOURCECADO\_GENERATION\_PR..."](https://github.com/fisherxz/sourcecado/commit/4e866c2b605c10e1a57060776fd1626408557f3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40031070)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->