### PR TITLE
feat(A6.3): streaming multi-turn Research Chat — live reasoning trace + motion

### DIFF
--- a/src/app/api/agent/stream/route.ts
+++ b/src/app/api/agent/stream/route.ts
@@ -1,8 +1,14 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
-import { type ConversationTurn } from "@/lib/harness";
-import { answerWithMemory } from "@/lib/memory/answer";
+import { answerWithMemory, summarizeStep } from "@/lib/memory/answer";
+import { streamAgentResponse } from "@/lib/ui-message-stream";
+import type { ConversationTurn } from "@/lib/harness";
 
+// Streaming sibling of /api/agent: same memory agent run, but each tool step is
+// pushed to the client live (AI SDK UI-message-stream, via the ui-message-stream
+// boundary module) so the chat can render the reasoning trace as it happens. The
+// final answer is written only after answerWithMemory's citation post-check, so no
+// invalid citation ever streams.
 export async function POST(request: Request) {
   const body = await request.json().catch(() => null);
   const question = (body as { question?: unknown } | null)?.question;
@@ -10,17 +16,22 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "question is required" }, { status: 400 });
   }
   const history = parseHistory((body as { history?: unknown } | null)?.history);
+  const db = getDb();
 
-  try {
-    const db = getDb();
-    const result = await answerWithMemory(db, { question, history });
-    return NextResponse.json(result, {
-      status: result.status === "succeeded" ? 200 : 500,
+  return streamAgentResponse(async (writer) => {
+    const result = await answerWithMemory(db, {
+      question,
+      history,
+      onStep: (event) => writer.step(`step-${event.index}`, summarizeStep(event)),
     });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "agent run failed";
-    return NextResponse.json({ error: message }, { status: 500 });
-  }
+    if (result.answer) writer.answer(result.answer);
+    writer.meta({
+      runId: result.runId,
+      status: result.status,
+      steps: result.steps,
+      invalidCitations: result.invalidCitations,
+    });
+  });
 }
 
 // Accept only well-formed {role, content} turns; ignore anything malformed so a

--- a/src/app/chat/ChatClient.tsx
+++ b/src/app/chat/ChatClient.tsx
@@ -1,93 +1,175 @@
 "use client";
 
-import { useState, type FormEvent } from "react";
-import { Button, Card, Input } from "@/components/ui";
+import { useEffect, useRef, useState } from "react";
+import { EmptyState } from "@/components/ui";
+import { Composer } from "./Composer";
+import { MessageBubble } from "./MessageBubble";
+import { ReasoningTrace } from "./ReasoningTrace";
+import { runChat, type AssistantTurn, type ChatMeta, type ConversationTurn } from "./stream";
 
-interface AgentResult {
-  runId: number;
-  status: "succeeded" | "failed";
-  answer?: string;
-  steps: number;
+interface Exchange {
+  id: number;
+  question: string;
+  turn: AssistantTurn;
+  open: boolean; // reasoning trace expanded?
+  done: boolean;
+  errored?: boolean;
+}
+
+// A run that never settles would leave the "live" reasoning trace pulsing forever
+// (design-review P0-1). Abort after this so a hung stream resolves into an error.
+const RUN_TIMEOUT_MS = 90_000;
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== "undefined" && !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
 }
 
 export function ChatClient() {
-  const [question, setQuestion] = useState("");
-  const [loading, setLoading] = useState(false);
-  const [result, setResult] = useState<AgentResult | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [exchanges, setExchanges] = useState<Exchange[]>([]);
+  const [input, setInput] = useState("");
+  const [busy, setBusy] = useState(false);
+  const idRef = useRef(0);
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const pinnedRef = useRef(true);
 
-  async function onSubmit(event: FormEvent) {
-    event.preventDefault();
-    if (!question.trim() || loading) return;
-    setLoading(true);
-    setError(null);
-    setResult(null);
-    try {
-      const res = await fetch("/api/agent", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ question }),
-      });
-      const data = (await res.json()) as AgentResult & { error?: string };
-      if (data.error) {
-        setError(data.error);
-      } else {
-        setResult(data);
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Request failed");
-    } finally {
-      setLoading(false);
+  // Stick to the bottom while streaming, but never yank a user who scrolled up.
+  useEffect(() => {
+    function onScroll() {
+      pinnedRef.current =
+        window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 120;
     }
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+  useEffect(() => {
+    const el = bottomRef.current;
+    if (pinnedRef.current && el && typeof el.scrollIntoView === "function") {
+      // JS smooth-scroll is NOT downgraded by the prefers-reduced-motion CSS
+      // block (design-review P1-3) — branch on it explicitly.
+      el.scrollIntoView({ behavior: prefersReducedMotion() ? "auto" : "smooth", block: "end" });
+    }
+  }, [exchanges]);
+
+  function patch(id: number, update: (e: Exchange) => Exchange) {
+    setExchanges((prev) => prev.map((e) => (e.id === id ? update(e) : e)));
+  }
+
+  function submit() {
+    const question = input.trim();
+    if (!question || busy) return;
+
+    const history: ConversationTurn[] = exchanges
+      .filter((e) => e.done && e.turn.answer)
+      .flatMap((e) => [
+        { role: "user", content: e.question },
+        { role: "assistant", content: e.turn.answer },
+      ]);
+
+    const id = ++idRef.current;
+    setExchanges((prev) => [...prev, { id, question, turn: { steps: [], answer: "" }, open: true, done: false }]);
+    setInput("");
+    setBusy(true);
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), RUN_TIMEOUT_MS);
+
+    runChat(question, history, (turn) => patch(id, (e) => ({ ...e, turn })), controller.signal)
+      .then((finalTurn) => patch(id, (e) => ({ ...e, turn: finalTurn, done: true, open: false })))
+      .catch((err) => {
+        const message = controller.signal.aborted
+          ? "The run timed out before completing. Try again."
+          : err instanceof Error
+            ? err.message
+            : "The run could not complete.";
+        // errored: true settles the trace (no live row) and surfaces the failure
+        // as an alert — the "everything goes greige" thesis must hold on failure.
+        patch(id, (e) => ({ ...e, errored: true, done: true, open: false, turn: { ...e.turn, answer: message } }));
+      })
+      .finally(() => {
+        clearTimeout(timeout);
+        setBusy(false);
+      });
   }
 
   return (
-    <div className="mx-auto flex w-full max-w-2xl flex-col gap-4 px-6 py-8">
-      <div>
+    <div className="mx-auto flex min-h-screen w-full max-w-3xl flex-col px-6">
+      <header className="pb-4 pt-6">
         <h1 className="text-xl font-semibold tracking-tight text-text">Research Chat</h1>
         <p className="mt-1 text-[13px] text-muted">
-          Ask a question. The agent runs a traced multi-step loop through the gateway and tools.
+          Ask about anyone or anything in team memory. The agent searches sourced records and answers
+          with citations you can trace.
         </p>
+      </header>
+
+      <div className="flex-1 pb-6">
+        {exchanges.length === 0 ? (
+          <div className="grid h-full place-items-center py-16">
+            <EmptyState
+              title="Ask your team's memory"
+              description="Ask about a contact, company, or anything the team has sourced. Answers cite their sources."
+            />
+          </div>
+        ) : (
+          <div className="flex flex-col gap-6">
+            {exchanges.map((e) => (
+              <div key={e.id} className="flex flex-col gap-2">
+                <MessageBubble role="user">{e.question}</MessageBubble>
+                <div className="flex flex-col gap-2" aria-live="polite">
+                  {(e.turn.steps.length > 0 || !e.done) && (
+                    <ReasoningTrace
+                      steps={e.turn.steps}
+                      running={!e.done && !e.errored}
+                      open={e.open}
+                      onToggle={() => patch(e.id, (x) => ({ ...x, open: !x.open }))}
+                    />
+                  )}
+                  {e.errored ? (
+                    <div
+                      role="alert"
+                      className="rounded-[8px] bg-neg-bg px-3 py-2 text-[13px] text-neg-tx"
+                    >
+                      {e.turn.answer}
+                    </div>
+                  ) : e.turn.answer ? (
+                    <MessageBubble role="assistant">
+                      <span className="whitespace-pre-wrap">{e.turn.answer}</span>
+                    </MessageBubble>
+                  ) : null}
+                  {e.turn.meta ? <MetaFooter meta={e.turn.meta} /> : null}
+                </div>
+              </div>
+            ))}
+            <div ref={bottomRef} />
+          </div>
+        )}
       </div>
 
-      <form onSubmit={onSubmit} className="flex gap-2">
-        <Input
-          aria-label="Question"
-          placeholder="Ask the agent (e.g. echo hello)"
-          value={question}
-          onChange={(event) => setQuestion(event.target.value)}
-          disabled={loading}
-        />
-        <Button type="submit" disabled={loading || !question.trim()}>
-          {loading ? "Running…" : "Run"}
-        </Button>
-      </form>
+      <div className="sticky bottom-0 -mx-6">
+        <Composer value={input} onChange={setInput} onSubmit={submit} disabled={busy} />
+      </div>
+    </div>
+  );
+}
 
-      {error && (
-        <Card>
-          <div role="alert" className="text-[13px] text-text">Error: {error}</div>
-        </Card>
-      )}
-
-      {result && (
-        <Card>
-          <div className="flex items-center justify-between gap-3">
-            <span className="text-[13px] font-medium text-text">
-              Run #{result.runId} — {result.status} ({result.steps} step{result.steps === 1 ? "" : "s"})
-            </span>
-            <a className="text-[13px] text-accent-deep underline" href={`/runs/${result.runId}`}>
-              View trace
-            </a>
-          </div>
-          {result.answer ? (
-            <p className="mt-3 whitespace-pre-wrap text-[13px] text-text">{result.answer}</p>
-          ) : (
-            <p className="mt-3 text-[13px] text-muted">
-              No answer — the run ended as {result.status}. Open the trace for details.
-            </p>
-          )}
-        </Card>
-      )}
+function MetaFooter({ meta }: { meta: ChatMeta }) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted">
+      <span className="font-mono">Run #{meta.runId}</span>
+      <span aria-hidden>·</span>
+      <span>{meta.status}</span>
+      <span aria-hidden>·</span>
+      <span className="font-mono">
+        {meta.steps} step{meta.steps === 1 ? "" : "s"}
+      </span>
+      <span aria-hidden>·</span>
+      <a href={`/runs/${meta.runId}`} className="text-accent-deep underline">
+        View trace
+      </a>
+      {meta.invalidCitations.length > 0 ? (
+        <span className="text-warn-tx">
+          · {meta.invalidCitations.length} unverified citation{meta.invalidCitations.length === 1 ? "" : "s"} removed
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/src/app/chat/ChatClient.tsx
+++ b/src/app/chat/ChatClient.tsx
@@ -59,7 +59,7 @@ export function ChatClient() {
     if (!question || busy) return;
 
     const history: ConversationTurn[] = exchanges
-      .filter((e) => e.done && e.turn.answer)
+      .filter((e) => e.done && !e.errored && e.turn.answer)
       .flatMap((e) => [
         { role: "user", content: e.question },
         { role: "assistant", content: e.turn.answer },

--- a/src/app/chat/Composer.tsx
+++ b/src/app/chat/Composer.tsx
@@ -1,0 +1,48 @@
+import type { FormEvent, KeyboardEvent } from "react";
+import { Button } from "@/components/ui";
+
+// Sticky composer. Enter sends, Shift+Enter inserts a newline. Disabled (and the
+// button reads "Running…") while a turn is streaming.
+export function Composer({
+  value,
+  onChange,
+  onSubmit,
+  disabled,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  disabled: boolean;
+}) {
+  function submit() {
+    if (!disabled && value.trim()) onSubmit();
+  }
+  function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    submit();
+  }
+  function handleKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      submit();
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex items-end gap-2 border-t border-border bg-surface px-4 py-3">
+      <textarea
+        aria-label="Message"
+        rows={1}
+        value={value}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Ask about a contact, company, or anything in memory…"
+        className="max-h-40 min-h-[38px] flex-1 resize-none rounded-[6px] border border-border bg-canvas px-3 py-2 text-[13px] text-text outline-none placeholder:text-muted focus:border-accent focus:ring-[3px] focus:ring-accent-tint"
+      />
+      <Button type="submit" disabled={disabled || !value.trim()}>
+        {disabled ? "Running…" : "Send"}
+      </Button>
+    </form>
+  );
+}

--- a/src/app/chat/MessageBubble.tsx
+++ b/src/app/chat/MessageBubble.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+
+// User turns get the avocado-tint bubble (right); assistant turns render plain on
+// the canvas (left) so the answer reads as content, not a nested card.
+export function MessageBubble({ role, children }: { role: "user" | "assistant"; children: ReactNode }) {
+  if (role === "user") {
+    return (
+      <div
+        data-role="user"
+        className="message-enter ml-auto max-w-[78%] rounded-[8px] bg-accent-tint px-3 py-2 text-[13px] text-text"
+      >
+        {children}
+      </div>
+    );
+  }
+  return (
+    <div data-role="assistant" className="message-enter mr-auto max-w-[88%] text-[13px] leading-relaxed text-text">
+      {children}
+    </div>
+  );
+}

--- a/src/app/chat/ReasoningTrace.tsx
+++ b/src/app/chat/ReasoningTrace.tsx
@@ -1,0 +1,51 @@
+import { StepRow, PendingRow } from "./StepRow";
+import type { ChatStep } from "./stream";
+
+// The collapsible reasoning trace. While the agent runs it auto-expands and a live
+// PendingRow sits at the tail; once the answer lands the container collapses it to
+// a one-line "Reasoning · N steps". Collapse animates via grid-template-rows
+// (animation-safe) in globals.css.
+export function ReasoningTrace({
+  steps,
+  running,
+  open,
+  onToggle,
+}: {
+  steps: ChatStep[];
+  running: boolean;
+  open: boolean;
+  onToggle: () => void;
+}) {
+  const count = steps.length;
+  const pendingLabel = count === 0 ? "Searching memory" : "Composing answer";
+
+  return (
+    <div className="reasoning-trace">
+      <button
+        type="button"
+        aria-expanded={open}
+        onClick={onToggle}
+        className="flex items-center gap-1.5 text-[12px] font-medium text-muted transition-colors hover:text-text focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-accent-tint rounded-[4px]"
+      >
+        <span className={`chevron ${open ? "chevron--open" : ""}`} aria-hidden>
+          ▸
+        </span>
+        <span>Reasoning</span>
+        {count > 0 ? (
+          <span className="font-mono text-[11px] text-muted">
+            · {count} step{count === 1 ? "" : "s"}
+          </span>
+        ) : null}
+      </button>
+
+      <div className="reasoning-body" data-open={open}>
+        <ul className="reasoning-list mt-1.5 flex flex-col gap-1">
+          {steps.map((s) => (
+            <StepRow key={s.index} step={s} />
+          ))}
+          {running ? <PendingRow label={pendingLabel} /> : null}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/app/chat/StepRow.tsx
+++ b/src/app/chat/StepRow.tsx
@@ -1,0 +1,30 @@
+import type { ChatStep } from "./stream";
+
+// A settled reasoning step. data-state drives the left-rule colour in globals.css:
+// greige when done, brick when the tool errored. avocado is reserved for the live
+// PendingRow — the "avocado = live, greige = settled" language.
+export function StepRow({ step }: { step: ChatStep }) {
+  return (
+    <li data-state={step.ok ? "done" : "error"} className="step-row flex flex-col gap-0.5 pl-3 py-1">
+      <div className="flex items-baseline gap-2">
+        <span className="font-mono text-[11px] text-muted">{step.tool}</span>
+        <span className={`text-[12px] ${step.ok ? "text-muted" : "text-neg-tx"}`}>{step.detail}</span>
+      </div>
+      {step.thought ? <span className="text-[11px] leading-snug text-muted/80">{step.thought}</span> : null}
+    </li>
+  );
+}
+
+// The single live row at the tail of the trace while the agent is still working.
+export function PendingRow({ label }: { label: string }) {
+  return (
+    <li
+      data-state="working"
+      aria-busy="true"
+      className="step-row step-row--pending flex items-center gap-2 pl-3 py-1 text-[12px] text-accent-deep"
+    >
+      <span className="step-dot" aria-hidden />
+      <span>{label}…</span>
+    </li>
+  );
+}

--- a/src/app/chat/stream.ts
+++ b/src/app/chat/stream.ts
@@ -1,0 +1,117 @@
+// Client-side reader for the /api/agent/stream UI-message-stream (AI SDK v6 SSE).
+// We own the multi-turn state, so we reduce the AI SDK chunks into a small view
+// model instead of pulling in the React binding.
+
+export interface ChatStep {
+  index: number;
+  tool: string;
+  thought?: string;
+  ok: boolean;
+  detail: string;
+}
+
+export interface ChatMeta {
+  runId: number;
+  status: "succeeded" | "failed";
+  steps: number;
+  invalidCitations: string[];
+}
+
+export interface AssistantTurn {
+  steps: ChatStep[];
+  answer: string;
+  meta?: ChatMeta;
+}
+
+export interface ConversationTurn {
+  role: "user" | "assistant";
+  content: string;
+}
+
+// A decoded UI-message-stream chunk. Only the fields we consume are typed.
+export interface UiChunk {
+  type: string;
+  delta?: string;
+  data?: unknown;
+}
+
+// Pull every complete `data:` SSE event out of a rolling buffer, returning the
+// parsed chunks and whatever incomplete tail is left for the next read.
+export function drainSse(buffer: string): { chunks: UiChunk[]; rest: string } {
+  const chunks: UiChunk[] = [];
+  let rest = buffer;
+  let sep = rest.indexOf("\n\n");
+  while (sep !== -1) {
+    const rawEvent = rest.slice(0, sep);
+    rest = rest.slice(sep + 2);
+    for (const line of rawEvent.split("\n")) {
+      if (!line.startsWith("data:")) continue;
+      const payload = line.slice(5).trim();
+      if (!payload || payload === "[DONE]") continue;
+      try {
+        chunks.push(JSON.parse(payload) as UiChunk);
+      } catch {
+        // Ignore non-JSON keep-alives / partial lines.
+      }
+    }
+    sep = rest.indexOf("\n\n");
+  }
+  return { chunks, rest };
+}
+
+// Fold one chunk into the assistant turn. Pure and immutable so the React state
+// update is a straight replacement.
+export function applyChunk(turn: AssistantTurn, chunk: UiChunk): AssistantTurn {
+  switch (chunk.type) {
+    case "data-step": {
+      const step = chunk.data as ChatStep;
+      const exists = turn.steps.some((s) => s.index === step.index);
+      const steps = exists
+        ? turn.steps.map((s) => (s.index === step.index ? step : s))
+        : [...turn.steps, step];
+      return { ...turn, steps };
+    }
+    case "text-delta":
+      return { ...turn, answer: turn.answer + (chunk.delta ?? "") };
+    case "data-meta":
+      return { ...turn, meta: chunk.data as ChatMeta };
+    default:
+      return turn;
+  }
+}
+
+// Stream one agent turn. Calls onUpdate with the accumulating assistant turn each
+// time new chunks land, so the UI can render the reasoning trace live.
+export async function runChat(
+  question: string,
+  history: ConversationTurn[],
+  onUpdate: (turn: AssistantTurn) => void,
+  signal?: AbortSignal
+): Promise<AssistantTurn> {
+  const res = await fetch("/api/agent/stream", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ question, history }),
+    signal,
+  });
+  if (!res.ok && !res.body) {
+    throw new Error(`Stream failed (${res.status})`);
+  }
+  const reader = res.body!.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let turn: AssistantTurn = { steps: [], answer: "" };
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const { chunks, rest } = drainSse(buffer);
+    buffer = rest;
+    if (chunks.length) {
+      for (const chunk of chunks) turn = applyChunk(turn, chunk);
+      onUpdate(turn);
+    }
+  }
+  return turn;
+}

--- a/src/app/chat/stream.ts
+++ b/src/app/chat/stream.ts
@@ -94,7 +94,7 @@ export async function runChat(
     body: JSON.stringify({ question, history }),
     signal,
   });
-  if (!res.ok && !res.body) {
+  if (!res.ok) {
     throw new Error(`Stream failed (${res.status})`);
   }
   const reader = res.body!.getReader();

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -62,3 +62,112 @@ body {
   font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
 }
+
+/* ===========================================================================
+   Chat reasoning-trace motion — "avocado = live, greige = settled".
+   The only loud elements (avocado rule + pulsing dot) exist exactly as long as
+   the agent is working; completed steps settle to greige. Product register:
+   motion conveys state, never decoration. All effects flatten under
+   prefers-reduced-motion below.
+   =========================================================================== */
+:root {
+  --ease-out-quart: cubic-bezier(0.25, 1, 0.5, 1);
+  --ease-out-quint: cubic-bezier(0.22, 1, 0.36, 1);
+  --dur-base: 180ms;
+  --dur-answer: 240ms;
+  --dur-collapse: 320ms;
+}
+
+/* Reasoning steps: greige rule when settled, brick when errored, avocado while live. */
+.step-row {
+  border-left: 2px solid var(--border);
+  animation: step-in var(--dur-base) var(--ease-out-quart) both;
+}
+.step-row[data-state="error"] {
+  border-left-color: var(--neg-tx);
+}
+.step-row--pending {
+  border-left-color: var(--accent);
+}
+@keyframes step-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* The single live "working" indicator at the tail of the trace. */
+.step-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 9999px;
+  background: var(--accent);
+  animation: step-dot-pulse 1.1s var(--ease-out-quart) infinite;
+}
+@keyframes step-dot-pulse {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.4;
+    transform: scale(0.7);
+  }
+}
+
+/* Collapse the trace into "Reasoning · N steps" via grid-template-rows
+   (animation-safe — never animate height/top/margin). */
+.reasoning-body {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--dur-collapse) var(--ease-out-quart);
+  /* Bound the reflow to this subtree so the 320ms grid-rows collapse of a long
+     trace doesn't relayout the whole thread each frame (design-review P1-5). */
+  contain: layout paint;
+}
+.reasoning-body[data-open="true"] {
+  grid-template-rows: 1fr;
+}
+.reasoning-list {
+  overflow: hidden;
+  min-height: 0;
+}
+
+.chevron {
+  display: inline-block;
+  transition: transform var(--dur-base) var(--ease-out-quart);
+}
+.chevron--open {
+  transform: rotate(90deg);
+}
+
+/* User/assistant bubbles settle in with a gentle composed fade (no token typing — v2). */
+.message-enter {
+  animation: message-in var(--dur-answer) var(--ease-out-quart) both;
+}
+@keyframes message-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/chunk.ts
+++ b/src/chunk.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
-import { parseCsvRecords, serializeCsvRecord } from "./csv.js";
-import { IngestError } from "./ingest-error.js";
+import { parseCsvRecords, serializeCsvRecord } from "./csv";
+import { IngestError } from "./ingest-error";
 
 export interface TextChunk {
   chunkIndex: number;

--- a/src/extractors/csv.ts
+++ b/src/extractors/csv.ts
@@ -1,6 +1,6 @@
-import type { ExtractedCandidate, RelationshipType } from "../types.js";
-import { normalizeCsvHeader, parseCsvRecords } from "../csv.js";
-import type { ExtractionInput, Extractor } from "./types.js";
+import type { ExtractedCandidate, RelationshipType } from "../types";
+import { normalizeCsvHeader, parseCsvRecords } from "../csv";
+import type { ExtractionInput, Extractor } from "./types";
 
 export const CSV_EXTRACTOR_VERSION = "2";
 

--- a/src/extractors/llm.ts
+++ b/src/extractors/llm.ts
@@ -1,6 +1,6 @@
-import { sha256 } from "../chunk.js";
-import { getDb } from "../lib/db.js";
-import { callModel } from "../lib/model-gateway.js";
+import { sha256 } from "../chunk";
+import { getDb } from "../lib/db";
+import { callModel } from "../lib/model-gateway";
 import {
   ENTITY_TYPES,
   RELATIONSHIP_TYPES,
@@ -9,14 +9,14 @@ import {
   type ExtractedCandidateKind,
   type RelationshipType,
   type SourceType
-} from "../types.js";
+} from "../types";
 import {
   ExtractionError,
   type Extractor
-} from "./types.js";
+} from "./types";
 import { z } from "zod";
 
-export { ExtractionError } from "./types.js";
+export { ExtractionError } from "./types";
 
 export const LLM_EXTRACTOR_VERSION = "1";
 export const LLM_SCHEMA_VERSION = "1";

--- a/src/extractors/mock.ts
+++ b/src/extractors/mock.ts
@@ -1,5 +1,5 @@
-import type { ExtractedCandidate } from "../types.js";
-import type { ExtractionInput, Extractor } from "./types.js";
+import type { ExtractedCandidate } from "../types";
+import type { ExtractionInput, Extractor } from "./types";
 
 export const MOCK_EXTRACTOR_VERSION = "1";
 

--- a/src/extractors/types.ts
+++ b/src/extractors/types.ts
@@ -1,4 +1,4 @@
-import type { ExtractedCandidate, SourceType } from "../types.js";
+import type { ExtractedCandidate, SourceType } from "../types";
 
 export interface ExtractionInput {
   sourceId: string;

--- a/src/frontmatter.ts
+++ b/src/frontmatter.ts
@@ -1,6 +1,6 @@
 import { extname, basename } from "node:path";
-import { IngestError } from "./ingest-error.js";
-import { SOURCE_TYPES, type SourceType } from "./types.js";
+import { IngestError } from "./ingest-error";
+import { SOURCE_TYPES, type SourceType } from "./types";
 
 export interface ParsedSource {
   title: string;

--- a/src/lib/harness.ts
+++ b/src/lib/harness.ts
@@ -40,6 +40,17 @@ export interface ConversationTurn {
   content: string;
 }
 
+// Emitted after each executed tool step (never for the final answer). Carries the
+// model's rationale, the tool, and the observation so a streaming UI can render the
+// agent's live reasoning trace.
+export interface AgentStepEvent {
+  index: number;
+  tool: string;
+  thought?: string;
+  observation: string;
+  ok: boolean;
+}
+
 export interface RunAgentInput {
   question: string;
   registry: ToolRegistry;
@@ -51,6 +62,9 @@ export interface RunAgentInput {
   // Prior conversation turns for multi-turn chat. Threaded into the user prompt
   // (not the system prompt) and capped server-side in buildUserPrompt.
   history?: ConversationTurn[];
+  // Invoked after each executed tool step. Awaited so a streaming consumer can
+  // flush the step to the client before the next decide() runs.
+  onStep?: (event: AgentStepEvent) => void | Promise<void>;
 }
 
 export interface RunAgentResult {
@@ -119,6 +133,13 @@ export async function runAgent(input: RunAgentInput): Promise<RunAgentResult> {
         parentStepId: agentStep.id,
       });
       transcript.push(`Step ${step}: called ${decision.tool} -> ${observation}`);
+      await input.onStep?.({
+        index: step,
+        tool: decision.tool,
+        thought: decision.thought,
+        observation,
+        ok: observation.startsWith("Success"),
+      });
     }
 
     const message = `Agent did not finish within ${maxSteps} steps.`;

--- a/src/lib/memory/answer.ts
+++ b/src/lib/memory/answer.ts
@@ -1,0 +1,97 @@
+import { runAgent, type AgentStepEvent, type ConversationTurn } from "@/lib/harness";
+import { getRunTrace } from "@/lib/ledger";
+import { verifyAnswerCitations } from "@/lib/memory/citations";
+import { memoryRegistry, MEMORY_INSTRUCTIONS } from "@/lib/memory/answer-config";
+import type { Sql } from "@/lib/tools/types";
+
+export interface MemoryAnswer {
+  runId: number;
+  status: "succeeded" | "failed";
+  answer?: string;
+  steps: number;
+  invalidCitations: string[];
+}
+
+export interface AnswerWithMemoryInput {
+  question: string;
+  history?: ConversationTurn[];
+  onStep?: (event: AgentStepEvent) => void | Promise<void>;
+}
+
+// One agent run over team memory: the ReAct harness plus the citation post-check
+// that scrubs invented citations from the final answer. Shared by the JSON
+// /api/agent route and the streaming /api/agent/stream route (the latter passes
+// onStep). The post-check runs here, before any answer is returned/streamed, so a
+// bad citation never reaches the client.
+export async function answerWithMemory(db: Sql, input: AnswerWithMemoryInput): Promise<MemoryAnswer> {
+  const registry = memoryRegistry();
+  const result = await runAgent({
+    question: input.question,
+    history: input.history,
+    registry,
+    allowedClasses: new Set(["read"]),
+    instructions: MEMORY_INSTRUCTIONS,
+    db,
+    onStep: input.onStep,
+  });
+
+  let answer = result.answer;
+  let invalidCitations: string[] = [];
+  if (result.status === "succeeded" && answer !== undefined) {
+    const trace = await getRunTrace(db, result.runId);
+    const checked = verifyAnswerCitations(trace, answer);
+    answer = checked.answer;
+    invalidCitations = checked.invalidCitations;
+  }
+
+  return {
+    runId: result.runId,
+    status: result.status,
+    answer,
+    steps: result.steps,
+    invalidCitations,
+  };
+}
+
+// A tool step rendered in the chat's reasoning trace. `detail` is a short,
+// human-readable summary of the observation (not the raw tool JSON).
+export interface ChatStepPart {
+  index: number;
+  tool: string;
+  thought?: string;
+  ok: boolean;
+  detail: string;
+}
+
+export function summarizeStep(event: AgentStepEvent): ChatStepPart {
+  return {
+    index: event.index,
+    tool: event.tool,
+    thought: event.thought,
+    ok: event.ok,
+    detail: describeObservation(event),
+  };
+}
+
+function describeObservation(event: AgentStepEvent): string {
+  if (!event.ok) {
+    // Observation is "Error (type): message" — show just the message.
+    return event.observation.replace(/^Error \([^)]*\):\s*/, "").trim().slice(0, 160) || "failed";
+  }
+  const payload = event.observation.replace(/^Success:\s*/, "");
+  if (event.tool === "search_memory") {
+    try {
+      const r = JSON.parse(payload) as {
+        acceptedFacts?: unknown[];
+        gapFacts?: unknown[];
+        chunks?: unknown[];
+      };
+      const facts = (r.acceptedFacts?.length ?? 0) + (r.gapFacts?.length ?? 0);
+      const chunks = r.chunks?.length ?? 0;
+      return `${facts} fact${facts === 1 ? "" : "s"}, ${chunks} chunk${chunks === 1 ? "" : "s"}`;
+    } catch {
+      return "done";
+    }
+  }
+  return "done";
+}

--- a/src/lib/memory/chunk-store.ts
+++ b/src/lib/memory/chunk-store.ts
@@ -3,7 +3,9 @@ import type { MemoryActor } from "./actor";
 import { citationForChunk, type TextChunk } from "./chunk";
 import { toVectorLiteral } from "./embed";
 
-type Sql = postgres.Sql;
+// Accepts either a root handle or a transaction handle (callers pass the `tx`
+// from a `db.begin` callback; webpack type-checks this, vitest does not).
+type Sql = postgres.Sql | postgres.TransactionSql;
 
 /**
  * Shared transaction helper: DELETE old chunks for a source record, INSERT the

--- a/src/lib/memory/chunk.ts
+++ b/src/lib/memory/chunk.ts
@@ -1,8 +1,8 @@
 // Faithful port of src/chunk.ts + the citationForChunk helper from src/ingest.ts.
 // No DB calls — pure text processing.
 import { createHash } from "node:crypto";
-import { parseCsvRecords, serializeCsvRecord } from "../../csv.js";
-import { IngestError } from "../../ingest-error.js";
+import { parseCsvRecords, serializeCsvRecord } from "../../csv";
+import { IngestError } from "../../ingest-error";
 
 export interface TextChunk {
   chunkIndex: number;

--- a/src/lib/memory/extract.ts
+++ b/src/lib/memory/extract.ts
@@ -7,10 +7,10 @@
  */
 
 import type postgres from "postgres";
-import { createCsvExtractor } from "../../extractors/csv.js";
-import { createLlmExtractor, LLM_SCHEMA_VERSION } from "../../extractors/llm.js";
-import type { ExtractionInput, Extractor } from "../../extractors/types.js";
-import type { ExtractedCandidate, SourceType } from "../../types.js";
+import { createCsvExtractor } from "../../extractors/csv";
+import { createLlmExtractor, LLM_SCHEMA_VERSION } from "../../extractors/llm";
+import type { ExtractionInput, Extractor } from "../../extractors/types";
+import type { ExtractedCandidate, SourceType } from "../../types";
 import { sha256 } from "./chunk";
 
 // ---------------------------------------------------------------------------
@@ -76,6 +76,8 @@ interface ExistingFactSnapshot {
 }
 
 type Sql = postgres.Sql;
+// For helpers that run inside a `db.begin` callback and receive the tx handle.
+type Tx = postgres.Sql | postgres.TransactionSql;
 
 // ---------------------------------------------------------------------------
 // Public: refreshMemory
@@ -303,7 +305,7 @@ async function recordExtractionRun(
       ${run.metadata.schemaVersion},
       ${run.metadata.modelName},
       ${rawOutput},
-      ${db.json(parsedCandidates as postgres.JSONValue)},
+      ${db.json(parsedCandidates as unknown as postgres.JSONValue)},
       ${run.status},
       ${run.error}
     )
@@ -343,7 +345,7 @@ async function rebuildDerivedMemory(
   });
 }
 
-async function snapshotAcceptedFacts(db: Sql): Promise<ExistingFactSnapshot[]> {
+async function snapshotAcceptedFacts(db: Tx): Promise<ExistingFactSnapshot[]> {
   return db<ExistingFactSnapshot[]>`
     SELECT subject, predicate, object, source_record_id, source_chunk_id, confidence
     FROM semantic_facts
@@ -352,7 +354,7 @@ async function snapshotAcceptedFacts(db: Sql): Promise<ExistingFactSnapshot[]> {
 }
 
 async function restoreStaleFacts(
-  db: Sql,
+  db: Tx,
   previousFacts: ExistingFactSnapshot[],
   seenFacts: Set<string>
 ): Promise<void> {
@@ -382,7 +384,7 @@ async function restoreStaleFacts(
 }
 
 async function insertSemanticFact(
-  db: Sql,
+  db: Tx,
   candidate: ExtractedCandidate,
   chunk: SourceChunkRow,
   seen: Set<string>

--- a/src/lib/memory/ingest.ts
+++ b/src/lib/memory/ingest.ts
@@ -1,8 +1,8 @@
 import { readFile, readdir } from "node:fs/promises";
 import { join, relative, resolve, sep } from "node:path";
 import type postgres from "postgres";
-import { isSupportedSourcePath, parseSourceFile } from "../../frontmatter.js";
-import { IngestError, classifyIngestError, type IngestErrorCategory } from "../../ingest-error.js";
+import { isSupportedSourcePath, parseSourceFile } from "../../frontmatter";
+import { IngestError, classifyIngestError, type IngestErrorCategory } from "../../ingest-error";
 import { DEFAULT_ACTOR, type MemoryActor } from "./actor";
 import { chunkCsvRows, chunkText, sha256, slugifySourceId, type TextChunk } from "./chunk";
 import { writeChunksAndGrant } from "./chunk-store";

--- a/src/lib/ui-message-stream.ts
+++ b/src/lib/ui-message-stream.ts
@@ -1,0 +1,34 @@
+import { createUIMessageStream, createUIMessageStreamResponse } from "ai";
+
+// Boundary module for the AI SDK UI-message-stream transport. All `from "ai"`
+// usage for streaming lives here (model-boundary.test.ts allows this file and
+// model-gateway.ts) so AI SDK surface stays contained and auditable. Routes call
+// streamAgentResponse and never touch the SDK directly.
+
+export interface AgentStreamWriter {
+  // A reasoning step (reconciled by id). data is the rendered ChatStepPart.
+  step: (id: string, data: unknown) => void;
+  // The final answer, written as one composed assistant text part.
+  answer: (text: string) => void;
+  // Run metadata (runId, status, steps, invalidCitations).
+  meta: (data: unknown) => void;
+}
+
+export function streamAgentResponse(run: (writer: AgentStreamWriter) => Promise<void>): Response {
+  const stream = createUIMessageStream({
+    execute: async ({ writer }) => {
+      writer.write({ type: "start" });
+      await run({
+        step: (id, data) => writer.write({ type: "data-step", id, data }),
+        answer: (text) => {
+          writer.write({ type: "text-start", id: "answer" });
+          writer.write({ type: "text-delta", id: "answer", delta: text });
+          writer.write({ type: "text-end", id: "answer" });
+        },
+        meta: (data) => writer.write({ type: "data-meta", id: "meta", data }),
+      });
+    },
+    onError: (error) => (error instanceof Error ? error.message : String(error)),
+  });
+  return createUIMessageStreamResponse({ stream });
+}

--- a/tests/agent-stream-route.test.ts
+++ b/tests/agent-stream-route.test.ts
@@ -1,0 +1,84 @@
+import { vi } from "vitest";
+
+const { runAgentMock, getRunTraceMock } = vi.hoisted(() => ({
+  runAgentMock: vi.fn(),
+  getRunTraceMock: vi.fn(),
+}));
+vi.mock("@/lib/harness", () => ({ runAgent: runAgentMock }));
+vi.mock("@/lib/ledger", () => ({ getRunTrace: getRunTraceMock }));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue({}) }));
+
+import { POST } from "@/app/api/agent/stream/route";
+
+function postRequest(body: unknown): Request {
+  return new Request("http://localhost/api/agent/stream", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function readAll(res: Response): Promise<string> {
+  const reader = res.body!.getReader();
+  const dec = new TextDecoder();
+  let out = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += dec.decode(value, { stream: true });
+  }
+  return out;
+}
+
+describe("POST /api/agent/stream", () => {
+  beforeEach(() => {
+    runAgentMock.mockReset();
+    getRunTraceMock.mockResolvedValue(null); // no trace → citation check is a pass-through
+  });
+
+  it("returns 400 when question is missing", async () => {
+    const res = await POST(postRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("streams a data-step part per tool step, then the answer text and a meta part", async () => {
+    runAgentMock.mockImplementation(async (input: { onStep?: (e: unknown) => unknown }) => {
+      await input.onStep?.({
+        index: 1,
+        tool: "search_memory",
+        thought: "looking it up",
+        observation: 'Success: {"acceptedFacts":[1,2],"gapFacts":[],"chunks":[1]}',
+        ok: true,
+      });
+      return {
+        runId: 42,
+        status: "succeeded",
+        answer: "Acme Robotics is a Series B company [acme-md#chunk-1].",
+        steps: 1,
+      };
+    });
+
+    const res = await POST(postRequest({ question: "tell me about acme" }));
+    expect(res.status).toBe(200);
+
+    const body = await readAll(res);
+    // step part carries the tool, the rationale, and a human summary
+    expect(body).toContain("data-step");
+    expect(body).toContain("search_memory");
+    expect(body).toContain("2 facts, 1 chunk");
+    // the final answer is streamed as assistant text
+    expect(body).toContain("Acme Robotics is a Series B company");
+    // meta part carries the run id + status for the trace link
+    expect(body).toContain("data-meta");
+    expect(body).toContain("42");
+  });
+
+  it("still emits a meta part when the run fails with no answer", async () => {
+    runAgentMock.mockResolvedValue({ runId: 9, status: "failed", steps: 8 });
+    const res = await POST(postRequest({ question: "loop" }));
+    expect(res.status).toBe(200); // the stream itself is a 200; failure is carried in meta
+    const body = await readAll(res);
+    expect(body).toContain("data-meta");
+    expect(body).toContain("failed");
+  });
+});

--- a/tests/chat-stream.test.ts
+++ b/tests/chat-stream.test.ts
@@ -1,0 +1,65 @@
+import { applyChunk, drainSse, type AssistantTurn } from "@/app/chat/stream";
+
+const empty: AssistantTurn = { steps: [], answer: "" };
+
+describe("drainSse", () => {
+  it("parses complete SSE data events into chunks and leaves no remainder", () => {
+    const buf =
+      'data: {"type":"data-step","id":"step-1","data":{"index":1,"tool":"search_memory","ok":true,"detail":"2 facts, 1 chunk"}}\n\n' +
+      'data: {"type":"text-delta","id":"answer","delta":"Hello"}\n\n';
+    const { chunks, rest } = drainSse(buf);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toMatchObject({ type: "data-step" });
+    expect(chunks[1]).toMatchObject({ type: "text-delta", delta: "Hello" });
+    expect(rest).toBe("");
+  });
+
+  it("buffers a partial trailing event in rest until it completes", () => {
+    const { chunks, rest } = drainSse('data: {"type":"text-delta","id":"answer","delta":"Hi"}\n\ndata: {"type":"data-met');
+    expect(chunks).toHaveLength(1);
+    expect(rest).toContain("data-met");
+  });
+
+  it("ignores the [DONE] sentinel and non-JSON lines", () => {
+    const { chunks } = drainSse("data: [DONE]\n\n: keep-alive comment\n\n");
+    expect(chunks).toHaveLength(0);
+  });
+});
+
+describe("applyChunk", () => {
+  it("appends a new step and updates an existing step by index (reconciliation)", () => {
+    let turn = applyChunk(empty, {
+      type: "data-step",
+      data: { index: 1, tool: "search_memory", ok: true, detail: "loading" },
+    });
+    expect(turn.steps).toHaveLength(1);
+    turn = applyChunk(turn, {
+      type: "data-step",
+      data: { index: 1, tool: "search_memory", ok: true, detail: "2 facts, 1 chunk" },
+    });
+    expect(turn.steps).toHaveLength(1); // same index reconciles, not duplicates
+    expect(turn.steps[0].detail).toBe("2 facts, 1 chunk");
+  });
+
+  it("concatenates text-delta chunks into the answer", () => {
+    let turn = applyChunk(empty, { type: "text-delta", delta: "Acme " });
+    turn = applyChunk(turn, { type: "text-delta", delta: "Robotics" });
+    expect(turn.answer).toBe("Acme Robotics");
+  });
+
+  it("sets meta from a data-meta chunk", () => {
+    const turn = applyChunk(empty, {
+      type: "data-meta",
+      data: { runId: 42, status: "succeeded", steps: 1, invalidCitations: [] },
+    });
+    expect(turn.meta).toMatchObject({ runId: 42, status: "succeeded" });
+  });
+
+  it("ignores envelope chunks (start / text-start / text-end / finish)", () => {
+    let turn = applyChunk(empty, { type: "start" });
+    turn = applyChunk(turn, { type: "text-start", id: "answer" });
+    turn = applyChunk(turn, { type: "text-end", id: "answer" });
+    turn = applyChunk(turn, { type: "finish" });
+    expect(turn).toEqual(empty);
+  });
+});

--- a/tests/chat-stream.test.ts
+++ b/tests/chat-stream.test.ts
@@ -1,4 +1,5 @@
-import { applyChunk, drainSse, type AssistantTurn } from "@/app/chat/stream";
+import { vi } from "vitest";
+import { applyChunk, drainSse, runChat, type AssistantTurn } from "@/app/chat/stream";
 
 const empty: AssistantTurn = { steps: [], answer: "" };
 
@@ -61,5 +62,42 @@ describe("applyChunk", () => {
     turn = applyChunk(turn, { type: "text-end", id: "answer" });
     turn = applyChunk(turn, { type: "finish" });
     expect(turn).toEqual(empty);
+  });
+});
+
+function sseResponse(body: string, init: { status?: number } = {}): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(body));
+      controller.close();
+    },
+  });
+  return new Response(stream, { status: init.status ?? 200 });
+}
+
+describe("runChat", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("throws on a non-ok response instead of resolving an empty turn", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: "question is required" }), { status: 400 })
+      )
+    );
+    await expect(runChat("", [], () => {})).rejects.toThrow(/400/);
+  });
+
+  it("resolves the accumulated turn on a 200 SSE response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        sseResponse('data: {"type":"text-delta","id":"answer","delta":"Hi"}\n\n')
+      )
+    );
+    const turn = await runChat("hi", [], () => {});
+    expect(turn.answer).toBe("Hi");
   });
 });

--- a/tests/components/ChatClient.test.tsx
+++ b/tests/components/ChatClient.test.tsx
@@ -2,49 +2,100 @@
 import "@testing-library/jest-dom/vitest";
 import { vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const { runChatMock } = vi.hoisted(() => ({ runChatMock: vi.fn() }));
+vi.mock("@/app/chat/stream", () => ({ runChat: runChatMock }));
+
 import { ChatClient } from "@/app/chat/ChatClient";
 
 describe("ChatClient", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
+  beforeEach(() => runChatMock.mockReset());
 
-  it("renders the question input and run button", () => {
+  it("shows an empty state before any question", () => {
     render(<ChatClient />);
-    expect(screen.getByLabelText("Question")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /run/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /ask your team's memory/i })).toBeInTheDocument();
   });
 
-  it("shows an accessible alert when the request fails", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      json: async () => ({ error: "DB connection failed" }),
+  it("streams steps live, then renders the cited answer and re-enables the composer", async () => {
+    let resolveRun: (turn: unknown) => void = () => {};
+    runChatMock.mockImplementation((_q: string, _h: unknown, onUpdate?: (t: unknown) => void) => {
+      if (!onUpdate) return Promise.resolve({ steps: [], answer: "" });
+      onUpdate({ steps: [{ index: 1, tool: "search_memory", ok: true, detail: "2 facts, 1 chunk" }], answer: "" });
+      return new Promise((resolve) => {
+        resolveRun = resolve;
+      });
     });
-    vi.stubGlobal("fetch", fetchMock);
 
     render(<ChatClient />);
-    fireEvent.change(screen.getByLabelText("Question"), { target: { value: "will fail" } });
-    fireEvent.click(screen.getByRole("button", { name: /run/i }));
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "tell me about acme" } });
+    fireEvent.submit(screen.getByRole("textbox"));
 
-    await waitFor(() => expect(screen.getByRole("alert")).toBeInTheDocument());
-    expect(screen.getByRole("alert")).toHaveTextContent("DB connection failed");
-  });
+    // user message + live reasoning step + busy composer
+    await waitFor(() => expect(screen.getByText("tell me about acme")).toBeInTheDocument());
+    expect(screen.getByText("search_memory")).toBeInTheDocument();
+    expect(screen.getByRole("listitem", { busy: true })).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toBeDisabled();
 
-  it("posts the question and shows the run result with a trace link", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      json: async () => ({ runId: 42, status: "succeeded", answer: "Echoed hello", steps: 2 }),
+    resolveRun({
+      steps: [{ index: 1, tool: "search_memory", ok: true, detail: "2 facts, 1 chunk" }],
+      answer: "Acme Robotics is Series B [acme-md#chunk-1].",
+      meta: { runId: 42, status: "succeeded", steps: 1, invalidCitations: [] },
     });
-    vi.stubGlobal("fetch", fetchMock);
 
-    render(<ChatClient />);
-    fireEvent.change(screen.getByLabelText("Question"), { target: { value: "echo hello" } });
-    fireEvent.click(screen.getByRole("button", { name: /run/i }));
-
-    await waitFor(() => expect(screen.getByText(/Run #42/)).toBeInTheDocument());
-    expect(screen.getByText("Echoed hello")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText(/Acme Robotics is Series B/)).toBeInTheDocument());
+    expect(screen.queryByRole("listitem", { busy: true })).not.toBeInTheDocument(); // settled
+    expect(screen.getByRole("textbox")).not.toBeDisabled();
     expect(screen.getByRole("link", { name: /view trace/i })).toHaveAttribute("href", "/runs/42");
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/agent",
-      expect.objectContaining({ method: "POST" }),
+    // P1-4: streaming content lives in a polite live region for screen readers.
+    expect(screen.getByText(/Acme Robotics is Series B/).closest("[aria-live]")).toHaveAttribute(
+      "aria-live",
+      "polite"
     );
+  });
+
+  it("settles to an error state (no live row, composer re-enabled) when the stream fails", async () => {
+    // Guard the teardown no-arg call (vitest cleanup) so only the real run rejects.
+    runChatMock.mockImplementation((_q: string, _h: unknown, onUpdate?: (t: unknown) => void) =>
+      onUpdate ? Promise.reject(new Error("stream dropped")) : Promise.resolve({ steps: [], answer: "" })
+    );
+    render(<ChatClient />);
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "boom" } });
+    fireEvent.submit(screen.getByRole("textbox"));
+
+    // P0-1: a failed/stalled run must SETTLE — the avocado "live" row is gone,
+    // the failure is surfaced as an alert, and the composer is usable again.
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/stream dropped/i);
+    expect(screen.queryByRole("listitem", { busy: true })).not.toBeInTheDocument();
+    expect(screen.getByRole("textbox")).not.toBeDisabled();
+  });
+
+  it("sends prior turns as history on a follow-up question", async () => {
+    runChatMock.mockResolvedValue({
+      steps: [],
+      answer: "First answer.",
+      meta: { runId: 1, status: "succeeded", steps: 0, invalidCitations: [] },
+    });
+    render(<ChatClient />);
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "first question" } });
+    fireEvent.submit(screen.getByRole("textbox"));
+    await waitFor(() => expect(screen.getByText("First answer.")).toBeInTheDocument());
+
+    runChatMock.mockResolvedValue({
+      steps: [],
+      answer: "Second answer.",
+      meta: { runId: 2, status: "succeeded", steps: 0, invalidCitations: [] },
+    });
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "follow up" } });
+    fireEvent.submit(screen.getByRole("textbox"));
+    await waitFor(() => expect(screen.getByText("Second answer.")).toBeInTheDocument());
+
+    // the second call's history carries the first exchange (user + assistant)
+    const secondCallHistory = runChatMock.mock.calls[1][1];
+    expect(secondCallHistory).toEqual([
+      { role: "user", content: "first question" },
+      { role: "assistant", content: "First answer." },
+    ]);
   });
 });

--- a/tests/components/ChatClient.test.tsx
+++ b/tests/components/ChatClient.test.tsx
@@ -98,4 +98,29 @@ describe("ChatClient", () => {
       { role: "assistant", content: "First answer." },
     ]);
   });
+
+  it("excludes an errored exchange's message from the next turn's history", async () => {
+    runChatMock
+      .mockImplementationOnce((_q: string, _h: unknown, onUpdate?: (t: unknown) => void) =>
+        onUpdate ? Promise.reject(new Error("stream dropped")) : Promise.resolve({ steps: [], answer: "" })
+      )
+      .mockResolvedValueOnce({
+        steps: [],
+        answer: "Second answer.",
+        meta: { runId: 2, status: "succeeded", steps: 0, invalidCitations: [] },
+      });
+
+    render(<ChatClient />);
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "first question" } });
+    fireEvent.submit(screen.getByRole("textbox"));
+    await screen.findByRole("alert");
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "follow up" } });
+    fireEvent.submit(screen.getByRole("textbox"));
+    await waitFor(() => expect(screen.getByText("Second answer.")).toBeInTheDocument());
+
+    const secondCallHistory = runChatMock.mock.calls[1][1];
+    expect(secondCallHistory).toEqual([]);
+  });
 });

--- a/tests/components/chat-pieces.test.tsx
+++ b/tests/components/chat-pieces.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { StepRow, PendingRow } from "@/app/chat/StepRow";
+import { ReasoningTrace } from "@/app/chat/ReasoningTrace";
+import { MessageBubble } from "@/app/chat/MessageBubble";
+import { Composer } from "@/app/chat/Composer";
+import type { ChatStep } from "@/app/chat/stream";
+
+const step = (over: Partial<ChatStep> = {}): ChatStep => ({
+  index: 1,
+  tool: "search_memory",
+  ok: true,
+  detail: "2 facts, 1 chunk",
+  ...over,
+});
+
+describe("StepRow", () => {
+  it("renders the tool and detail and marks a successful step done", () => {
+    render(
+      <ul>
+        <StepRow step={step()} />
+      </ul>
+    );
+    expect(screen.getByText("search_memory")).toBeInTheDocument();
+    expect(screen.getByText(/2 facts, 1 chunk/)).toBeInTheDocument();
+    expect(screen.getByRole("listitem")).toHaveAttribute("data-state", "done");
+  });
+
+  it("marks a failed step with the error state", () => {
+    render(
+      <ul>
+        <StepRow step={step({ ok: false, detail: "source not allowed" })} />
+      </ul>
+    );
+    expect(screen.getByRole("listitem")).toHaveAttribute("data-state", "error");
+  });
+});
+
+describe("PendingRow", () => {
+  it("is busy and shows a working label", () => {
+    render(
+      <ul>
+        <PendingRow label="Searching memory" />
+      </ul>
+    );
+    const li = screen.getByRole("listitem");
+    expect(li).toHaveAttribute("aria-busy", "true");
+    expect(li).toHaveAttribute("data-state", "working");
+    expect(screen.getByText(/Searching memory/)).toBeInTheDocument();
+  });
+});
+
+describe("ReasoningTrace", () => {
+  it("shows the step count and reflects open state via aria-expanded", () => {
+    render(<ReasoningTrace steps={[step(), step({ index: 2 })]} running={false} open={true} onToggle={() => {}} />);
+    const toggle = screen.getByRole("button", { name: /reasoning/i });
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText(/2 steps/)).toBeInTheDocument();
+  });
+
+  it("calls onToggle when the header is clicked", () => {
+    const onToggle = vi.fn();
+    render(<ReasoningTrace steps={[step()]} running={false} open={false} onToggle={onToggle} />);
+    fireEvent.click(screen.getByRole("button", { name: /reasoning/i }));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a live pending row while the agent is running", () => {
+    render(<ReasoningTrace steps={[step()]} running={true} open={true} onToggle={() => {}} />);
+    expect(screen.getByRole("listitem", { busy: true })).toBeInTheDocument();
+  });
+
+  it("renders no pending row once the run has settled", () => {
+    render(<ReasoningTrace steps={[step()]} running={false} open={true} onToggle={() => {}} />);
+    expect(screen.queryByRole("listitem", { busy: true })).not.toBeInTheDocument();
+  });
+});
+
+describe("MessageBubble", () => {
+  it("tags the role and renders its content", () => {
+    const { rerender } = render(<MessageBubble role="user">Hello there</MessageBubble>);
+    expect(screen.getByText("Hello there").closest("[data-role]")).toHaveAttribute("data-role", "user");
+    rerender(<MessageBubble role="assistant">Reply</MessageBubble>);
+    expect(screen.getByText("Reply").closest("[data-role]")).toHaveAttribute("data-role", "assistant");
+  });
+});
+
+describe("Composer", () => {
+  it("submits the typed value and disables while busy", () => {
+    const onSubmit = vi.fn();
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <Composer value="who is acme" onChange={onChange} onSubmit={onSubmit} disabled={false} />
+    );
+    fireEvent.submit(screen.getByRole("textbox"));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+
+    rerender(<Composer value="" onChange={onChange} onSubmit={onSubmit} disabled={true} />);
+    expect(screen.getByRole("textbox")).toBeDisabled();
+    expect(screen.getByRole("button", { name: /send|running/i })).toBeDisabled();
+  });
+
+  it("submits on Enter but not on Shift+Enter", () => {
+    const onSubmit = vi.fn();
+    render(<Composer value="hi" onChange={() => {}} onSubmit={onSubmit} disabled={false} />);
+    const box = screen.getByRole("textbox");
+    fireEvent.keyDown(box, { key: "Enter", shiftKey: true });
+    expect(onSubmit).not.toHaveBeenCalled();
+    fireEvent.keyDown(box, { key: "Enter", shiftKey: false });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/harness-onstep.test.ts
+++ b/tests/harness-onstep.test.ts
@@ -1,0 +1,94 @@
+import { vi } from "vitest";
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+import type { ModelGatewayProvider } from "@/lib/model-gateway";
+import { runAgent, type AgentStepEvent } from "@/lib/harness";
+import { createToolRegistry } from "@/lib/tools/registry";
+import { echoTool } from "@/lib/tools/echo";
+import type { Tool } from "@/lib/tools/types";
+
+async function resetLedgerTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS tool_calls CASCADE`;
+  await db`DROP TABLE IF EXISTS model_calls CASCADE`;
+  await db`DROP TABLE IF EXISTS run_steps CASCADE`;
+  await db`DROP TABLE IF EXISTS runs CASCADE`;
+  await db`DROP TABLE IF EXISTS schema_migrations CASCADE`;
+  await runMigrations(db);
+}
+
+const ALLOWED = new Set<Tool["permissionClass"]>(["read", "reason"]);
+
+describe("runAgent onStep", () => {
+  beforeEach(async () => {
+    await resetLedgerTables();
+  });
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("emits one onStep event per executed tool step (not for the final answer)", async () => {
+    const registry = createToolRegistry([echoTool]);
+    const provider = vi
+      .fn<ModelGatewayProvider>()
+      .mockResolvedValueOnce({
+        object: { action: "tool", tool: "echo", args: '{"text":"hello"}', thought: "let me echo" },
+      })
+      .mockResolvedValueOnce({ object: { action: "final", answer: "Echoed hello" } });
+
+    const events: AgentStepEvent[] = [];
+    const result = await runAgent({
+      question: "echo hello",
+      registry,
+      allowedClasses: ALLOWED,
+      provider,
+      onStep: (e) => {
+        events.push(e);
+      },
+    });
+
+    expect(result.status).toBe("succeeded");
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ index: 1, tool: "echo", ok: true, thought: "let me echo" });
+    expect(events[0].observation).toContain("hello");
+  });
+
+  it("marks a failed tool step with ok:false", async () => {
+    const registry = createToolRegistry([echoTool]); // echo requires { text }
+    const provider = vi
+      .fn<ModelGatewayProvider>()
+      .mockResolvedValueOnce({ object: { action: "tool", tool: "echo", args: '{"wrong":1}' } })
+      .mockResolvedValueOnce({ object: { action: "final", answer: "done" } });
+
+    const events: AgentStepEvent[] = [];
+    await runAgent({ question: "x", registry, allowedClasses: ALLOWED, provider, onStep: (e) => events.push(e) });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ index: 1, tool: "echo", ok: false });
+  });
+
+  it("awaits an async onStep before continuing the loop", async () => {
+    const registry = createToolRegistry([echoTool]);
+    const provider = vi
+      .fn<ModelGatewayProvider>()
+      .mockResolvedValueOnce({ object: { action: "tool", tool: "echo", args: '{"text":"a"}' } })
+      .mockResolvedValueOnce({ object: { action: "tool", tool: "echo", args: '{"text":"b"}' } })
+      .mockResolvedValueOnce({ object: { action: "final", answer: "ok" } });
+
+    const order: string[] = [];
+    await runAgent({
+      question: "x",
+      registry,
+      allowedClasses: ALLOWED,
+      provider,
+      onStep: async (e) => {
+        order.push(`start-${e.index}`);
+        await Promise.resolve();
+        order.push(`end-${e.index}`);
+      },
+    });
+
+    // Each onStep fully resolves before the next step's onStep starts.
+    expect(order).toEqual(["start-1", "end-1", "start-2", "end-2"]);
+  });
+});

--- a/tests/memory-summarize-step.test.ts
+++ b/tests/memory-summarize-step.test.ts
@@ -1,0 +1,36 @@
+import { summarizeStep } from "@/lib/memory/answer";
+
+describe("summarizeStep", () => {
+  it("counts facts and chunks for a successful search_memory step", () => {
+    const part = summarizeStep({
+      index: 1,
+      tool: "search_memory",
+      ok: true,
+      observation: 'Success: {"acceptedFacts":[1,2,3],"gapFacts":[1],"chunks":[1,2]}',
+    });
+    expect(part).toMatchObject({ index: 1, tool: "search_memory", ok: true });
+    expect(part.detail).toBe("4 facts, 2 chunks");
+  });
+
+  it("singularizes one fact / one chunk", () => {
+    const part = summarizeStep({
+      index: 2,
+      tool: "search_memory",
+      ok: true,
+      observation: 'Success: {"acceptedFacts":[1],"gapFacts":[],"chunks":[1]}',
+    });
+    expect(part.detail).toBe("1 fact, 1 chunk");
+  });
+
+  it("surfaces the error message (without the Error(...) prefix) for a failed step", () => {
+    const part = summarizeStep({
+      index: 1,
+      tool: "search_memory",
+      ok: false,
+      observation: "Error (permission_denied): source not allowed",
+    });
+    expect(part.ok).toBe(false);
+    expect(part.detail).toContain("source not allowed");
+    expect(part.detail).not.toContain("Error (");
+  });
+});

--- a/tests/model-boundary.test.ts
+++ b/tests/model-boundary.test.ts
@@ -2,7 +2,12 @@ import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
 
 const srcRoot = join(process.cwd(), "src");
-const allowedProviderFile = join("src", "lib", "model-gateway.ts");
+// AI SDK surface is contained to two audited boundary modules: the model gateway
+// (model calls) and the UI-message-stream transport (chat streaming).
+const allowedProviderFiles = new Set([
+  join("src", "lib", "model-gateway.ts"),
+  join("src", "lib", "ui-message-stream.ts"),
+]);
 
 function listSourceFiles(dir: string): string[] {
   return readdirSync(dir).flatMap((entry) => {
@@ -20,7 +25,7 @@ describe("model provider boundary", () => {
 
     for (const file of listSourceFiles(srcRoot)) {
       const relativePath = relative(process.cwd(), file);
-      if (relativePath === allowedProviderFile) {
+      if (allowedProviderFiles.has(relativePath)) {
         continue;
       }
 


### PR DESCRIPTION
Builds the deferred **A6.3 chat render** on the merged cited-memory engine (PR #9). Keeps the custom agent harness and streams its step events over the Vercel AI SDK UI-message-stream; `/chat` renders a multi-turn thread with a live, collapsing reasoning trace. Design-reviewed (`/plan-design-review`) and TDD throughout.

### Architecture
- **Keep the harness, stream its steps.** Ledger, permission gating, and the citation post-check stay intact. `runAgent` gains an `onStep(event)` callback.
- **`/api/agent/stream`** wraps the run in `createUIMessageStream`; the final answer is written *after* the citation post-check, so no invalid citation ever streams. Shared **`answerWithMemory()`** helper; the JSON `/api/agent` route refactored onto it.
- **`src/lib/ui-message-stream.ts`** is the single AI SDK transport boundary (model-boundary test allows it alongside `model-gateway.ts`). **No `@ai-sdk/react`** — its `4.0.2` depends on `ai@7`, a cross-major mismatch with our `ai@6` (would bundle a 2nd `ai`). The client parses the SSE itself (`chat/stream.ts`) and owns multi-turn state.

### UI + motion ( `/impeccable animate` )
- Streaming `ChatClient` + `StepRow` / `ReasoningTrace` / `MessageBubble` / `Composer`.
- Motion thesis **"avocado = live, greige = settled"**: live pending row pulses avocado, settled steps go greige, trace collapses via animation-safe `grid-template-rows`, full `prefers-reduced-motion` block. Tokens in `globals.css`.

### Design-review fixes applied (verdict: ship-with-fixes, P0:1/P1:4)
- **P0-1** failure terminus — 90s abort + any failure settles the trace and renders a `role="alert"` (DESIGN.md error treatment).
- **P1-3** reduced-motion JS scroll (`matchMedia` branch) · **P1-4** `aria-live="polite"` region · **P1-5** `contain: layout paint` on the collapse. P1-2 (composing-state) was already built.

### Verification
- **333 tests green** (~28 new across harness `onStep`, stream parser, stream route, chat components, failure terminus), 0 regressions.
- Live end-to-end on the dev server: streamed cited answer (`acme-robotics#chunk-1`, `contacts-csv#row-1`, `invalidCitations: []`) on Anthropic + hash retrieval.

### Not in this PR / notes
- The impeccable skill install (`.claude/skills/impeccable/`) is intentionally **not** committed here (separate tooling concern).
- **Pre-existing** (`main`) `npm run build` break: write-path files import `../../*.js` that webpack can't resolve (vitest/esbuild can); the chat path and dev server are unaffected. One-line `extensionAlias` fix, out of scope here.
- Deferred: A4.2 import UI, v2 token-by-token typing, the cosmetic P2 polish slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an SSE-based streaming chat experience with live, toggleable reasoning steps, partial answers, and per-run metadata (including trace links and invalid-citation warnings).
  * Introduced a new composer and message rendering components with a multi-exchange chat UI.
* **Bug Fixes**
  * Improved resilience to malformed follow-up history; invalid inputs now fall back instead of failing.
  * Added clearer request validation for missing questions and consistent handling of failed runs while streaming.
* **Style**
  * Refined reasoning-trace motion/animations and added reduced-motion support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a streaming multi-turn Research Chat: the existing ReAct harness gains an `onStep` callback, a new `/api/agent/stream` route wraps `answerWithMemory` in the AI SDK UI-message-stream transport, and the `/chat` page is rebuilt as a live SSE client with a collapsible reasoning trace and reduced-motion support.

- **Streaming pipeline**: `runAgent` emits `AgentStepEvent` per tool step (awaited, so each step flushes before the next starts); `answerWithMemory` summarises them into `ChatStepPart`s; `streamAgentResponse` writes step, text-delta, and meta chunks; `runChat` on the client reduces the SSE feed into an `AssistantTurn` view model.
- **Multi-turn state**: `ChatClient` owns conversation history, filters out errored exchanges, and enforces a 90 s abort timeout; the composer is locked while a run is active and re-enabled in `.finally()`.
- **Motion & accessibility**: reasoning trace collapses via `grid-template-rows` (animation-safe), all motion flattens under `prefers-reduced-motion`, JS scroll branches on `matchMedia`, and streaming content lives in an `aria-live=\"polite\"` region.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the happy path; there is one failure mode on the streaming path where a server-side exception after tool steps are already flushed produces no visible error to the user.

When the server throws inside the AI SDK execute callback after SSE data has already been written (e.g., the database call in getRunTrace fails after the agent completes), the HTTP status is already 200 and the AI SDK writes an error chunk to the stream. The client's applyChunk ignores unknown chunk types, so runChat resolves normally and ChatClient marks the exchange done without the errored flag — no answer bubble, no error alert, just silence. The rest of the change — harness onStep, answerWithMemory extraction, SSE parser, multi-turn history, abort timeout, and motion — is clean and well-tested.

src/app/chat/stream.ts (applyChunk default case) and src/lib/ui-message-stream.ts (onError wire format) are the two files that need attention to close the silent-failure path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/api/agent/stream/route.ts | New streaming route: validates input, delegates to answerWithMemory, streams steps and final answer via AI SDK UI-message-stream. No try/catch around the streamAgentResponse body — server errors after streaming starts are silently lost. |
| src/app/chat/stream.ts | Client-side SSE parser and turn accumulator. Correctly throws on !res.ok. applyChunk ignores all unknown chunk types via default fallthrough, which means AI SDK error events emitted mid-stream are silently dropped. |
| src/app/chat/ChatClient.tsx | Multi-turn streaming chat client. Correctly filters errored exchanges from history, handles abort/timeout, settles exchanges on error. Scroll-pinning and reduced-motion branch are well-handled. |
| src/lib/harness.ts | Adds AgentStepEvent and onStep callback. The callback is awaited before the next loop iteration, ensuring flush ordering. |
| src/lib/memory/answer.ts | New shared helper encapsulating the agent run + citation post-check. Clean extraction from the old route; onStep threading is minimal and correct. |
| src/lib/ui-message-stream.ts | AI SDK transport boundary. onError converts exceptions to strings but the resulting error chunk type is not handled by the client parser, creating a silent-failure path when the execute callback throws after streaming begins. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User (browser)
    participant CC as ChatClient
    participant RC as runChat / stream.ts
    participant SR as /api/agent/stream
    participant AWM as answerWithMemory
    participant RH as runAgent (harness)

    U->>CC: submit question
    CC->>CC: build history from prior exchanges
    CC->>RC: runChat(question, history, onUpdate, signal)
    RC->>SR: POST /api/agent/stream (SSE)
    SR->>AWM: "answerWithMemory(db, {question, history, onStep})"
    AWM->>RH: "runAgent({…, onStep})"

    loop ReAct tool loop
        RH->>RH: decide() → tool call
        RH->>RH: executeToolCall()
        RH-->>AWM: onStep(event)
        AWM-->>SR: summarizeStep(event)
        SR-->>RC: SSE data-step chunk
        RC-->>CC: onUpdate(accumulatingTurn)
        CC-->>U: live reasoning trace row
    end

    RH->>RH: decide() → final answer
    RH-->>AWM: "result {status, answer, steps}"
    AWM->>AWM: getRunTrace + verifyAnswerCitations
    AWM-->>SR: MemoryAnswer
    SR-->>RC: SSE text-delta + data-meta chunks
    RC-->>CC: onUpdate(finalTurn)
    RC-->>CC: Promise resolves (finalTurn)
    CC->>CC: mark exchange done, collapse trace
    CC-->>U: answer bubble + MetaFooter
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User (browser)
    participant CC as ChatClient
    participant RC as runChat / stream.ts
    participant SR as /api/agent/stream
    participant AWM as answerWithMemory
    participant RH as runAgent (harness)

    U->>CC: submit question
    CC->>CC: build history from prior exchanges
    CC->>RC: runChat(question, history, onUpdate, signal)
    RC->>SR: POST /api/agent/stream (SSE)
    SR->>AWM: "answerWithMemory(db, {question, history, onStep})"
    AWM->>RH: "runAgent({…, onStep})"

    loop ReAct tool loop
        RH->>RH: decide() → tool call
        RH->>RH: executeToolCall()
        RH-->>AWM: onStep(event)
        AWM-->>SR: summarizeStep(event)
        SR-->>RC: SSE data-step chunk
        RC-->>CC: onUpdate(accumulatingTurn)
        CC-->>U: live reasoning trace row
    end

    RH->>RH: decide() → final answer
    RH-->>AWM: "result {status, answer, steps}"
    AWM->>AWM: getRunTrace + verifyAnswerCitations
    AWM-->>SR: MemoryAnswer
    SR-->>RC: SSE text-delta + data-meta chunks
    RC-->>CC: onUpdate(finalTurn)
    RC-->>CC: Promise resolves (finalTurn)
    CC->>CC: mark exchange done, collapse trace
    CC-->>U: answer bubble + MetaFooter
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix(r0): exclude errored exchanges from ..."](https://github.com/fisherxz/sourcecado/commit/82a9f7e232dbebcfbf1938f616636a7585a5edf2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40133284)</sub>

<!-- /greptile_comment -->