### PR TITLE
feat(rt-R3): tool orchestrator choke point — executeTool() + toLlmToolDefinition

### DIFF
--- a/src/lib/agent-loop.ts
+++ b/src/lib/agent-loop.ts
@@ -1,31 +1,18 @@
-import { z } from "zod";
-import {
-  failRunStep,
-  failToolCall,
-  finishRunStep,
-  finishToolCall,
-  startRunStep,
-  startToolCall,
-} from "./ledger";
 import { streamAgentTurn, type LlmTurnOutcome } from "./model-gateway";
 import type {
   LlmAdapter,
   LlmMessage,
   LlmStreamEvent,
-  LlmToolDefinition,
   LlmToolResultBlock,
   StopReason,
 } from "./llm/types";
+import { executeTool, toLlmToolDefinition, type ToolExecutionResult } from "./tools/orchestrator";
 import type { ToolRegistry } from "./tools/registry";
-import type { PermissionClass, Sql, Tool } from "./tools/types";
+import type { PermissionClass, Sql } from "./tools/types";
+
+export type { ToolExecutionResult } from "./tools/orchestrator";
 
 const DEFAULT_MAX_STEPS = 8;
-const TOOL_RESULT_MAX_CHARS = 16_000;
-
-export interface ToolExecutionResult {
-  content: string;
-  isError: boolean;
-}
 
 export interface AgentLoopInput {
   messages: LlmMessage[];
@@ -144,7 +131,8 @@ export async function runAgentLoop(input: AgentLoopInput): Promise<AgentLoopResu
     const resultBlocks: LlmToolResultBlock[] = [];
     for (const block of toolUseBlocks) {
       await input.onEvent?.({ type: "tool_start", id: block.id, name: block.name, input: block.input });
-      const result = await executeToolUseBlock({
+      const result = await executeTool({
+        toolUseId: block.id,
         name: block.name,
         input: block.input,
         registry: input.registry,
@@ -181,90 +169,4 @@ async function drain(
 
 function syntheticAssistantMessage(text: string): LlmMessage {
   return { role: "assistant", content: [{ type: "text", text }] };
-}
-
-function toLlmToolDefinition(tool: Tool): LlmToolDefinition {
-  let inputSchema: unknown = {};
-  try {
-    inputSchema = z.toJSONSchema(tool.argsSchema);
-  } catch {
-    inputSchema = {};
-  }
-  return { name: tool.name, description: tool.description, inputSchema };
-}
-
-// --- Internal tool execution -------------------------------------------------
-// Temporary home (Judgment call #1): R3 lifts this verbatim into
-// src/lib/tools/orchestrator.ts as `executeTool`/`toLlmToolDefinition`, then
-// updates the imports above instead of the local definitions.
-
-interface ExecuteToolUseBlockInput {
-  name: string;
-  input: unknown;
-  registry: ToolRegistry;
-  allowed: Set<PermissionClass>;
-  db: Sql;
-  runId: number;
-  parentStepId: number;
-}
-
-async function executeToolUseBlock(opts: ExecuteToolUseBlockInput): Promise<ToolExecutionResult> {
-  const { name, input, registry, allowed, db, runId, parentStepId } = opts;
-  const tool = registry.get(name);
-
-  const toolStep = await startRunStep(db, {
-    runId,
-    parentStepId,
-    stepKind: "tool",
-    name,
-    input: { args: input },
-  });
-  const toolCall = await startToolCall(db, {
-    runId,
-    runStepId: toolStep.id,
-    toolName: name,
-    arguments: input,
-    metadata: { permissionClass: tool?.permissionClass ?? null },
-  });
-
-  const fail = async (errorType: string, message: string): Promise<ToolExecutionResult> => {
-    await failToolCall(db, { toolCallId: toolCall.id, errorType, errorMessage: message });
-    await failRunStep(db, { runStepId: toolStep.id, errorType, errorMessage: message });
-    return truncate(`Error (${errorType}): ${message}`, true);
-  };
-
-  if (!tool) {
-    return fail("unknown_tool", `Unknown tool: ${name}.`);
-  }
-  if (!allowed.has(tool.permissionClass)) {
-    return fail(
-      "permission_denied",
-      `Tool ${name} (class ${tool.permissionClass}) is not permitted for this run.`
-    );
-  }
-  const parsed = tool.argsSchema.safeParse(input);
-  if (!parsed.success) {
-    return fail("invalid_args", `Invalid arguments for ${name}: ${parsed.error.message}`);
-  }
-
-  try {
-    const result = await tool.execute(parsed.data, { db, runId, parentStepId: toolStep.id });
-    await finishToolCall(db, { toolCallId: toolCall.id, result });
-    await finishRunStep(db, { runStepId: toolStep.id, output: result });
-    return truncate(`Success: ${JSON.stringify(result)}`, false);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return fail("tool_error", `Tool ${name} failed: ${message}`);
-  }
-}
-
-function truncate(content: string, isError: boolean): ToolExecutionResult {
-  if (content.length <= TOOL_RESULT_MAX_CHARS) {
-    return { content, isError };
-  }
-  const overflow = content.length - TOOL_RESULT_MAX_CHARS;
-  return {
-    content: `${content.slice(0, TOOL_RESULT_MAX_CHARS)}\n\n[truncated ${overflow} chars]`,
-    isError,
-  };
 }

--- a/src/lib/tools/orchestrator.ts
+++ b/src/lib/tools/orchestrator.ts
@@ -1,0 +1,121 @@
+import { z } from "zod";
+import {
+  failRunStep,
+  failToolCall,
+  finishRunStep,
+  finishToolCall,
+  startRunStep,
+  startToolCall,
+} from "../ledger";
+import type { LlmToolDefinition } from "../llm/types";
+import type { ToolRegistry } from "./registry";
+import type { PermissionClass, Sql, Tool } from "./types";
+
+export const TOOL_RESULT_MAX_CHARS = 16_000;
+
+export interface ToolExecutionResult {
+  content: string; // final, already-truncated text for a tool_result block
+  isError: boolean;
+}
+
+export interface ExecuteToolInput {
+  // Accepted for shape-parity with the contracts brief §4; not read here —
+  // the caller uses the tool_use block's id directly to build the
+  // LlmToolResultBlock.
+  toolUseId: string;
+  name: string;
+  input: unknown; // native object from LlmToolUseBlock.input — never a JSON string
+  registry: ToolRegistry;
+  allowed: Set<PermissionClass>;
+  db: Sql;
+  runId: number;
+  parentStepId: number;
+}
+
+// The choke point every tool call passes through: validate → permission gate
+// → execute → ledger log → truncate. Denials and failures return an is_error
+// result; nothing throws.
+export async function executeTool(opts: ExecuteToolInput): Promise<ToolExecutionResult> {
+  const { name, input, registry, allowed, db, runId, parentStepId } = opts;
+  const tool = registry.get(name);
+
+  // Ledger rows open unconditionally before any validation so every branch
+  // (including unknown_tool/permission_denied) is ledger-visible.
+  const toolStep = await startRunStep(db, {
+    runId,
+    parentStepId,
+    stepKind: "tool",
+    name,
+    input: { args: input },
+  });
+  const toolCall = await startToolCall(db, {
+    runId,
+    runStepId: toolStep.id,
+    toolName: name,
+    arguments: input,
+    metadata: { permissionClass: tool?.permissionClass ?? null },
+  });
+
+  if (!tool) {
+    return failTool(db, toolStep.id, toolCall.id, "unknown_tool", `Unknown tool: ${name}.`);
+  }
+  if (!allowed.has(tool.permissionClass)) {
+    return failTool(
+      db,
+      toolStep.id,
+      toolCall.id,
+      "permission_denied",
+      `Tool ${name} (class ${tool.permissionClass}) is not permitted for this run.`
+    );
+  }
+  const parsed = tool.argsSchema.safeParse(input);
+  if (!parsed.success) {
+    return failTool(
+      db,
+      toolStep.id,
+      toolCall.id,
+      "invalid_args",
+      `Invalid arguments for ${name}: ${parsed.error.message}`
+    );
+  }
+
+  try {
+    const result = await tool.execute(parsed.data, { db, runId, parentStepId: toolStep.id });
+    await finishToolCall(db, { toolCallId: toolCall.id, result });
+    await finishRunStep(db, { runStepId: toolStep.id, output: result });
+    return { content: truncate(`Success: ${JSON.stringify(result)}`), isError: false };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return failTool(db, toolStep.id, toolCall.id, "tool_error", `Tool ${name} failed: ${message}`);
+  }
+}
+
+// Tool → LlmToolDefinition, used to build the API `tools:` param. Lives here
+// (not registry.ts) since JSON-Schema conversion is a call-boundary concern.
+export function toLlmToolDefinition(tool: Tool): LlmToolDefinition {
+  let inputSchema: unknown = {};
+  try {
+    inputSchema = z.toJSONSchema(tool.argsSchema);
+  } catch {
+    inputSchema = {};
+  }
+  return { name: tool.name, description: tool.description, inputSchema };
+}
+
+function truncate(content: string): string {
+  if (content.length <= TOOL_RESULT_MAX_CHARS) return content;
+  const overflow = content.length - TOOL_RESULT_MAX_CHARS;
+  return `${content.slice(0, TOOL_RESULT_MAX_CHARS)}\n\n[truncated ${overflow} chars]`;
+}
+
+async function failTool(
+  db: Sql,
+  runStepId: number,
+  toolCallId: number,
+  errorType: string,
+  message: string
+): Promise<ToolExecutionResult> {
+  await failToolCall(db, { toolCallId, errorType, errorMessage: message });
+  await failRunStep(db, { runStepId, errorType, errorMessage: message });
+  return { content: truncate(`Error (${errorType}): ${message}`), isError: true };
+}

--- a/tests/tool-orchestrator.test.ts
+++ b/tests/tool-orchestrator.test.ts
@@ -1,0 +1,282 @@
+import { z } from "zod";
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+import {
+  executeTool,
+  toLlmToolDefinition,
+  TOOL_RESULT_MAX_CHARS,
+} from "@/lib/tools/orchestrator";
+import { createToolRegistry } from "@/lib/tools/registry";
+import { echoTool } from "@/lib/tools/echo";
+import { startRun, startRunStep } from "@/lib/ledger";
+import type { PermissionClass, Tool } from "@/lib/tools/types";
+
+async function resetLedgerTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS tool_calls CASCADE`;
+  await db`DROP TABLE IF EXISTS model_calls CASCADE`;
+  await db`DROP TABLE IF EXISTS run_steps CASCADE`;
+  await db`DROP TABLE IF EXISTS runs CASCADE`;
+  await db`DROP TABLE IF EXISTS schema_migrations CASCADE`;
+  await runMigrations(db);
+}
+
+async function seedAgentStep() {
+  const db = getDb();
+  const run = await startRun(db, { runType: "agent_chat", title: "t", input: {} });
+  const step = await startRunStep(db, { runId: run.id, stepKind: "agent", name: "agent_loop", input: {} });
+  return { db, runId: run.id, parentStepId: step.id };
+}
+
+const ALLOWED = new Set<PermissionClass>(["read", "reason"]);
+
+afterAll(async () => {
+  await closeDb();
+});
+
+describe("executeTool", () => {
+  beforeEach(async () => {
+    await resetLedgerTables();
+  });
+
+  it("executes a registered tool", async () => {
+    const { db, runId, parentStepId } = await seedAgentStep();
+    const registry = createToolRegistry([echoTool]);
+
+    const result = await executeTool({
+      toolUseId: "call-1",
+      name: "echo",
+      input: { text: "hello" },
+      registry,
+      allowed: ALLOWED,
+      db,
+      runId,
+      parentStepId,
+    });
+
+    expect(result).toEqual({ content: 'Success: {"echoed":"hello"}', isError: false });
+
+    const steps = await db`
+      SELECT step_kind, name, status FROM run_steps
+      WHERE run_id = ${runId} AND step_kind = 'tool'
+    `;
+    expect(steps).toHaveLength(1);
+    expect(steps[0]).toMatchObject({ step_kind: "tool", name: "echo", status: "succeeded" });
+
+    const calls = await db`
+      SELECT tool_name, status, result_json FROM tool_calls WHERE run_id = ${runId}
+    `;
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ tool_name: "echo", status: "succeeded" });
+    expect(calls[0].result_json).toEqual({ echoed: "hello" });
+  });
+
+  it("truncates an oversized success result", async () => {
+    const { db, runId, parentStepId } = await seedAgentStep();
+    const bigTool: Tool = {
+      name: "big",
+      description: "Returns an oversized payload.",
+      permissionClass: "read",
+      argsSchema: z.object({}),
+      async execute() {
+        return { blob: "x".repeat(TOOL_RESULT_MAX_CHARS + 5_000) };
+      },
+    };
+    const registry = createToolRegistry([bigTool]);
+
+    const result = await executeTool({
+      toolUseId: "call-1",
+      name: "big",
+      input: {},
+      registry,
+      allowed: ALLOWED,
+      db,
+      runId,
+      parentStepId,
+    });
+
+    const json = JSON.stringify({ blob: "x".repeat(TOOL_RESULT_MAX_CHARS + 5_000) });
+    const full = `Success: ${json}`;
+    const overflow = full.length - TOOL_RESULT_MAX_CHARS;
+    expect(result.isError).toBe(false);
+    expect(result.content).toBe(
+      `${full.slice(0, TOOL_RESULT_MAX_CHARS)}\n\n[truncated ${overflow} chars]`
+    );
+  });
+
+  it("returns an is_error result for an unknown tool name", async () => {
+    const { db, runId, parentStepId } = await seedAgentStep();
+    const registry = createToolRegistry([echoTool]);
+
+    await expect(
+      executeTool({
+        toolUseId: "call-1",
+        name: "nope",
+        input: {},
+        registry,
+        allowed: ALLOWED,
+        db,
+        runId,
+        parentStepId,
+      })
+    ).resolves.toEqual({ content: "Error (unknown_tool): Unknown tool: nope.", isError: true });
+
+    const calls = await db`SELECT status, error_type FROM tool_calls WHERE run_id = ${runId}`;
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ status: "failed", error_type: "unknown_tool" });
+  });
+
+  it("returns an is_error result when the tool's permission class is not allowed", async () => {
+    const { db, runId, parentStepId } = await seedAgentStep();
+    const adminTool: Tool = {
+      name: "danger",
+      description: "Requires admin.",
+      permissionClass: "admin",
+      argsSchema: z.object({}),
+      async execute() {
+        return { ok: true };
+      },
+    };
+    const registry = createToolRegistry([adminTool]);
+
+    await expect(
+      executeTool({
+        toolUseId: "call-1",
+        name: "danger",
+        input: {},
+        registry,
+        allowed: ALLOWED,
+        db,
+        runId,
+        parentStepId,
+      })
+    ).resolves.toMatchObject({ isError: true });
+
+    const calls = await db`SELECT status, error_type FROM tool_calls WHERE run_id = ${runId}`;
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({ status: "failed", error_type: "permission_denied" });
+  });
+
+  it("returns an is_error result when args fail schema validation", async () => {
+    const { db, runId, parentStepId } = await seedAgentStep();
+    const registry = createToolRegistry([echoTool]);
+
+    const result = await executeTool({
+      toolUseId: "call-1",
+      name: "echo",
+      input: { text: 42 },
+      registry,
+      allowed: ALLOWED,
+      db,
+      runId,
+      parentStepId,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Error (invalid_args): Invalid arguments for echo:");
+
+    const calls = await db`SELECT status, error_type FROM tool_calls WHERE run_id = ${runId}`;
+    expect(calls[0]).toMatchObject({ status: "failed", error_type: "invalid_args" });
+  });
+
+  it("returns an is_error result when the tool's execute throws", async () => {
+    const { db, runId, parentStepId } = await seedAgentStep();
+    const brokenTool: Tool = {
+      name: "broken",
+      description: "Always throws.",
+      permissionClass: "read",
+      argsSchema: z.object({}),
+      async execute() {
+        throw new Error("kaboom");
+      },
+    };
+    const registry = createToolRegistry([brokenTool]);
+
+    await expect(
+      executeTool({
+        toolUseId: "call-1",
+        name: "broken",
+        input: {},
+        registry,
+        allowed: ALLOWED,
+        db,
+        runId,
+        parentStepId,
+      })
+    ).resolves.toEqual({
+      content: "Error (tool_error): Tool broken failed: kaboom",
+      isError: true,
+    });
+
+    const calls = await db`SELECT status, error_type, error_message FROM tool_calls WHERE run_id = ${runId}`;
+    expect(calls[0]).toMatchObject({ status: "failed", error_type: "tool_error" });
+    expect(calls[0].error_message).toContain("kaboom");
+  });
+
+  it("truncates an oversized error message the same way as success", async () => {
+    const { db, runId, parentStepId } = await seedAgentStep();
+    const noisyTool: Tool = {
+      name: "noisy",
+      description: "Throws an oversized error.",
+      permissionClass: "read",
+      argsSchema: z.object({}),
+      async execute() {
+        throw new Error("e".repeat(TOOL_RESULT_MAX_CHARS + 3_000));
+      },
+    };
+    const registry = createToolRegistry([noisyTool]);
+
+    const result = await executeTool({
+      toolUseId: "call-1",
+      name: "noisy",
+      input: {},
+      registry,
+      allowed: ALLOWED,
+      db,
+      runId,
+      parentStepId,
+    });
+
+    const full = `Error (tool_error): Tool noisy failed: ${"e".repeat(TOOL_RESULT_MAX_CHARS + 3_000)}`;
+    const overflow = full.length - TOOL_RESULT_MAX_CHARS;
+    expect(result.isError).toBe(true);
+    expect(result.content).toBe(
+      `${full.slice(0, TOOL_RESULT_MAX_CHARS)}\n\n[truncated ${overflow} chars]`
+    );
+  });
+});
+
+describe("toLlmToolDefinition", () => {
+  it("toLlmToolDefinition produces a JSON Schema reflecting the tool's argsSchema", () => {
+    const def = toLlmToolDefinition(echoTool);
+
+    expect(def.name).toBe("echo");
+    expect(def.description).toBe(echoTool.description);
+    const schema = def.inputSchema as { properties?: Record<string, { type?: string }> };
+    expect(schema.properties?.text?.type).toBe("string");
+  });
+
+  it("toLlmToolDefinition falls back to an empty schema when z.toJSONSchema throws", () => {
+    // z.toJSONSchema cannot represent bigint and throws on it — a real,
+    // deterministic trigger for the catch branch. (The plan's
+    // vi.spyOn(z, "toJSONSchema") approach is impossible here: ESM module
+    // namespaces are not configurable under vitest.)
+    const unrepresentableTool: Tool = {
+      name: "unrepresentable",
+      description: "argsSchema cannot be converted to JSON Schema.",
+      permissionClass: "read",
+      argsSchema: z.bigint() as unknown as Tool["argsSchema"],
+      async execute() {
+        return {};
+      },
+    };
+    expect(() => z.toJSONSchema(unrepresentableTool.argsSchema)).toThrow();
+
+    const def = toLlmToolDefinition(unrepresentableTool);
+    expect(def).toEqual({
+      name: "unrepresentable",
+      description: unrepresentableTool.description,
+      inputSchema: {},
+    });
+  });
+});


### PR DESCRIPTION
## Summary

R3 of the Runtime Solidification Sprint (plan: `docs/superpowers/plans/2026-07-14-r3-tool-orchestrator-plan.md`).

- **New `src/lib/tools/orchestrator.ts`** — `executeTool()`, the one choke point every tool call passes through: ledger rows open unconditionally → unknown-tool check → permission gate → `argsSchema.safeParse` → execute → ledger finish/fail → truncate. All four failure codes (`unknown_tool`, `permission_denied`, `invalid_args`, `tool_error`) return `{ content: "Error (<code>): <message>", isError: true }` — **nothing throws**. `TOOL_RESULT_MAX_CHARS = 16_000` truncation with a visible `[truncated N chars]` notice on both success and error content. Plus `toLlmToolDefinition()` (Tool → JSON Schema for the API `tools:` param) with a `{}` fallback when `z.toJSONSchema` can't represent the schema.
- **`src/lib/agent-loop.ts` cutover (Task 4)** — R2's private placeholder copies (`executeToolUseBlock`/`toLlmToolDefinition`/`truncate`) deleted; the loop now imports from `./tools/orchestrator` and re-exports `ToolExecutionResult`. **Parity proof: `tests/agent-loop.test.ts` passes with zero edits (15/15).**
- `harness.ts`, `tools/types.ts`, `tools/registry.ts` untouched, per plan.

## Plan deviation (1, test mechanics only)

The plan locked `vi.spyOn(z, "toJSONSchema")` for the fallback test, but that's impossible under vitest ESM (module namespaces aren't configurable). Replaced with a `z.bigint()` argsSchema — `z.toJSONSchema` deterministically throws `"BigInt cannot be represented in JSON Schema"` — which exercises the real catch branch with no mocking. Verified empirically before swapping.

## Gates

- Full suite: **310 passed / 78 pre-existing failed / 1 todo** (baseline 301/78; +9 = the new orchestrator tests, zero new failures — the 78 are the known better-sqlite3 CLI suites)
- `npx tsc --noEmit` clean; `npm run lint` = pre-existing embed.ts warning only; `npm run build` green (all routes present)
- Live chat probe (openai override; anthropic billing-blocked): `POST /api/agent` → run 2 **succeeded**, 2 steps (`search_memory` → final), `/runs/2` renders, `tool_calls` row `succeeded` through the new `executeTool` path

## Test plan

- `npx vitest run tests/tool-orchestrator.test.ts` — 9/9 (happy path, oversized-success truncation, all four failure codes via `.resolves`, oversized-error truncation, JSON-Schema export, `{}` fallback)
- `npx vitest run tests/agent-loop.test.ts` — 15/15 unchanged (parity proof)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts the R2 tool-execution logic from `agent-loop.ts` into a dedicated `src/lib/tools/orchestrator.ts` module, making `executeTool()` the single, authoritative path for every tool call. `agent-loop.ts` is updated to import from the new module and re-export `ToolExecutionResult` for backward compatibility, and the private `truncate` helper is refactored to return a `string` rather than a full result object.

- **New `orchestrator.ts`**: ledger rows open unconditionally before any validation so all four error codes (`unknown_tool`, `permission_denied`, `invalid_args`, `tool_error`) are ledger-visible; `TOOL_RESULT_MAX_CHARS = 16 000` truncation applied uniformly to both success and error content; `toLlmToolDefinition()` with a `{}` fallback when `z.toJSONSchema` can't represent the schema.
- **`agent-loop.ts` cutover**: all private placeholder copies deleted; the loop now delegates entirely to `orchestrator.ts`, with parity confirmed by the existing 15-test `agent-loop` suite passing unchanged.
- **New tests** (`tests/tool-orchestrator.test.ts`): 9 integration tests covering the happy path, all four failure codes, truncation on both success and error paths, JSON Schema export, and the `z.bigint()` fallback workaround for ESM mocking constraints.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one recommended ordering fix in the success path of executeTool to prevent ledger rows from being corrupted by a late-throwing JSON.stringify call.

The refactoring is clean and parity-tested against both the existing agent-loop suite and 9 new orchestrator tests. The one substantive concern is in the success path: finishToolCall and finishRunStep mark both rows 'succeeded' before JSON.stringify(result) is evaluated. A non-serializable tool result causes the catch block to overwrite those rows to 'failed', producing a misleading audit trail for a tool that actually completed. Moving the stringify call before the ledger writes (a one-line reorder) eliminates the inconsistency.

src/lib/tools/orchestrator.ts — the success branch ordering around JSON.stringify and ledger writes.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/tools/orchestrator.ts | New central choke point for tool execution: clean extraction from agent-loop with good ledger visibility for all failure modes; ledger ordering risk when JSON.stringify throws after records are already finalized as 'succeeded'. |
| src/lib/agent-loop.ts | Private executeToolUseBlock and helper functions removed; imports from orchestrator.ts; re-exports ToolExecutionResult for backward compatibility — a clean, minimal cutover with no behavioral change. |
| tests/tool-orchestrator.test.ts | 9 integration tests covering happy path, all four error codes, truncation on both success and error, JSON Schema export, and the bigint fallback; well-isolated with beforeEach table reset and closeDb afterAll. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant AL as agent-loop.ts
    participant ORC as orchestrator.ts (executeTool)
    participant LED as ledger.ts
    participant TOOL as Tool.execute()

    AL->>ORC: "executeTool({ toolUseId, name, input, ... })"
    ORC->>LED: "startRunStep({ stepKind:"tool", name, ... })"
    LED-->>ORC: "toolStep { id }"
    ORC->>LED: "startToolCall({ toolName, arguments, ... })"
    LED-->>ORC: "toolCall { id }"

    alt unknown tool
        ORC->>LED: failToolCall + failRunStep
        ORC-->>AL: "{ content:"Error (unknown_tool):…", isError:true }"
    else permission denied
        ORC->>LED: failToolCall + failRunStep
        ORC-->>AL: "{ content:"Error (permission_denied):…", isError:true }"
    else invalid args
        ORC->>LED: failToolCall + failRunStep
        ORC-->>AL: "{ content:"Error (invalid_args):…", isError:true }"
    else execute
        ORC->>TOOL: tool.execute(parsedData, ctx)
        TOOL-->>ORC: result
        ORC->>LED: finishToolCall(result)
        ORC->>LED: finishRunStep(result)
        ORC-->>AL: "{ content: truncate("Success: "+JSON.stringify(result)), isError:false }"
    else tool throws
        TOOL-->>ORC: throws Error
        ORC->>LED: failToolCall + failRunStep
        ORC-->>AL: "{ content:"Error (tool_error):…", isError:true }"
    end

    AL->>AL: push LlmToolResultBlock to messages[]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant AL as agent-loop.ts
    participant ORC as orchestrator.ts (executeTool)
    participant LED as ledger.ts
    participant TOOL as Tool.execute()

    AL->>ORC: "executeTool({ toolUseId, name, input, ... })"
    ORC->>LED: "startRunStep({ stepKind:"tool", name, ... })"
    LED-->>ORC: "toolStep { id }"
    ORC->>LED: "startToolCall({ toolName, arguments, ... })"
    LED-->>ORC: "toolCall { id }"

    alt unknown tool
        ORC->>LED: failToolCall + failRunStep
        ORC-->>AL: "{ content:"Error (unknown_tool):…", isError:true }"
    else permission denied
        ORC->>LED: failToolCall + failRunStep
        ORC-->>AL: "{ content:"Error (permission_denied):…", isError:true }"
    else invalid args
        ORC->>LED: failToolCall + failRunStep
        ORC-->>AL: "{ content:"Error (invalid_args):…", isError:true }"
    else execute
        ORC->>TOOL: tool.execute(parsedData, ctx)
        TOOL-->>ORC: result
        ORC->>LED: finishToolCall(result)
        ORC->>LED: finishRunStep(result)
        ORC-->>AL: "{ content: truncate("Success: "+JSON.stringify(result)), isError:false }"
    else tool throws
        TOOL-->>ORC: throws Error
        ORC->>LED: failToolCall + failRunStep
        ORC-->>AL: "{ content:"Error (tool_error):…", isError:true }"
    end

    AL->>AL: push LlmToolResultBlock to messages[]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["refactor(rt-R3): agent-loop.ts cuts over..."](https://github.com/fisherxz/sourcecado/commit/074bd3e629801e16fb80809701564615f2260f70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44328871)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->