### PR TITLE
feat(rt-R4): context assembly + two-layer memory contract

### DIFF
--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -1,0 +1,88 @@
+import type { Sql } from "./tools/types";
+import { DEFAULT_ACTOR, type MemoryActor } from "./memory/actor";
+import { listMemoryIndexRows } from "./memory/sources";
+
+export interface SystemPromptSection {
+  title: string;
+  body: string;
+}
+
+// Joins sections into one system-prompt string. Order matters — callers pass
+// sections in the order they want them to appear.
+export function buildSystemPrompt(sections: SystemPromptSection[]): string {
+  return sections.map((s) => `## ${s.title}\n${s.body}`).join("\n\n");
+}
+
+export const IDENTITY_SECTION: SystemPromptSection = {
+  title: "Identity",
+  body:
+    "You are a sourcing agent with access to team memory and tools. Decide when to search, when to answer directly, and when to record a finding.",
+};
+
+// Replaces the deleted MEMORY_INSTRUCTIONS four-section contract. Free-format:
+// no fixed section headers, no "call search_memory every turn."
+export const TOOL_USE_GUIDANCE_SECTION: SystemPromptSection = {
+  title: "Tool-Use Guidance",
+  body:
+    "Search memory when the index below isn't enough to answer confidently — you decide when that is. Whenever you cite memory, cite inline as `sourceId#chunk-N` (or `#row-N`); never invent a citation id. If memory doesn't cover something, say so plainly instead of guessing.",
+};
+
+const MEMORY_INDEX_MAX_CHARS = 4000;
+
+// Built once per run from a SQL query (title/date/kind for every permitted,
+// non-archived source, plus the last ~20 memory notes), rendered as capped
+// markdown. Truncates whole lines only, never mid-line.
+export async function buildMemoryIndexSection(
+  db: Sql,
+  actor: MemoryActor = DEFAULT_ACTOR
+): Promise<SystemPromptSection> {
+  const { sources, recentNotes } = await listMemoryIndexRows(db, actor);
+
+  const lines: string[] = [];
+  if (sources.length === 0) {
+    lines.push("No memory sources are indexed yet.");
+  } else {
+    lines.push("Sources:");
+    for (const s of sources) {
+      lines.push(
+        `- ${s.sourceId} (${s.sourceType}, updated ${s.updatedAt.slice(0, 10)}): ${s.title ?? "(untitled)"}`
+      );
+    }
+  }
+  if (recentNotes.length > 0) {
+    lines.push("", "Recent notes:");
+    for (const n of recentNotes) {
+      lines.push(`- ${n.sourceId} (updated ${n.updatedAt.slice(0, 10)}): ${n.title ?? "(untitled)"}`);
+    }
+  }
+
+  return { title: "Memory Index", body: capMemoryIndexLines(lines) };
+}
+
+function capMemoryIndexLines(lines: string[]): string {
+  let body = "";
+  let shown = 0;
+  for (const line of lines) {
+    const candidate = body ? `${body}\n${line}` : line;
+    if (candidate.length > MEMORY_INDEX_MAX_CHARS) break;
+    body = candidate;
+    shown++;
+  }
+  const omitted = lines.length - shown;
+  if (omitted > 0) {
+    body += `\n...(${omitted} more sources not shown)`;
+  }
+  return body;
+}
+
+// The memory-chat path's system-prompt composer: identity + tool-use
+// guidance + the injected memory index, in that order. Callers (e.g.
+// answerWithMemory) pass the returned string into runAgent()'s existing
+// per-run `instructions` slot.
+export async function buildMemoryAnswerInstructions(
+  db: Sql,
+  actor: MemoryActor = DEFAULT_ACTOR
+): Promise<string> {
+  const memoryIndex = await buildMemoryIndexSection(db, actor);
+  return buildSystemPrompt([IDENTITY_SECTION, TOOL_USE_GUIDANCE_SECTION, memoryIndex]);
+}

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -38,10 +38,13 @@ export async function buildMemoryIndexSection(
 ): Promise<SystemPromptSection> {
   const { sources, recentNotes } = await listMemoryIndexRows(db, actor);
 
+  // `sources` and `recentNotes` are disjoint (listMemoryIndexRows splits notes
+  // out), so each entry renders in exactly one section.
   const lines: string[] = [];
-  if (sources.length === 0) {
+  if (sources.length === 0 && recentNotes.length === 0) {
     lines.push("No memory sources are indexed yet.");
-  } else {
+  }
+  if (sources.length > 0) {
     lines.push("Sources:");
     for (const s of sources) {
       lines.push(
@@ -50,7 +53,8 @@ export async function buildMemoryIndexSection(
     }
   }
   if (recentNotes.length > 0) {
-    lines.push("", "Recent notes:");
+    if (lines.length > 0) lines.push("");
+    lines.push("Recent notes:");
     for (const n of recentNotes) {
       lines.push(`- ${n.sourceId} (updated ${n.updatedAt.slice(0, 10)}): ${n.title ?? "(untitled)"}`);
     }

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -19,7 +19,7 @@ export const IDENTITY_SECTION: SystemPromptSection = {
     "You are a sourcing agent with access to team memory and tools. Decide when to search, when to answer directly, and when to record a finding.",
 };
 
-// Replaces the deleted MEMORY_INSTRUCTIONS four-section contract. Free-format:
+// Replaces the deleted four-section memory-answer contract. Free-format:
 // no fixed section headers, no "call search_memory every turn."
 export const TOOL_USE_GUIDANCE_SECTION: SystemPromptSection = {
   title: "Tool-Use Guidance",

--- a/src/lib/memory/answer-config.ts
+++ b/src/lib/memory/answer-config.ts
@@ -2,35 +2,6 @@ import { createToolRegistry } from "../tools/registry";
 import type { ToolRegistry } from "../tools/registry";
 import { searchMemoryTool } from "../tools/search-memory";
 
-export const MEMORY_INSTRUCTIONS = `## Memory Answer Contract
-
-You are a memory-grounded sourcing assistant. Follow these rules strictly:
-
-1. **Call search_memory first — on every turn.** Before answering any question, call search_memory
-   to retrieve relevant sourcing memory. Never answer from prior training knowledge alone. On
-   follow-up turns in a conversation, call search_memory AGAIN before citing — never reuse a citation
-   from an earlier turn without re-retrieving it this turn (uncited prior-turn ids are dropped).
-
-2. **Four-section format.** Your final answer MUST use exactly these four sections in this order:
-   Answer: <direct answer to the question, citing sources>
-   Evidence: <the acceptedFacts and chunks that support the answer>
-   Gaps: <candidate, conflicted, or stale facts from gapFacts; if none, write "None">
-   Next Action: <what to do next based on memory gaps>
-
-3. **Strict citation grounding.** Only cite ids that appear in the search_memory result
-   (the citation fields of acceptedFacts, gapFacts, or chunks). NEVER invent a citation id.
-   Format citations inline as: sourceId#chunk-N or sourceId#row-N.
-
-4. **Fact-first, chunk-fallback.** Prefer acceptedFacts for the Answer and Evidence sections.
-   If acceptedFacts is empty, fall back to chunks.
-
-5. **Always surface gaps.** List candidate, conflicted, and stale facts from gapFacts in the
-   Gaps section. Do not omit them.
-
-6. **Refuse on empty.** If the search_memory result is entirely empty (no facts, no chunks),
-   reply with "no relevant memory" (when sources exist but nothing matched) or
-   "no indexed memory yet" (when memory is empty). This is a valid answer, not an error.`;
-
 export function memoryRegistry(): ToolRegistry {
   return createToolRegistry([searchMemoryTool]);
 }

--- a/src/lib/memory/answer.ts
+++ b/src/lib/memory/answer.ts
@@ -1,7 +1,9 @@
 import { runAgent, type AgentStepEvent, type ConversationTurn } from "@/lib/harness";
+import { buildMemoryAnswerInstructions } from "@/lib/context";
 import { getRunTrace } from "@/lib/ledger";
+import type { LlmMessage } from "@/lib/llm/types";
 import { verifyAnswerCitations } from "@/lib/memory/citations";
-import { memoryRegistry, MEMORY_INSTRUCTIONS } from "@/lib/memory/answer-config";
+import { memoryRegistry } from "@/lib/memory/answer-config";
 import type { Sql } from "@/lib/tools/types";
 
 export interface MemoryAnswer {
@@ -10,6 +12,9 @@ export interface MemoryAnswer {
   answer?: string;
   steps: number;
   invalidCitations: string[];
+  // The full transcript produced by this run (RunAgentResult.messages) —
+  // consumed by R6's chat-session persistence via the streaming route.
+  messages: LlmMessage[];
 }
 
 export interface AnswerWithMemoryInput {
@@ -25,12 +30,13 @@ export interface AnswerWithMemoryInput {
 // bad citation never reaches the client.
 export async function answerWithMemory(db: Sql, input: AnswerWithMemoryInput): Promise<MemoryAnswer> {
   const registry = memoryRegistry();
+  const instructions = await buildMemoryAnswerInstructions(db);
   const result = await runAgent({
     question: input.question,
     history: input.history,
     registry,
     allowedClasses: new Set(["read"]),
-    instructions: MEMORY_INSTRUCTIONS,
+    instructions,
     db,
     onStep: input.onStep,
   });
@@ -50,6 +56,7 @@ export async function answerWithMemory(db: Sql, input: AnswerWithMemoryInput): P
     answer,
     steps: result.steps,
     invalidCitations,
+    messages: result.messages,
   };
 }
 

--- a/src/lib/memory/citations.ts
+++ b/src/lib/memory/citations.ts
@@ -4,11 +4,18 @@ import type { MemoryBundle } from "./retrieve";
 const CITATION_PATTERN = "[A-Za-z0-9._/-]+#(?:chunk|row)-\\d+";
 
 /** Walk a run trace and collect every MemoryBundle from search_memory tool calls. */
-export function collectBundlesFromTrace(trace: RunTrace | null): MemoryBundle[] {
+export function collectBundlesFromTrace(
+  trace: RunTrace | null,
+  sinceStepId?: number
+): MemoryBundle[] {
   if (!trace) return [];
   const bundles: MemoryBundle[] = [];
   function walk(steps: RunStepTrace[]) {
     for (const step of steps) {
+      // Multi-turn chat sessions (R6) nest a fresh "agent" step per turn
+      // under the same run; step ids are assigned sequentially, so this
+      // scopes the walk to only steps created after the given turn boundary.
+      if (sinceStepId !== undefined && step.id <= sinceStepId) continue;
       for (const tc of step.toolCalls) {
         if (tc.toolName === "search_memory" && tc.status === "succeeded" && tc.result) {
           bundles.push(tc.result as MemoryBundle);
@@ -59,15 +66,24 @@ export function checkCitations(
 }
 
 /**
- * Full citation post-check pipeline: walk the trace → collect allowed citations
- * → strip any citation tokens the agent invented. Returns the sanitized answer
+ * Citation post-check pipeline, run check-on-use: walk the trace (scoped to
+ * steps after `sinceStepId` when given) → collect allowed citations → strip
+ * any citation tokens the agent invented. Turns with no in-scope
+ * search_memory call skip the check entirely. Returns the sanitized answer
  * and the list of invalid citation ids.
  */
 export function verifyAnswerCitations(
   trace: RunTrace | null,
-  answer: string
+  answer: string,
+  sinceStepId?: number
 ): { answer: string; invalidCitations: string[] } {
-  const bundles = collectBundlesFromTrace(trace);
+  const bundles = collectBundlesFromTrace(trace, sinceStepId);
+  // Check-on-use: only validate/strip citations on turns where
+  // search_memory was actually called in-scope. No bundles -> nothing to
+  // validate against, nothing to strip (leave the answer untouched).
+  if (bundles.length === 0) {
+    return { answer, invalidCitations: [] };
+  }
   const allowed = collectAllowedCitations(bundles);
   const { sanitizedAnswer, invalid } = checkCitations(answer, allowed);
   return { answer: sanitizedAnswer, invalidCitations: invalid };

--- a/src/lib/memory/sources.ts
+++ b/src/lib/memory/sources.ts
@@ -64,3 +64,47 @@ export async function setSourceArchived(
   if (!row) return null;
   return { sourceId: row.source_id, archived: row.archived_at != null };
 }
+
+export interface MemoryIndexRow {
+  sourceId: string;
+  title: string | null;
+  sourceType: string;
+  updatedAt: string;
+}
+
+export interface MemoryIndexRows {
+  sources: MemoryIndexRow[];
+  recentNotes: MemoryIndexRow[];
+}
+
+// Memory-index query for R4 context assembly (src/lib/context.ts): the
+// actor's permitted, non-archived sources (title/type/date), newest-updated
+// first, plus the subset that are memory notes capped to the last 20. Kept
+// here (not context.ts) — same DB-query-over-source_records concern as
+// listSources/setSourceArchived above.
+export async function listMemoryIndexRows(
+  db: Sql,
+  actor: MemoryActor = DEFAULT_ACTOR
+): Promise<MemoryIndexRows> {
+  const allowed = await resolveAllowedSourceIds(db, actor);
+  if (allowed.length === 0) return { sources: [], recentNotes: [] };
+
+  const rows = await db<
+    { source_id: string; title: string | null; source_type: string; updated_at: Date }[]
+  >`
+    SELECT source_id, title, source_type, updated_at
+    FROM source_records
+    WHERE source_id = ANY(${allowed})
+    ORDER BY updated_at DESC
+  `;
+
+  const sources: MemoryIndexRow[] = rows.map((r) => ({
+    sourceId: r.source_id,
+    title: r.title,
+    sourceType: r.source_type,
+    updatedAt: r.updated_at.toISOString(),
+  }));
+  const recentNotes = sources.filter((s) => s.sourceType === "note").slice(0, 20);
+
+  return { sources, recentNotes };
+}

--- a/src/lib/memory/sources.ts
+++ b/src/lib/memory/sources.ts
@@ -79,9 +79,10 @@ export interface MemoryIndexRows {
 
 // Memory-index query for R4 context assembly (src/lib/context.ts): the
 // actor's permitted, non-archived sources (title/type/date), newest-updated
-// first, plus the subset that are memory notes capped to the last 20. Kept
-// here (not context.ts) — same DB-query-over-source_records concern as
-// listSources/setSourceArchived above.
+// first, split into two DISJOINT lists — non-note `sources` and memory `notes`
+// (capped to the last 20). Disjoint so context.ts can render them as separate
+// sections without listing a note in both. Kept here (not context.ts) — same
+// DB-query-over-source_records concern as listSources/setSourceArchived above.
 export async function listMemoryIndexRows(
   db: Sql,
   actor: MemoryActor = DEFAULT_ACTOR
@@ -98,13 +99,14 @@ export async function listMemoryIndexRows(
     ORDER BY updated_at DESC
   `;
 
-  const sources: MemoryIndexRow[] = rows.map((r) => ({
+  const all: MemoryIndexRow[] = rows.map((r) => ({
     sourceId: r.source_id,
     title: r.title,
     sourceType: r.source_type,
     updatedAt: r.updated_at.toISOString(),
   }));
-  const recentNotes = sources.filter((s) => s.sourceType === "note").slice(0, 20);
+  const recentNotes = all.filter((s) => s.sourceType === "note").slice(0, 20);
+  const sources = all.filter((s) => s.sourceType !== "note");
 
   return { sources, recentNotes };
 }

--- a/tests/agent-route-history.test.ts
+++ b/tests/agent-route-history.test.ts
@@ -7,6 +7,9 @@ const { runAgentMock, getRunTraceMock } = vi.hoisted(() => ({
 vi.mock("@/lib/harness", () => ({ runAgent: runAgentMock }));
 vi.mock("@/lib/ledger", () => ({ getRunTrace: getRunTraceMock }));
 vi.mock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue({}) }));
+vi.mock("@/lib/context", () => ({
+  buildMemoryAnswerInstructions: vi.fn().mockResolvedValue("stub instructions"),
+}));
 
 import { POST } from "@/app/api/agent/route";
 

--- a/tests/agent-route.test.ts
+++ b/tests/agent-route.test.ts
@@ -7,6 +7,9 @@ const { runAgentMock, getRunTraceMock } = vi.hoisted(() => ({
 vi.mock("@/lib/harness", () => ({ runAgent: runAgentMock }));
 vi.mock("@/lib/ledger", () => ({ getRunTrace: getRunTraceMock }));
 vi.mock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue({}) }));
+vi.mock("@/lib/context", () => ({
+  buildMemoryAnswerInstructions: vi.fn().mockResolvedValue("stub instructions"),
+}));
 
 import { POST } from "@/app/api/agent/route";
 

--- a/tests/agent-stream-route.test.ts
+++ b/tests/agent-stream-route.test.ts
@@ -7,6 +7,9 @@ const { runAgentMock, getRunTraceMock } = vi.hoisted(() => ({
 vi.mock("@/lib/harness", () => ({ runAgent: runAgentMock }));
 vi.mock("@/lib/ledger", () => ({ getRunTrace: getRunTraceMock }));
 vi.mock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue({}) }));
+vi.mock("@/lib/context", () => ({
+  buildMemoryAnswerInstructions: vi.fn().mockResolvedValue("stub instructions"),
+}));
 
 import { POST } from "@/app/api/agent/stream/route";
 

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -24,11 +24,11 @@ async function resetMemoryTables(): Promise<void> {
 
 async function insertSourceRow(
   db: ReturnType<typeof getDb>,
-  opts: { sourceId: string; title: string }
+  opts: { sourceId: string; title: string; sourceType?: string }
 ): Promise<void> {
   await db`
     INSERT INTO source_records (source_id, path, title, source_type, content_hash, raw_text)
-    VALUES (${opts.sourceId}, ${"/test/" + opts.sourceId}, ${opts.title}, 'markdown', ${"hash-" + opts.sourceId}, '')
+    VALUES (${opts.sourceId}, ${"/test/" + opts.sourceId}, ${opts.title}, ${opts.sourceType ?? "markdown"}, ${"hash-" + opts.sourceId}, '')
   `;
   await db`
     INSERT INTO source_permissions (principal_type, principal_id, source_id, access)
@@ -88,6 +88,35 @@ describe("buildMemoryIndexSection (postgres)", () => {
     expect(section.body).toContain("acme");
     expect(section.body).toContain("Acme");
     expect(section.body).toContain("markdown");
+  });
+
+  it("lists a note only once — under 'Recent notes:', not also under 'Sources:'", async () => {
+    const db = getDb();
+    await insertSourceRow(db, { sourceId: "doc-1", title: "Doc One", sourceType: "markdown" });
+    await insertSourceRow(db, { sourceId: "note-1", title: "Note One", sourceType: "note" });
+    const section = await buildMemoryIndexSection(db, DEFAULT_ACTOR);
+
+    // The note id must appear exactly once in the whole body.
+    const occurrences = section.body.split("note-1").length - 1;
+    expect(occurrences).toBe(1);
+    // Non-note source lives under Sources:, the note under Recent notes:.
+    const sourcesIdx = section.body.indexOf("Sources:");
+    const notesIdx = section.body.indexOf("Recent notes:");
+    expect(sourcesIdx).toBeGreaterThanOrEqual(0);
+    expect(notesIdx).toBeGreaterThan(sourcesIdx);
+    expect(section.body.slice(sourcesIdx, notesIdx)).toContain("doc-1");
+    expect(section.body.slice(sourcesIdx, notesIdx)).not.toContain("note-1");
+    expect(section.body.slice(notesIdx)).toContain("note-1");
+  });
+
+  it("renders a note-only workspace under 'Recent notes:' with no empty 'Sources:' header", async () => {
+    const db = getDb();
+    await insertSourceRow(db, { sourceId: "note-only", title: "Solo Note", sourceType: "note" });
+    const section = await buildMemoryIndexSection(db, DEFAULT_ACTOR);
+    expect(section.body).toContain("Recent notes:");
+    expect(section.body).toContain("note-only");
+    expect(section.body).not.toContain("Sources:");
+    expect(section.body).not.toContain("No memory sources are indexed yet.");
   });
 
   it("caps the rendered body and appends an overflow notice when too many sources are indexed", async () => {

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+import { DEFAULT_ACTOR } from "@/lib/memory/actor";
+import {
+  buildSystemPrompt,
+  buildMemoryIndexSection,
+  buildMemoryAnswerInstructions,
+  IDENTITY_SECTION,
+  TOOL_USE_GUIDANCE_SECTION,
+  type SystemPromptSection,
+} from "@/lib/context";
+
+async function resetMemoryTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS source_permissions CASCADE`;
+  await db`DROP TABLE IF EXISTS extraction_runs CASCADE`;
+  await db`DROP TABLE IF EXISTS semantic_facts CASCADE`;
+  await db`DROP TABLE IF EXISTS memory_chunks CASCADE`;
+  await db`DROP TABLE IF EXISTS source_records CASCADE`;
+  await db`DROP TABLE IF EXISTS schema_migrations CASCADE`;
+  await runMigrations(db);
+}
+
+async function insertSourceRow(
+  db: ReturnType<typeof getDb>,
+  opts: { sourceId: string; title: string }
+): Promise<void> {
+  await db`
+    INSERT INTO source_records (source_id, path, title, source_type, content_hash, raw_text)
+    VALUES (${opts.sourceId}, ${"/test/" + opts.sourceId}, ${opts.title}, 'markdown', ${"hash-" + opts.sourceId}, '')
+  `;
+  await db`
+    INSERT INTO source_permissions (principal_type, principal_id, source_id, access)
+    VALUES (${DEFAULT_ACTOR.actorType}, ${DEFAULT_ACTOR.actorId}, ${opts.sourceId}, 'read')
+  `;
+}
+
+describe("buildSystemPrompt", () => {
+  it("joins sections as '## Title\\nBody' separated by blank lines, in order", () => {
+    const sections: SystemPromptSection[] = [
+      { title: "One", body: "first" },
+      { title: "Two", body: "second" },
+    ];
+    const prompt = buildSystemPrompt(sections);
+    expect(prompt).toBe("## One\nfirst\n\n## Two\nsecond");
+  });
+
+  it("returns an empty string for an empty section list", () => {
+    expect(buildSystemPrompt([])).toBe("");
+  });
+});
+
+describe("fixed sections", () => {
+  it("IDENTITY_SECTION and TOOL_USE_GUIDANCE_SECTION carry no fixed four-section format language", () => {
+    expect(IDENTITY_SECTION.title).toBe("Identity");
+    expect(TOOL_USE_GUIDANCE_SECTION.body).not.toMatch(/Answer:|Evidence:|Gaps:|Next Action:/);
+    expect(TOOL_USE_GUIDANCE_SECTION.body).toMatch(/sourceId#chunk-N/);
+  });
+});
+
+describe("buildMemoryIndexSection (postgres)", () => {
+  let savedApiKey: string | undefined;
+
+  beforeEach(async () => {
+    savedApiKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    await resetMemoryTables();
+  });
+
+  afterEach(async () => {
+    if (savedApiKey !== undefined) process.env.OPENAI_API_KEY = savedApiKey;
+    else delete process.env.OPENAI_API_KEY;
+    await closeDb();
+  });
+
+  it("renders a 'No memory sources are indexed yet.' body when nothing is indexed", async () => {
+    const db = getDb();
+    const section = await buildMemoryIndexSection(db, DEFAULT_ACTOR);
+    expect(section.title).toBe("Memory Index");
+    expect(section.body).toContain("No memory sources are indexed yet.");
+  });
+
+  it("lists permitted sources with title/type/date", async () => {
+    const db = getDb();
+    await insertSourceRow(db, { sourceId: "acme", title: "Acme" });
+    const section = await buildMemoryIndexSection(db, DEFAULT_ACTOR);
+    expect(section.body).toContain("acme");
+    expect(section.body).toContain("Acme");
+    expect(section.body).toContain("markdown");
+  });
+
+  it("caps the rendered body and appends an overflow notice when too many sources are indexed", async () => {
+    const db = getDb();
+    const longTitle = "X".repeat(80);
+    for (let i = 0; i < 150; i++) {
+      await insertSourceRow(db, { sourceId: `src-${i}`, title: longTitle });
+    }
+    const section = await buildMemoryIndexSection(db, DEFAULT_ACTOR);
+    expect(section.body).toMatch(/\.\.\.\(\d+ more sources not shown\)/);
+    // Cap check: strip the overflow-notice line before measuring — the
+    // capped list content itself must not exceed 4000 chars.
+    const withoutNotice = section.body.replace(/\n\.\.\.\(\d+ more sources not shown\)$/, "");
+    expect(withoutNotice.length).toBeLessThanOrEqual(4000);
+  });
+});
+
+describe("buildMemoryAnswerInstructions (postgres)", () => {
+  beforeEach(async () => {
+    delete process.env.OPENAI_API_KEY;
+    await resetMemoryTables();
+  });
+
+  afterEach(async () => {
+    await closeDb();
+  });
+
+  it("composes identity + tool-use guidance + memory index, in that order", async () => {
+    const db = getDb();
+    const instructions = await buildMemoryAnswerInstructions(db, DEFAULT_ACTOR);
+    const identityIdx = instructions.indexOf("## Identity");
+    const guidanceIdx = instructions.indexOf("## Tool-Use Guidance");
+    const indexIdx = instructions.indexOf("## Memory Index");
+    expect(identityIdx).toBeGreaterThanOrEqual(0);
+    expect(guidanceIdx).toBeGreaterThan(identityIdx);
+    expect(indexIdx).toBeGreaterThan(guidanceIdx);
+  });
+});

--- a/tests/harness-multiturn.test.ts
+++ b/tests/harness-multiturn.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from "vitest";
 import { conversationTurnsToMessages } from "@/lib/harness";
-import { MEMORY_INSTRUCTIONS } from "@/lib/memory/answer-config";
 
 describe("conversationTurnsToMessages — multi-turn history", () => {
   it("maps user/assistant turns to LlmMessage in order", () => {
@@ -38,11 +37,5 @@ describe("conversationTurnsToMessages — multi-turn history", () => {
     if (message.role === "user") {
       expect(message.content.length).toBeLessThan(huge.length);
     }
-  });
-});
-
-describe("MEMORY_INSTRUCTIONS — multi-turn citation safety (N3)", () => {
-  it("requires calling search_memory every turn so prior-turn citations are not scrubbed", () => {
-    expect(MEMORY_INSTRUCTIONS).toMatch(/every turn|each turn|follow-up/i);
   });
 });

--- a/tests/memory-answer.test.ts
+++ b/tests/memory-answer.test.ts
@@ -3,7 +3,7 @@ import { getRunTrace } from "@/lib/ledger";
 import { runMigrations } from "@/lib/migrate";
 import type { LlmAdapter, LlmStreamEvent } from "@/lib/llm/types";
 import { runAgent } from "@/lib/harness";
-import { collectAllowedCitations, checkCitations, collectBundlesFromTrace } from "@/lib/memory/citations";
+import { collectAllowedCitations, checkCitations, collectBundlesFromTrace, verifyAnswerCitations } from "@/lib/memory/citations";
 import { memoryRegistry } from "@/lib/memory/answer-config";
 import { DEFAULT_ACTOR, type MemoryActor } from "@/lib/memory/actor";
 import { embedText, toVectorLiteral } from "@/lib/memory/embed";
@@ -206,6 +206,106 @@ describe("checkCitations", () => {
     const { invalid } = checkCitations(answer, allowed);
     // "outreach-md#chunk-1" is not in allowed — should be flagged
     expect(invalid).toContain("outreach-md#chunk-1");
+  });
+});
+
+describe("verifyAnswerCitations — check-on-use per turn", () => {
+  function fakeTrace(steps: Array<{ id: number; bundle?: MemoryBundle }>): import("@/lib/ledger").RunTrace {
+    return {
+      id: 1,
+      runType: "agent_chat",
+      status: "succeeded",
+      title: null,
+      input: null,
+      output: null,
+      metadata: null,
+      errorType: null,
+      errorMessage: null,
+      error: null,
+      startedAt: new Date(),
+      completedAt: null,
+      createdAt: new Date(),
+      steps: steps.map((s) => ({
+        id: s.id,
+        runId: 1,
+        parentStepId: null,
+        stepKind: "tool",
+        name: "search_memory",
+        status: "succeeded",
+        input: null,
+        output: null,
+        metadata: null,
+        errorType: null,
+        errorMessage: null,
+        error: null,
+        startedAt: new Date(),
+        completedAt: null,
+        createdAt: new Date(),
+        children: [],
+        modelCalls: [],
+        toolCalls: s.bundle
+          ? [
+              {
+                id: s.id,
+                runId: 1,
+                runStepId: s.id,
+                toolName: "search_memory",
+                status: "succeeded",
+                arguments: null,
+                result: s.bundle,
+                metadata: null,
+                errorType: null,
+                errorMessage: null,
+                startedAt: new Date(),
+                completedAt: null,
+                createdAt: new Date(),
+              },
+            ]
+          : [],
+      })),
+    } as unknown as import("@/lib/ledger").RunTrace;
+  }
+
+  const bundleWithCitation = (citation: string): MemoryBundle => ({
+    intent: "generic",
+    acceptedFacts: [],
+    gapFacts: [],
+    chunks: [{ text: "t", citation, score: 0.9 }],
+  });
+
+  it("skips the check (answer untouched) when no search_memory call is in scope", () => {
+    const trace = fakeTrace([]); // no steps at all this turn
+    const answer = "Made-up cite ghost#chunk-1 with nothing to validate against.";
+    const { answer: result, invalidCitations } = verifyAnswerCitations(trace, answer);
+    expect(result).toBe(answer); // unchanged, not stripped
+    expect(invalidCitations).toHaveLength(0);
+  });
+
+  it("runs the check when a search_memory call is in scope, stripping invented citations", () => {
+    const trace = fakeTrace([{ id: 1, bundle: bundleWithCitation("real#chunk-1") }]);
+    const answer = "See real#chunk-1 and ghost#chunk-9.";
+    const { answer: result, invalidCitations } = verifyAnswerCitations(trace, answer);
+    expect(result).toContain("real#chunk-1");
+    expect(result).toContain("[unverified citation removed]");
+    expect(invalidCitations).toContain("ghost#chunk-9");
+  });
+
+  it("sinceStepId excludes an earlier turn's search_memory bundle from this turn's allow-list", () => {
+    const trace = fakeTrace([
+      { id: 1, bundle: bundleWithCitation("turn1#chunk-1") }, // earlier turn
+      { id: 5, bundle: bundleWithCitation("turn2#chunk-1") }, // this turn
+    ]);
+    const answer = "turn1#chunk-1 turn2#chunk-1";
+    const { invalidCitations } = verifyAnswerCitations(trace, answer, 3);
+    // turn1's citation is out of scope (step id 1 <= sinceStepId 3) -> invalid.
+    expect(invalidCitations).toContain("turn1#chunk-1");
+    expect(invalidCitations).not.toContain("turn2#chunk-1");
+  });
+
+  it("returns unchanged answer for a null trace", () => {
+    const { answer, invalidCitations } = verifyAnswerCitations(null, "no trace here");
+    expect(answer).toBe("no trace here");
+    expect(invalidCitations).toHaveLength(0);
   });
 });
 

--- a/tests/memory-sources.test.ts
+++ b/tests/memory-sources.test.ts
@@ -4,7 +4,7 @@ import { runMigrations } from "@/lib/migrate";
 import { DEFAULT_ACTOR } from "@/lib/memory/actor";
 import { ingestFiles } from "@/lib/memory/ingest";
 import { searchMemory } from "@/lib/memory/retrieve";
-import { listSources, setSourceArchived } from "@/lib/memory/sources";
+import { listMemoryIndexRows, listSources, setSourceArchived } from "@/lib/memory/sources";
 
 function bytes(text: string): Uint8Array {
   return new TextEncoder().encode(text);
@@ -78,5 +78,90 @@ describe("memory sources management (list + archive)", () => {
     await ingestFiles(db, [{ name: "acme.md", bytes: bytes("# Acme\n\nAcme.") }]);
     const res = await setSourceArchived(db, { sourceId: "no-such-source", archived: true });
     expect(res).toBeNull();
+  });
+});
+
+describe("listMemoryIndexRows", () => {
+  let savedApiKey: string | undefined;
+
+  beforeEach(async () => {
+    savedApiKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    await resetMemoryTables();
+  });
+
+  afterEach(async () => {
+    if (savedApiKey !== undefined) process.env.OPENAI_API_KEY = savedApiKey;
+    else delete process.env.OPENAI_API_KEY;
+    await closeDb();
+  });
+
+  async function insertSourceRow(
+    db: ReturnType<typeof getDb>,
+    opts: { sourceId: string; title: string; sourceType: string; updatedAt?: string }
+  ): Promise<void> {
+    await db`
+      INSERT INTO source_records (source_id, path, title, source_type, content_hash, raw_text, updated_at)
+      VALUES (
+        ${opts.sourceId}, ${"/test/" + opts.sourceId}, ${opts.title}, ${opts.sourceType},
+        ${"hash-" + opts.sourceId}, '', ${opts.updatedAt ? new Date(opts.updatedAt) : new Date()}
+      )
+    `;
+  }
+
+  async function grantRead(db: ReturnType<typeof getDb>, sourceId: string): Promise<void> {
+    await db`
+      INSERT INTO source_permissions (principal_type, principal_id, source_id, access)
+      VALUES (${DEFAULT_ACTOR.actorType}, ${DEFAULT_ACTOR.actorId}, ${sourceId}, 'read')
+    `;
+  }
+
+  it("returns only permitted, non-archived sources with title/type/date", async () => {
+    const db = getDb();
+    await insertSourceRow(db, { sourceId: "a", title: "Alpha", sourceType: "markdown" });
+    await insertSourceRow(db, { sourceId: "b", title: "Beta", sourceType: "csv" });
+    await grantRead(db, "a");
+    // "b" is never granted -> must not appear.
+
+    const { sources, recentNotes } = await listMemoryIndexRows(db, DEFAULT_ACTOR);
+    expect(sources).toHaveLength(1);
+    expect(sources[0]).toMatchObject({ sourceId: "a", title: "Alpha", sourceType: "markdown" });
+    expect(recentNotes).toHaveLength(0);
+  });
+
+  it("excludes archived sources", async () => {
+    const db = getDb();
+    await insertSourceRow(db, { sourceId: "arch", title: "Archived", sourceType: "markdown" });
+    await grantRead(db, "arch");
+    await db`UPDATE source_records SET archived_at = now() WHERE source_id = 'arch'`;
+
+    const { sources } = await listMemoryIndexRows(db, DEFAULT_ACTOR);
+    expect(sources).toHaveLength(0);
+  });
+
+  it("caps recentNotes to the 20 most-recently-updated note rows", async () => {
+    const db = getDb();
+    for (let i = 0; i < 25; i++) {
+      const sourceId = `note-${i}`;
+      await insertSourceRow(db, {
+        sourceId,
+        title: `Note ${i}`,
+        sourceType: "note",
+        updatedAt: new Date(Date.now() - (25 - i) * 1000).toISOString(),
+      });
+      await grantRead(db, sourceId);
+    }
+
+    const { recentNotes } = await listMemoryIndexRows(db, DEFAULT_ACTOR);
+    expect(recentNotes).toHaveLength(20);
+    // Most recently updated (note-24, inserted with the latest timestamp) is first.
+    expect(recentNotes[0].sourceId).toBe("note-24");
+  });
+
+  it("returns empty lists when the actor has no permitted sources", async () => {
+    const db = getDb();
+    const { sources, recentNotes } = await listMemoryIndexRows(db, DEFAULT_ACTOR);
+    expect(sources).toEqual([]);
+    expect(recentNotes).toEqual([]);
   });
 });

--- a/tests/memory-sources.test.ts
+++ b/tests/memory-sources.test.ts
@@ -158,6 +158,19 @@ describe("listMemoryIndexRows", () => {
     expect(recentNotes[0].sourceId).toBe("note-24");
   });
 
+  it("splits notes out of sources — the two lists are disjoint", async () => {
+    const db = getDb();
+    await insertSourceRow(db, { sourceId: "doc", title: "Doc", sourceType: "markdown" });
+    await insertSourceRow(db, { sourceId: "note", title: "Note", sourceType: "note" });
+    await grantRead(db, "doc");
+    await grantRead(db, "note");
+
+    const { sources, recentNotes } = await listMemoryIndexRows(db, DEFAULT_ACTOR);
+    expect(sources.map((s) => s.sourceId)).toEqual(["doc"]);
+    expect(recentNotes.map((s) => s.sourceId)).toEqual(["note"]);
+    expect(sources.some((s) => s.sourceType === "note")).toBe(false);
+  });
+
   it("returns empty lists when the actor has no permitted sources", async () => {
     const db = getDb();
     const { sources, recentNotes } = await listMemoryIndexRows(db, DEFAULT_ACTOR);


### PR DESCRIPTION
## Summary

R4 slice of the runtime-solidification sprint (plan: `docs/superpowers/plans/2026-07-14-r4-context-memory-plan.md`). Replaces the rigid `MEMORY_INSTRUCTIONS` four-section prose contract with a sectioned system prompt built by the new `src/lib/context.ts`, and makes the citation post-check check-on-use per turn.

- **`src/lib/memory/sources.ts`**: new `listMemoryIndexRows` — permitted, non-archived sources (title/type/date, newest-updated first) plus the last 20 memory notes, via the existing `resolveAllowedSourceIds` chokepoint.
- **`src/lib/context.ts` (new)**: `buildSystemPrompt` section joiner, fixed `IDENTITY_SECTION` + free-format `TOOL_USE_GUIDANCE_SECTION` (no four-section format, no "search every turn"), `buildMemoryIndexSection` (4,000-char cap, whole-line truncation + overflow notice), and `buildMemoryAnswerInstructions` composer.
- **`src/lib/memory/citations.ts`**: `collectBundlesFromTrace`/`verifyAnswerCitations` gain an optional `sinceStepId` turn-scoping param; when no in-scope `search_memory` call produced bundles, the answer passes through untouched (check-on-use).
- **`src/lib/memory/answer.ts`**: wired to `buildMemoryAnswerInstructions(db)`; `MemoryAnswer` gains additive `messages: LlmMessage[]` (for R6 session persistence).
- **`src/lib/memory/answer-config.ts`**: `MEMORY_INSTRUCTIONS` deleted (zero references remain in `src/`/`tests/`); `memoryRegistry()` stays.
- Route tests (`agent-route`, `agent-route-history`, `agent-stream-route`) mock `@/lib/context` per the plan's eng-review must-fix; stale `MEMORY_INSTRUCTIONS` block removed from `tests/harness-multiturn.test.ts`.

**Plan deviation (1, trivial):** the plan's own `context.ts` comment contained the literal `MEMORY_INSTRUCTIONS`, contradicting its zero-match grep verify step — reworded so the mechanical check stays meaningful.

## Gates

- Full suite: **324 passed / 78 pre-existing failed / 1 todo** (baseline 310/78/1; +14 net = 15 new tests − 1 deleted stale test; **zero new failures** — all 78 are the legacy better-sqlite3 suites)
- `npx tsc --noEmit`: clean
- `npm run lint`: pre-existing `embed.ts` warning only
- `npm run build`: green, all routes present
- Live probe (openai override): seeded a note, asked `/api/agent` about it → run 3 **succeeded**, 2 steps (`search_memory` → final), valid citation, zero invalid; system prompt renders `## Identity` / `## Tool-Use Guidance` / `## Memory Index` with the note listed; `/runs/3` renders; `tool_calls` ledger row `succeeded`.

## Out of scope (per plan)

- `harness.ts` / `agent-loop.ts` / `tools/orchestrator.ts` / `llm/*` untouched (R1–R3 owned); pgvector engine untouched.
- `sinceStepId` has no production caller yet — R6 threads it when multi-turn sessions land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the rigid four-section `MEMORY_INSTRUCTIONS` prose contract with a structured system prompt built by `src/lib/context.ts`, introduces per-turn citation scoping (`sinceStepId`) in the citation pipeline, and adds `listMemoryIndexRows` to power the new memory index section. The overall architecture is well-structured and the test coverage is thorough, but two behavioural issues need resolution before merging.

- **Notes duplicated in rendered memory index**: `buildMemoryIndexSection` iterates `sources` (all types, including notes) and then iterates `recentNotes` (a filtered subset of those same notes), so every note source appears twice in the LLM's system prompt.
- **Check-on-use bypass passes fabricated citations**: the new `bundles.length === 0` early-return in `verifyAnswerCitations` passes the answer through unmodified when `search_memory` was not called this turn.
- **`sinceStepId` prunes child steps of excluded parents**: the `continue` in the walk loop also skips `walk(step.children)`, silently dropping children of pruned steps even if their own ids exceed the boundary.

<h3>Confidence Score: 3/5</h3>

Two defects in the changed code — note duplication in the rendered system prompt and fabricated citations reaching clients when search is skipped — need fixes before this is safe to ship.

The note-duplication bug causes every note source to appear twice in every agent system prompt, silently wasting context budget and potentially confusing the LLM. The check-on-use change removes a hard safety guarantee: previously all citation-pattern tokens were stripped when no search was performed; now they pass through, so a hallucinated sourceId#chunk-N can reach the client unchanged if the agent skips search_memory. The rest of the PR is well-executed and clean.

src/lib/context.ts (buildMemoryIndexSection note duplication) and src/lib/memory/citations.ts (check-on-use bypass) need the most attention before merging.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/context.ts | New context assembly module: buildMemoryIndexSection renders both sources (all types) and recentNotes (note subset), causing every note to appear twice in the rendered index. Cap logic and section ordering are otherwise correct. |
| src/lib/memory/citations.ts | Check-on-use bypass introduced: when bundles.length === 0, fabricated citation tokens pass through unstripped. The sinceStepId pruning also silently skips children of excluded parent steps. |
| src/lib/memory/sources.ts | New listMemoryIndexRows query correctly uses the resolveAllowedSourceIds chokepoint, sorts newest-first, and caps notes at 20 via JS-side filter. |
| src/lib/memory/answer.ts | Wired to buildMemoryAnswerInstructions; adds messages: LlmMessage[] to MemoryAnswer for R6 session persistence. Change is clean and minimal. |
| src/lib/memory/answer-config.ts | MEMORY_INSTRUCTIONS deleted; memoryRegistry() retained. Zero remaining references confirmed by tests. |
| tests/context.test.ts | Good coverage of cap logic and section ordering, but no test seeds both note and non-note sources to catch the duplication in the combined render. |
| tests/memory-answer.test.ts | New verifyAnswerCitations unit tests are thorough and explicitly cover the check-on-use, sinceStepId scoping, and null-trace paths. |
| tests/memory-sources.test.ts | Added listMemoryIndexRows integration tests covering permissions, archiving, notes cap, and empty actor — comprehensive and well-structured. |
| tests/agent-route.test.ts | Adds vi.mock('@/lib/context') to prevent the async DB context call from running in unit tests; correct and minimal. |
| tests/agent-route-history.test.ts | Same mock pattern as agent-route.test.ts; correctly isolates context assembly. |
| tests/agent-stream-route.test.ts | Same mock pattern; no issues. |
| tests/harness-multiturn.test.ts | Stale MEMORY_INSTRUCTIONS import and the N3 test that enforced every-turn search were correctly removed alongside the deleted export. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Route as API Route
    participant Answer as answerWithMemory
    participant Context as buildMemoryAnswerInstructions
    participant Sources as listMemoryIndexRows
    participant Harness as runAgent
    participant Citations as verifyAnswerCitations
    participant Bundles as collectBundlesFromTrace

    Route->>Answer: "POST /api/agent {question}"
    Answer->>Context: buildMemoryAnswerInstructions(db)
    Context->>Sources: listMemoryIndexRows(db, actor)
    Sources-->>Context: "{sources[], recentNotes[]}"
    Context-->>Answer: system prompt string
    Answer->>Harness: "runAgent({question, instructions, registry})"
    Harness-->>Answer: "{runId, answer, steps, messages}"
    Answer->>Citations: verifyAnswerCitations(trace, answer, sinceStepId?)
    Citations->>Bundles: collectBundlesFromTrace(trace, sinceStepId?)
    Bundles-->>Citations: MemoryBundle[]
    alt "bundles.length === 0"
        Citations-->>Answer: "answer unchanged, invalidCitations=[]"
    else bundles found
        Citations-->>Answer: sanitized answer, invalidCitations
    end
    Answer-->>Route: "MemoryAnswer {runId, answer, invalidCitations, messages}"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Route as API Route
    participant Answer as answerWithMemory
    participant Context as buildMemoryAnswerInstructions
    participant Sources as listMemoryIndexRows
    participant Harness as runAgent
    participant Citations as verifyAnswerCitations
    participant Bundles as collectBundlesFromTrace

    Route->>Answer: "POST /api/agent {question}"
    Answer->>Context: buildMemoryAnswerInstructions(db)
    Context->>Sources: listMemoryIndexRows(db, actor)
    Sources-->>Context: "{sources[], recentNotes[]}"
    Context-->>Answer: system prompt string
    Answer->>Harness: "runAgent({question, instructions, registry})"
    Harness-->>Answer: "{runId, answer, steps, messages}"
    Answer->>Citations: verifyAnswerCitations(trace, answer, sinceStepId?)
    Citations->>Bundles: collectBundlesFromTrace(trace, sinceStepId?)
    Bundles-->>Citations: MemoryBundle[]
    alt "bundles.length === 0"
        Citations-->>Answer: "answer unchanged, invalidCitations=[]"
    else bundles found
        Citations-->>Answer: sanitized answer, invalidCitations
    end
    Answer-->>Route: "MemoryAnswer {runId, answer, invalidCitations, messages}"
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/lib/memory/citations.ts`, line 80-90 ([link](https://github.com/fisherxz/sourcecado/blob/4aecc57e3c57687dd8942e957655a56a2a6f840e/src/lib/memory/citations.ts#L80-L90)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Check-on-use passes fabricated citations when no search was performed**

   Previously, `verifyAnswerCitations` always built an `allowed` set (empty when no `search_memory` call existed) and stripped every citation token not in it. Now, if `bundles.length === 0`, the answer is returned verbatim — meaning citation-pattern strings the LLM produced without ever calling `search_memory` reach the client unchecked.

   Concretely: if the LLM responds to a greeting with "See `abc#chunk-1` for more" and skips `search_memory`, `abc#chunk-1` is a fabricated citation that now passes through. The old code would have stripped it; the new code lets it through. The system-prompt instruction "never invent a citation id" is advisory, not enforced by the pipeline in the no-search path.


2. `src/lib/memory/citations.ts`, line 13-25 ([link](https://github.com/fisherxz/sourcecado/blob/4aecc57e3c57687dd8942e957655a56a2a6f840e/src/lib/memory/citations.ts#L13-L25)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`sinceStepId` filter also skips children of pruned parent steps**

   When `step.id <= sinceStepId` the loop does `continue`, which bypasses both the tool-call scan and the `walk(step.children)` recursive call. If the trace structure ever has a parent step with a small id that contains children with ids larger than `sinceStepId` (possible in deeply nested R6 scenarios), those children are silently excluded from the in-scope bundle collection, causing their `search_memory` results to be treated as if they never happened.

   `sinceStepId` has no production caller today, but the skipping logic should be explicit: pruning child traversal by parent id is only correct if the invariant "all children of a step created before the boundary also have ids before the boundary" is guaranteed by the ledger schema. That invariant isn't stated or enforced here.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(r4): delete MEMORY\_INSTRUCTIONS, wi..."](https://github.com/fisherxz/sourcecado/commit/4aecc57e3c57687dd8942e957655a56a2a6f840e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44337840)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic memory context to agent responses, including identity, tool guidance, permitted sources, and recent notes.
  * Memory answers now include the complete agent message transcript.
  * Added support for listing authorized, non-archived memory sources.

* **Bug Fixes**
  * Citation validation now applies only to memory results used in the current turn.
  * Answers without in-scope memory results are preserved without unnecessary citation warnings.

* **Tests**
  * Added coverage for context generation, memory indexing, authorization filtering, citation handling, and multi-turn behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->