### PR TITLE
feat(rt-R5): streaming rewire — typed LlmStreamEvents + tool lifecycle over SSE

### DIFF
--- a/src/app/api/agent/stream/route.ts
+++ b/src/app/api/agent/stream/route.ts
@@ -55,6 +55,12 @@ export async function POST(request: Request) {
       writer.answerEnd();
     } else if (result.answer) {
       writer.answerFlush(result.answer);
+    } else {
+      // Run ended with no authoritative answer (e.g. failed mid-stream after a
+      // search_memory gated further live streaming): close any answer part that
+      // pre-search narration left open, so the SSE text part is well-formed for
+      // every consumer. Idempotent — a no-op when nothing streamed live.
+      writer.answerEnd();
     }
 
     writer.meta({

--- a/src/app/api/agent/stream/route.ts
+++ b/src/app/api/agent/stream/route.ts
@@ -4,11 +4,13 @@ import { answerWithMemory, summarizeStep } from "@/lib/memory/answer";
 import { streamAgentResponse } from "@/lib/ui-message-stream";
 import type { ConversationTurn } from "@/lib/harness";
 
-// Streaming sibling of /api/agent: same memory agent run, but each tool step is
-// pushed to the client live (AI SDK UI-message-stream, via the ui-message-stream
-// boundary module) so the chat can render the reasoning trace as it happens. The
-// final answer is written only after answerWithMemory's citation post-check, so no
-// invalid citation ever streams.
+// Streaming sibling of /api/agent: same memory agent run, but tool steps and
+// the model's own text stream to the client live. Text streams token-by-token
+// only while no search_memory call has happened this run (nothing to check
+// yet); once one fires, subsequent text is held back and the authoritative,
+// citation-checked answer is flushed once at the end — so no invalid citation
+// ever streams. See docs/superpowers/plans/2026-07-14-r5-streaming-rewire-plan.md
+// Judgment call #2 for the exact gating rules.
 export async function POST(request: Request) {
   const body = await request.json().catch(() => null);
   const question = (body as { question?: unknown } | null)?.question;
@@ -19,12 +21,37 @@ export async function POST(request: Request) {
   const db = getDb();
 
   return streamAgentResponse(async (writer) => {
+    // Gate coupling note: this checks the literal tool name "search_memory"
+    // because memoryRegistry() registers exactly that one tool today — "any
+    // tool call" and "search_memory called" are the same event. If another
+    // citation-bearing tool ever joins the registry, gate on any tool_start.
+    let searchCalledSoFar = false;
+    let streamedLive = false;
+
     const result = await answerWithMemory(db, {
       question,
       history,
-      onStep: (event) => writer.step(`step-${event.index}`, summarizeStep(event)),
+      onStep: (event) => {
+        writer.step(`step-${event.index}`, summarizeStep(event));
+        if (event.tool === "search_memory") searchCalledSoFar = true;
+      },
+      onAgentLoopEvent: (event) => {
+        if (event.type === "tool_start") {
+          writer.toolPending(event.name);
+          if (event.name === "search_memory") searchCalledSoFar = true;
+        } else if (event.type === "llm" && event.event.type === "text_delta" && !searchCalledSoFar) {
+          writer.answerDelta(event.event.delta);
+          streamedLive = true;
+        }
+      },
     });
-    if (result.answer) writer.answer(result.answer);
+
+    if (streamedLive && !searchCalledSoFar) {
+      writer.answerEnd();
+    } else if (result.answer) {
+      writer.answerFlush(result.answer);
+    }
+
     writer.meta({
       runId: result.runId,
       status: result.status,

--- a/src/app/api/agent/stream/route.ts
+++ b/src/app/api/agent/stream/route.ts
@@ -31,6 +31,11 @@ export async function POST(request: Request) {
     const result = await answerWithMemory(db, {
       question,
       history,
+      // Abort the run when the client disconnects (or the client-side 90s
+      // timeout fires): Next aborts request.signal on connection close, and the
+      // AI SDK stream swallows write-after-cancel, so this signal is the only
+      // thing that actually terminates the background loop.
+      signal: request.signal,
       onStep: (event) => {
         writer.step(`step-${event.index}`, summarizeStep(event));
         if (event.tool === "search_memory") searchCalledSoFar = true;

--- a/src/app/chat/ChatClient.tsx
+++ b/src/app/chat/ChatClient.tsx
@@ -121,6 +121,7 @@ export function ChatClient() {
                       running={!e.done && !e.errored}
                       open={e.open}
                       onToggle={() => patch(e.id, (x) => ({ ...x, open: !x.open }))}
+                      pendingTool={e.turn.pendingTool}
                     />
                   )}
                   {e.errored ? (

--- a/src/app/chat/ReasoningTrace.tsx
+++ b/src/app/chat/ReasoningTrace.tsx
@@ -10,14 +10,20 @@ export function ReasoningTrace({
   running,
   open,
   onToggle,
+  pendingTool,
 }: {
   steps: ChatStep[];
   running: boolean;
   open: boolean;
   onToggle: () => void;
+  pendingTool?: string;
 }) {
   const count = steps.length;
-  const pendingLabel = count === 0 ? "Searching memory" : "Composing answer";
+  const pendingLabel = pendingTool
+    ? `Running ${pendingTool}`
+    : count === 0
+      ? "Searching memory"
+      : "Composing answer";
 
   return (
     <div className="reasoning-trace">

--- a/src/app/chat/stream.ts
+++ b/src/app/chat/stream.ts
@@ -21,6 +21,10 @@ export interface AssistantTurn {
   steps: ChatStep[];
   answer: string;
   meta?: ChatMeta;
+  // Name of the tool currently dispatched but not yet settled into a ChatStep,
+  // shown in the reasoning trace's live pending row. Cleared once the matching
+  // data-step or the run's data-meta lands.
+  pendingTool?: string;
 }
 
 export interface ConversationTurn {
@@ -69,12 +73,14 @@ export function applyChunk(turn: AssistantTurn, chunk: UiChunk): AssistantTurn {
       const steps = exists
         ? turn.steps.map((s) => (s.index === step.index ? step : s))
         : [...turn.steps, step];
-      return { ...turn, steps };
+      return { ...turn, steps, pendingTool: undefined };
     }
+    case "data-tool-pending":
+      return { ...turn, pendingTool: (chunk.data as { tool: string }).tool };
     case "text-delta":
       return { ...turn, answer: turn.answer + (chunk.delta ?? "") };
     case "data-meta":
-      return { ...turn, meta: chunk.data as ChatMeta };
+      return { ...turn, meta: chunk.data as ChatMeta, pendingTool: undefined };
     default:
       return turn;
   }

--- a/src/lib/harness.ts
+++ b/src/lib/harness.ts
@@ -35,6 +35,12 @@ export interface RunAgentInput {
   // Invoked after each executed tool step. Awaited so a streaming consumer can
   // flush the step to the client before the next turn runs.
   onStep?: (event: AgentStepEvent) => void | Promise<void>;
+  // Raw agent-loop events (llm text/thinking deltas, tool_start, tool_end),
+  // forwarded 1:1 before the existing tool_end→onStep collapse. Optional and
+  // additive — omitting it reproduces today's behavior exactly. Consumed by
+  // the streaming route (R5) for true token streaming; the JSON /api/agent
+  // route and existing tests never set it.
+  onAgentLoopEvent?: (event: AgentLoopEvent) => void | Promise<void>;
   providerName?: string;
   // Test seam: injected LlmAdapter, forwarded to streamAgentTurn. Mirrors the old
   // `provider` seam's purpose for the new native tool-calling loop.
@@ -98,8 +104,10 @@ export async function runAgent(input: RunAgentInput): Promise<RunAgentResult> {
 
     let stepCounter = 0;
     let thoughtBuffer = "";
-    const onEvent = input.onStep
+    const onEvent = input.onStep || input.onAgentLoopEvent
       ? async (event: AgentLoopEvent): Promise<void> => {
+          await input.onAgentLoopEvent?.(event);
+          if (!input.onStep) return;
           if (event.type === "llm" && (event.event.type === "text_delta" || event.event.type === "thinking_delta")) {
             thoughtBuffer += event.event.delta;
             return;

--- a/src/lib/memory/answer.ts
+++ b/src/lib/memory/answer.ts
@@ -24,6 +24,10 @@ export interface AnswerWithMemoryInput {
   onStep?: (event: AgentStepEvent) => void | Promise<void>;
   // Raw agent-loop events, forwarded 1:1 to runAgent — see RunAgentInput.
   onAgentLoopEvent?: (event: AgentLoopEvent) => void | Promise<void>;
+  // Client disconnect / timeout signal, forwarded to runAgent so the loop
+  // aborts between steps (and its provider fetch is cancelled) instead of
+  // running to completion in the background. See RunAgentInput.signal.
+  signal?: AbortSignal;
 }
 
 // One agent run over team memory: the ReAct harness plus the citation post-check
@@ -43,6 +47,7 @@ export async function answerWithMemory(db: Sql, input: AnswerWithMemoryInput): P
     db,
     onStep: input.onStep,
     onAgentLoopEvent: input.onAgentLoopEvent,
+    signal: input.signal,
   });
 
   let answer = result.answer;

--- a/src/lib/memory/answer.ts
+++ b/src/lib/memory/answer.ts
@@ -1,4 +1,5 @@
 import { runAgent, type AgentStepEvent, type ConversationTurn } from "@/lib/harness";
+import type { AgentLoopEvent } from "@/lib/agent-loop";
 import { buildMemoryAnswerInstructions } from "@/lib/context";
 import { getRunTrace } from "@/lib/ledger";
 import type { LlmMessage } from "@/lib/llm/types";
@@ -21,6 +22,8 @@ export interface AnswerWithMemoryInput {
   question: string;
   history?: ConversationTurn[];
   onStep?: (event: AgentStepEvent) => void | Promise<void>;
+  // Raw agent-loop events, forwarded 1:1 to runAgent — see RunAgentInput.
+  onAgentLoopEvent?: (event: AgentLoopEvent) => void | Promise<void>;
 }
 
 // One agent run over team memory: the ReAct harness plus the citation post-check
@@ -39,6 +42,7 @@ export async function answerWithMemory(db: Sql, input: AnswerWithMemoryInput): P
     instructions,
     db,
     onStep: input.onStep,
+    onAgentLoopEvent: input.onAgentLoopEvent,
   });
 
   let answer = result.answer;

--- a/src/lib/ui-message-stream.ts
+++ b/src/lib/ui-message-stream.ts
@@ -8,8 +8,19 @@ import { createUIMessageStream, createUIMessageStreamResponse } from "ai";
 export interface AgentStreamWriter {
   // A reasoning step (reconciled by id). data is the rendered ChatStepPart.
   step: (id: string, data: unknown) => void;
-  // The final answer, written as one composed assistant text part.
-  answer: (text: string) => void;
+  // A tool has just been dispatched and is running; the reasoning trace shows
+  // its name in the live pending row until the matching data-step settles.
+  toolPending: (tool: string) => void;
+  // One incremental chunk of the assistant's own generated text. Lazily opens
+  // the "answer" text part on first use.
+  answerDelta: (delta: string) => void;
+  // Closes the "answer" text part with no further content — used when every
+  // token was already streamed live via answerDelta and needs no correction.
+  answerEnd: () => void;
+  // Appends `text` as one more delta (starting the part fresh if nothing has
+  // streamed yet) and closes it. Safe to call whether or not answerDelta ran
+  // first — this is the authoritative, citation-checked flush.
+  answerFlush: (text: string) => void;
   // Run metadata (runId, status, steps, invalidCitations).
   meta: (data: unknown) => void;
 }
@@ -18,12 +29,31 @@ export function streamAgentResponse(run: (writer: AgentStreamWriter) => Promise<
   const stream = createUIMessageStream({
     execute: async ({ writer }) => {
       writer.write({ type: "start" });
+      let answerStarted = false;
+      const ensureStarted = () => {
+        if (!answerStarted) {
+          writer.write({ type: "text-start", id: "answer" });
+          answerStarted = true;
+        }
+      };
       await run({
         step: (id, data) => writer.write({ type: "data-step", id, data }),
-        answer: (text) => {
-          writer.write({ type: "text-start", id: "answer" });
+        toolPending: (tool) => writer.write({ type: "data-tool-pending", id: "tool-pending", data: { tool } }),
+        answerDelta: (delta) => {
+          ensureStarted();
+          writer.write({ type: "text-delta", id: "answer", delta });
+        },
+        answerEnd: () => {
+          if (answerStarted) {
+            writer.write({ type: "text-end", id: "answer" });
+            answerStarted = false;
+          }
+        },
+        answerFlush: (text) => {
+          ensureStarted();
           writer.write({ type: "text-delta", id: "answer", delta: text });
           writer.write({ type: "text-end", id: "answer" });
+          answerStarted = false;
         },
         meta: (data) => writer.write({ type: "data-meta", id: "meta", data }),
       });

--- a/tests/agent-stream-route.test.ts
+++ b/tests/agent-stream-route.test.ts
@@ -84,4 +84,112 @@ describe("POST /api/agent/stream", () => {
     expect(body).toContain("data-meta");
     expect(body).toContain("failed");
   });
+
+  it("streams the answer live token-by-token when search_memory was never called", async () => {
+    runAgentMock.mockImplementation(
+      async (input: {
+        onStep?: (e: unknown) => unknown;
+        onAgentLoopEvent?: (e: unknown) => unknown;
+      }) => {
+        await input.onAgentLoopEvent?.({ type: "llm", event: { type: "text_delta", delta: "Acme is " } });
+        await input.onAgentLoopEvent?.({ type: "llm", event: { type: "text_delta", delta: "a Series B co." } });
+        return { runId: 7, status: "succeeded", answer: "Acme is a Series B co.", steps: 0 };
+      }
+    );
+
+    const res = await POST(postRequest({ question: "what is acme" }));
+    const body = await readAll(res);
+
+    // Two separate text-delta writes prove live streaming, not one final flush.
+    const deltaCount = (body.match(/"type":"text-delta"/g) ?? []).length;
+    expect(deltaCount).toBe(2);
+    expect(body).toContain("Acme is ");
+    expect(body).toContain("a Series B co.");
+    expect(body).toContain("data-meta");
+  });
+
+  it("buffers text once search_memory is called and flushes the checked answer once at the end", async () => {
+    runAgentMock.mockImplementation(
+      async (input: {
+        onStep?: (e: unknown) => unknown;
+        onAgentLoopEvent?: (e: unknown) => unknown;
+      }) => {
+        await input.onAgentLoopEvent?.({ type: "tool_start", id: "call-1", name: "search_memory", input: {} });
+        // Any text after the tool_start must NOT be forwarded live.
+        await input.onAgentLoopEvent?.({ type: "llm", event: { type: "text_delta", delta: "should not stream" } });
+        await input.onStep?.({
+          index: 1,
+          tool: "search_memory",
+          observation: 'Success: {"acceptedFacts":[],"gapFacts":[],"chunks":[]}',
+          ok: true,
+        });
+        return {
+          runId: 8,
+          status: "succeeded",
+          answer: "Acme Robotics is a Series B company [acme-md#chunk-1].",
+          steps: 1,
+        };
+      }
+    );
+
+    const res = await POST(postRequest({ question: "tell me about acme" }));
+    const body = await readAll(res);
+
+    expect(body).not.toContain("should not stream");
+    // Exactly one text-delta write carries the final, checked answer.
+    const deltaLines = body.split("\n").filter((l) => l.includes('"type":"text-delta"'));
+    expect(deltaLines).toHaveLength(1);
+    expect(body).toContain("Acme Robotics is a Series B company");
+    expect(body).toContain("data-tool-pending");
+    expect(body).toContain("search_memory");
+  });
+
+  it("still streams the answer in one shot when the caller never emits onAgentLoopEvent (backward compatible)", async () => {
+    runAgentMock.mockImplementation(async (input: { onStep?: (e: unknown) => unknown }) => {
+      await input.onStep?.({
+        index: 1,
+        tool: "search_memory",
+        observation: 'Success: {"acceptedFacts":[1],"gapFacts":[],"chunks":[1]}',
+        ok: true,
+      });
+      return { runId: 9, status: "succeeded", answer: "Answer with no live events.", steps: 1 };
+    });
+
+    const res = await POST(postRequest({ question: "tell me about acme" }));
+    const body = await readAll(res);
+    expect(body).toContain("Answer with no live events.");
+  });
+
+  it("accepts that pre-tool narration streams live AND reappears in the step's thought field (Judgment call #3 — documented, not suppressed)", async () => {
+    runAgentMock.mockImplementation(
+      async (input: {
+        onStep?: (e: unknown) => unknown;
+        onAgentLoopEvent?: (e: unknown) => unknown;
+      }) => {
+        await input.onAgentLoopEvent?.({ type: "llm", event: { type: "text_delta", delta: "checking memory..." } });
+        await input.onAgentLoopEvent?.({ type: "tool_start", id: "call-1", name: "search_memory", input: {} });
+        await input.onStep?.({
+          index: 1,
+          tool: "search_memory",
+          observation: 'Success: {"acceptedFacts":[],"gapFacts":[],"chunks":[]}',
+          ok: true,
+          thought: "checking memory...",
+        });
+        return {
+          runId: 10,
+          status: "succeeded",
+          answer: "Acme is a Series B company.",
+          steps: 1,
+        };
+      }
+    );
+
+    const res = await POST(postRequest({ question: "tell me about acme" }));
+    const body = await readAll(res);
+
+    // The narration streamed live before the tool_start gate closed...
+    expect(body).toContain("checking memory...");
+    // ...and also reappears verbatim as the step's thought line — accepted duplication, not suppressed.
+    expect(body).toContain('"thought":"checking memory..."');
+  });
 });

--- a/tests/agent-stream-route.test.ts
+++ b/tests/agent-stream-route.test.ts
@@ -85,6 +85,35 @@ describe("POST /api/agent/stream", () => {
     expect(body).toContain("failed");
   });
 
+  it("closes the open answer text part when the run fails after narration streamed and a search fired", async () => {
+    // Regression for the mixed live-then-search failure path: pre-search
+    // narration opens the "answer" text part (answerStarted), search_memory then
+    // gates further streaming, and the run fails with no result.answer. Neither
+    // the answerEnd nor the answerFlush branch used to run, so text-start was
+    // never matched by text-end and the SSE part was left open. The stream must
+    // emit exactly one text-end for the narration part, with no phantom flush.
+    runAgentMock.mockImplementation(
+      async (input: {
+        onStep?: (e: unknown) => unknown;
+        onAgentLoopEvent?: (e: unknown) => unknown;
+      }) => {
+        await input.onAgentLoopEvent?.({ type: "llm", event: { type: "text_delta", delta: "checking memory..." } });
+        await input.onAgentLoopEvent?.({ type: "tool_start", id: "call-1", name: "search_memory", input: {} });
+        return { runId: 12, status: "failed", steps: 8 };
+      }
+    );
+
+    const res = await POST(postRequest({ question: "loop after narration" }));
+    const body = await readAll(res);
+
+    expect(body).toContain("checking memory...");
+    // The open answer part is closed exactly once, and no answer was flushed.
+    const endCount = (body.match(/"type":"text-end"/g) ?? []).length;
+    expect(endCount).toBe(1);
+    expect(body).toContain("data-meta");
+    expect(body).toContain("failed");
+  });
+
   it("streams the answer live token-by-token when search_memory was never called", async () => {
     runAgentMock.mockImplementation(
       async (input: {

--- a/tests/agent-stream-route.test.ts
+++ b/tests/agent-stream-route.test.ts
@@ -160,6 +160,25 @@ describe("POST /api/agent/stream", () => {
     expect(body).toContain("Answer with no live events.");
   });
 
+  it("forwards the request's abort signal into runAgent so a client disconnect terminates the loop", async () => {
+    // The AI SDK's UI-message-stream swallows write-after-cancel (safeEnqueue),
+    // so a disconnected client never makes writer.write throw — the only thing
+    // that actually stops the background loop is the request's AbortSignal,
+    // checked between steps and passed to the provider fetch. Guard that it is
+    // threaded end-to-end; drop it and runs keep burning credits after a leave.
+    let received: AbortSignal | undefined;
+    runAgentMock.mockImplementation(async (input: { signal?: AbortSignal }) => {
+      received = input.signal;
+      return { runId: 11, status: "succeeded", answer: "ok", steps: 0 };
+    });
+
+    const req = postRequest({ question: "hi" });
+    await readAll(await POST(req));
+
+    expect(received).toBeInstanceOf(AbortSignal);
+    expect(received).toBe(req.signal);
+  });
+
   it("accepts that pre-tool narration streams live AND reappears in the step's thought field (Judgment call #3 — documented, not suppressed)", async () => {
     runAgentMock.mockImplementation(
       async (input: {

--- a/tests/chat-stream.test.ts
+++ b/tests/chat-stream.test.ts
@@ -63,6 +63,29 @@ describe("applyChunk", () => {
     turn = applyChunk(turn, { type: "finish" });
     expect(turn).toEqual(empty);
   });
+
+  it("sets pendingTool from a data-tool-pending chunk", () => {
+    const turn = applyChunk(empty, { type: "data-tool-pending", data: { tool: "search_memory" } });
+    expect(turn.pendingTool).toBe("search_memory");
+  });
+
+  it("clears pendingTool once the matching step settles", () => {
+    let turn = applyChunk(empty, { type: "data-tool-pending", data: { tool: "search_memory" } });
+    turn = applyChunk(turn, {
+      type: "data-step",
+      data: { index: 1, tool: "search_memory", ok: true, detail: "2 facts, 1 chunk" },
+    });
+    expect(turn.pendingTool).toBeUndefined();
+  });
+
+  it("clears pendingTool once the run's meta lands", () => {
+    let turn = applyChunk(empty, { type: "data-tool-pending", data: { tool: "search_memory" } });
+    turn = applyChunk(turn, {
+      type: "data-meta",
+      data: { runId: 1, status: "succeeded", steps: 1, invalidCitations: [] },
+    });
+    expect(turn.pendingTool).toBeUndefined();
+  });
 });
 
 function sseResponse(body: string, init: { status?: number } = {}): Response {

--- a/tests/components/chat-pieces.test.tsx
+++ b/tests/components/chat-pieces.test.tsx
@@ -76,6 +76,18 @@ describe("ReasoningTrace", () => {
     render(<ReasoningTrace steps={[step()]} running={false} open={true} onToggle={() => {}} />);
     expect(screen.queryByRole("listitem", { busy: true })).not.toBeInTheDocument();
   });
+
+  it("shows the pending tool name in the live row when given", () => {
+    render(
+      <ReasoningTrace steps={[]} running={true} open={true} onToggle={() => {}} pendingTool="search_memory" />
+    );
+    expect(screen.getByText(/Running search_memory/)).toBeInTheDocument();
+  });
+
+  it("falls back to the generic label when no pending tool is given", () => {
+    render(<ReasoningTrace steps={[]} running={true} open={true} onToggle={() => {}} />);
+    expect(screen.getByText(/Searching memory/)).toBeInTheDocument();
+  });
 });
 
 describe("MessageBubble", () => {

--- a/tests/harness-agent-loop-event.test.ts
+++ b/tests/harness-agent-loop-event.test.ts
@@ -1,0 +1,100 @@
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+import { runAgent, type AgentStepEvent } from "@/lib/harness";
+import { createToolRegistry } from "@/lib/tools/registry";
+import { echoTool } from "@/lib/tools/echo";
+import type { Tool } from "@/lib/tools/types";
+import type { LlmAdapter, LlmStreamEvent } from "@/lib/llm/types";
+
+async function resetLedgerTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS tool_calls CASCADE`;
+  await db`DROP TABLE IF EXISTS model_calls CASCADE`;
+  await db`DROP TABLE IF EXISTS run_steps CASCADE`;
+  await db`DROP TABLE IF EXISTS runs CASCADE`;
+  await db`DROP TABLE IF EXISTS schema_migrations CASCADE`;
+  await runMigrations(db);
+}
+
+const ALLOWED = new Set<Tool["permissionClass"]>(["read", "reason"]);
+
+// A fake adapter: turn 1 emits a text delta then calls echo; turn 2 answers.
+const fakeAdapter: LlmAdapter = async function* (request): AsyncGenerator<LlmStreamEvent> {
+  const isFirstTurn = request.messages.filter((m) => m.role === "assistant").length === 0;
+  if (isFirstTurn) {
+    yield { type: "text_delta", delta: "checking..." };
+    yield { type: "tool_call_start", id: "call-1", name: "echo" };
+    yield { type: "tool_call_end", id: "call-1", name: "echo", input: { text: "hi" } };
+    yield { type: "turn_end", stopReason: "tool_use", usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } };
+    return;
+  }
+  yield { type: "text_delta", delta: "done" };
+  yield { type: "turn_end", stopReason: "end", usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } };
+};
+
+describe("runAgent onAgentLoopEvent", () => {
+  beforeEach(async () => {
+    await resetLedgerTables();
+  });
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("forwards llm and tool_start/tool_end events without disturbing onStep", async () => {
+    const registry = createToolRegistry([echoTool]);
+    const loopEvents: string[] = [];
+    const stepEvents: AgentStepEvent[] = [];
+
+    const result = await runAgent({
+      question: "echo hi",
+      registry,
+      allowedClasses: ALLOWED,
+      adapter: fakeAdapter,
+      onStep: (e) => {
+        stepEvents.push(e);
+      },
+      onAgentLoopEvent: (e) => {
+        loopEvents.push(e.type);
+      },
+    });
+
+    expect(result.status).toBe("succeeded");
+    expect(loopEvents).toContain("llm");
+    expect(loopEvents).toContain("tool_start");
+    expect(loopEvents).toContain("tool_end");
+    // onStep is unaffected — still one event, still only fired for the completed tool step.
+    expect(stepEvents).toHaveLength(1);
+    expect(stepEvents[0]).toMatchObject({ tool: "echo", ok: true });
+  });
+
+  it("omitting onAgentLoopEvent reproduces today's behavior (no throw, same result)", async () => {
+    const registry = createToolRegistry([echoTool]);
+    const result = await runAgent({
+      question: "echo hi",
+      registry,
+      allowedClasses: ALLOWED,
+      adapter: fakeAdapter,
+    });
+    expect(result.status).toBe("succeeded");
+  });
+
+  it("fires onAgentLoopEvent even when onStep is omitted (no silent no-op)", async () => {
+    const registry = createToolRegistry([echoTool]);
+    const loopEvents: string[] = [];
+
+    const result = await runAgent({
+      question: "echo hi",
+      registry,
+      allowedClasses: ALLOWED,
+      adapter: fakeAdapter,
+      onAgentLoopEvent: (e) => {
+        loopEvents.push(e.type);
+      },
+    });
+
+    expect(result.status).toBe("succeeded");
+    expect(loopEvents).toContain("llm");
+    expect(loopEvents).toContain("tool_start");
+    expect(loopEvents).toContain("tool_end");
+  });
+});

--- a/tests/memory-answer-agent-loop-event.test.ts
+++ b/tests/memory-answer-agent-loop-event.test.ts
@@ -1,0 +1,45 @@
+import { vi } from "vitest";
+
+const { runAgentMock } = vi.hoisted(() => ({ runAgentMock: vi.fn() }));
+vi.mock("@/lib/harness", () => ({ runAgent: runAgentMock }));
+vi.mock("@/lib/ledger", () => ({ getRunTrace: vi.fn().mockResolvedValue(null) }));
+vi.mock("@/lib/context", () => ({
+  buildMemoryAnswerInstructions: vi.fn().mockResolvedValue("instructions"),
+}));
+
+import { answerWithMemory } from "@/lib/memory/answer";
+
+describe("answerWithMemory onAgentLoopEvent passthrough", () => {
+  // Braced body on purpose: mockReset() returns the mock, and vitest treats a
+  // function returned from beforeEach as a cleanup hook (it would then invoke
+  // the mock itself with no args during teardown).
+  beforeEach(() => {
+    runAgentMock.mockReset();
+  });
+
+  it("forwards onAgentLoopEvent to runAgent unchanged", async () => {
+    runAgentMock.mockImplementation(async (input: { onAgentLoopEvent?: (e: unknown) => void }) => {
+      input.onAgentLoopEvent?.({ type: "llm", event: { type: "text_delta", delta: "hi" } });
+      return { runId: 1, status: "succeeded", answer: "hi", steps: 1, messages: [] };
+    });
+
+    const events: unknown[] = [];
+    await answerWithMemory({} as never, {
+      question: "q",
+      onAgentLoopEvent: (e) => {
+        events.push(e);
+      },
+    });
+
+    expect(events).toHaveLength(1);
+    expect(runAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({ onAgentLoopEvent: expect.any(Function) })
+    );
+  });
+
+  it("works with onAgentLoopEvent omitted (backward compatible)", async () => {
+    runAgentMock.mockResolvedValue({ runId: 1, status: "succeeded", answer: "hi", steps: 1, messages: [] });
+    const result = await answerWithMemory({} as never, { question: "q" });
+    expect(result.answer).toBe("hi");
+  });
+});

--- a/tests/ui-message-stream.test.ts
+++ b/tests/ui-message-stream.test.ts
@@ -1,0 +1,83 @@
+import { vi } from "vitest";
+
+const writes: unknown[] = [];
+const { createUIMessageStreamMock, createUIMessageStreamResponseMock } = vi.hoisted(() => ({
+  createUIMessageStreamMock: vi.fn(),
+  createUIMessageStreamResponseMock: vi.fn(() => new Response(null)),
+}));
+vi.mock("ai", () => ({
+  createUIMessageStream: createUIMessageStreamMock,
+  createUIMessageStreamResponse: createUIMessageStreamResponseMock,
+}));
+
+import { streamAgentResponse, type AgentStreamWriter } from "@/lib/ui-message-stream";
+
+async function capture(run: (writer: AgentStreamWriter) => Promise<void>): Promise<unknown[]> {
+  writes.length = 0;
+  createUIMessageStreamMock.mockImplementation(({ execute }: { execute: (opts: { writer: { write: (c: unknown) => void } }) => Promise<void> }) => {
+    const writer = { write: (chunk: unknown) => writes.push(chunk) };
+    return execute({ writer });
+  });
+  streamAgentResponse(run);
+  await new Promise((r) => setTimeout(r, 0));
+  return writes;
+}
+
+describe("streamAgentResponse writer", () => {
+  it("answerDelta streams multiple deltas under one text-start/text-end pair", async () => {
+    const out = await capture(async (writer) => {
+      writer.answerDelta("Hel");
+      writer.answerDelta("lo");
+      writer.answerEnd();
+    });
+    expect(out).toContainEqual({ type: "text-start", id: "answer" });
+    expect(out).toContainEqual({ type: "text-delta", id: "answer", delta: "Hel" });
+    expect(out).toContainEqual({ type: "text-delta", id: "answer", delta: "lo" });
+    expect(out).toContainEqual({ type: "text-end", id: "answer" });
+    expect(out.filter((c) => (c as { type: string }).type === "text-start")).toHaveLength(1);
+  });
+
+  it("answerEnd is a no-op if nothing was ever started", async () => {
+    const out = await capture(async (writer) => {
+      writer.answerEnd();
+    });
+    expect(out.some((c) => (c as { type: string }).type === "text-start")).toBe(false);
+    expect(out.some((c) => (c as { type: string }).type === "text-end")).toBe(false);
+  });
+
+  it("answerFlush starts fresh when nothing streamed yet (today's one-shot behavior)", async () => {
+    const out = await capture(async (writer) => {
+      writer.answerFlush("full answer");
+    });
+    expect(out).toContainEqual({ type: "text-start", id: "answer" });
+    expect(out).toContainEqual({ type: "text-delta", id: "answer", delta: "full answer" });
+    expect(out).toContainEqual({ type: "text-end", id: "answer" });
+  });
+
+  it("answerFlush appends after live deltas instead of restarting the part", async () => {
+    const out = await capture(async (writer) => {
+      writer.answerDelta("checking... ");
+      writer.answerFlush("final answer");
+    });
+    expect(out.filter((c) => (c as { type: string }).type === "text-start")).toHaveLength(1);
+    expect(out).toContainEqual({ type: "text-delta", id: "answer", delta: "checking... " });
+    expect(out).toContainEqual({ type: "text-delta", id: "answer", delta: "final answer" });
+    expect(out.filter((c) => (c as { type: string }).type === "text-end")).toHaveLength(1);
+  });
+
+  it("toolPending writes a data-tool-pending part with the tool name", async () => {
+    const out = await capture(async (writer) => {
+      writer.toolPending("search_memory");
+    });
+    expect(out).toContainEqual({ type: "data-tool-pending", id: "tool-pending", data: { tool: "search_memory" } });
+  });
+
+  it("step and meta are unchanged", async () => {
+    const out = await capture(async (writer) => {
+      writer.step("step-1", { ok: true });
+      writer.meta({ runId: 1 });
+    });
+    expect(out).toContainEqual({ type: "data-step", id: "step-1", data: { ok: true } });
+    expect(out).toContainEqual({ type: "data-meta", id: "meta", data: { runId: 1 } });
+  });
+});


### PR DESCRIPTION
## Summary

R5 of the Runtime Solidification Sprint (plan: `docs/superpowers/plans/2026-07-14-r5-streaming-rewire-plan.md`). Replaces the single end-of-run answer flush in `/api/agent/stream` with typed re-emission of `LlmStreamEvent`s + tool lifecycle over the existing SSE channel:

- **True token streaming** when no `search_memory` call happens this run — the model's own `text_delta`s forward live to the chat bubble.
- **Citation safety preserved**: once any `search_memory` `tool_start` fires, subsequent text is held back and the authoritative, citation-checked `result.answer` is flushed once at the end. An invalid citation still never reaches the client.
- **Live tool indicator**: `data-tool-pending` part + `AssistantTurn.pendingTool` + "Running search_memory" pending row in the reasoning trace.

## Changes

- `src/lib/harness.ts` (flagged additive deviation into R2-owned file): optional `onAgentLoopEvent` on `RunAgentInput`; `onEvent` now built off `onStep || onAgentLoopEvent`, raw event forwarded first — no silent no-op when `onStep` is omitted.
- `src/lib/memory/answer.ts`: same additive passthrough on `AnswerWithMemoryInput`.
- `src/lib/ui-message-stream.ts`: one-shot `answer()` retired for `answerDelta` / `answerEnd` / `answerFlush` / `toolPending` (lazy text-start, append-or-fresh flush). AI SDK surface stays confined to this boundary file (model-boundary test green).
- `src/app/api/agent/stream/route.ts`: consumes both hooks; `searchCalledSoFar`/`streamedLive` gating per plan Judgment call #2. Gate couples to the literal tool name `search_memory` — safe while `memoryRegistry()` registers exactly one tool; commented in the route.
- `src/app/chat/stream.ts`, `ReasoningTrace.tsx`, `ChatClient.tsx`: `pendingTool` plumbing, cleared on step settle / meta.
- Accepted, documented edge case (plan Judgment call #3): pre-tool narration streams live and also reappears as the step's `thought` line — asserted by a dedicated route test, not suppressed.

## Tests

+23 tests (347 passed / 78 pre-existing legacy-sqlite failures / 1 todo; baseline 324/78/1, **zero new failures**), all TDD red→green:
- `tests/harness-agent-loop-event.test.ts` (new, 3) — includes the onAgentLoopEvent-without-onStep path from the eng review's must-fix #1
- `tests/memory-answer-agent-loop-event.test.ts` (new, 2)
- `tests/ui-message-stream.test.ts` (new, 6)
- `tests/agent-stream-route.test.ts` (+4) — live streaming, buffered flush, backward-compat, narration double-surfacing
- `tests/chat-stream.test.ts` (+3), `tests/components/chat-pieces.test.tsx` (+2)

## Gates

- `npx vitest run`: 347/78-pre-existing/1 todo, zero new failures
- `npx tsc --noEmit`: clean
- `npm run lint`: pre-existing `embed.ts` warning only
- `npm run build`: green, `/api/agent/stream` + `/chat` present
- `tests/model-boundary.test.ts`: pass
- Live probe (openai override): search path → 1 buffered text-delta + `data-tool-pending` + 0 invalidCitations, `/runs/2` renders; no-search path → **33 live text-deltas**, 0 tool calls

## Plan deviations (test mechanics only)

1. Plan's fake adapter `return {stopReason}` dropped — repo's adapter seam yields events only (matches `tests/harness.test.ts`).
2. Plan's `beforeEach(() => mock.mockReset())` one-liner replaced with a braced body: `mockReset()` returns the mock and vitest invokes a function returned from `beforeEach` as a cleanup hook — with no args — which crashed the mock at teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added incremental assistant response streaming for faster visible output.
  * Added clear progress indicators showing which tool is currently running.
  * Improved response handling when memory search is used, with a final verified answer after the search completes.
  * Preserved streamed steps, metadata, and citations in the conversation view.

* **Bug Fixes**
  * Improved handling of pending tool states so progress indicators clear reliably when processing finishes.

* **Tests**
  * Added coverage for streaming, tool progress updates, memory search behavior, and backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR rewires the `/api/agent/stream` route from a single end-of-run flush to typed, incremental SSE events: live `text_delta` forwarding when no `search_memory` call has occurred, a `data-tool-pending` part for the live reasoning trace indicator, and a citation-checked `answerFlush` once any search tool fires.

- **`harness.ts` / `answer.ts`**: additive `onAgentLoopEvent` hook threaded alongside `onStep`; raw events forwarded before the existing `tool_end → onStep` collapse, with correct backward compat.
- **`ui-message-stream.ts`**: `answer()` replaced with `answerDelta` / `answerEnd` / `answerFlush` / `toolPending`; lazy text-part open via `ensureStarted`.
- **Route gating logic**: a real issue exists in the `streamedLive=true + searchCalledSoFar=true` branch — `answerFlush` appends the full authoritative answer to the still-open text part rather than replacing it, so the client's accumulated `turn.answer` becomes `[pre-tool narration][full answer]`. This contaminated string is rendered verbatim and is also threaded into multi-turn conversation history.

<h3>Confidence Score: 3/5</h3>

The no-search path and pure buffered path work correctly; the problematic path where the model narrates before calling search_memory produces a client answer that is the pre-tool thought prepended to the authoritative response, and that string is stored in conversation history for future turns.

The gating logic in the route has a real gap: once pre-tool text has streamed live and search_memory subsequently fires, answerFlush appends the citation-checked answer to the already-open text part instead of replacing it. Every multi-turn conversation where the model thinks aloud before searching will accumulate corrupted history. The rest of the PR — the harness hook plumbing, ui-message-stream writer, pendingTool lifecycle, and test suite — is clean and well-exercised.

src/app/api/agent/stream/route.ts — the branch covering streamedLive=true + searchCalledSoFar=true needs either a retract/reset mechanism or suppression of live streaming when a tool call is eventually made.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/app/api/agent/stream/route.ts | Introduces dual gating (searchCalledSoFar + streamedLive) for live vs. buffered text streaming; the branch covering pre-tool narration followed by a successful search concatenates narration text with the authoritative answer in the client's turn.answer, corrupting the displayed response and conversation history. |
| src/lib/harness.ts | Additive change: onAgentLoopEvent hook threaded alongside existing onStep with correct ordering (raw event fires first, then onStep collapse). onEvent handler is created if either hook is provided, preserving backward compat. |
| src/lib/ui-message-stream.ts | answer() replaced with answerDelta/answerEnd/answerFlush + toolPending; lazy text-start via ensureStarted is correct. answerFlush appends rather than resets when answerStarted=true, which is intentional for the hybrid streaming scenario. |
| src/lib/memory/answer.ts | Minimal passthrough change: onAgentLoopEvent forwarded verbatim to runAgent, no new logic introduced. |
| src/app/chat/stream.ts | pendingTool field added to AssistantTurn; applyChunk correctly sets it on data-tool-pending and clears it on data-step and data-meta. Logic is clean. |
| src/app/chat/ReasoningTrace.tsx | pendingTool prop wired correctly; pendingLabel derivation is straightforward and safe. |
| src/app/chat/ChatClient.tsx | pendingTool threaded from e.turn to ReasoningTrace; one-line change, correct. |
| tests/agent-stream-route.test.ts | Four new tests covering live streaming, buffered flush, backward compat, and the narration double-surfacing edge case. The narration test asserts the current (contaminating) behavior rather than guarding against it. |
| tests/ui-message-stream.test.ts | Six tests covering the new writer surface (answerDelta, answerEnd, answerFlush, toolPending); well-structured and complete. |
| tests/harness-agent-loop-event.test.ts | New integration tests with a real fake adapter verifying onAgentLoopEvent receives llm/tool_start/tool_end events and that onStep still fires correctly alongside it. |
| tests/memory-answer-agent-loop-event.test.ts | Two passthrough tests for answerWithMemory; correct use of braced beforeEach body to avoid the mockReset teardown crash. |
| tests/chat-stream.test.ts | Three new applyChunk tests for pendingTool lifecycle; all correct. |
| tests/components/chat-pieces.test.tsx | Two component tests verifying the pendingTool label rendering path; straightforward and accurate. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as ChatClient
    participant R as /api/agent/stream
    participant H as harness.ts (runAgent)
    participant L as agentLoop

    C->>R: "POST {question, history}"
    R->>H: "answerWithMemory({onStep, onAgentLoopEvent})"
    H->>L: "runAgentLoop({onEvent})"

    loop Turn 1 (no search yet)
        L-->>H: "AgentLoopEvent {type:llm, text_delta}"
        H-->>R: onAgentLoopEvent(llm.text_delta)
        Note over R: !searchCalledSoFar → answerDelta, streamedLive=true
        R-->>C: SSE text-delta (live token)
    end

    L-->>H: "AgentLoopEvent {type:tool_start, name:search_memory}"
    H-->>R: onAgentLoopEvent(tool_start)
    Note over R: searchCalledSoFar=true
    R-->>C: SSE data-tool-pending

    L-->>H: "AgentLoopEvent {type:tool_end}"
    H-->>R: "onStep({index, tool, thought, observation})"
    R-->>C: SSE data-step

    L-->>H: "AgentLoopEvent {type:llm, text_delta} post-search"
    H-->>R: onAgentLoopEvent(llm.text_delta)
    Note over R: searchCalledSoFar=true, gated out

    H->>R: "return result {answer, runId, status}"
    Note over R: streamedLive&&!searchCalledSoFar=false, result.answer=true
    Note over R: answerFlush — answerStarted already true, narration+answer concatenated
    R-->>C: SSE text-delta (full answer appended)
    R-->>C: SSE text-end
    R-->>C: SSE data-meta
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as ChatClient
    participant R as /api/agent/stream
    participant H as harness.ts (runAgent)
    participant L as agentLoop

    C->>R: "POST {question, history}"
    R->>H: "answerWithMemory({onStep, onAgentLoopEvent})"
    H->>L: "runAgentLoop({onEvent})"

    loop Turn 1 (no search yet)
        L-->>H: "AgentLoopEvent {type:llm, text_delta}"
        H-->>R: onAgentLoopEvent(llm.text_delta)
        Note over R: !searchCalledSoFar → answerDelta, streamedLive=true
        R-->>C: SSE text-delta (live token)
    end

    L-->>H: "AgentLoopEvent {type:tool_start, name:search_memory}"
    H-->>R: onAgentLoopEvent(tool_start)
    Note over R: searchCalledSoFar=true
    R-->>C: SSE data-tool-pending

    L-->>H: "AgentLoopEvent {type:tool_end}"
    H-->>R: "onStep({index, tool, thought, observation})"
    R-->>C: SSE data-step

    L-->>H: "AgentLoopEvent {type:llm, text_delta} post-search"
    H-->>R: onAgentLoopEvent(llm.text_delta)
    Note over R: searchCalledSoFar=true, gated out

    H->>R: "return result {answer, runId, status}"
    Note over R: streamedLive&&!searchCalledSoFar=false, result.answer=true
    Note over R: answerFlush — answerStarted already true, narration+answer concatenated
    R-->>C: SSE text-delta (full answer appended)
    R-->>C: SSE text-end
    R-->>C: SSE data-meta
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(r5): live tool-name label in the re..."](https://github.com/fisherxz/sourcecado/commit/53caab18cb3b084a3af8b94e6250d348eda97d1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44381082)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->

---
**Deferral note (added by supervisor):** `streamAgentTurn` capturePayloads/redactionMode parity remains deferred — now to **R6** (session persistence is the next payload consumer). Latent-only today: no live caller sets redactionMode. Tracked in progress.md carry-forwards.