### PR TITLE
feat(rt-R6): server-side chat sessions — resume latest + New chat

### DIFF
--- a/src/app/api/agent/stream/route.ts
+++ b/src/app/api/agent/stream/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
 import { appendMessages, getOrCreateLatestSession, loadSessionMessages } from "@/lib/chat/sessions";
-import { conversationTurnsToMessages, type ConversationTurn } from "@/lib/harness";
+import type { ConversationTurn } from "@/lib/harness";
 import { answerWithMemory, summarizeStep } from "@/lib/memory/answer";
 import { DEFAULT_ACTOR } from "@/lib/memory/actor";
 import { streamAgentResponse } from "@/lib/ui-message-stream";
-import type { LlmUserMessage } from "@/lib/llm/types";
+import type { LlmAssistantBlock, LlmMessage, LlmUserMessage } from "@/lib/llm/types";
 
 // Streaming sibling of /api/agent: same memory agent run, but tool steps and
 // the model's own text stream to the client live. Text streams token-by-token
@@ -20,6 +20,13 @@ export async function POST(request: Request) {
   if (typeof question !== "string" || !question.trim()) {
     return NextResponse.json({ error: "question is required" }, { status: 400 });
   }
+  // R6: `history` is still accepted, for request-shape compatibility, but
+  // intentionally not forwarded to answerWithMemory below — the persisted
+  // session's `priorMessages` (loaded below) supersedes it for this route.
+  // Passing both double-fed the whole conversation into every turn's
+  // transcript. /api/agent (the non-stream route) has no persisted session
+  // and legitimately still uses client-sent history.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- parsed for validation only, deliberately not forwarded (see comment above)
   const history = parseHistory((body as { history?: unknown } | null)?.history);
   const db = getDb();
 
@@ -42,7 +49,6 @@ export async function POST(request: Request) {
 
     const result = await answerWithMemory(db, {
       question,
-      history,
       priorMessages,
       // Abort the run when the client disconnects (or the client-side 90s
       // timeout fires): Next aborts request.signal on connection close, and the
@@ -67,11 +73,11 @@ export async function POST(request: Request) {
     // Persist the loop's newly-produced messages after it settles, tagged with
     // the run id — on both success and failure (even a failed run's synthetic
     // error message should show up on reload). `result.messages` is the full
-    // transcript runAgent built (system + history + priorMessages + the new
-    // user message + whatever the loop produced); slice off exactly that
-    // known prefix.
-    const priorPrefixLength = 1 + conversationTurnsToMessages(history).length + priorMessages.length + 1;
-    const producedMessages = result.messages.slice(priorPrefixLength);
+    // transcript runAgent built (system + priorMessages + the new user
+    // message + whatever the loop produced); slice off exactly that known
+    // prefix.
+    const priorPrefixLength = priorMessages.length + 2; // system + priorMessages + user message
+    const producedMessages = withCheckedAnswer(result.messages.slice(priorPrefixLength), result.answer);
     await appendMessages(db, session.id, producedMessages, result.runId);
 
     if (streamedLive && !searchCalledSoFar) {
@@ -93,6 +99,28 @@ export async function POST(request: Request) {
       invalidCitations: result.invalidCitations,
     });
   });
+}
+
+// answerWithMemory scrubs invalid citations out of `result.answer`, but
+// `result.messages` (sourced from the raw agent loop) still carries the
+// pre-check text on the final assistant message. Persisting the raw
+// messages would resurrect a scrubbed citation on reload, so replace that
+// message's text with the checked answer before it's written — tool_use
+// blocks (if any) on that message are left in place; every earlier message
+// is untouched. No-op when the slice has no assistant message (e.g. a
+// failed run) or no checked answer exists.
+function withCheckedAnswer(messages: LlmMessage[], answer: string | undefined): LlmMessage[] {
+  if (answer === undefined) return messages;
+  const lastAssistantIndex = messages.map((m) => m.role).lastIndexOf("assistant");
+  if (lastAssistantIndex === -1) return messages;
+
+  const original = messages[lastAssistantIndex] as { role: "assistant"; content: LlmAssistantBlock[] };
+  const toolUseBlocks = original.content.filter((block) => block.type === "tool_use");
+  const newContent: LlmAssistantBlock[] = [{ type: "text", text: answer }, ...toolUseBlocks];
+
+  const updated = [...messages];
+  updated[lastAssistantIndex] = { role: "assistant", content: newContent };
+  return updated;
 }
 
 // Accept only well-formed {role, content} turns; ignore anything malformed so a

--- a/src/app/api/agent/stream/route.ts
+++ b/src/app/api/agent/stream/route.ts
@@ -76,7 +76,12 @@ export async function POST(request: Request) {
     // transcript runAgent built (system + priorMessages + the new user
     // message + whatever the loop produced); slice off exactly that known
     // prefix.
-    const priorPrefixLength = priorMessages.length + 2; // system + priorMessages + user message
+    // system + priorMessages + user message. The `+ 2` (rather than
+    // `+ history.length + 2`) is valid ONLY because `history` is not forwarded
+    // to answerWithMemory on this route (see lines 23-30); harness assembles
+    // `[system, ...conversationTurnsToMessages(history), ...priorMessages, user]`,
+    // so if history is ever re-forwarded here, add its message count too.
+    const priorPrefixLength = priorMessages.length + 2;
     const producedMessages = withCheckedAnswer(result.messages.slice(priorPrefixLength), result.answer);
     await appendMessages(db, session.id, producedMessages, result.runId);
 

--- a/src/app/api/agent/stream/route.ts
+++ b/src/app/api/agent/stream/route.ts
@@ -1,8 +1,11 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { appendMessages, getOrCreateLatestSession, loadSessionMessages } from "@/lib/chat/sessions";
+import { conversationTurnsToMessages, type ConversationTurn } from "@/lib/harness";
 import { answerWithMemory, summarizeStep } from "@/lib/memory/answer";
+import { DEFAULT_ACTOR } from "@/lib/memory/actor";
 import { streamAgentResponse } from "@/lib/ui-message-stream";
-import type { ConversationTurn } from "@/lib/harness";
+import type { LlmUserMessage } from "@/lib/llm/types";
 
 // Streaming sibling of /api/agent: same memory agent run, but tool steps and
 // the model's own text stream to the client live. Text streams token-by-token
@@ -20,6 +23,15 @@ export async function POST(request: Request) {
   const history = parseHistory((body as { history?: unknown } | null)?.history);
   const db = getDb();
 
+  // Chat-session continuity (R6): resume this actor's latest session and load
+  // its prior turns (already LlmMessage-shaped, full fidelity) before the
+  // turn's input is assembled. The new user message is persisted immediately
+  // — durable even if the loop below fails or the request aborts.
+  const session = await getOrCreateLatestSession(db, DEFAULT_ACTOR);
+  const priorMessages = await loadSessionMessages(db, session.id);
+  const userMessage: LlmUserMessage = { role: "user", content: question };
+  await appendMessages(db, session.id, [userMessage]);
+
   return streamAgentResponse(async (writer) => {
     // Gate coupling note: this checks the literal tool name "search_memory"
     // because memoryRegistry() registers exactly that one tool today — "any
@@ -31,6 +43,7 @@ export async function POST(request: Request) {
     const result = await answerWithMemory(db, {
       question,
       history,
+      priorMessages,
       // Abort the run when the client disconnects (or the client-side 90s
       // timeout fires): Next aborts request.signal on connection close, and the
       // AI SDK stream swallows write-after-cancel, so this signal is the only
@@ -50,6 +63,16 @@ export async function POST(request: Request) {
         }
       },
     });
+
+    // Persist the loop's newly-produced messages after it settles, tagged with
+    // the run id — on both success and failure (even a failed run's synthetic
+    // error message should show up on reload). `result.messages` is the full
+    // transcript runAgent built (system + history + priorMessages + the new
+    // user message + whatever the loop produced); slice off exactly that
+    // known prefix.
+    const priorPrefixLength = 1 + conversationTurnsToMessages(history).length + priorMessages.length + 1;
+    const producedMessages = result.messages.slice(priorPrefixLength);
+    await appendMessages(db, session.id, producedMessages, result.runId);
 
     if (streamedLive && !searchCalledSoFar) {
       writer.answerEnd();

--- a/src/app/chat/ChatClient.tsx
+++ b/src/app/chat/ChatClient.tsx
@@ -5,6 +5,7 @@ import { EmptyState } from "@/components/ui";
 import { Composer } from "./Composer";
 import { MessageBubble } from "./MessageBubble";
 import { ReasoningTrace } from "./ReasoningTrace";
+import type { ResumedExchange } from "./resume";
 import { runChat, type AssistantTurn, type ChatMeta, type ConversationTurn } from "./stream";
 
 interface Exchange {
@@ -24,8 +25,16 @@ function prefersReducedMotion(): boolean {
   return typeof window !== "undefined" && !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
 }
 
-export function ChatClient() {
-  const [exchanges, setExchanges] = useState<Exchange[]>([]);
+export function ChatClient({ initialExchanges = [] }: { initialExchanges?: ResumedExchange[] }) {
+  const [exchanges, setExchanges] = useState<Exchange[]>(() =>
+    initialExchanges.map((resumed, index) => ({
+      id: -(index + 1), // negative ids so they never collide with idRef's live-turn counter
+      question: resumed.question,
+      turn: { steps: [], answer: resumed.answer },
+      open: false,
+      done: true,
+    }))
+  );
   const [input, setInput] = useState("");
   const [busy, setBusy] = useState(false);
   const idRef = useRef(0);

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -13,7 +13,10 @@ export default async function ChatPage({
   const { new: forceNew } = await searchParams;
   const db = getDb();
 
-  if (forceNew) {
+  // Presence of `?new` starts a fresh session, but guard the obvious falsy
+  // strings — `?new=0` / `?new=false` read as "not new" and shouldn't create
+  // one (the "New chat" link always passes `?new=1`).
+  if (forceNew && forceNew !== "0" && forceNew !== "false") {
     await createSession(db, DEFAULT_ACTOR);
     redirect("/chat");
   }

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,5 +1,35 @@
+import { redirect } from "next/navigation";
+import { getDb } from "@/lib/db";
+import { createSession, getOrCreateLatestSession, loadSessionMessages } from "@/lib/chat/sessions";
+import { DEFAULT_ACTOR } from "@/lib/memory/actor";
+import { mapMessagesToResumedExchanges } from "./resume";
 import { ChatClient } from "./ChatClient";
 
-export default function ChatPage() {
-  return <ChatClient />;
+export default async function ChatPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ new?: string }>;
+}) {
+  const { new: forceNew } = await searchParams;
+  const db = getDb();
+
+  if (forceNew) {
+    await createSession(db, DEFAULT_ACTOR);
+    redirect("/chat");
+  }
+
+  const session = await getOrCreateLatestSession(db, DEFAULT_ACTOR);
+  const messages = await loadSessionMessages(db, session.id);
+  const initialExchanges = mapMessagesToResumedExchanges(messages);
+
+  return (
+    <>
+      <div className="mx-auto w-full max-w-3xl px-6 pt-4 text-right">
+        <a href="/chat?new=1" className="text-[13px] text-accent-deep underline">
+          New chat
+        </a>
+      </div>
+      <ChatClient initialExchanges={initialExchanges} />
+    </>
+  );
 }

--- a/src/app/chat/resume.ts
+++ b/src/app/chat/resume.ts
@@ -1,0 +1,37 @@
+import type { LlmMessage } from "@/lib/llm/types";
+
+export interface ResumedExchange {
+  question: string;
+  answer: string;
+}
+
+// Folds a session's persisted transcript into display-only {question,
+// answer} pairs. Deliberately does not reconstruct the reasoning trace
+// (ChatStep[]) or run meta (ChatMeta) — chat_messages doesn't store either,
+// and R6 is a minimal resume, not a trace replay (see plan Judgment call 4).
+export function mapMessagesToResumedExchanges(messages: LlmMessage[]): ResumedExchange[] {
+  const exchanges: ResumedExchange[] = [];
+  let current: { question: string; answerParts: string[] } | null = null;
+
+  for (const message of messages) {
+    if (message.role === "system") continue;
+
+    if (message.role === "user") {
+      if (current) exchanges.push({ question: current.question, answer: current.answerParts.join(" ") });
+      current = { question: message.content, answerParts: [] };
+      continue;
+    }
+
+    if (!current) continue; // orphaned assistant/tool_result with no preceding question
+
+    if (message.role === "assistant") {
+      for (const block of message.content) {
+        if (block.type === "text" && block.text) current.answerParts.push(block.text);
+      }
+    }
+    // tool_result messages contribute nothing to the displayed answer text.
+  }
+
+  if (current) exchanges.push({ question: current.question, answer: current.answerParts.join(" ") });
+  return exchanges;
+}

--- a/src/lib/chat/sessions.ts
+++ b/src/lib/chat/sessions.ts
@@ -1,0 +1,71 @@
+import type postgres from "postgres";
+import type { Sql } from "../tools/types";
+import { DEFAULT_ACTOR, type MemoryActor } from "../memory/actor";
+import type { LlmMessage } from "../llm/types";
+
+export interface ChatSession {
+  id: string | number;
+}
+
+// Always inserts a fresh row — used for the "new chat" path, where the whole
+// point is a session that did NOT exist a moment ago.
+export async function createSession(db: Sql, actor: MemoryActor = DEFAULT_ACTOR): Promise<ChatSession> {
+  const [row] = await db<{ id: string }[]>`
+    INSERT INTO chat_sessions (actor_type, actor_id)
+    VALUES (${actor.actorType}, ${actor.actorId})
+    RETURNING id
+  `;
+  return { id: row.id };
+}
+
+// Resume-latest-or-create-new: the actor's most recently updated session, or
+// a brand new one if they have none yet.
+export async function getOrCreateLatestSession(db: Sql, actor: MemoryActor = DEFAULT_ACTOR): Promise<ChatSession> {
+  const [existing] = await db<{ id: string }[]>`
+    SELECT id FROM chat_sessions
+    WHERE actor_type = ${actor.actorType} AND actor_id = ${actor.actorId}
+    ORDER BY updated_at DESC
+    LIMIT 1
+  `;
+  if (existing) return { id: existing.id };
+  return createSession(db, actor);
+}
+
+// Persists messages in order and bumps chat_sessions.updated_at. `runId`
+// tags assistant/tool_result rows; user/system rows always get NULL run_id
+// regardless of what's passed, since they're recorded before any run starts.
+// Wrapped in one transaction (mirrors the db.begin pattern in migrate.ts /
+// memory/notes.ts) so a multi-row call (e.g. an assistant tool_use message
+// plus its paired tool_result message) can't persist half-written — a
+// dropped INSERT mid-call would otherwise leave an unpaired tool_use row
+// that every future turn re-threads into the model, which providers reject.
+export async function appendMessages(
+  db: Sql,
+  sessionId: number,
+  messages: LlmMessage[],
+  runId?: number
+): Promise<void> {
+  if (messages.length === 0) return;
+
+  await db.begin(async (tx) => {
+    for (const message of messages) {
+      const rowRunId = message.role === "user" || message.role === "system" ? null : (runId ?? null);
+      await tx`
+        INSERT INTO chat_messages (session_id, role, content_json, run_id)
+        VALUES (${sessionId}, ${message.role}, ${db.json(message.content as any)}, ${rowRunId})
+      `;
+    }
+    await tx`UPDATE chat_sessions SET updated_at = now() WHERE id = ${sessionId}`;
+  });
+}
+
+// SELECT role, content_json FROM chat_messages WHERE session_id = $1 ORDER BY
+// id, then rows.map(r => ({ role: r.role, content: r.content_json }) as
+// LlmMessage) — direct reassembly, no reshaping (brief §6).
+export async function loadSessionMessages(db: Sql, sessionId: number): Promise<LlmMessage[]> {
+  const rows = await db<{ role: string; content_json: unknown }[]>`
+    SELECT role, content_json FROM chat_messages WHERE session_id = ${sessionId} ORDER BY id
+  `;
+  return rows.map((r) => ({ role: r.role, content: r.content_json }) as LlmMessage);
+}
+

--- a/src/lib/chat/sessions.ts
+++ b/src/lib/chat/sessions.ts
@@ -39,6 +39,11 @@ export async function getOrCreateLatestSession(db: Sql, actor: MemoryActor = DEF
 // plus its paired tool_result message) can't persist half-written — a
 // dropped INSERT mid-call would otherwise leave an unpaired tool_use row
 // that every future turn re-threads into the model, which providers reject.
+// The `FOR UPDATE` row lock serializes concurrent appends to the same session
+// (reachable in v1 because every client shares DEFAULT_ACTOR): without it, two
+// overlapping transactions can interleave the auto-incremented message ids and
+// drop another turn's row between an assistant tool_use and its tool_result,
+// breaking the same adjacency the transaction exists to protect.
 export async function appendMessages(
   db: Sql,
   sessionId: number,
@@ -48,6 +53,7 @@ export async function appendMessages(
   if (messages.length === 0) return;
 
   await db.begin(async (tx) => {
+    await tx`SELECT id FROM chat_sessions WHERE id = ${sessionId} FOR UPDATE`;
     for (const message of messages) {
       const rowRunId = message.role === "user" || message.role === "system" ? null : (runId ?? null);
       await tx`

--- a/src/lib/chat/sessions.ts
+++ b/src/lib/chat/sessions.ts
@@ -52,7 +52,7 @@ export async function appendMessages(
       const rowRunId = message.role === "user" || message.role === "system" ? null : (runId ?? null);
       await tx`
         INSERT INTO chat_messages (session_id, role, content_json, run_id)
-        VALUES (${sessionId}, ${message.role}, ${toJson(tx as unknown as Sql, message.content)}, ${rowRunId})
+        VALUES (${sessionId}, ${message.role}, ${toJson(tx, message.content)}, ${rowRunId})
       `;
     }
     await tx`UPDATE chat_sessions SET updated_at = now() WHERE id = ${sessionId}`;
@@ -69,6 +69,6 @@ export async function loadSessionMessages(db: Sql, sessionId: number): Promise<L
   return rows.map((r) => ({ role: r.role, content: r.content_json }) as LlmMessage);
 }
 
-function toJson(db: Sql, value: unknown) {
+function toJson(db: postgres.Sql | postgres.TransactionSql, value: unknown) {
   return db.json(value as postgres.JSONValue);
 }

--- a/src/lib/chat/sessions.ts
+++ b/src/lib/chat/sessions.ts
@@ -4,30 +4,30 @@ import { DEFAULT_ACTOR, type MemoryActor } from "../memory/actor";
 import type { LlmMessage } from "../llm/types";
 
 export interface ChatSession {
-  id: string | number;
+  id: number;
 }
 
 // Always inserts a fresh row — used for the "new chat" path, where the whole
 // point is a session that did NOT exist a moment ago.
 export async function createSession(db: Sql, actor: MemoryActor = DEFAULT_ACTOR): Promise<ChatSession> {
-  const [row] = await db<{ id: string }[]>`
+  const [row] = await db<{ id: number }[]>`
     INSERT INTO chat_sessions (actor_type, actor_id)
     VALUES (${actor.actorType}, ${actor.actorId})
     RETURNING id
   `;
-  return { id: row.id };
+  return { id: Number(row.id) };
 }
 
 // Resume-latest-or-create-new: the actor's most recently updated session, or
 // a brand new one if they have none yet.
 export async function getOrCreateLatestSession(db: Sql, actor: MemoryActor = DEFAULT_ACTOR): Promise<ChatSession> {
-  const [existing] = await db<{ id: string }[]>`
+  const [existing] = await db<{ id: number }[]>`
     SELECT id FROM chat_sessions
     WHERE actor_type = ${actor.actorType} AND actor_id = ${actor.actorId}
     ORDER BY updated_at DESC
     LIMIT 1
   `;
-  if (existing) return { id: existing.id };
+  if (existing) return { id: Number(existing.id) };
   return createSession(db, actor);
 }
 
@@ -52,7 +52,7 @@ export async function appendMessages(
       const rowRunId = message.role === "user" || message.role === "system" ? null : (runId ?? null);
       await tx`
         INSERT INTO chat_messages (session_id, role, content_json, run_id)
-        VALUES (${sessionId}, ${message.role}, ${db.json(message.content as any)}, ${rowRunId})
+        VALUES (${sessionId}, ${message.role}, ${toJson(tx, message.content)}, ${rowRunId})
       `;
     }
     await tx`UPDATE chat_sessions SET updated_at = now() WHERE id = ${sessionId}`;
@@ -69,3 +69,6 @@ export async function loadSessionMessages(db: Sql, sessionId: number): Promise<L
   return rows.map((r) => ({ role: r.role, content: r.content_json }) as LlmMessage);
 }
 
+function toJson(db: Sql, value: unknown) {
+  return db.json(value as postgres.JSONValue);
+}

--- a/src/lib/chat/sessions.ts
+++ b/src/lib/chat/sessions.ts
@@ -52,7 +52,7 @@ export async function appendMessages(
       const rowRunId = message.role === "user" || message.role === "system" ? null : (runId ?? null);
       await tx`
         INSERT INTO chat_messages (session_id, role, content_json, run_id)
-        VALUES (${sessionId}, ${message.role}, ${toJson(tx, message.content)}, ${rowRunId})
+        VALUES (${sessionId}, ${message.role}, ${toJson(tx as unknown as Sql, message.content)}, ${rowRunId})
       `;
     }
     await tx`UPDATE chat_sessions SET updated_at = now() WHERE id = ${sessionId}`;

--- a/src/lib/harness.ts
+++ b/src/lib/harness.ts
@@ -32,6 +32,11 @@ export interface RunAgentInput {
   // Prior conversation turns for multi-turn chat. Threaded into messages[] ahead
   // of the current question, capped server-side in conversationTurnsToMessages.
   history?: ConversationTurn[];
+  // Full-fidelity prior messages for a resumed chat session (R6). Threaded
+  // into messages[] immediately before the new user message — unlike
+  // `history`, these are already LlmMessage-shaped, so no string-only
+  // downgrade happens and tool_use/tool_result blocks survive intact.
+  priorMessages?: LlmMessage[];
   // Invoked after each executed tool step. Awaited so a streaming consumer can
   // flush the step to the client before the next turn runs.
   onStep?: (event: AgentStepEvent) => void | Promise<void>;
@@ -99,6 +104,7 @@ export async function runAgent(input: RunAgentInput): Promise<RunAgentResult> {
     const messages: LlmMessage[] = [
       { role: "system", content: input.instructions ?? DEFAULT_IDENTITY },
       ...conversationTurnsToMessages(input.history),
+      ...(input.priorMessages ?? []),
       { role: "user", content: input.question },
     ];
 

--- a/src/lib/memory/answer.ts
+++ b/src/lib/memory/answer.ts
@@ -21,6 +21,9 @@ export interface MemoryAnswer {
 export interface AnswerWithMemoryInput {
   question: string;
   history?: ConversationTurn[];
+  // Full-fidelity prior session messages (R6), forwarded straight through to
+  // runAgent's priorMessages — see RunAgentInput.priorMessages.
+  priorMessages?: LlmMessage[];
   onStep?: (event: AgentStepEvent) => void | Promise<void>;
   // Raw agent-loop events, forwarded 1:1 to runAgent — see RunAgentInput.
   onAgentLoopEvent?: (event: AgentLoopEvent) => void | Promise<void>;
@@ -41,6 +44,7 @@ export async function answerWithMemory(db: Sql, input: AnswerWithMemoryInput): P
   const result = await runAgent({
     question: input.question,
     history: input.history,
+    priorMessages: input.priorMessages,
     registry,
     allowedClasses: new Set(["read"]),
     instructions,

--- a/src/migrations/005_chat_sessions.sql
+++ b/src/migrations/005_chat_sessions.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS chat_messages (
   session_id    BIGINT NOT NULL REFERENCES chat_sessions(id) ON DELETE CASCADE,
   role          TEXT NOT NULL CHECK (role IN ('system', 'user', 'assistant', 'tool_result')),
   content_json  JSONB NOT NULL,
-  run_id        BIGINT REFERENCES runs(id) ON DELETE SET NULL,
+  run_id        BIGINT,
   created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 

--- a/src/migrations/005_chat_sessions.sql
+++ b/src/migrations/005_chat_sessions.sql
@@ -1,0 +1,27 @@
+-- 005_chat_sessions.sql — R6 server-side chat session persistence.
+-- content_json stores exactly the `content` field of the corresponding
+-- LlmMessage variant (a string for system/user; an array of
+-- LlmAssistantBlock/LlmToolResultBlock for assistant/tool_result), so
+-- round-tripping is a direct { role, content: row.content_json } reassembly.
+-- run_id is nullable since system/user rows precede any run.
+
+CREATE TABLE IF NOT EXISTS chat_sessions (
+  id            BIGSERIAL PRIMARY KEY,
+  actor_type    TEXT NOT NULL,
+  actor_id      TEXT NOT NULL,
+  title         TEXT,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS chat_messages (
+  id            BIGSERIAL PRIMARY KEY,
+  session_id    BIGINT NOT NULL REFERENCES chat_sessions(id) ON DELETE CASCADE,
+  role          TEXT NOT NULL CHECK (role IN ('system', 'user', 'assistant', 'tool_result')),
+  content_json  JSONB NOT NULL,
+  run_id        BIGINT REFERENCES runs(id) ON DELETE SET NULL,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS chat_messages_session_idx ON chat_messages(session_id, id);
+CREATE INDEX IF NOT EXISTS chat_sessions_actor_idx ON chat_sessions(actor_type, actor_id, updated_at DESC);

--- a/src/migrations/005_chat_sessions.sql
+++ b/src/migrations/005_chat_sessions.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS chat_messages (
   session_id    BIGINT NOT NULL REFERENCES chat_sessions(id) ON DELETE CASCADE,
   role          TEXT NOT NULL CHECK (role IN ('system', 'user', 'assistant', 'tool_result')),
   content_json  JSONB NOT NULL,
-  run_id        BIGINT,
+  run_id        BIGINT REFERENCES runs(id) ON DELETE SET NULL,
   created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 

--- a/tests/agent-stream-route.test.ts
+++ b/tests/agent-stream-route.test.ts
@@ -1,17 +1,42 @@
 import { vi } from "vitest";
 
-const { runAgentMock, getRunTraceMock } = vi.hoisted(() => ({
-  runAgentMock: vi.fn(),
-  getRunTraceMock: vi.fn(),
+const { runAgentMock, getRunTraceMock, getOrCreateLatestSessionMock, loadSessionMessagesMock, appendMessagesMock } =
+  vi.hoisted(() => ({
+    runAgentMock: vi.fn(),
+    getRunTraceMock: vi.fn(),
+    getOrCreateLatestSessionMock: vi.fn(),
+    loadSessionMessagesMock: vi.fn(),
+    appendMessagesMock: vi.fn(),
+  }));
+vi.mock("@/lib/harness", () => ({
+  runAgent: runAgentMock,
+  // Route uses this (unmocked, real behavior would be []) to compute the
+  // produced-messages slice offset; no test here sends body.history.
+  conversationTurnsToMessages: () => [],
 }));
-vi.mock("@/lib/harness", () => ({ runAgent: runAgentMock }));
 vi.mock("@/lib/ledger", () => ({ getRunTrace: getRunTraceMock }));
 vi.mock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue({}) }));
 vi.mock("@/lib/context", () => ({
   buildMemoryAnswerInstructions: vi.fn().mockResolvedValue("stub instructions"),
 }));
+vi.mock("@/lib/chat/sessions", () => ({
+  getOrCreateLatestSession: getOrCreateLatestSessionMock,
+  loadSessionMessages: loadSessionMessagesMock,
+  appendMessages: appendMessagesMock,
+}));
 
 import { POST } from "@/app/api/agent/stream/route";
+import { DEFAULT_ACTOR } from "@/lib/memory/actor";
+
+// Minimal transcript shape (system + user + one produced assistant message)
+// for tests that don't care about the exact messages[] content — just that
+// `result.messages` exists so the route's persist-after-settle slice doesn't
+// crash on `.slice()` of `undefined`.
+const STUB_MESSAGES = [
+  { role: "system", content: "stub instructions" },
+  { role: "user", content: "stub question" },
+  { role: "assistant", content: [{ type: "text", text: "stub" }] },
+];
 
 function postRequest(body: unknown): Request {
   return new Request("http://localhost/api/agent/stream", {
@@ -37,6 +62,9 @@ describe("POST /api/agent/stream", () => {
   beforeEach(() => {
     runAgentMock.mockReset();
     getRunTraceMock.mockResolvedValue(null); // no trace → citation check is a pass-through
+    getOrCreateLatestSessionMock.mockReset().mockResolvedValue({ id: 7 });
+    loadSessionMessagesMock.mockReset().mockResolvedValue([]);
+    appendMessagesMock.mockReset().mockResolvedValue(undefined);
   });
 
   it("returns 400 when question is missing", async () => {
@@ -58,6 +86,7 @@ describe("POST /api/agent/stream", () => {
         status: "succeeded",
         answer: "Acme Robotics is a Series B company [acme-md#chunk-1].",
         steps: 1,
+        messages: STUB_MESSAGES,
       };
     });
 
@@ -77,7 +106,7 @@ describe("POST /api/agent/stream", () => {
   });
 
   it("still emits a meta part when the run fails with no answer", async () => {
-    runAgentMock.mockResolvedValue({ runId: 9, status: "failed", steps: 8 });
+    runAgentMock.mockResolvedValue({ runId: 9, status: "failed", steps: 8, messages: STUB_MESSAGES });
     const res = await POST(postRequest({ question: "loop" }));
     expect(res.status).toBe(200); // the stream itself is a 200; failure is carried in meta
     const body = await readAll(res);
@@ -99,7 +128,7 @@ describe("POST /api/agent/stream", () => {
       }) => {
         await input.onAgentLoopEvent?.({ type: "llm", event: { type: "text_delta", delta: "checking memory..." } });
         await input.onAgentLoopEvent?.({ type: "tool_start", id: "call-1", name: "search_memory", input: {} });
-        return { runId: 12, status: "failed", steps: 8 };
+        return { runId: 12, status: "failed", steps: 8, messages: STUB_MESSAGES };
       }
     );
 
@@ -122,7 +151,7 @@ describe("POST /api/agent/stream", () => {
       }) => {
         await input.onAgentLoopEvent?.({ type: "llm", event: { type: "text_delta", delta: "Acme is " } });
         await input.onAgentLoopEvent?.({ type: "llm", event: { type: "text_delta", delta: "a Series B co." } });
-        return { runId: 7, status: "succeeded", answer: "Acme is a Series B co.", steps: 0 };
+        return { runId: 7, status: "succeeded", answer: "Acme is a Series B co.", steps: 0, messages: STUB_MESSAGES };
       }
     );
 
@@ -157,6 +186,7 @@ describe("POST /api/agent/stream", () => {
           status: "succeeded",
           answer: "Acme Robotics is a Series B company [acme-md#chunk-1].",
           steps: 1,
+          messages: STUB_MESSAGES,
         };
       }
     );
@@ -181,7 +211,7 @@ describe("POST /api/agent/stream", () => {
         observation: 'Success: {"acceptedFacts":[1],"gapFacts":[],"chunks":[1]}',
         ok: true,
       });
-      return { runId: 9, status: "succeeded", answer: "Answer with no live events.", steps: 1 };
+      return { runId: 9, status: "succeeded", answer: "Answer with no live events.", steps: 1, messages: STUB_MESSAGES };
     });
 
     const res = await POST(postRequest({ question: "tell me about acme" }));
@@ -198,7 +228,7 @@ describe("POST /api/agent/stream", () => {
     let received: AbortSignal | undefined;
     runAgentMock.mockImplementation(async (input: { signal?: AbortSignal }) => {
       received = input.signal;
-      return { runId: 11, status: "succeeded", answer: "ok", steps: 0 };
+      return { runId: 11, status: "succeeded", answer: "ok", steps: 0, messages: STUB_MESSAGES };
     });
 
     const req = postRequest({ question: "hi" });
@@ -228,6 +258,7 @@ describe("POST /api/agent/stream", () => {
           status: "succeeded",
           answer: "Acme is a Series B company.",
           steps: 1,
+          messages: STUB_MESSAGES,
         };
       }
     );
@@ -239,5 +270,66 @@ describe("POST /api/agent/stream", () => {
     expect(body).toContain("checking memory...");
     // ...and also reappears verbatim as the step's thought line — accepted duplication, not suppressed.
     expect(body).toContain('"thought":"checking memory..."');
+  });
+
+  describe("session persistence (R6)", () => {
+    it("loads prior session messages before running the turn and threads them in as priorMessages", async () => {
+      const prior = [
+        { role: "user", content: "earlier question" },
+        { role: "assistant", content: [{ type: "text", text: "earlier answer" }] },
+      ];
+      loadSessionMessagesMock.mockResolvedValue(prior);
+      runAgentMock.mockResolvedValue({
+        runId: 50,
+        status: "succeeded",
+        answer: "ok",
+        steps: 0,
+        messages: [{ role: "system", content: "stub" }, ...prior, { role: "user", content: "follow-up question" }],
+      });
+
+      const res = await POST(postRequest({ question: "follow-up question" }));
+      await readAll(res);
+
+      expect(getOrCreateLatestSessionMock).toHaveBeenCalledWith(expect.anything(), DEFAULT_ACTOR);
+      expect(loadSessionMessagesMock).toHaveBeenCalledWith(expect.anything(), 7);
+      expect(runAgentMock).toHaveBeenCalledWith(expect.objectContaining({ priorMessages: prior }));
+    });
+
+    it("persists the user message immediately and the produced messages after the turn, tagged with the run id", async () => {
+      runAgentMock.mockResolvedValue({
+        runId: 51,
+        status: "succeeded",
+        answer: "ok",
+        steps: 0,
+        messages: STUB_MESSAGES,
+      });
+
+      const res = await POST(postRequest({ question: "hello there" }));
+      await readAll(res);
+
+      expect(appendMessagesMock).toHaveBeenCalledTimes(2);
+      // first call: the new user message, persisted immediately, no runId
+      expect(appendMessagesMock.mock.calls[0][1]).toBe(7);
+      expect(appendMessagesMock.mock.calls[0][2]).toEqual([{ role: "user", content: "hello there" }]);
+      expect(appendMessagesMock.mock.calls[0][3]).toBeUndefined();
+      // second call: the loop's produced messages, tagged with the run id
+      expect(appendMessagesMock.mock.calls[1][1]).toBe(7);
+      expect(appendMessagesMock.mock.calls[1][3]).toBe(51);
+    });
+
+    it("still persists the turn's messages when the loop fails", async () => {
+      runAgentMock.mockResolvedValue({
+        runId: 52,
+        status: "failed",
+        steps: 8,
+        messages: STUB_MESSAGES,
+      });
+
+      const res = await POST(postRequest({ question: "loop" }));
+      await readAll(res);
+
+      expect(appendMessagesMock).toHaveBeenCalledTimes(2); // user message + failure message, same as success path
+      expect(appendMessagesMock.mock.calls[1][3]).toBe(52);
+    });
   });
 });

--- a/tests/agent-stream-route.test.ts
+++ b/tests/agent-stream-route.test.ts
@@ -10,9 +10,6 @@ const { runAgentMock, getRunTraceMock, getOrCreateLatestSessionMock, loadSession
   }));
 vi.mock("@/lib/harness", () => ({
   runAgent: runAgentMock,
-  // Route uses this (unmocked, real behavior would be []) to compute the
-  // produced-messages slice offset; no test here sends body.history.
-  conversationTurnsToMessages: () => [],
 }));
 vi.mock("@/lib/ledger", () => ({ getRunTrace: getRunTraceMock }));
 vi.mock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue({}) }));
@@ -330,6 +327,101 @@ describe("POST /api/agent/stream", () => {
 
       expect(appendMessagesMock).toHaveBeenCalledTimes(2); // user message + failure message, same as success path
       expect(appendMessagesMock.mock.calls[1][3]).toBe(52);
+    });
+
+    it("does not double-feed client-sent history: the persisted session's priorMessages supersede it, and runAgent receives history undefined", async () => {
+      const prior = [
+        { role: "user", content: "earlier question" },
+        { role: "assistant", content: [{ type: "text", text: "earlier answer" }] },
+      ];
+      loadSessionMessagesMock.mockResolvedValue(prior);
+      runAgentMock.mockResolvedValue({
+        runId: 61,
+        status: "succeeded",
+        answer: "ok",
+        steps: 0,
+        messages: [
+          { role: "system", content: "stub" },
+          ...prior,
+          { role: "user", content: "new question" },
+          { role: "assistant", content: [{ type: "text", text: "ok" }] },
+        ],
+      });
+
+      const res = await POST(
+        postRequest({
+          question: "new question",
+          history: [{ role: "user", content: "client-sent history turn" }],
+        })
+      );
+      await readAll(res);
+
+      expect(runAgentMock).toHaveBeenCalledWith(
+        expect.objectContaining({ history: undefined, priorMessages: prior })
+      );
+    });
+
+    it("persists the citation-checked answer text, not the raw pre-check text, on the final assistant message (tool_use blocks preserved)", async () => {
+      const rawAnswer = "Acme is here [bad-doc#chunk-9].";
+      const checkedAnswer = "Acme is here [[unverified citation removed]].";
+      const toolUseBlock = { type: "tool_use", id: "call-1", name: "noop", input: {} };
+      runAgentMock.mockResolvedValue({
+        runId: 62,
+        status: "succeeded",
+        answer: rawAnswer,
+        steps: 1,
+        messages: [
+          { role: "system", content: "stub" },
+          { role: "user", content: "tell me about acme" },
+          { role: "assistant", content: [{ type: "text", text: rawAnswer }, toolUseBlock] },
+        ],
+      });
+      getRunTraceMock.mockResolvedValue({
+        id: 62,
+        steps: [
+          {
+            id: 1,
+            children: [],
+            toolCalls: [
+              {
+                toolName: "search_memory",
+                status: "succeeded",
+                result: { acceptedFacts: [], gapFacts: [], chunks: [{ citation: "good-doc#chunk-1" }] },
+              },
+            ],
+          },
+        ],
+      });
+
+      const res = await POST(postRequest({ question: "tell me about acme" }));
+      await readAll(res);
+
+      expect(appendMessagesMock.mock.calls[1][2]).toEqual([
+        { role: "assistant", content: [{ type: "text", text: checkedAnswer }, toolUseBlock] },
+      ]);
+    });
+
+    it("persists exactly the loop's produced messages for a clean success turn (no system prompt, no dropped assistant reply)", async () => {
+      runAgentMock.mockResolvedValue({
+        runId: 63,
+        status: "succeeded",
+        answer: "hi there",
+        steps: 0,
+        messages: [
+          { role: "system", content: "stub instructions" },
+          { role: "user", content: "hello there" },
+          { role: "assistant", content: [{ type: "text", text: "hi there" }] },
+        ],
+      });
+
+      const res = await POST(postRequest({ question: "hello there" }));
+      await readAll(res);
+
+      expect(appendMessagesMock.mock.calls[1][2]).toEqual([
+        { role: "assistant", content: [{ type: "text", text: "hi there" }] },
+      ]);
+      expect(appendMessagesMock.mock.calls[1][1]).toBe(7);
+      expect(appendMessagesMock.mock.calls[1][3]).toBe(63);
     });
   });
 });

--- a/tests/chat-page.test.tsx
+++ b/tests/chat-page.test.tsx
@@ -1,0 +1,71 @@
+import { vi } from "vitest";
+
+const { createSessionMock, getOrCreateLatestSessionMock, loadSessionMessagesMock, redirectMock } = vi.hoisted(() => ({
+  createSessionMock: vi.fn(),
+  getOrCreateLatestSessionMock: vi.fn(),
+  loadSessionMessagesMock: vi.fn(),
+  redirectMock: vi.fn(() => {
+    throw new Error("NEXT_REDIRECT");
+  }),
+}));
+vi.mock("@/lib/chat/sessions", () => ({
+  createSession: createSessionMock,
+  getOrCreateLatestSession: getOrCreateLatestSessionMock,
+  loadSessionMessages: loadSessionMessagesMock,
+}));
+vi.mock("@/lib/db", () => ({ getDb: vi.fn().mockReturnValue({}) }));
+vi.mock("next/navigation", () => ({ redirect: redirectMock }));
+
+import ChatPage from "@/app/chat/page";
+import { ChatClient } from "@/app/chat/ChatClient";
+
+describe("ChatPage", () => {
+  beforeEach(() => {
+    createSessionMock.mockReset();
+    getOrCreateLatestSessionMock.mockReset();
+    loadSessionMessagesMock.mockReset();
+    redirectMock.mockClear();
+  });
+
+  it("resumes the latest session and passes its mapped history into ChatClient", async () => {
+    getOrCreateLatestSessionMock.mockResolvedValue({ id: 5 });
+    loadSessionMessagesMock.mockResolvedValue([
+      { role: "user", content: "hi" },
+      { role: "assistant", content: [{ type: "text", text: "hello" }] },
+    ]);
+
+    const element = await ChatPage({ searchParams: Promise.resolve({}) });
+    expect(getOrCreateLatestSessionMock).toHaveBeenCalled();
+    expect(createSessionMock).not.toHaveBeenCalled();
+
+    const clientElement = findElementOfType(element, ChatClient);
+    expect(clientElement?.props.initialExchanges).toEqual([{ question: "hi", answer: "hello" }]);
+  });
+
+  it("with ?new=1, creates a fresh session and redirects to /chat", async () => {
+    createSessionMock.mockResolvedValue({ id: 9 });
+
+    await expect(ChatPage({ searchParams: Promise.resolve({ new: "1" }) })).rejects.toThrow("NEXT_REDIRECT");
+    expect(createSessionMock).toHaveBeenCalled();
+    expect(getOrCreateLatestSessionMock).not.toHaveBeenCalled();
+    expect(redirectMock).toHaveBeenCalledWith("/chat");
+  });
+});
+
+// React elements expose their tree via .props.children; walk it to find a
+// node whose type matches the given component.
+function findElementOfType(node: unknown, type: unknown): { props: Record<string, unknown> } | null {
+  if (node == null || typeof node !== "object") return null;
+  const el = node as { type?: unknown; props?: { children?: unknown } };
+  if (el.type === type) return el as { props: Record<string, unknown> };
+  const children = el.props?.children;
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      const found = findElementOfType(child, type);
+      if (found) return found;
+    }
+  } else if (children) {
+    return findElementOfType(children, type);
+  }
+  return null;
+}

--- a/tests/chat-resume.test.ts
+++ b/tests/chat-resume.test.ts
@@ -1,0 +1,66 @@
+import type { LlmAssistantMessage, LlmMessage, LlmToolResultMessage, LlmUserMessage } from "@/lib/llm/types";
+import { mapMessagesToResumedExchanges } from "@/app/chat/resume";
+
+function user(content: string): LlmUserMessage {
+  return { role: "user", content };
+}
+function assistantText(text: string): LlmAssistantMessage {
+  return { role: "assistant", content: [{ type: "text", text }] };
+}
+function assistantToolUse(text: string, id: string, name: string): LlmAssistantMessage {
+  return { role: "assistant", content: [{ type: "text", text }, { type: "tool_use", id, name, input: {} }] };
+}
+function toolResult(id: string, name: string, content: string): LlmToolResultMessage {
+  return { role: "tool_result", content: [{ toolUseId: id, toolName: name, content, isError: false }] };
+}
+
+describe("mapMessagesToResumedExchanges", () => {
+  it("returns an empty list for no messages", () => {
+    expect(mapMessagesToResumedExchanges([])).toEqual([]);
+  });
+
+  it("pairs a single question with its answer", () => {
+    const messages: LlmMessage[] = [user("hi there"), assistantText("hello!")];
+    expect(mapMessagesToResumedExchanges(messages)).toEqual([{ question: "hi there", answer: "hello!" }]);
+  });
+
+  it("concatenates assistant text across a tool-use turn, skipping tool_result content", () => {
+    const messages: LlmMessage[] = [
+      user("tell me about acme"),
+      assistantToolUse("Let me check.", "call_1", "search_memory"),
+      toolResult("call_1", "search_memory", "found 2 facts"),
+      assistantText("Acme is a Series B company."),
+    ];
+    expect(mapMessagesToResumedExchanges(messages)).toEqual([
+      { question: "tell me about acme", answer: "Let me check. Acme is a Series B company." },
+    ]);
+  });
+
+  it("handles multiple turns in one session", () => {
+    const messages: LlmMessage[] = [
+      user("first question"),
+      assistantText("first answer"),
+      user("second question"),
+      assistantText("second answer"),
+    ];
+    expect(mapMessagesToResumedExchanges(messages)).toEqual([
+      { question: "first question", answer: "first answer" },
+      { question: "second question", answer: "second answer" },
+    ]);
+  });
+
+  it("includes a trailing turn even without a following user message", () => {
+    const messages: LlmMessage[] = [user("only question"), assistantText("only answer")];
+    expect(mapMessagesToResumedExchanges(messages)).toEqual([{ question: "only question", answer: "only answer" }]);
+  });
+
+  it("skips a system message defensively (never persisted in practice)", () => {
+    const messages: LlmMessage[] = [{ role: "system", content: "instructions" }, user("q"), assistantText("a")];
+    expect(mapMessagesToResumedExchanges(messages)).toEqual([{ question: "q", answer: "a" }]);
+  });
+
+  it("ignores an orphaned assistant/tool_result message with no preceding user turn", () => {
+    const messages: LlmMessage[] = [assistantText("stray"), user("q"), assistantText("a")];
+    expect(mapMessagesToResumedExchanges(messages)).toEqual([{ question: "q", answer: "a" }]);
+  });
+});

--- a/tests/chat-sessions-migrate.test.ts
+++ b/tests/chat-sessions-migrate.test.ts
@@ -1,0 +1,83 @@
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+
+async function resetChatTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS chat_messages CASCADE`;
+  await db`DROP TABLE IF EXISTS chat_sessions CASCADE`;
+  await db`DELETE FROM schema_migrations WHERE name = '005_chat_sessions.sql'`;
+  await runMigrations(db);
+}
+
+describe("005 chat sessions migration", () => {
+  beforeEach(async () => {
+    await resetChatTables();
+  });
+
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("creates chat_sessions and chat_messages", async () => {
+    const db = getDb();
+    const result = await db<{ table_name: string }[]>`
+      SELECT table_name FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name IN ('chat_sessions', 'chat_messages')
+      ORDER BY table_name
+    `;
+    expect(result.map((r) => r.table_name)).toEqual(["chat_messages", "chat_sessions"]);
+  });
+
+  it("chat_messages.role rejects a value outside the allowed set", async () => {
+    const db = getDb();
+    const [session] = await db<{ id: number }[]>`
+      INSERT INTO chat_sessions (actor_type, actor_id) VALUES ('test_client', 'x') RETURNING id
+    `;
+    await expect(
+      db`INSERT INTO chat_messages (session_id, role, content_json) VALUES (${session.id}, 'bogus', '"x"')`
+    ).rejects.toThrow();
+  });
+
+  it("chat_messages_session_idx and chat_sessions_actor_idx exist", async () => {
+    const db = getDb();
+    const result = await db<{ indexname: string }[]>`
+      SELECT indexname FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND indexname IN ('chat_messages_session_idx', 'chat_sessions_actor_idx')
+    `;
+    expect(result.map((r) => r.indexname).sort()).toEqual([
+      "chat_messages_session_idx",
+      "chat_sessions_actor_idx",
+    ]);
+  });
+
+  it("deleting a session cascades to its messages", async () => {
+    const db = getDb();
+    const [session] = await db<{ id: number }[]>`
+      INSERT INTO chat_sessions (actor_type, actor_id) VALUES ('test_client', 'x') RETURNING id
+    `;
+    await db`INSERT INTO chat_messages (session_id, role, content_json) VALUES (${session.id}, 'user', '"hi"')`;
+    await db`DELETE FROM chat_sessions WHERE id = ${session.id}`;
+    const remaining = await db`SELECT 1 FROM chat_messages WHERE session_id = ${session.id}`;
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("a run being deleted sets chat_messages.run_id to NULL, not blocking the delete", async () => {
+    const db = getDb();
+    const [run] = await db<{ id: number }[]>`
+      INSERT INTO runs (run_type, status) VALUES ('agent_chat_stream', 'succeeded') RETURNING id
+    `;
+    const [session] = await db<{ id: number }[]>`
+      INSERT INTO chat_sessions (actor_type, actor_id) VALUES ('test_client', 'x') RETURNING id
+    `;
+    const [message] = await db<{ id: number }[]>`
+      INSERT INTO chat_messages (session_id, role, content_json, run_id)
+      VALUES (${session.id}, 'assistant', '[]', ${run.id}) RETURNING id
+    `;
+    await db`DELETE FROM runs WHERE id = ${run.id}`;
+    const [row] = await db<{ run_id: number | null }[]>`
+      SELECT run_id FROM chat_messages WHERE id = ${message.id}
+    `;
+    expect(row.run_id).toBeNull();
+  });
+});

--- a/tests/chat-sessions.test.ts
+++ b/tests/chat-sessions.test.ts
@@ -40,7 +40,7 @@ describe("chat session persistence", () => {
     const session = await getOrCreateLatestSession(db, ACTOR);
     const rows = await db`SELECT id FROM chat_sessions WHERE actor_type = ${ACTOR.actorType} AND actor_id = ${ACTOR.actorId}`;
     expect(rows).toHaveLength(1);
-    expect(rows[0].id).toBe(session.id);
+    expect(Number(rows[0].id)).toBe(session.id);
   });
 
   it("getOrCreateLatestSession returns the most recently updated session, not just most recently created", async () => {

--- a/tests/chat-sessions.test.ts
+++ b/tests/chat-sessions.test.ts
@@ -127,4 +127,24 @@ describe("chat session persistence", () => {
     const loaded = await loadSessionMessages(db, session.id);
     expect(loaded.map((m) => m.content)).toEqual(["first", "second"]);
   });
+
+  it("appendMessages is atomic: a mid-batch failure rolls back the whole call, persisting no rows and leaving updated_at untouched", async () => {
+    const db = getDb();
+    const session = await createSession(db, ACTOR);
+    const [before] = await db<{ updated_at: Date }[]>`SELECT updated_at FROM chat_sessions WHERE id = ${session.id}`;
+
+    // Second message has a role the CHECK constraint rejects, so its INSERT
+    // throws mid-batch. The db.begin wrapper must roll back the first (valid)
+    // INSERT too — otherwise a dropped write would leave an unpaired row that
+    // poisons every future turn (the invariant the plan's eng review demanded).
+    const good = { role: "user", content: "kept?" } as LlmUserMessage;
+    const bad = { role: "bogus", content: "boom" } as unknown as LlmUserMessage;
+
+    await expect(appendMessages(db, session.id, [good, bad])).rejects.toThrow();
+
+    const rows = await db`SELECT 1 FROM chat_messages WHERE session_id = ${session.id}`;
+    expect(rows).toHaveLength(0);
+    const [after] = await db<{ updated_at: Date }[]>`SELECT updated_at FROM chat_sessions WHERE id = ${session.id}`;
+    expect(after.updated_at.getTime()).toBe(before.updated_at.getTime());
+  });
 });

--- a/tests/chat-sessions.test.ts
+++ b/tests/chat-sessions.test.ts
@@ -67,6 +67,9 @@ describe("chat session persistence", () => {
   it("appendMessages + loadSessionMessages round-trip every LlmMessage variant", async () => {
     const db = getDb();
     const session = await createSession(db, ACTOR);
+    const [run] = await db<{ id: number }[]>`
+      INSERT INTO runs (run_type, status) VALUES ('agent_chat_stream', 'succeeded') RETURNING id
+    `;
     const userMsg: LlmUserMessage = { role: "user", content: "tell me about acme" };
     const assistantMsg: LlmAssistantMessage = {
       role: "assistant",
@@ -81,7 +84,7 @@ describe("chat session persistence", () => {
     };
 
     await appendMessages(db, session.id, [userMsg]);
-    await appendMessages(db, session.id, [assistantMsg, toolResultMsg], 42);
+    await appendMessages(db, session.id, [assistantMsg, toolResultMsg], run.id);
 
     const loaded = await loadSessionMessages(db, session.id);
     expect(loaded).toEqual([userMsg, assistantMsg, toolResultMsg]);
@@ -90,7 +93,10 @@ describe("chat session persistence", () => {
   it("forces run_id to NULL for user/system rows even if a runId is passed", async () => {
     const db = getDb();
     const session = await createSession(db, ACTOR);
-    await appendMessages(db, session.id, [{ role: "user", content: "hi" } as LlmUserMessage], 99);
+    const [run] = await db<{ id: number }[]>`
+      INSERT INTO runs (run_type, status) VALUES ('agent_chat_stream', 'succeeded') RETURNING id
+    `;
+    await appendMessages(db, session.id, [{ role: "user", content: "hi" } as LlmUserMessage], run.id);
     const rows = await db<{ run_id: number | null }[]>`SELECT run_id FROM chat_messages WHERE session_id = ${session.id}`;
     expect(rows[0].run_id).toBeNull();
   });

--- a/tests/chat-sessions.test.ts
+++ b/tests/chat-sessions.test.ts
@@ -1,0 +1,124 @@
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+import type { MemoryActor } from "@/lib/memory/actor";
+import type { LlmAssistantMessage, LlmToolResultMessage, LlmUserMessage } from "@/lib/llm/types";
+import {
+  appendMessages,
+  createSession,
+  getOrCreateLatestSession,
+  loadSessionMessages,
+} from "@/lib/chat/sessions";
+
+async function resetChatTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS chat_messages CASCADE`;
+  await db`DROP TABLE IF EXISTS chat_sessions CASCADE`;
+  await db`DELETE FROM schema_migrations WHERE name = '005_chat_sessions.sql'`;
+  await runMigrations(db);
+}
+
+const ACTOR: MemoryActor = { actorType: "test_client", actorId: "chat-sessions-test" };
+const OTHER_ACTOR: MemoryActor = { actorType: "test_client", actorId: "other-actor" };
+
+describe("chat session persistence", () => {
+  beforeEach(async () => {
+    await resetChatTables();
+  });
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("createSession always inserts a new row", async () => {
+    const db = getDb();
+    const a = await createSession(db, ACTOR);
+    const b = await createSession(db, ACTOR);
+    expect(a.id).not.toBe(b.id);
+  });
+
+  it("getOrCreateLatestSession creates one when none exists", async () => {
+    const db = getDb();
+    const session = await getOrCreateLatestSession(db, ACTOR);
+    const rows = await db`SELECT id FROM chat_sessions WHERE actor_type = ${ACTOR.actorType} AND actor_id = ${ACTOR.actorId}`;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(session.id);
+  });
+
+  it("getOrCreateLatestSession returns the most recently updated session, not just most recently created", async () => {
+    const db = getDb();
+    const older = await createSession(db, ACTOR);
+    await new Promise((r) => setTimeout(r, 10));
+    const newer = await createSession(db, ACTOR);
+    // touch `older` after `newer` was created so it becomes latest by updated_at
+    await appendMessages(db, older.id, [{ role: "user", content: "hi" } as LlmUserMessage]);
+
+    const latest = await getOrCreateLatestSession(db, ACTOR);
+    expect(latest.id).toBe(older.id);
+    expect(latest.id).not.toBe(newer.id);
+  });
+
+  it("sessions are isolated per actor", async () => {
+    const db = getDb();
+    const mine = await createSession(db, ACTOR);
+    await createSession(db, OTHER_ACTOR);
+    const latest = await getOrCreateLatestSession(db, ACTOR);
+    expect(latest.id).toBe(mine.id);
+  });
+
+  it("appendMessages + loadSessionMessages round-trip every LlmMessage variant", async () => {
+    const db = getDb();
+    const session = await createSession(db, ACTOR);
+    const userMsg: LlmUserMessage = { role: "user", content: "tell me about acme" };
+    const assistantMsg: LlmAssistantMessage = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "Let me check." },
+        { type: "tool_use", id: "call_1", name: "search_memory", input: { query: "acme" } },
+      ],
+    };
+    const toolResultMsg: LlmToolResultMessage = {
+      role: "tool_result",
+      content: [{ toolUseId: "call_1", toolName: "search_memory", content: "found 2 facts", isError: false }],
+    };
+
+    await appendMessages(db, session.id, [userMsg]);
+    await appendMessages(db, session.id, [assistantMsg, toolResultMsg], 42);
+
+    const loaded = await loadSessionMessages(db, session.id);
+    expect(loaded).toEqual([userMsg, assistantMsg, toolResultMsg]);
+  });
+
+  it("forces run_id to NULL for user/system rows even if a runId is passed", async () => {
+    const db = getDb();
+    const session = await createSession(db, ACTOR);
+    await appendMessages(db, session.id, [{ role: "user", content: "hi" } as LlmUserMessage], 99);
+    const rows = await db<{ run_id: number | null }[]>`SELECT run_id FROM chat_messages WHERE session_id = ${session.id}`;
+    expect(rows[0].run_id).toBeNull();
+  });
+
+  it("appendMessages bumps chat_sessions.updated_at", async () => {
+    const db = getDb();
+    const session = await createSession(db, ACTOR);
+    const [before] = await db<{ updated_at: Date }[]>`SELECT updated_at FROM chat_sessions WHERE id = ${session.id}`;
+    await new Promise((r) => setTimeout(r, 10));
+    await appendMessages(db, session.id, [{ role: "user", content: "hi" } as LlmUserMessage]);
+    const [after] = await db<{ updated_at: Date }[]>`SELECT updated_at FROM chat_sessions WHERE id = ${session.id}`;
+    expect(after.updated_at.getTime()).toBeGreaterThan(before.updated_at.getTime());
+  });
+
+  it("appendMessages is a no-op for an empty array", async () => {
+    const db = getDb();
+    const session = await createSession(db, ACTOR);
+    await expect(appendMessages(db, session.id, [])).resolves.toBeUndefined();
+    const rows = await db`SELECT 1 FROM chat_messages WHERE session_id = ${session.id}`;
+    expect(rows).toHaveLength(0);
+  });
+
+  it("loadSessionMessages returns rows in insertion order", async () => {
+    const db = getDb();
+    const session = await createSession(db, ACTOR);
+    await appendMessages(db, session.id, [{ role: "user", content: "first" } as LlmUserMessage]);
+    await appendMessages(db, session.id, [{ role: "user", content: "second" } as LlmUserMessage]);
+    const loaded = await loadSessionMessages(db, session.id);
+    expect(loaded.map((m) => m.content)).toEqual(["first", "second"]);
+  });
+});

--- a/tests/components/ChatClient.test.tsx
+++ b/tests/components/ChatClient.test.tsx
@@ -123,4 +123,15 @@ describe("ChatClient", () => {
     const secondCallHistory = runChatMock.mock.calls[1][1];
     expect(secondCallHistory).toEqual([]);
   });
+
+  it("seeds resumed exchanges from initialExchanges without calling runChat", () => {
+    render(
+      <ChatClient
+        initialExchanges={[{ question: "earlier question", answer: "earlier answer" }]}
+      />
+    );
+    expect(screen.getByText("earlier question")).toBeInTheDocument();
+    expect(screen.getByText("earlier answer")).toBeInTheDocument();
+    expect(runChatMock).not.toHaveBeenCalled();
+  });
 });

--- a/tests/harness.test.ts
+++ b/tests/harness.test.ts
@@ -6,7 +6,7 @@ import { runAgent } from "@/lib/harness";
 import { createToolRegistry } from "@/lib/tools/registry";
 import { echoTool } from "@/lib/tools/echo";
 import type { Tool } from "@/lib/tools/types";
-import type { LlmAdapter, LlmStreamEvent } from "@/lib/llm/types";
+import type { LlmAdapter, LlmMessage, LlmStreamEvent } from "@/lib/llm/types";
 
 async function resetLedgerTables(): Promise<void> {
   const db = getDb();
@@ -196,5 +196,30 @@ describe("runAgent", () => {
 
     await runAgent({ question: "x", registry, adapter: capturingAdapter });
     expect(capturedSystem).toMatch(/sourcing agent/i);
+  });
+
+  it("threads priorMessages into messages[] immediately before the new user message", async () => {
+    let capturedMessages: unknown[] | undefined;
+    const capturingAdapter: LlmAdapter = async function* (request) {
+      // Snapshot now: agent-loop.ts pushes the model's reply onto this same
+      // array (by reference) once the turn ends, so a live reference would
+      // observe post-turn mutations instead of what was actually sent.
+      capturedMessages = [...request.messages];
+      yield { type: "text_delta", delta: "ok" };
+      yield { type: "turn_end", stopReason: "end", usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } };
+    };
+    const registry = createToolRegistry([echoTool]);
+    const prior: LlmMessage[] = [
+      { role: "user", content: "earlier question" },
+      { role: "assistant", content: [{ type: "text", text: "earlier answer" }] },
+    ];
+
+    await runAgent({ question: "new question", registry, adapter: capturingAdapter, priorMessages: prior });
+
+    expect(capturedMessages).toEqual([
+      { role: "system", content: expect.stringMatching(/sourcing agent/i) },
+      ...prior,
+      { role: "user", content: "new question" },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Slice R6 of the runtime solidification sprint (plan: `docs/superpowers/plans/2026-07-14-r6-chat-sessions-plan.md`). Chat history now persists to Postgres: `/chat` resumes the actor's latest session on load and survives reload; a "New chat" link starts a fresh session. No session-management UI, no client-held session id — the stream route's request/response JSON is unchanged from R5.

- **Migration `005_chat_sessions.sql`** — `chat_sessions` + `chat_messages`, SQL verbatim from the contracts brief §6 (locked).
- **`src/lib/chat/sessions.ts`** — `createSession` / `getOrCreateLatestSession` / `appendMessages` (transactional, forces `run_id NULL` on user/system rows) / `loadSessionMessages` (direct `{role, content_json}` reassembly).
- **`src/app/chat/resume.ts`** — pure fold of `LlmMessage[]` into display-only `{question, answer}` pairs (no trace replay, per Judgment call 4).
- **Stream route** — loads prior messages before the turn, persists the user message immediately (durable even if the loop fails/aborts), persists the loop's produced messages after settle on success AND failure, tagged with the run id. Client-sent `history` is now accepted-and-ignored on this route — the persisted session supersedes it (plan Edit 2; prevents double-feeding the transcript to the model).
- **Additive `priorMessages?: LlmMessage[]`** on `RunAgentInput` + `AnswerWithMemoryInput`, threaded into the loop transcript immediately before the new user message with full tool_use/tool_result fidelity (Judgment call 8).
- **`page.tsx`** — async Server Component: resume-latest, `?new=1` → `createSession` + `redirect("/chat")`. **`ChatClient.tsx`** — one additive `initialExchanges` prop seeding settled, trace-free exchanges.
- **Citation safety on resume** — the persisted final assistant message carries the citation-checked answer text (`withCheckedAnswer`), so a scrubbed citation can't reappear on reload.

## Plan deviations (all reviewed)

1. Two `sessions.ts` tests insert a real `runs` row instead of the plan's fake run ids 42/99 (FK makes fake ids impossible; locked SQL kept intact).
2. One assertion coerces `Number(rows[0].id)` (postgres.js returns BIGSERIAL as string — the plan's verbatim assertion was internally inconsistent with its own Number() conversion).
3. `toJson` helper signature is `postgres.Sql | postgres.TransactionSql` (repo pattern, chunk-store.ts) — the plan's `Sql`-only signature doesn't compile at the `tx` call site.
4. "New chat" link renders as a sibling fragment above `ChatClient` rather than the plan's single flex wrapper (which would have collided with ChatClient's own layout — anticipated by the plan's own note).
5. Final-review fix: the plan's Task-4 sketch was implemented first with `history` still threaded alongside `priorMessages` (double-feed); fixed back to the plan's own Edit 2 in 69124b3 with a pinning test.

## Deferred / known-minor (for tickets)

- **Unbounded `priorMessages` / no session rotation**: `history` was capped (12 turns/4000 chars) but the persisted transcript is threaded uncapped and `getOrCreateLatestSession` resumes forever — long-lived sessions will eventually hit provider context limits. Needs a cap cut at a user-message boundary (never splitting tool_use/tool_result pairs). Ticket before production use.
- `?new=` accepts any truthy value (`?new=0` also creates a session); repeated New-chat clicks accumulate empty session rows (fold into the existing getOrCreateLatestSession TOCTOU note).
- Post-settle persistence runs before `answerFlush` — a DB write failure suppresses an answer the run produced (durability-before-display, deliberate).
- Mid-loop assistant narration on non-final produced messages persists unscrubbed and joins into the resumed display — parity with what R5 streams live, not a regression.
- Carry-forward unchanged from R2/R5: `streamAgentTurn` capture/redaction parity still open.

## Gates

- Full suite: **380 passed / 78 failed / 1 todo** (baseline 349/78/1 → +31 new tests, **zero new failures**; all 78 = pre-existing legacy better-sqlite3 suites).
- `tsc --noEmit` clean; lint = pre-existing embed.ts warning only; `npm run build` GREEN (`/chat` now ƒ dynamic — expected, it reads `searchParams`).
- Live smoke (openai override, port 3100): ask → reload shows the exchange from Postgres; `?new=1` → 307 to `/chat`, fresh session, old conversation hidden; DB rows verified (user row `run_id NULL`, assistant/tool_result tagged with run id); **two-turn probe recalled turn-1 context purely from the server-persisted session with no client history sent**.
- Final whole-branch review (subagent): 1 Critical + 2 Important found → fixed in 69124b3 → re-verified, verdict **Ready to merge: Yes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat conversations now automatically resume from the latest saved session.
  * Added support for starting a fresh conversation.
  * Previous questions and answers are restored when reopening chat.
  * Conversation messages and completed responses are saved for continuity.

* **Bug Fixes**
  * Prevented duplicate history from being submitted during resumed chats.
  * Persisted citation-checked answers to avoid invalid citations reappearing.

* **Tests**
  * Added coverage for session persistence, resuming conversations, new-chat flows, and message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds server-side chat session persistence via two new Postgres tables (`chat_sessions` / `chat_messages`). The stream route now loads prior messages before each turn and persists the user message eagerly and the loop's produced messages after settle; the `/chat` page resumes the actor's latest session on load and exposes a "New chat" link.

- **Migration `005_chat_sessions.sql`** — well-constrained schema with role CHECK, cascade on delete, and FK to `runs` with `ON DELETE SET NULL`; indexes cover the two hot queries.
- **`sessions.ts`** — transactional `appendMessages` guards against half-written tool_use/tool_result pairs; `getOrCreateLatestSession` correctly orders by `updated_at DESC`.
- **`withCheckedAnswer`** — correctly replaces the raw pre-check text on the last assistant message before persistence so scrubbed citations can't resurrect on reload, while preserving `tool_use` blocks.
- **`ChatClient` seeding** — negative IDs for resumed exchanges prevent collisions with the live-turn counter; `initialExchanges` is a pure lazy-init with no side effects.

<h3>Confidence Score: 4/5</h3>

Safe to merge for a single-actor deployment; the two findings are non-blocking edge cases with acknowledged workarounds already in the PR notes.

The session persistence, eager user-message durability, citation-safety on reload, and the priorPrefixLength slice all work correctly for the current call paths. The priorPrefixLength formula relies on an implicit invariant (no history alongside priorMessages) that isn't enforced in code, creating a latent double-persistence risk if the stream route is ever refactored. The ?new= truthiness check accepts '0' and 'false' as triggers for a new session, which the PR already notes as a known-minor issue. Both are style or speculative concerns rather than present defects.

src/app/api/agent/stream/route.ts (the priorPrefixLength invariant) and src/app/chat/page.tsx (the ?new= truthy check) are the two spots worth a second look before extending this code path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/migrations/005_chat_sessions.sql | Adds chat_sessions and chat_messages tables with correct FK on runs(id) ON DELETE SET NULL, cascade on session delete, role CHECK constraint, and compound indexes — schema matches the described round-trip contract. |
| src/lib/chat/sessions.ts | Core session CRUD: createSession, getOrCreateLatestSession, appendMessages (transactional), and loadSessionMessages. Logic is sound; the acknowledged TOCTOU in getOrCreateLatestSession and the unbounded session growth are deferred by design. |
| src/app/api/agent/stream/route.ts | Integrates session persistence into the streaming turn: loads priors, persists user message eagerly, runs the agent, then persists produced messages. The priorPrefixLength slice formula is correct for current code but has an implicit invariant (history must be absent) not enforced in code. |
| src/app/chat/page.tsx | Async Server Component: resumes latest session on load, creates a new session on ?new=*. The truthy check on forceNew means any non-empty string (including '0' and 'false') triggers session creation. |
| src/app/chat/resume.ts | Clean fold of LlmMessage[] into ResumedExchange[] pairs; correctly skips system and tool_result messages, handles orphaned messages, and handles trailing unanswered turns. |
| src/lib/harness.ts | Additive priorMessages?: LlmMessage[] field threaded into messages[] after history and before the new user turn; RunAgentResult.messages now exposed for session persistence. Clean change with no behavioral regression on existing callers. |
| src/app/chat/ChatClient.tsx | Additive initialExchanges prop seeds settled, trace-free exchanges from persisted session; negative IDs prevent collision with live-turn counter. Resumed exchanges are filtered into the client-side history that the stream route intentionally discards. |
| src/lib/memory/answer.ts | Passthrough of new priorMessages field to runAgent; no logic change. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant ChatPage as /chat (Server Component)
    participant StreamRoute as POST /api/agent/stream
    participant Sessions as sessions.ts
    participant DB as Postgres
    participant Agent as answerWithMemory / runAgent

    Browser->>ChatPage: GET /chat
    ChatPage->>Sessions: getOrCreateLatestSession(DEFAULT_ACTOR)
    Sessions->>DB: SELECT id FROM chat_sessions ORDER BY updated_at DESC LIMIT 1
    DB-->>Sessions: session row (or none → INSERT)
    Sessions-->>ChatPage: "{ id }"
    ChatPage->>Sessions: loadSessionMessages(session.id)
    Sessions->>DB: SELECT role, content_json FROM chat_messages ORDER BY id
    DB-->>Sessions: prior LlmMessage[]
    ChatPage-->>Browser: HTML with initialExchanges (resumed pairs)

    Browser->>StreamRoute: "POST { question }"
    StreamRoute->>Sessions: getOrCreateLatestSession(DEFAULT_ACTOR)
    Sessions-->>StreamRoute: "{ id }"
    StreamRoute->>Sessions: loadSessionMessages(session.id)
    Sessions-->>StreamRoute: priorMessages[]
    StreamRoute->>Sessions: appendMessages([userMessage])
    Sessions->>DB: "INSERT chat_messages (role=user, run_id=NULL) + UPDATE updated_at"
    StreamRoute->>Agent: "answerWithMemory({ question, priorMessages })"
    Agent-->>StreamRoute: "result { messages[], answer, runId }"
    StreamRoute->>StreamRoute: withCheckedAnswer(producedSlice, answer)
    StreamRoute->>Sessions: appendMessages(producedMessages, runId)
    Sessions->>DB: INSERT chat_messages (tagged with run_id) + UPDATE updated_at
    StreamRoute-->>Browser: SSE stream (answer + meta)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant ChatPage as /chat (Server Component)
    participant StreamRoute as POST /api/agent/stream
    participant Sessions as sessions.ts
    participant DB as Postgres
    participant Agent as answerWithMemory / runAgent

    Browser->>ChatPage: GET /chat
    ChatPage->>Sessions: getOrCreateLatestSession(DEFAULT_ACTOR)
    Sessions->>DB: SELECT id FROM chat_sessions ORDER BY updated_at DESC LIMIT 1
    DB-->>Sessions: session row (or none → INSERT)
    Sessions-->>ChatPage: "{ id }"
    ChatPage->>Sessions: loadSessionMessages(session.id)
    Sessions->>DB: SELECT role, content_json FROM chat_messages ORDER BY id
    DB-->>Sessions: prior LlmMessage[]
    ChatPage-->>Browser: HTML with initialExchanges (resumed pairs)

    Browser->>StreamRoute: "POST { question }"
    StreamRoute->>Sessions: getOrCreateLatestSession(DEFAULT_ACTOR)
    Sessions-->>StreamRoute: "{ id }"
    StreamRoute->>Sessions: loadSessionMessages(session.id)
    Sessions-->>StreamRoute: priorMessages[]
    StreamRoute->>Sessions: appendMessages([userMessage])
    Sessions->>DB: "INSERT chat_messages (role=user, run_id=NULL) + UPDATE updated_at"
    StreamRoute->>Agent: "answerWithMemory({ question, priorMessages })"
    Agent-->>StreamRoute: "result { messages[], answer, runId }"
    StreamRoute->>StreamRoute: withCheckedAnswer(producedSlice, answer)
    StreamRoute->>Sessions: appendMessages(producedMessages, runId)
    Sessions->>DB: INSERT chat_messages (tagged with run_id) + UPDATE updated_at
    StreamRoute-->>Browser: SSE stream (answer + meta)
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(r6): stream route drops client histo..."](https://github.com/fisherxz/sourcecado/commit/69124b3b4c5c216a2f04d376f01c296bd003f034) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44398425)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->