### PR TITLE
fix(prompt): production system prompt v5 + add_memory_note registration

### DIFF
--- a/procedures/outreach-tone.md
+++ b/procedures/outreach-tone.md
@@ -1,3 +1,3 @@
 # Outreach Tone
 
-Next actions should be direct, useful, and human. Do not draft outreach unless the user asks for it.
+Outreach drafts are core deliverables: produce them ready for the Director's review whenever the ask calls for one. Drafts are direct, useful, and human. Sending is always the Director's act.

--- a/src/app/api/agent/stream/route.ts
+++ b/src/app/api/agent/stream/route.ts
@@ -22,9 +22,10 @@ export async function POST(request: Request) {
 
   return streamAgentResponse(async (writer) => {
     // Gate coupling note: this checks the literal tool name "search_memory"
-    // because memoryRegistry() registers exactly that one tool today — "any
-    // tool call" and "search_memory called" are the same event. If another
-    // citation-bearing tool ever joins the registry, gate on any tool_start.
+    // because it is the registry's only citation-bearing tool — add_memory_note
+    // returns {sourceId} only, never citation ids, so it cannot make a streamed
+    // citation invalid. If another citation-bearing tool ever joins the
+    // registry, gate on any tool_start.
     let searchCalledSoFar = false;
     let streamedLive = false;
 

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -13,19 +13,74 @@ export function buildSystemPrompt(sections: SystemPromptSection[]): string {
   return sections.map((s) => `## ${s.title}\n${s.body}`).join("\n\n");
 }
 
+// The production sourcing-agent system prompt (v5), §1–§7. Prose is approved
+// verbatim — see docs/superpowers/plans/2026-07-15-sourcing-agent-system-prompt.md.
+// Static and cacheable; order matters. The dynamic Memory Index and Environment
+// sections are appended per run below the cache boundary.
+
 export const IDENTITY_SECTION: SystemPromptSection = {
-  title: "Identity",
+  title: "Identity & mission",
   body:
-    "You are a sourcing agent with access to team memory and tools. Decide when to search, when to answer directly, and when to record a finding.",
+    "You are Sourcecado's sourcing agent. You work inside Research Chat for Codeology's Sourcing Directors — the officers responsible for building the club's external relationships with companies, alumni, sponsors, speakers, and partners. Your job is to deliver sourcing outcomes the Director can act on immediately: the exact people worth reaching out to and why, outreach drafts ready for their review, a follow-up plan for every live lead, and organization research that ends in a concrete plan for how to approach them.",
 };
 
-// Replaces the deleted four-section memory-answer contract. Free-format:
-// no fixed section headers, no "call search_memory every turn."
-export const TOOL_USE_GUIDANCE_SECTION: SystemPromptSection = {
-  title: "Tool-Use Guidance",
+export const PERSISTENCE_SECTION: SystemPromptSection = {
+  title: "Persistence",
   body:
-    "Search memory when the index below isn't enough to answer confidently — you decide when that is. Whenever you cite memory, cite inline as `sourceId#chunk-N` (or `#row-N`); never invent a citation id. If memory doesn't cover something, say so plainly instead of guessing.",
+    "Resolve the Director's ask fully before yielding: understand the outcome they need, gather what it takes, and end with the deliverable itself — a shortlist, a draft, a plan — not a description of one. A recommendation without a next action is unfinished: name who to contact, with what message, on what timing.",
 };
+
+export const ACTING_VS_ASKING_SECTION: SystemPromptSection = {
+  title: "Acting vs asking",
+  body:
+    "Prefer acting through tools over asking the Director for information a tool could fetch. Ask before acting only when an action is hard to reverse or intent is genuinely ambiguous — a clarifying question is cheap, but so is a memory search; a wrong guess written into team memory is expensive. Call tools silently for routine, low-risk steps; narrate only complex, sensitive, or requested work — narration the Director didn't need is latency between them and the deliverable.",
+};
+
+export const SOURCING_DOCTRINE_SECTION: SystemPromptSection = {
+  title: "Sourcing doctrine",
+  body: [
+    "Sourcing here means external-facing relationship work — never applicant recruiting or admissions. Speak the team's language: a **Contact** is a person or organization Codeology may want a relationship with; a **Sourcing Lead** is a Contact currently worth outreach — a state of a Contact, not a separate record; an **Organization** can itself be a Contact and contain Contacts; a **Target Persona** is a role pattern worth finding, not an individual. Semesters turn over and officers graduate — the deliverables you produce and the memory behind them are how sourcing survives that turnover.",
+    "",
+    "Defaults for common situations:",
+    "- Before recommending or drafting for a Contact, check memory for prior outreach with them or their Organization — re-contacting someone the club already reached, or who already said no, burns the relationship this system exists to protect.",
+    "- Every name on a shortlist carries its why-now: the timely reason this Contact is a Sourcing Lead today. A name without a why-now is a Contact, not a recommendation.",
+    "- When memory shows a Past Collaborator or an existing route to a target, lead with the warm path before proposing cold outreach — warm re-engagement is why the club keeps this memory.",
+    "- When a Director reports what happened with outreach, record it as an Outreach Outcome and propose the next Follow-Up Sequence step — an outcome that lives only in chat is lost at semester turnover.",
+    "- When evidence is missing, stale, or conflicting, surface it as a Knowledge Gap beside the deliverable — conflicting sources appear side by side with citations, never silently resolved into a clean claim.",
+    "- When work produces something durable — an outcome, a correction, a relationship fact — record it as a note; chat is not memory.",
+    "- When live web evidence contradicts memory about a Contact's current role or company, trust the fresher source, flag the stale memory as a Knowledge Gap, and record the correction.",
+    "- Outreach drafts are deliverables for the Director's review — direct, useful, human, and personalized only with professionally relevant facts (a draft that shows off research the Contact didn't share reads as surveillance and loses the reply); sending is always the Director's act.",
+  ].join("\n"),
+};
+
+export const MEMORY_CITATIONS_SECTION: SystemPromptSection = {
+  title: "Memory & citations",
+  body:
+    'Team memory is your primary evidence for anything about Codeology\'s relationships and history, reached through your memory tools; the Memory Index below shows what\'s indexed. Before producing anything that depends on Contacts, Organizations, outreach history, past decisions, or team preferences, search memory first; if confidence is still low after searching, say what you checked. Every factual sourcing claim carries an inline citation to a real id from your tool results (`sourceId#chunk-N` or `#row-N` for memory). If memory has nothing relevant, say so plainly — "no sources found" is a correct answer; an invented one never is.',
+};
+
+export const CAPABILITIES_SECTION: SystemPromptSection = {
+  title: "Capabilities envelope",
+  body:
+    "Your tools appear in your tool list and will grow over time — describe your capabilities from that list, and scope commitments to it: offer what your tools can deliver today, and treat everything else as the Director's work to do outside this chat.",
+};
+
+export const COMMUNICATION_SECTION: SystemPromptSection = {
+  title: "Communication",
+  body:
+    "Answer greetings and questions about yourself directly, without tools. Lead with the deliverable, then the evidence behind it, then what's still unknown, then the next action worth taking — the Director should be able to act the moment they finish reading. A shortlist entry is two lines: the name-and-role, then the why-now. Use the team's vocabulary; markdown only where it clarifies.",
+};
+
+// The static, cacheable prompt sections in §1–§7 order.
+export const STATIC_SECTIONS: SystemPromptSection[] = [
+  IDENTITY_SECTION,
+  PERSISTENCE_SECTION,
+  ACTING_VS_ASKING_SECTION,
+  SOURCING_DOCTRINE_SECTION,
+  MEMORY_CITATIONS_SECTION,
+  CAPABILITIES_SECTION,
+  COMMUNICATION_SECTION,
+];
 
 const MEMORY_INDEX_MAX_CHARS = 4000;
 
@@ -79,14 +134,22 @@ function capMemoryIndexLines(lines: string[]): string {
   return body;
 }
 
-// The memory-chat path's system-prompt composer: identity + tool-use
-// guidance + the injected memory index, in that order. Callers (e.g.
-// answerWithMemory) pass the returned string into runAgent()'s existing
-// per-run `instructions` slot.
+// A Sourcing Lead is defined by timeliness, so ranking needs today's date. Built
+// per run from new Date() at call time and appended below the cache boundary
+// (after the memory index), never part of STATIC_SECTIONS.
+export function buildEnvironmentSection(now: Date = new Date()): SystemPromptSection {
+  return { title: "Environment", body: `Today's date: ${now.toISOString().slice(0, 10)}` };
+}
+
+// The memory-chat path's system-prompt composer: the static v5 sections (§1–§7),
+// then the per-run memory index, then the dynamic Environment date — in that
+// order. Callers (e.g. answerWithMemory) pass the returned string into
+// runAgent()'s existing per-run `instructions` slot.
 export async function buildMemoryAnswerInstructions(
   db: Sql,
   actor: MemoryActor = DEFAULT_ACTOR
 ): Promise<string> {
   const memoryIndex = await buildMemoryIndexSection(db, actor);
-  return buildSystemPrompt([IDENTITY_SECTION, TOOL_USE_GUIDANCE_SECTION, memoryIndex]);
+  const environment = buildEnvironmentSection();
+  return buildSystemPrompt([...STATIC_SECTIONS, memoryIndex, environment]);
 }

--- a/src/lib/memory/answer-config.ts
+++ b/src/lib/memory/answer-config.ts
@@ -1,7 +1,8 @@
 import { createToolRegistry } from "../tools/registry";
 import type { ToolRegistry } from "../tools/registry";
 import { searchMemoryTool } from "../tools/search-memory";
+import { addMemoryNoteTool } from "../tools/add-memory-note";
 
 export function memoryRegistry(): ToolRegistry {
-  return createToolRegistry([searchMemoryTool]);
+  return createToolRegistry([searchMemoryTool, addMemoryNoteTool]);
 }

--- a/src/lib/memory/answer.ts
+++ b/src/lib/memory/answer.ts
@@ -2,7 +2,7 @@ import { runAgent, type AgentStepEvent, type ConversationTurn } from "@/lib/harn
 import type { AgentLoopEvent } from "@/lib/agent-loop";
 import { buildMemoryAnswerInstructions } from "@/lib/context";
 import { getRunTrace } from "@/lib/ledger";
-import type { LlmMessage } from "@/lib/llm/types";
+import type { LlmAdapter, LlmMessage } from "@/lib/llm/types";
 import { verifyAnswerCitations } from "@/lib/memory/citations";
 import { memoryRegistry } from "@/lib/memory/answer-config";
 import type { Sql } from "@/lib/tools/types";
@@ -28,6 +28,9 @@ export interface AnswerWithMemoryInput {
   // aborts between steps (and its provider fetch is cancelled) instead of
   // running to completion in the background. See RunAgentInput.signal.
   signal?: AbortSignal;
+  // Test seam: injected LlmAdapter, forwarded to runAgent. Mirrors
+  // RunAgentInput.adapter; production callers never set it.
+  adapter?: LlmAdapter;
 }
 
 // One agent run over team memory: the ReAct harness plus the citation post-check
@@ -42,12 +45,15 @@ export async function answerWithMemory(db: Sql, input: AnswerWithMemoryInput): P
     question: input.question,
     history: input.history,
     registry,
-    allowedClasses: new Set(["read"]),
+    // §4's record-as-note doctrine (add_memory_note, class write_internal) is
+    // dead wiring unless the chat run permits that class alongside read.
+    allowedClasses: new Set(["read", "write_internal"]),
     instructions,
     db,
     onStep: input.onStep,
     onAgentLoopEvent: input.onAgentLoopEvent,
     signal: input.signal,
+    adapter: input.adapter,
   });
 
   let answer = result.answer;

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -6,8 +6,9 @@ import {
   buildSystemPrompt,
   buildMemoryIndexSection,
   buildMemoryAnswerInstructions,
+  buildEnvironmentSection,
   IDENTITY_SECTION,
-  TOOL_USE_GUIDANCE_SECTION,
+  STATIC_SECTIONS,
   type SystemPromptSection,
 } from "@/lib/context";
 
@@ -51,11 +52,27 @@ describe("buildSystemPrompt", () => {
   });
 });
 
-describe("fixed sections", () => {
-  it("IDENTITY_SECTION and TOOL_USE_GUIDANCE_SECTION carry no fixed four-section format language", () => {
-    expect(IDENTITY_SECTION.title).toBe("Identity");
-    expect(TOOL_USE_GUIDANCE_SECTION.body).not.toMatch(/Answer:|Evidence:|Gaps:|Next Action:/);
-    expect(TOOL_USE_GUIDANCE_SECTION.body).toMatch(/sourceId#chunk-N/);
+describe("static sections (v5)", () => {
+  it("STATIC_SECTIONS are the seven v5 sections in §1–§7 order", () => {
+    expect(STATIC_SECTIONS.map((s) => s.title)).toEqual([
+      "Identity & mission",
+      "Persistence",
+      "Acting vs asking",
+      "Sourcing doctrine",
+      "Memory & citations",
+      "Capabilities envelope",
+      "Communication",
+    ]);
+    expect(STATIC_SECTIONS[0]).toBe(IDENTITY_SECTION);
+  });
+
+  it("carries the v5 doctrine, not the retired free-format guidance", () => {
+    const doctrine = STATIC_SECTIONS.find((s) => s.title === "Sourcing doctrine")!;
+    expect(doctrine.body).toMatch(/why-now/);
+    const memory = STATIC_SECTIONS.find((s) => s.title === "Memory & citations")!;
+    expect(memory.body).toMatch(/sourceId#chunk-N/);
+    // No section carries the deleted identity text.
+    expect(STATIC_SECTIONS.some((s) => /sourcing agent with access to team memory/.test(s.body))).toBe(false);
   });
 });
 
@@ -144,14 +161,32 @@ describe("buildMemoryAnswerInstructions (postgres)", () => {
     await closeDb();
   });
 
-  it("composes identity + tool-use guidance + memory index, in that order", async () => {
+  it("composes the seven static sections, then the memory index, then Environment last", async () => {
     const db = getDb();
     const instructions = await buildMemoryAnswerInstructions(db, DEFAULT_ACTOR);
-    const identityIdx = instructions.indexOf("## Identity");
-    const guidanceIdx = instructions.indexOf("## Tool-Use Guidance");
+
+    // Every static header appears, in §1–§7 order.
+    const staticIdxs = STATIC_SECTIONS.map((s) => instructions.indexOf(`## ${s.title}`));
+    expect(staticIdxs.every((i) => i >= 0)).toBe(true);
+    for (let i = 1; i < staticIdxs.length; i++) {
+      expect(staticIdxs[i]).toBeGreaterThan(staticIdxs[i - 1]);
+    }
+
+    // Memory Index follows the static sections; Environment follows the index and is last.
     const indexIdx = instructions.indexOf("## Memory Index");
-    expect(identityIdx).toBeGreaterThanOrEqual(0);
-    expect(guidanceIdx).toBeGreaterThan(identityIdx);
-    expect(indexIdx).toBeGreaterThan(guidanceIdx);
+    const envIdx = instructions.indexOf("## Environment");
+    expect(indexIdx).toBeGreaterThan(staticIdxs[staticIdxs.length - 1]);
+    expect(envIdx).toBeGreaterThan(indexIdx);
+
+    // The Environment section carries today's date and is the trailing section.
+    expect(instructions).toMatch(/## Environment\nToday's date: \d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe("buildEnvironmentSection", () => {
+  it("renders today's date as an ISO YYYY-MM-DD line", () => {
+    const section = buildEnvironmentSection(new Date("2026-07-15T09:30:00Z"));
+    expect(section.title).toBe("Environment");
+    expect(section.body).toBe("Today's date: 2026-07-15");
   });
 });

--- a/tests/memory-answer.test.ts
+++ b/tests/memory-answer.test.ts
@@ -5,6 +5,7 @@ import type { LlmAdapter, LlmStreamEvent } from "@/lib/llm/types";
 import { runAgent } from "@/lib/harness";
 import { collectAllowedCitations, checkCitations, collectBundlesFromTrace, verifyAnswerCitations } from "@/lib/memory/citations";
 import { memoryRegistry } from "@/lib/memory/answer-config";
+import { answerWithMemory } from "@/lib/memory/answer";
 import { DEFAULT_ACTOR, type MemoryActor } from "@/lib/memory/actor";
 import { embedText, toVectorLiteral } from "@/lib/memory/embed";
 import type { MemoryBundle } from "@/lib/memory/retrieve";
@@ -85,6 +86,23 @@ async function insertFact(
   `;
 }
 
+
+// ---------------------------------------------------------------------------
+// Pure unit tests — memoryRegistry composition
+// ---------------------------------------------------------------------------
+
+describe("memoryRegistry", () => {
+  it("registers both search_memory (read) and add_memory_note (write_internal)", () => {
+    const registry = memoryRegistry();
+    expect(registry.get("search_memory")?.permissionClass).toBe("read");
+    expect(registry.get("add_memory_note")?.permissionClass).toBe("write_internal");
+    // add_memory_note is only listed once its write_internal class is allowed.
+    expect(registry.list(new Set(["read"])).map((t) => t.name)).toEqual(["search_memory"]);
+    expect(
+      registry.list(new Set(["read", "write_internal"])).map((t) => t.name).sort()
+    ).toEqual(["add_memory_note", "search_memory"]);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Pure unit tests — collectAllowedCitations
@@ -467,5 +485,52 @@ describe("search_memory agentic flow (mock provider + postgres)", () => {
 
     const { invalid } = checkCitations(result.answer!, allowed);
     expect(invalid).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration — write_internal permission decision (answer.ts allowedClasses)
+// ---------------------------------------------------------------------------
+
+describe("answerWithMemory add_memory_note (mock provider + postgres)", () => {
+  let savedApiKey: string | undefined;
+
+  beforeEach(async () => {
+    savedApiKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY; // force offline hash embedding
+    const db = getDb();
+    await resetAllTables(db);
+  });
+
+  afterEach(async () => {
+    if (savedApiKey !== undefined) {
+      process.env.OPENAI_API_KEY = savedApiKey;
+    } else {
+      delete process.env.OPENAI_API_KEY;
+    }
+    await closeDb();
+  });
+
+  it("executes an add_memory_note tool call end-to-end (write_internal is permitted)", async () => {
+    const db = getDb();
+    const adapter = sequentialAdapter([
+      () => toolCallTurn("add_memory_note", { title: "Acme intro call", text: "Acme is warm; follow up next week." }),
+      () => finalTurn("Recorded the Acme outcome."),
+    ]);
+
+    const result = await answerWithMemory(db, {
+      question: "Record that Acme is warm and we should follow up next week.",
+      adapter,
+    });
+
+    expect(result.status).toBe("succeeded");
+
+    // The note must have actually been written — a permission_denied on
+    // write_internal would leave source_records empty and still "succeed".
+    const notes = await db<{ source_id: string; title: string }[]>`
+      SELECT source_id, title FROM source_records WHERE source_type = 'note'
+    `;
+    expect(notes).toHaveLength(1);
+    expect(notes[0].title).toBe("Acme intro call");
   });
 });


### PR DESCRIPTION
## What

Ships the approved production sourcing-agent system prompt (v5) and wires the memory-note recording tool it references. Prose is APPROVED VERBATIM from the spec: `docs/superpowers/plans/2026-07-15-sourcing-agent-system-prompt.md`.

## Changes

- **`src/lib/context.ts`** — Replace the placeholder `IDENTITY_SECTION` / `TOOL_USE_GUIDANCE_SECTION` with the seven v5 sections as `SystemPromptSection`s (Identity & mission, Persistence, Acting vs asking, Sourcing doctrine, Memory & citations, Capabilities envelope, Communication), exported as `STATIC_SECTIONS` in §1–§7 order. `buildMemoryAnswerInstructions` now composes `[...STATIC_SECTIONS, memoryIndex, environment]`.
- **Dynamic Environment date** — new `buildEnvironmentSection()` renders `Today's date: YYYY-MM-DD` from `new Date()` at call time, appended **after** the memory index, below the cache boundary (a Sourcing Lead is defined by timeliness, so ranking needs today's date). Not part of `STATIC_SECTIONS`.
- **`src/lib/memory/answer-config.ts`** — Register `addMemoryNoteTool` in `memoryRegistry()` alongside `searchMemoryTool`; §4's record-as-note doctrine is dead text without it.
- **`src/lib/memory/answer.ts`** — Extend the memory-chat run's `allowedClasses` from `{read}` to `{read, write_internal}` so the registered tool isn't refused at the orchestrator permission gate. Added an `adapter` test seam (mirrors `RunAgentInput.adapter`) to prove the decision end-to-end.
- **`procedures/outreach-tone.md`** (F4) — Old body ("Do not draft outreach unless the user asks for it") contradicted §1/§4; replaced so drafting is core deliverable work while sending stays the Director's act.
- **Tests** — Retire assertions on the old prompt text. Add: (a) `memoryRegistry()` lists `search_memory` (read) and `add_memory_note` (write_internal); (b) `buildMemoryAnswerInstructions` contains all seven headers + Memory Index + a `Today's date: \d{4}-\d{2}-\d{2}` Environment section ordered last; (c) an `add_memory_note` call executes end-to-end through `answerWithMemory` and persists a note row.

## Permission decision (spec item 5c)

`add_memory_note` is permission class `write_internal`, but chat runs previously allowed only `{read}` (harness `DEFAULT_ALLOWED` is `read`+`reason`). Registering the tool without widening the run's `allowedClasses` would be dead wiring — every call would hit `permission_denied` at the orchestrator choke point. This PR widens the memory-chat run's authority by exactly that one recording tool: it's the only `write_internal` tool in the registry; search stays `read`, and no `draft`/`enrich`/`admin` class is granted. The end-to-end test guards the decision — a regression to `{read}` would leave `source_records` empty and fail it.

## Verification

- `npx tsc --noEmit` — clean
- `npm test` — 353 passed / 78 pre-existing better-sqlite3 (legacy SQLite) failures / 1 todo; **+4 new tests, zero new failures**
- `npm run build` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ships the v5 production system prompt for the sourcing agent and wires the `add_memory_note` tool that the new prompt's §4 doctrine depends on. Without the tool registration and the `write_internal` permission addition to the chat run, the record-as-note instructions would have been dead text.

- **`src/lib/context.ts`**: Replaces two placeholder sections with seven structured v5 prompt sections (`STATIC_SECTIONS`), adds a per-run `buildEnvironmentSection()` that injects today's UTC date below the cache boundary.
- **`src/lib/memory/answer-config.ts` / `answer.ts`**: Registers `addMemoryNoteTool` in `memoryRegistry()` and widens `allowedClasses` from `{read}` to `{read, write_internal}`; a new `adapter` test seam on `AnswerWithMemoryInput` makes the permission decision verifiable end-to-end.
- **Tests**: New assertions cover section ordering, v5 doctrine content, registry composition, and an integration test that proves an `add_memory_note` call actually persists a `source_records` row.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the permission widening is scoped precisely to one new tool, the end-to-end test guards the decision, and no existing behavior is broken.

The core wiring is correct and well-tested. The two findings are cosmetic: a stale comment in the streaming route that now misrepresents the registry size, and a missing describeObservation branch that leaves add_memory_note steps showing as done in the UI trace instead of the persisted sourceId. Neither affects runtime correctness.

src/app/api/agent/stream/route.ts — the gate-coupling comment should be updated to reflect the two-tool registry; src/lib/memory/answer.ts — describeObservation could add an add_memory_note branch for richer step traces.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/context.ts | Replaces two placeholder sections with seven v5 system-prompt sections exported as STATIC_SECTIONS; adds buildEnvironmentSection() injecting today's UTC date below the cache boundary. Order and composition are correct. |
| src/lib/memory/answer-config.ts | Registers addMemoryNoteTool (write_internal) alongside searchMemoryTool (read) in memoryRegistry(). Minimal, correct change. |
| src/lib/memory/answer.ts | Widens allowedClasses to include write_internal, adds adapter test seam, imports LlmAdapter. Logic is correct; describeObservation has no case for add_memory_note so its steps always show as "done" in the UI trace. |
| src/app/api/agent/stream/route.ts | Unchanged in this PR, but now carries a stale comment asserting memoryRegistry() has "exactly that one tool" — the registry now has two. Gate logic remains correct for add_memory_note (not citation-bearing), but the comment misleads future maintainers. |
| tests/context.test.ts | Retires old section assertions, adds tests for STATIC_SECTIONS ordering, v5 doctrine content, environment date rendering, and correct ordering in buildMemoryAnswerInstructions output. Coverage is thorough. |
| tests/memory-answer.test.ts | Adds unit test for memoryRegistry composition (both tools, correct permission classes) and an end-to-end integration test verifying add_memory_note actually persists a row when write_internal is permitted. |
| procedures/outreach-tone.md | Updates the outreach-tone procedure to align with §1/§4: drafting is now a core deliverable; sending remains the Director's act. Consistent with the new system prompt. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Director as Director (HTTP)
    participant Route as /api/agent/stream
    participant AWM as answerWithMemory
    participant Harness as runAgent (ReAct)
    participant Registry as memoryRegistry
    participant Search as search_memory (read)
    participant Write as add_memory_note (write_internal)
    participant DB as Postgres

    Director->>Route: "POST { question }"
    Route->>AWM: "answerWithMemory(db, { question })"
    AWM->>Registry: memoryRegistry()
    Registry-->>AWM: "{ search_memory, add_memory_note }"
    AWM->>Harness: "runAgent(allowedClasses={read, write_internal})"
    Harness->>Search: execute(query)
    Search->>DB: vector search
    DB-->>Search: chunks + facts
    Search-->>Harness: MemoryBundle
    Harness->>Write: "execute({title, text})"
    Write->>DB: INSERT source_records + chunks + permissions
    DB-->>Write: "{ sourceId }"
    Write-->>Harness: "{ sourceId }"
    Harness-->>AWM: answer
    AWM->>AWM: verifyAnswerCitations
    AWM-->>Route: MemoryAnswer
    Route-->>Director: streamed answer
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Director as Director (HTTP)
    participant Route as /api/agent/stream
    participant AWM as answerWithMemory
    participant Harness as runAgent (ReAct)
    participant Registry as memoryRegistry
    participant Search as search_memory (read)
    participant Write as add_memory_note (write_internal)
    participant DB as Postgres

    Director->>Route: "POST { question }"
    Route->>AWM: "answerWithMemory(db, { question })"
    AWM->>Registry: memoryRegistry()
    Registry-->>AWM: "{ search_memory, add_memory_note }"
    AWM->>Harness: "runAgent(allowedClasses={read, write_internal})"
    Harness->>Search: execute(query)
    Search->>DB: vector search
    DB-->>Search: chunks + facts
    Search-->>Harness: MemoryBundle
    Harness->>Write: "execute({title, text})"
    Write->>DB: INSERT source_records + chunks + permissions
    DB-->>Write: "{ sourceId }"
    Write-->>Harness: "{ sourceId }"
    Harness-->>AWM: answer
    AWM->>AWM: verifyAnswerCitations
    AWM-->>Route: MemoryAnswer
    Route-->>Director: streamed answer
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/lib/memory/answer.ts`, line 104-118 ([link](https://github.com/fisherxz/sourcecado/blob/463a444c3d283a6342ebcc612091ac00c1900495/src/lib/memory/answer.ts#L104-L118)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`add_memory_note` step always shows as "done" in the UI trace**

   `describeObservation` has an explicit branch for `search_memory` that summarises facts and chunks, but `add_memory_note` falls through to the generic `"done"` return. The tool result includes `{ sourceId }`, so the step trace could render something like `"recorded note-<id>"` at no cost — useful when the Director is watching the reasoning trace to verify an outcome was actually persisted.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(prompt): align outreach-tone procedu..."](https://github.com/fisherxz/sourcecado/commit/463a444c3d283a6342ebcc612091ac00c1900495) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44402115)</sub>

<!-- /greptile_comment -->