### PR TITLE
feat(rt-R8): AI SDK rip-out — model-gateway on raw @anthropic-ai/sdk + openai, drop @ai-sdk/*

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,8 @@ ANTHROPIC_API_KEY=
 # R7 external tools
 TAVILY_API_KEY=
 APOLLO_API_KEY=
-# Opt-in: run the real-network live-smoke test in tests/web-fetch-tool.test.ts.
-# (Tavily's own live-smoke test gates on TAVILY_API_KEY being present instead;
-# Apollo has no live-smoke test — its live smoke is deferred until the key is provided.)
+# Opt-in: run the real-network live-smoke tests in tests/web-fetch-tool.test.ts
+# and tests/web-search-tool.test.ts. Both skip by default so external state
+# (network reachability, Tavily account quota) can't turn the suite red.
+# (Apollo has no live-smoke test — its live smoke is deferred until the key is provided.)
 SOURCECADO_RUN_LIVE_SMOKE=

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "sourcecado",
       "version": "0.2.0",
       "dependencies": {
-        "@ai-sdk/anthropic": "^3.0.85",
-        "@ai-sdk/deepseek": "^2.0.39",
-        "@ai-sdk/openai": "^3.0.73",
         "@anthropic-ai/sdk": "^0.111.0",
         "ai": "^6.0.208",
         "better-sqlite3": "^11.9.1",
@@ -53,38 +50,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@ai-sdk/anthropic": {
-      "version": "3.0.85",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.85.tgz",
-      "integrity": "sha512-fNeDB644l5wbRNQU0FnI+F7UTtOenMnPtACfMPUJaS2zJfuBlseEa1TMg+otHkETZgaJB+6Na51NQEv0+m7czw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.30"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/deepseek": {
-      "version": "2.0.39",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/deepseek/-/deepseek-2.0.39.tgz",
-      "integrity": "sha512-3wUq1cvqSWkRadCSqcDXBLpOwUAe+JqfWQZS0fK0sWiqDeTIEzsse+r7xcN2x5XpJjefT0d7FQTa3u2lZ/yxbg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.30"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
     "node_modules/@ai-sdk/gateway": {
       "version": "3.0.133",
       "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.133.tgz",
@@ -94,22 +59,6 @@
         "@ai-sdk/provider": "3.0.10",
         "@ai-sdk/provider-utils": "4.0.30",
         "@vercel/oidc": "3.2.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/openai": {
-      "version": "3.0.73",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.73.tgz",
-      "integrity": "sha512-+3x9oxHv9Xp33Iv2L8D+e5hqmZi64jofBKig/9611JKyfV59NdkaDDajtwc0CxOEfARgCVq1BW7dP+526gKOKw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.30"
       },
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
     "refresh": "tsx scripts/refresh.ts"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.85",
-    "@ai-sdk/deepseek": "^2.0.39",
-    "@ai-sdk/openai": "^3.0.73",
     "@anthropic-ai/sdk": "^0.111.0",
     "ai": "^6.0.208",
     "better-sqlite3": "^11.9.1",

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -136,9 +136,13 @@ function capMemoryIndexLines(lines: string[]): string {
 
 // A Sourcing Lead is defined by timeliness, so ranking needs today's date. Built
 // per run from new Date() at call time and appended below the cache boundary
-// (after the memory index), never part of STATIC_SECTIONS.
+// (after the memory index), never part of STATIC_SECTIONS. Rendered in the
+// Codeology team's timezone (America/Los_Angeles), not UTC — otherwise "today"
+// flips a calendar day early every evening for the Berkeley team. en-CA gives
+// the YYYY-MM-DD ISO shape.
 export function buildEnvironmentSection(now: Date = new Date()): SystemPromptSection {
-  return { title: "Environment", body: `Today's date: ${now.toISOString().slice(0, 10)}` };
+  const today = new Intl.DateTimeFormat("en-CA", { timeZone: "America/Los_Angeles" }).format(now);
+  return { title: "Environment", body: `Today's date: ${today}` };
 }
 
 // The memory-chat path's system-prompt composer: the static v5 sections (§1–§7),

--- a/src/lib/memory/notes.ts
+++ b/src/lib/memory/notes.ts
@@ -8,9 +8,9 @@ type Sql = postgres.Sql;
 
 export async function addMemoryNote(
   db: Sql,
-  args: { title: string; text: string; actor?: MemoryActor }
+  args: { title: string; text: string; actor?: MemoryActor; runId?: number }
 ): Promise<{ sourceId: string }> {
-  const { title, text, actor = DEFAULT_ACTOR } = args;
+  const { title, text, actor = DEFAULT_ACTOR, runId } = args;
 
   const titleSlug = slugifySourceId(title);
   const sourceId = `note-${titleSlug}-${sha256(text).slice(0, 8)}`;
@@ -25,13 +25,25 @@ export async function addMemoryNote(
 
   await db.begin(async (tx) => {
     const [source] = await tx<{ id: string; source_id: string }[]>`
-      INSERT INTO source_records (source_id, path, title, source_type, content_hash, raw_text)
-      VALUES (${sourceId}, ${path}, ${title}, 'note', ${contentHash}, ${text})
+      INSERT INTO source_records (
+        source_id, path, title, source_type, content_hash, raw_text,
+        created_by_run_id, created_by_actor_type, created_by_actor_id
+      )
+      VALUES (
+        ${sourceId}, ${path}, ${title}, 'note', ${contentHash}, ${text},
+        ${runId ?? null}, ${actor.actorType}, ${actor.actorId}
+      )
       ON CONFLICT (path) DO UPDATE SET
-        title        = EXCLUDED.title,
-        content_hash = EXCLUDED.content_hash,
-        raw_text     = EXCLUDED.raw_text,
-        updated_at   = now()
+        title                 = EXCLUDED.title,
+        content_hash          = EXCLUDED.content_hash,
+        raw_text              = EXCLUDED.raw_text,
+        -- Preserve an existing run attribution when a run-less path (e.g. the
+        -- direct /api/memory/note route) re-adds identical text; a real writing
+        -- run always wins over null so the note stays traceable.
+        created_by_run_id     = COALESCE(EXCLUDED.created_by_run_id, source_records.created_by_run_id),
+        created_by_actor_type = EXCLUDED.created_by_actor_type,
+        created_by_actor_id   = EXCLUDED.created_by_actor_id,
+        updated_at            = now()
       RETURNING id, source_id
     `;
 

--- a/src/lib/model-gateway.ts
+++ b/src/lib/model-gateway.ts
@@ -1,11 +1,8 @@
 import { createHash } from "node:crypto";
-import { createAnthropic } from "@ai-sdk/anthropic";
-import { deepseek } from "@ai-sdk/deepseek";
-import { openai } from "@ai-sdk/openai";
-import type { LanguageModel } from "ai";
-import { embed, embedMany, generateObject, generateText } from "ai";
+import Anthropic from "@anthropic-ai/sdk";
+import OpenAIClient from "openai";
 import type postgres from "postgres";
-import type { z } from "zod";
+import { z } from "zod"; // value import — z.toJSONSchema is a runtime call now
 import { failRunStep, finishRunStep, startRunStep } from "./ledger";
 import { anthropicAdapter } from "./llm/anthropic";
 import { createOpenAiCompatAdapter } from "./llm/openai-compat";
@@ -272,13 +269,11 @@ async function executeProvider(
   return executeDefaultProvider(input, providerName, model);
 }
 
-// Resolve the AI SDK language model for text/object generation. Embeddings stay
-// on OpenAI. Keeps the gateway's single provider abstraction (ADR-0004) uniform
-// across deepseek/anthropic without leaking provider details to callers.
-// @ai-sdk/anthropic expects a base URL that includes the `/v1` segment and posts
-// to `${baseURL}/messages`. Some environments export ANTHROPIC_BASE_URL as the
-// bare host (the official SDK's convention, which appends /v1 itself), which 404s
-// here. Normalize: honor a configured base but ensure it carries a version path.
+// @ai-sdk/anthropic expected a base URL that includes the `/v1` segment and
+// posts to `${baseURL}/messages`. Some environments export ANTHROPIC_BASE_URL
+// as the bare host, which 404'd there. This normalizer keeps its tested
+// contract (the /v1-suffixed form); toBareAnthropicHost() strips it back off
+// for the raw SDK, which appends the versioned path itself.
 export function resolveAnthropicBaseUrl(raw?: string): string {
   const configured = raw?.trim();
   if (!configured) return "https://api.anthropic.com/v1";
@@ -286,22 +281,190 @@ export function resolveAnthropicBaseUrl(raw?: string): string {
   return /\/v\d+$/.test(trimmed) ? trimmed : `${trimmed}/v1`;
 }
 
-function generationModel(providerName: string, model: string): LanguageModel {
-  if (providerName === "anthropic") {
-    requireEnv("ANTHROPIC_API_KEY");
-    const provider = createAnthropic({
-      baseURL: resolveAnthropicBaseUrl(process.env.ANTHROPIC_BASE_URL),
-    });
-    return provider(model);
-  }
-  if (providerName !== "deepseek") {
+// The raw @anthropic-ai/sdk client posts to `${baseURL}/v1/messages` itself —
+// unlike @ai-sdk/anthropic it wants the bare host, not a version-suffixed URL.
+export function toBareAnthropicHost(versionedBaseUrl: string): string {
+  return versionedBaseUrl.replace(/\/v\d+$/, "");
+}
+
+// DeepSeek's own server-side default governs when no explicit max_tokens is
+// sent (@ai-sdk/deepseek passed `max_tokens: undefined`), so this flat constant
+// reproduces existing DeepSeek behavior. Anthropic does NOT use it — see
+// anthropicMaxTokensForModel(), which reproduces @ai-sdk/anthropic's per-model
+// default rather than shrinking it.
+const DEFAULT_MAX_TOKENS = 4096;
+
+// Mirrors @ai-sdk/anthropic's maxOutputTokensForModel table — the raw SDK has
+// no implicit default and requires max_tokens on every request. Without this,
+// every claude-sonnet-4-* call (incl. the configured claude-sonnet-4-6) would
+// silently drop from an effective 64000 ceiling to 4096, truncating both
+// harness.ts's decide() and extractors/llm.ts's document-wide extraction.
+function anthropicMaxTokensForModel(model: string): number {
+  return /^claude-sonnet-4-/.test(model) ? 64000 : DEFAULT_MAX_TOKENS;
+}
+
+function anthropicClient(): Anthropic {
+  requireEnv("ANTHROPIC_API_KEY");
+  return new Anthropic({
+    apiKey: process.env.ANTHROPIC_API_KEY,
+    baseURL: toBareAnthropicHost(resolveAnthropicBaseUrl(process.env.ANTHROPIC_BASE_URL)),
+  });
+}
+
+function deepseekClient(): OpenAIClient {
+  requireEnv("DEEPSEEK_API_KEY");
+  return new OpenAIClient({ apiKey: process.env.DEEPSEEK_API_KEY, baseURL: "https://api.deepseek.com" });
+}
+
+function openaiEmbeddingClient(): OpenAIClient {
+  requireEnv("OPENAI_API_KEY");
+  return new OpenAIClient({ apiKey: process.env.OPENAI_API_KEY });
+}
+
+function assertSupportedGenerationProvider(
+  providerName: string,
+): asserts providerName is "anthropic" | "deepseek" {
+  if (providerName !== "anthropic" && providerName !== "deepseek") {
     throw new ModelGatewayError(
       "config_error",
       `Unsupported generation provider: ${providerName}. Set SOURCECADO_GENERATION_PROVIDER to "anthropic" or "deepseek".`,
     );
   }
-  requireEnv("DEEPSEEK_API_KEY");
-  return deepseek(model);
+}
+
+function toGenerationJsonSchema(schema: z.ZodType): unknown {
+  return z.toJSONSchema(schema);
+}
+
+async function generateTextAnthropic(input: GenerateTextInput, model: string): Promise<ModelGatewayProviderResult> {
+  const client = anthropicClient();
+  const response = await client.messages.create({
+    model,
+    max_tokens: anthropicMaxTokensForModel(model),
+    system: input.system,
+    messages: [{ role: "user", content: input.prompt }],
+  });
+  const text = response.content
+    .filter((block): block is Anthropic.TextBlock => block.type === "text")
+    .map((block) => block.text)
+    .join("");
+  return {
+    text,
+    usage: {
+      inputTokens: response.usage.input_tokens,
+      outputTokens: response.usage.output_tokens,
+      totalTokens: response.usage.input_tokens + response.usage.output_tokens,
+    },
+    rawResponse: response,
+  };
+}
+
+async function generateObjectAnthropic(input: GenerateObjectInput, model: string): Promise<ModelGatewayProviderResult> {
+  const client = anthropicClient();
+  const toolName = "emit_object";
+  const jsonSchema = toGenerationJsonSchema(input.schema);
+  const response = await client.messages.create({
+    model,
+    max_tokens: anthropicMaxTokensForModel(model),
+    system: input.system,
+    messages: [{ role: "user", content: input.prompt }],
+    tools: [
+      {
+        name: toolName,
+        description: "Emit the structured result for this task. Always call this tool exactly once.",
+        input_schema: jsonSchema as Anthropic.Tool["input_schema"],
+      },
+    ],
+    tool_choice: { type: "tool", name: toolName },
+  });
+  const toolUse = response.content.find(
+    (block): block is Anthropic.ToolUseBlock => block.type === "tool_use" && block.name === toolName,
+  );
+  return {
+    object: toolUse?.input,
+    usage: {
+      inputTokens: response.usage.input_tokens,
+      outputTokens: response.usage.output_tokens,
+      totalTokens: response.usage.input_tokens + response.usage.output_tokens,
+    },
+    rawResponse: response,
+  };
+}
+
+async function generateTextDeepseek(input: GenerateTextInput, model: string): Promise<ModelGatewayProviderResult> {
+  const client = deepseekClient();
+  const messages: OpenAIClient.Chat.ChatCompletionMessageParam[] = [];
+  if (input.system) messages.push({ role: "system", content: input.system });
+  messages.push({ role: "user", content: input.prompt });
+  const response = await client.chat.completions.create({ model, max_tokens: DEFAULT_MAX_TOKENS, messages });
+  return {
+    text: response.choices[0]?.message.content ?? "",
+    usage: {
+      inputTokens: response.usage?.prompt_tokens ?? null,
+      outputTokens: response.usage?.completion_tokens ?? null,
+      totalTokens: response.usage?.total_tokens ?? null,
+    },
+    rawResponse: response,
+  };
+}
+
+async function generateObjectDeepseek(input: GenerateObjectInput, model: string): Promise<ModelGatewayProviderResult> {
+  const client = deepseekClient();
+  const jsonSchema = toGenerationJsonSchema(input.schema);
+  const promptWithSchema = [
+    input.prompt,
+    "",
+    "Respond with a single strict JSON object matching this schema and no other text:",
+    JSON.stringify(jsonSchema),
+  ].join("\n");
+  const messages: OpenAIClient.Chat.ChatCompletionMessageParam[] = [];
+  if (input.system) messages.push({ role: "system", content: input.system });
+  messages.push({ role: "user", content: promptWithSchema });
+  const response = await client.chat.completions.create({
+    model,
+    max_tokens: DEFAULT_MAX_TOKENS,
+    response_format: { type: "json_object" },
+    messages,
+  });
+  const raw = response.choices[0]?.message.content ?? "{}";
+  let object: unknown;
+  try {
+    object = JSON.parse(raw);
+  } catch (error) {
+    throw new ModelGatewayError("invalid_output", "Model provider returned malformed JSON for generate_object.", {
+      cause: error,
+    });
+  }
+  return {
+    object,
+    usage: {
+      inputTokens: response.usage?.prompt_tokens ?? null,
+      outputTokens: response.usage?.completion_tokens ?? null,
+      totalTokens: response.usage?.total_tokens ?? null,
+    },
+    rawResponse: response,
+  };
+}
+
+async function embedOpenai(input: EmbedInput, model: string): Promise<ModelGatewayProviderResult> {
+  const client = openaiEmbeddingClient();
+  const response = await client.embeddings.create({ model, input: input.value });
+  return {
+    embedding: response.data[0]?.embedding,
+    usage: { tokens: response.usage?.total_tokens ?? null },
+    rawResponse: response,
+  };
+}
+
+async function embedManyOpenai(input: EmbedManyInput, model: string): Promise<ModelGatewayProviderResult> {
+  const client = openaiEmbeddingClient();
+  const response = await client.embeddings.create({ model, input: input.values });
+  const embeddings = [...response.data].sort((a, b) => a.index - b.index).map((entry) => entry.embedding);
+  return {
+    embeddings,
+    usage: { tokens: response.usage?.total_tokens ?? null },
+    rawResponse: response,
+  };
 }
 
 async function executeDefaultProvider(
@@ -310,56 +473,20 @@ async function executeDefaultProvider(
   model: string,
 ): Promise<ModelGatewayProviderResult> {
   switch (input.kind) {
-    case "generate_text": {
-      const result = await generateText({
-        model: generationModel(providerName, model),
-        prompt: input.prompt,
-        system: input.system,
-      });
-      return {
-        text: result.text,
-        usage: result.totalUsage ?? result.usage,
-        rawResponse: result.response.body ?? result.response,
-      };
-    }
-    case "generate_object": {
-      const result = await generateObject({
-        model: generationModel(providerName, model),
-        prompt: input.prompt,
-        system: input.system,
-        schema: input.schema,
-        schemaName: input.schemaName,
-      });
-      return {
-        object: result.object,
-        usage: result.usage,
-        rawResponse: result.response.body ?? result.response,
-      };
-    }
-    case "embed": {
-      requireEnv("OPENAI_API_KEY");
-      const result = await embed({
-        model: openai.embedding(model),
-        value: input.value,
-      });
-      return {
-        embedding: result.embedding,
-        usage: result.usage,
-        rawResponse: result.response?.body ?? result.response,
-      };
-    }
-    case "embed_many": {
-      requireEnv("OPENAI_API_KEY");
-      const result = await embedMany({
-        model: openai.embedding(model),
-        values: input.values,
-      });
-      return {
-        embeddings: result.embeddings,
-        usage: result.usage,
-        rawResponse: result.responses,
-      };
-    }
+    case "generate_text":
+      assertSupportedGenerationProvider(providerName);
+      return providerName === "anthropic"
+        ? generateTextAnthropic(input, model)
+        : generateTextDeepseek(input, model);
+    case "generate_object":
+      assertSupportedGenerationProvider(providerName);
+      return providerName === "anthropic"
+        ? generateObjectAnthropic(input, model)
+        : generateObjectDeepseek(input, model);
+    case "embed":
+      return embedOpenai(input, model);
+    case "embed_many":
+      return embedManyOpenai(input, model);
   }
 }
 

--- a/src/lib/tools/add-memory-note.ts
+++ b/src/lib/tools/add-memory-note.ts
@@ -8,6 +8,8 @@ export const addMemoryNoteTool: Tool<{ title: string; text: string }, { sourceId
   permissionClass: "write_internal",
   argsSchema: z.object({ title: z.string().min(1), text: z.string().min(1) }),
   async execute(args, ctx) {
-    return addMemoryNote(ctx.db, { title: args.title, text: args.text });
+    // Stamp the writing run so a note produced by a (possibly prompt-injected)
+    // chat run is traceable back to that run and archivable.
+    return addMemoryNote(ctx.db, { title: args.title, text: args.text, runId: ctx.runId });
   },
 };

--- a/src/migrations/006_note_provenance.sql
+++ b/src/migrations/006_note_provenance.sql
@@ -1,0 +1,11 @@
+-- 006_note_provenance.sql — provenance stamp for memory notes (poisoned-note traceability).
+-- A note written by a chat run (whose text may be prompt-injected) needs the writing
+-- run and actor recorded on its source_records row, so a bad note can be traced back to
+-- the run that produced it and archived. Run link is SET NULL on run delete (mirrors
+-- semantic_facts): losing the run pointer must not delete the note itself.
+
+ALTER TABLE source_records ADD COLUMN IF NOT EXISTS created_by_run_id BIGINT REFERENCES runs(id) ON DELETE SET NULL;
+ALTER TABLE source_records ADD COLUMN IF NOT EXISTS created_by_actor_type TEXT;
+ALTER TABLE source_records ADD COLUMN IF NOT EXISTS created_by_actor_id TEXT;
+
+CREATE INDEX IF NOT EXISTS source_records_created_by_run_idx ON source_records(created_by_run_id);

--- a/tests/anthropic-base-url.test.ts
+++ b/tests/anthropic-base-url.test.ts
@@ -1,4 +1,4 @@
-import { resolveAnthropicBaseUrl } from "@/lib/model-gateway";
+import { resolveAnthropicBaseUrl, toBareAnthropicHost } from "@/lib/model-gateway";
 
 describe("resolveAnthropicBaseUrl", () => {
   it("defaults to the versioned Anthropic API base", () => {
@@ -16,5 +16,23 @@ describe("resolveAnthropicBaseUrl", () => {
     expect(resolveAnthropicBaseUrl("https://proxy.internal/anthropic/v2")).toBe(
       "https://proxy.internal/anthropic/v2",
     );
+  });
+});
+
+describe("toBareAnthropicHost", () => {
+  it("strips a trailing /v1 segment", () => {
+    expect(toBareAnthropicHost("https://api.anthropic.com/v1")).toBe("https://api.anthropic.com");
+  });
+
+  it("strips a trailing /v2 (or other version) segment", () => {
+    expect(toBareAnthropicHost("https://proxy.internal/anthropic/v2")).toBe("https://proxy.internal/anthropic");
+  });
+
+  it("is a no-op when there is no version segment", () => {
+    expect(toBareAnthropicHost("https://api.anthropic.com")).toBe("https://api.anthropic.com");
+  });
+
+  it("composes with resolveAnthropicBaseUrl for the default case", () => {
+    expect(toBareAnthropicHost(resolveAnthropicBaseUrl(undefined))).toBe("https://api.anthropic.com");
   });
 });

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -189,4 +189,10 @@ describe("buildEnvironmentSection", () => {
     expect(section.title).toBe("Environment");
     expect(section.body).toBe("Today's date: 2026-07-15");
   });
+
+  it("uses the team's Los Angeles timezone, not UTC, for the calendar day", () => {
+    // 2026-07-16T05:00:00Z is still 2026-07-15 (22:00 PDT) in America/Los_Angeles.
+    const section = buildEnvironmentSection(new Date("2026-07-16T05:00:00Z"));
+    expect(section.body).toBe("Today's date: 2026-07-15");
+  });
 });

--- a/tests/memory-notes.test.ts
+++ b/tests/memory-notes.test.ts
@@ -5,6 +5,7 @@ import { DEFAULT_ACTOR } from "@/lib/memory/actor";
 import { addMemoryNote } from "@/lib/memory/notes";
 import { searchMemory } from "@/lib/memory/retrieve";
 import { addMemoryNoteTool } from "@/lib/tools/add-memory-note";
+import { startRun } from "@/lib/ledger";
 
 async function resetMemoryTables(): Promise<void> {
   const db = getDb();
@@ -128,6 +129,42 @@ describe("addMemoryNote (postgres)", () => {
     });
     const found = bundle.chunks.some((c) => c.citation.startsWith(id2));
     expect(found).toBe(true);
+  });
+
+  it("stamps the writing run and actor onto the source row (poisoned-note traceability)", async () => {
+    const db = getDb();
+    const run = await startRun(db, { runType: "agent_chat", title: "note-provenance", input: {} });
+
+    const { sourceId } = await addMemoryNoteTool.execute(
+      { title: "Injected Note", text: "Possibly prompt-injected content." },
+      { db, runId: run.id, parentStepId: 0 }
+    );
+
+    const [row] = await db<
+      { created_by_run_id: string | null; created_by_actor_type: string; created_by_actor_id: string }[]
+    >`
+      SELECT created_by_run_id, created_by_actor_type, created_by_actor_id
+      FROM source_records WHERE source_id = ${sourceId}
+    `;
+    expect(row).toBeDefined();
+    expect(Number(row.created_by_run_id)).toBe(run.id);
+    expect(row.created_by_actor_type).toBe(DEFAULT_ACTOR.actorType);
+    expect(row.created_by_actor_id).toBe(DEFAULT_ACTOR.actorId);
+  });
+
+  it("run-less re-add (direct API path) preserves an existing run attribution", async () => {
+    const db = getDb();
+    const run = await startRun(db, { runType: "agent_chat", title: "note-preserve", input: {} });
+    const args = { title: "Traced Note", text: "Content written first by a chat run." };
+
+    const { sourceId } = await addMemoryNote(db, { ...args, runId: run.id });
+    // Re-add identical text through the run-less path (no runId).
+    await addMemoryNote(db, args);
+
+    const [row] = await db<{ created_by_run_id: string | null }[]>`
+      SELECT created_by_run_id FROM source_records WHERE source_id = ${sourceId}
+    `;
+    expect(Number(row.created_by_run_id)).toBe(run.id);
   });
 
   it("idempotent: adding identical note twice does not duplicate memory_chunks", async () => {

--- a/tests/model-gateway-anthropic-provider.test.ts
+++ b/tests/model-gateway-anthropic-provider.test.ts
@@ -1,0 +1,141 @@
+import { z } from "zod";
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+
+const { messagesCreateMock, anthropicCtorMock } = vi.hoisted(() => ({
+  messagesCreateMock: vi.fn(),
+  anthropicCtorMock: vi.fn(),
+}));
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: class {
+    messages = { create: messagesCreateMock };
+    constructor(opts: unknown) {
+      anthropicCtorMock(opts);
+    }
+  },
+}));
+
+// Import after the mock so callModel picks up the mocked constructor.
+const { callModel } = await import("@/lib/model-gateway");
+
+async function resetLedgerTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS tool_calls CASCADE`;
+  await db`DROP TABLE IF EXISTS model_calls CASCADE`;
+  await db`DROP TABLE IF EXISTS run_steps CASCADE`;
+  await db`DROP TABLE IF EXISTS runs CASCADE`;
+  await db`DROP TABLE IF EXISTS schema_migrations CASCADE`;
+  await runMigrations(db);
+}
+
+describe("callModel() — Anthropic raw SDK path", () => {
+  const savedKey = process.env.ANTHROPIC_API_KEY;
+
+  beforeEach(async () => {
+    await resetLedgerTables();
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test-key";
+    messagesCreateMock.mockReset();
+    anthropicCtorMock.mockReset();
+  });
+
+  afterEach(async () => {
+    if (savedKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = savedKey;
+    await closeDb();
+  });
+
+  it("constructs the client with the bare host (no /v1 suffix)", async () => {
+    messagesCreateMock.mockResolvedValue({
+      content: [{ type: "text", text: "hi" }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+    await callModel(getDb(), {
+      kind: "generate_text",
+      taskName: "t",
+      promptVersion: "1",
+      prompt: "hi",
+      providerName: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+    expect(anthropicCtorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "https://api.anthropic.com" }),
+    );
+  });
+
+  it("generate_text concatenates text blocks and maps usage", async () => {
+    messagesCreateMock.mockResolvedValue({
+      content: [{ type: "text", text: "Hello " }, { type: "text", text: "world" }],
+      usage: { input_tokens: 10, output_tokens: 5 },
+    });
+    const result = await callModel(getDb(), {
+      kind: "generate_text",
+      taskName: "t",
+      promptVersion: "1",
+      prompt: "hi",
+      providerName: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+    expect(result.text).toBe("Hello world");
+    expect(result.usage).toMatchObject({ inputTokens: 10, outputTokens: 5, totalTokens: 15 });
+    expect(messagesCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ max_tokens: 64000, model: "claude-sonnet-4-6" }),
+    );
+  });
+
+  it("falls back to 4096 max_tokens for a non-sonnet-4 model family", async () => {
+    messagesCreateMock.mockResolvedValue({
+      content: [{ type: "text", text: "hi" }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+    await callModel(getDb(), {
+      kind: "generate_text",
+      taskName: "t",
+      promptVersion: "1",
+      prompt: "hi",
+      providerName: "anthropic",
+      model: "claude-haiku-4-5",
+    });
+    expect(messagesCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ max_tokens: 4096 }),
+    );
+  });
+
+  it("generate_object forces a single tool call and extracts its input", async () => {
+    messagesCreateMock.mockResolvedValue({
+      content: [{ type: "tool_use", id: "toolu_1", name: "emit_object", input: { ok: true } }],
+      usage: { input_tokens: 4, output_tokens: 2 },
+    });
+    const result = await callModel(getDb(), {
+      kind: "generate_object",
+      taskName: "t",
+      promptVersion: "1",
+      prompt: "hi",
+      schema: z.object({ ok: z.boolean() }),
+      providerName: "anthropic",
+      model: "claude-sonnet-4-6",
+    });
+    expect(result.object).toEqual({ ok: true });
+    const call = messagesCreateMock.mock.calls[0][0];
+    expect(call.tool_choice).toEqual({ type: "tool", name: "emit_object" });
+    expect(call.tools).toHaveLength(1);
+    expect(call.tools[0].name).toBe("emit_object");
+  });
+
+  it("raises schema_error when the tool call's input fails schema validation", async () => {
+    messagesCreateMock.mockResolvedValue({
+      content: [{ type: "tool_use", id: "toolu_1", name: "emit_object", input: { ok: "not-a-bool" } }],
+      usage: { input_tokens: 4, output_tokens: 2 },
+    });
+    await expect(
+      callModel(getDb(), {
+        kind: "generate_object",
+        taskName: "t",
+        promptVersion: "1",
+        prompt: "hi",
+        schema: z.object({ ok: z.boolean() }),
+        providerName: "anthropic",
+        model: "claude-sonnet-4-6",
+      }),
+    ).rejects.toMatchObject({ code: "schema_error" });
+  });
+});

--- a/tests/model-gateway-deepseek-provider.test.ts
+++ b/tests/model-gateway-deepseek-provider.test.ts
@@ -1,0 +1,118 @@
+import { z } from "zod";
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+
+const { chatCreateMock, openaiCtorMock } = vi.hoisted(() => ({
+  chatCreateMock: vi.fn(),
+  openaiCtorMock: vi.fn(),
+}));
+vi.mock("openai", () => ({
+  default: class {
+    chat = { completions: { create: chatCreateMock } };
+    embeddings = { create: vi.fn() };
+    constructor(opts: unknown) {
+      openaiCtorMock(opts);
+    }
+  },
+}));
+
+const { callModel } = await import("@/lib/model-gateway");
+
+async function resetLedgerTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS tool_calls CASCADE`;
+  await db`DROP TABLE IF EXISTS model_calls CASCADE`;
+  await db`DROP TABLE IF EXISTS run_steps CASCADE`;
+  await db`DROP TABLE IF EXISTS runs CASCADE`;
+  await db`DROP TABLE IF EXISTS schema_migrations CASCADE`;
+  await runMigrations(db);
+}
+
+describe("callModel() — DeepSeek raw SDK path", () => {
+  const savedKey = process.env.DEEPSEEK_API_KEY;
+
+  beforeEach(async () => {
+    await resetLedgerTables();
+    process.env.DEEPSEEK_API_KEY = "sk-deepseek-test-key";
+    chatCreateMock.mockReset();
+    openaiCtorMock.mockReset();
+  });
+
+  afterEach(async () => {
+    if (savedKey === undefined) delete process.env.DEEPSEEK_API_KEY;
+    else process.env.DEEPSEEK_API_KEY = savedKey;
+    await closeDb();
+  });
+
+  it("constructs the client pointed at DeepSeek's base URL", async () => {
+    chatCreateMock.mockResolvedValue({
+      choices: [{ message: { content: "hi" } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    });
+    await callModel(getDb(), {
+      kind: "generate_text",
+      taskName: "t",
+      promptVersion: "1",
+      prompt: "hi",
+      providerName: "deepseek",
+      model: "deepseek-chat",
+    });
+    expect(openaiCtorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: "https://api.deepseek.com" }),
+    );
+  });
+
+  it("generate_text maps choices[0].message.content and usage", async () => {
+    chatCreateMock.mockResolvedValue({
+      choices: [{ message: { content: "Hello there" } }],
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+    });
+    const result = await callModel(getDb(), {
+      kind: "generate_text",
+      taskName: "t",
+      promptVersion: "1",
+      prompt: "hi",
+      providerName: "deepseek",
+      model: "deepseek-chat",
+    });
+    expect(result.text).toBe("Hello there");
+    expect(result.usage).toMatchObject({ inputTokens: 10, outputTokens: 5, totalTokens: 15 });
+  });
+
+  it("generate_object sends response_format json_object and parses the result", async () => {
+    chatCreateMock.mockResolvedValue({
+      choices: [{ message: { content: JSON.stringify({ candidates: ["Ada"] }) } }],
+      usage: { prompt_tokens: 4, completion_tokens: 2, total_tokens: 6 },
+    });
+    const result = await callModel(getDb(), {
+      kind: "generate_object",
+      taskName: "t",
+      promptVersion: "1",
+      prompt: "extract",
+      schema: z.object({ candidates: z.array(z.string()) }),
+      providerName: "deepseek",
+      model: "deepseek-chat",
+    });
+    expect(result.object).toEqual({ candidates: ["Ada"] });
+    const call = chatCreateMock.mock.calls[0][0];
+    expect(call.response_format).toEqual({ type: "json_object" });
+  });
+
+  it("raises invalid_output when the model returns malformed JSON", async () => {
+    chatCreateMock.mockResolvedValue({
+      choices: [{ message: { content: "not json" } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    });
+    await expect(
+      callModel(getDb(), {
+        kind: "generate_object",
+        taskName: "t",
+        promptVersion: "1",
+        prompt: "extract",
+        schema: z.object({ candidates: z.array(z.string()) }),
+        providerName: "deepseek",
+        model: "deepseek-chat",
+      }),
+    ).rejects.toMatchObject({ code: "invalid_output" });
+  });
+});

--- a/tests/model-gateway-embed-provider.test.ts
+++ b/tests/model-gateway-embed-provider.test.ts
@@ -1,0 +1,97 @@
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+
+const { embeddingsCreateMock, openaiCtorMock } = vi.hoisted(() => ({
+  embeddingsCreateMock: vi.fn(),
+  openaiCtorMock: vi.fn(),
+}));
+vi.mock("openai", () => ({
+  default: class {
+    chat = { completions: { create: vi.fn() } };
+    embeddings = { create: embeddingsCreateMock };
+    constructor(opts: unknown) {
+      openaiCtorMock(opts);
+    }
+  },
+}));
+
+const { callModel } = await import("@/lib/model-gateway");
+
+async function resetLedgerTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS tool_calls CASCADE`;
+  await db`DROP TABLE IF EXISTS model_calls CASCADE`;
+  await db`DROP TABLE IF EXISTS run_steps CASCADE`;
+  await db`DROP TABLE IF EXISTS runs CASCADE`;
+  await db`DROP TABLE IF EXISTS schema_migrations CASCADE`;
+  await runMigrations(db);
+}
+
+describe("callModel() — OpenAI embeddings raw SDK path", () => {
+  const savedKey = process.env.OPENAI_API_KEY;
+
+  beforeEach(async () => {
+    await resetLedgerTables();
+    process.env.OPENAI_API_KEY = "sk-openai-test-key";
+    embeddingsCreateMock.mockReset();
+    openaiCtorMock.mockReset();
+  });
+
+  afterEach(async () => {
+    if (savedKey === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = savedKey;
+    await closeDb();
+  });
+
+  it("embed maps data[0].embedding and usage.total_tokens", async () => {
+    embeddingsCreateMock.mockResolvedValue({
+      data: [{ index: 0, embedding: [0.1, 0.2, 0.3] }],
+      usage: { prompt_tokens: 3, total_tokens: 3 },
+    });
+    const result = await callModel(getDb(), {
+      kind: "embed",
+      taskName: "t",
+      promptVersion: "1",
+      value: "hello",
+      providerName: "openai",
+      model: "text-embedding-3-small",
+    });
+    expect(result.embedding).toEqual([0.1, 0.2, 0.3]);
+    // callModel returns NORMALIZED usage; the provider's {tokens:3} maps to
+    // inputTokens+totalTokens (normalizeUsage's embedding-usage branch).
+    expect(result.usage).toMatchObject({ inputTokens: 3, totalTokens: 3 });
+  });
+
+  it("embed_many re-sorts by index before mapping embeddings", async () => {
+    embeddingsCreateMock.mockResolvedValue({
+      data: [
+        { index: 1, embedding: [0.2] },
+        { index: 0, embedding: [0.1] },
+      ],
+      usage: { prompt_tokens: 2, total_tokens: 2 },
+    });
+    const result = await callModel(getDb(), {
+      kind: "embed_many",
+      taskName: "t",
+      promptVersion: "1",
+      values: ["a", "b"],
+      providerName: "openai",
+      model: "text-embedding-3-small",
+    });
+    expect(result.embeddings).toEqual([[0.1], [0.2]]);
+  });
+
+  it("requires OPENAI_API_KEY", async () => {
+    delete process.env.OPENAI_API_KEY;
+    await expect(
+      callModel(getDb(), {
+        kind: "embed",
+        taskName: "t",
+        promptVersion: "1",
+        value: "hello",
+        providerName: "openai",
+        model: "text-embedding-3-small",
+      }),
+    ).rejects.toMatchObject({ code: "missing_config" });
+  });
+});

--- a/tests/package-deps.test.ts
+++ b/tests/package-deps.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+describe("package.json dependencies", () => {
+  const pkg = JSON.parse(readFileSync(join(process.cwd(), "package.json"), "utf8"));
+  const depNames = [
+    ...Object.keys(pkg.dependencies ?? {}),
+    ...Object.keys(pkg.devDependencies ?? {}),
+  ];
+
+  it("does not depend on the @ai-sdk/* provider packages", () => {
+    const aiSdkDeps = depNames.filter((name) => name.startsWith("@ai-sdk/"));
+    expect(aiSdkDeps).toEqual([]);
+  });
+
+  it("still depends on `ai` (R5's ui-message-stream SSE transport)", () => {
+    // Full removal of `ai` is ticketed separately (rewrite the SSE transport
+    // off createUIMessageStream — docs/superpowers/plans/2026-07-21-ticket-remove-ai-sdk-ui-stream.md).
+    // Until then `ai` is a deliberate dependency.
+    expect(pkg.dependencies).toHaveProperty("ai");
+  });
+
+  it("depends on the raw Anthropic and OpenAI SDKs", () => {
+    expect(pkg.dependencies).toHaveProperty("@anthropic-ai/sdk");
+    expect(pkg.dependencies).toHaveProperty("openai");
+  });
+});

--- a/tests/web-search-tool.test.ts
+++ b/tests/web-search-tool.test.ts
@@ -98,8 +98,12 @@ describe("webSearchTool", () => {
     ).rejects.toThrow(/Unexpected token/);
   });
 
-  it.skipIf(!process.env.TAVILY_API_KEY)(
-    "live: searches Tavily for a real query when TAVILY_API_KEY is present",
+  // Gated on the explicit SOURCECADO_RUN_LIVE_SMOKE opt-in (like web_fetch's
+  // live smoke), NOT on TAVILY_API_KEY presence — .env.local carries the key
+  // for the DB suites, and an over-quota account (HTTP 433) must not turn the
+  // default suite red on external billing state.
+  it.skipIf(!process.env.SOURCECADO_RUN_LIVE_SMOKE)(
+    "live: searches Tavily for a real query (opt-in via SOURCECADO_RUN_LIVE_SMOKE)",
     async () => {
       const result = await webSearchTool.execute(
         { query: "Sourcecado sourcing operating system" },


### PR DESCRIPTION
## R8 — AI SDK rip-out (model-gateway → raw SDKs)

Migrates `callModel`'s `generate_text`/`generate_object`/`embed`/`embed_many`
internals in `src/lib/model-gateway.ts` off the Vercel AI SDK onto the raw
`@anthropic-ai/sdk` + `openai` clients, with **zero change to `callModel`'s
external contract** (`CallModelInput`/`CallModelResult`/`ModelGatewayProvider`).
Plan: `docs/superpowers/plans/2026-07-14-r8-ai-sdk-ripout-plan.md` (Task 5
reconciled 2026-07-21).

### What changed
- **Anthropic** (`messages.create`): `generate_object` via a single **forced
  tool** (`tool_choice`); `anthropicMaxTokensForModel` reproduces
  `@ai-sdk/anthropic`'s 64000 ceiling for `claude-sonnet-4-*` (4096 fallback)
  so `harness.decide()` + `extractors/llm.ts` aren't silently truncated;
  `toBareAnthropicHost` strips `/v1` for the raw client.
- **DeepSeek** (raw `openai` client @ `api.deepseek.com`): `generate_object`
  via `response_format: json_object` + `JSON.parse` (→ `invalid_output` on
  malformed).
- **Embeddings** (raw `openai` `embeddings.create`): `embed_many` re-sorted by
  `index`.
- `generationModel()` deleted; `config_error`/`missing_config` behavior
  preserved (pre-existing gateway tests pass byte-for-byte).
- **Removed `@ai-sdk/anthropic|deepseek|openai`** from `package.json`.

### Scope decision (Task 5, reconciled with Fisher)
`ai` is **kept** — `ui-message-stream.ts` (R5, merged) deliberately uses
`createUIMessageStream` as the SSE transport, and the model-boundary test
enshrines it. Fully removing `ai` requires rewriting that transport (R5
domain) → ticketed: `docs/superpowers/plans/2026-07-21-ticket-remove-ai-sdk-ui-stream.md`.
`package-deps.test.ts` locks the current state (no `@ai-sdk/*`; `ai` +
`@anthropic-ai/sdk` + `openai` present).

### Cross-slice fix included
`web_search`'s live-smoke test was gating on `TAVILY_API_KEY` presence; since
`.env.local` carries the key for the DB suites and the Tavily account is over
quota (HTTP 433), it turned the default suite red on external billing state.
Re-gated on the `SOURCECADO_RUN_LIVE_SMOKE` opt-in (matching `web_fetch`). No
production code touched.

### Gates
- Full suite: **PASS — zero new failures** vs. the 78 legacy better-sqlite3
  suites (the standing pre-existing P0; 9 files, unrelated to this slice).
- `tsc --noEmit` clean · lint = only the pre-existing `embed.ts` warning ·
  `npm run build` GREEN.
- 19 new/updated R8 tests (base-url, anthropic/deepseek/embed provider paths,
  package-deps) + 39 regression tests (extractors/memory) green.
- One test-assertion bug in the plan's embed test corrected (asserted raw
  `{tokens}` vs the normalized usage shape `callModel` actually returns).

### Also riding this branch (2 carried `rt-R7` fixes, committed onto the branch)
Not part of the R8 migration, but present in the diff and green under the suite:
- `8988c39` — pin the Environment-section date to `America/Los_Angeles` (was
  UTC, which flipped "today" a day early for the Berkeley team). `context.ts` +
  test.
- `bc428a5` — stamp the writing run + actor onto memory notes for poison-note
  traceability (adds migration `006_note_provenance.sql`, `notes.ts`,
  `add-memory-note.ts`, test).

If you'd prefer these in a separate PR, say so and I'll split them out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the model gateway to raw Anthropic and OpenAI clients. The main changes are:

- Raw SDK paths for text, structured output, and embeddings.
- Removal of the three `@ai-sdk/*` provider packages.
- Run and actor provenance for memory notes.
- Los Angeles dates in the environment prompt.
- Explicit opt-in for Tavily live tests.

<h3>Confidence Score: 4/5</h3>

The provider compatibility and note provenance paths need fixes before merging.

- Explicit Anthropic proxy versions can be replaced with `/v1`.
- DeepSeek callers can receive newly truncated output.
- Note upserts can persist a mismatched run and actor.

src/lib/model-gateway.ts; src/lib/memory/notes.ts

<details open><summary><h3>Security Review</h3></summary>

A run-less note upsert can retain one run ID while replacing its actor identity. This can misattribute the origin of a poisoned memory note.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/model-gateway.ts | Replaces AI SDK helpers with raw clients, but rewrites explicit Anthropic proxy versions and limits DeepSeek output to 4,096 tokens. |
| src/lib/memory/notes.ts | Adds note provenance, but a conflict update can combine one run with another actor. |
| src/migrations/006_note_provenance.sql | Adds nullable provenance columns, a run foreign key, and an index. |
| src/lib/tools/add-memory-note.ts | Passes the writing run ID into memory-note creation. |
| src/lib/context.ts | Renders the environment date in the America/Los_Angeles timezone. |
| package.json | Removes unused AI SDK provider adapters while retaining the raw SDK dependencies. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[callModel] --> B{Call kind}
  B -->|Generate| C{Provider}
  C -->|Anthropic| D[Anthropic messages API]
  C -->|DeepSeek| E[OpenAI-compatible chat API]
  B -->|Embed| F[OpenAI embeddings API]
  D --> G[Validate and normalize]
  E --> G
  F --> G
  G --> H[Record model call]
  I[add_memory_note] --> J[Upsert note provenance]
  J --> K[Write chunks and permissions]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  A[callModel] --> B{Call kind}
  B -->|Generate| C{Provider}
  C -->|Anthropic| D[Anthropic messages API]
  C -->|DeepSeek| E[OpenAI-compatible chat API]
  B -->|Embed| F[OpenAI embeddings API]
  D --> G[Validate and normalize]
  E --> G
  F --> G
  G --> H[Record model call]
  I[add_memory_note] --> J[Upsert note provenance]
  J --> K[Write chunks and permissions]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(test): gate web\_search live-smoke on..."](https://github.com/fisherxz/sourcecado/commit/a4d54a422b6e4aa7852b3f407c882d846d679875) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46131974)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->