### PR TITLE
Feat/b1 contacts

### DIFF
--- a/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
+++ b/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
@@ -366,7 +366,7 @@ Type: AFK (mostly) · Blocked by: F2
 **Tasks:**
 - [x] B1.1 `organizations` + `contacts` (name, role, org_id) + `contact_aliases` migration (~2h) · AFK — `src/migrations/006_contacts.sql` (TDD, `tests/contacts-migrate.test.ts`)
 - [x] B1.2 `get_contact` + `get_organization` tools — alias resolution, `ambiguous` result state, org→contacts listing (~2.5h) · AFK — `src/lib/contacts/resolve.ts` + `src/lib/tools/get-contact.ts` + `src/lib/tools/get-organization.ts`, registered in `memoryRegistry()`
-- [ ] B1.3 `create_contact` tool (write_internal) — requires name+role+org, gap-flags missing fields (~1.5h) · AFK
+- [x] B1.3 `create_contact` tool (write_internal) — requires name+role+org, gap-flags missing fields (~1.5h) · AFK — `src/lib/contacts/create.ts` + `src/lib/tools/create-contact.ts`, registered in `memoryRegistry()`
 - [ ] B1.4 `outreach_history` migration — relationship timeline, pulled forward from B3 (~1.5h) · AFK
 - [ ] B1.5 `list_outreach_history` tool (read) (~1h) · AFK
 - [ ] B1.6 Contact Profile Card component (Identity/Relationship/Key Facts/Gaps) (~2h) · AFK

--- a/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
+++ b/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
@@ -477,8 +477,53 @@ and citations.
 - [ ] C2.2 `web_enrich_company` tool + citations (~1.5h) · AFK
 - [ ] C2.3 `web_enrich_contact` tool + citations (~1.5h) · AFK
 
+## C3 — Guided contact data-collection workflow
+Type: HITL · Blocked by: C1, C2, B1 (done) · Added: 2026-07-21, from B1.8 design-review feedback
+
+**What to build:** A human-directed, verified workflow for filling in what's missing on a
+Contact — distinct from C1/C2's autonomous enrichment tool calls. Two entry points: (1)
+automatically offered right after a thin Contact is created (B1.3's `create_contact` with
+gaps), and (2) a "Data collect" action on an existing Contact's profile card. The workflow
+asks the Director only for whichever fields are actually missing, and where the person is
+public enough to be found (news, interviews, LinkedIn), surfaces candidate results from C1/C2
+for the Director to review — every web-sourced candidate requires explicit Director
+confirmation that it's the same person before anything is written, reusing the same
+ask-don't-guess identity pattern already built for `get_contact`/`get_organization`
+(B1.2) rather than inventing a new one. A confirmed LinkedIn match can populate the Contact
+Profile Card's photo.
+
+Every field this workflow writes carries provenance: the value, where it came from (the
+Director typing it directly vs. a specific cited source/URL), who recorded it, and when —
+reusing the existing citation/source_record pattern already used for memory chunks rather
+than a new mechanism. "Who recorded it" is `DEFAULT_ACTOR` until Stage H ships; this workflow
+does not block on Stage H, but should read the actor from context (not hardcode it) so H's
+real login slots in later without a rewrite here.
+
+This is also where B1.6's "Key facts" section gets its real citation model: instead of a flat
+list of facts with no link back to how they were learned, each fact cites either the specific
+`outreach_history` entry + actor that produced it, or the external document/enrichment source
+that did. B1.6 shipped the flat version because this workflow (its actual source) didn't
+exist yet; revisit `ContactProfileCard`'s Key Facts section as part of this slice.
+
+**Acceptance criteria:**
+- [ ] A newly created thin Contact (B1.3, missing role/org/etc.) surfaces a "Data collect" prompt
+- [ ] An existing Contact's profile card has a "Data collect" action that asks only for what's missing
+- [ ] A web/enrichment-sourced candidate is never written without explicit Director confirmation it's the same person
+- [ ] Every field written through this workflow records value + source + actor + method + timestamp
+- [ ] A confirmed LinkedIn match can set the Contact's photo
+- [ ] Key Facts on the Contact Profile Card cite their originating interaction or external source, not just a bare fact
+
+**Tasks:**
+- [ ] C3.1 Design the guided workflow's step sequence + gap-detection logic (~2h) · HITL
+- [ ] C3.2 Candidate surfacing from Apollo/web enrichment + identity-confirmation UI (~2h) · AFK
+- [ ] C3.3 Field-level provenance write path (value + source + actor + method + timestamp) (~2h) · AFK
+- [ ] C3.4 "Data collect" entry points: new-connection intake + existing-profile trigger (~1.5h) · AFK
+- [ ] C3.5 Rework Contact Profile Card's Key Facts to cite their originating interaction/source (~1.5h) · AFK
+- [ ] C3.6 Verify guided workflow UX matches DESIGN.md (~1h) · HITL
+
 **FEATURE C DEMO:** research an Organization, enrich potential Contacts, keep citations,
-and see Apollo/web usage in the Run Ledger.
+see Apollo/web usage in the Run Ledger, and walk a new connection through guided data
+collection with a verified LinkedIn photo match.
 
 ---
 
@@ -644,6 +689,40 @@ outcome/feedback → memory update.
 - [ ] G3.3 Demo runbook + reset script (~1h) · AFK
 
 **FINAL DEMO:** the full sourcing loop, dependable and repeatable.
+
+---
+
+# H. ACTOR IDENTITY & ATTRIBUTION (deferred, not scheduled)
+
+Added: 2026-07-21, from B1.8 design-review feedback. Real login/session identity for
+individual Codeology officers, replacing the `DEFAULT_ACTOR` v1 sentinel
+(`src/lib/memory/actor.ts`, `MemoryActor { actorType: "user" | "oauth_client" |
+"test_client"; actorId: string }`) used across 8 files as of 2026-07-21. Explicitly not
+being built now — this section exists so the requirement isn't lost, and so whoever picks
+it up knows what already depends on it.
+
+## H1 — Per-officer login & session identity
+Type: HITL · Blocked by: none (can start anytime) · Status: not started, deferred
+
+**What to build:** Real authentication distinguishing individual Codeology officers, not
+just the single shared `test_client` sentinel — producing a `MemoryActor` per logged-in
+user that flows through every write path already wired to accept one.
+
+**Why it matters:** Every write path already threads a `MemoryActor` through
+(`DEFAULT_ACTOR` today) — `create_contact` (B1.3), `add_memory_note` (A7.1), the future
+outreach-outcome tools (B3), the artifact review flow (D1), human feedback (G1), and the
+guided data-collection workflow (C3) all want to record *which officer* did something, not
+just *that* something happened. Building this once, early, avoids retrofitting attribution
+into five-plus already-shipped write paths later. C3 in particular is written to read the
+actor from context rather than hardcode it, specifically so this slot can land later without
+a rewrite there.
+
+**Acceptance criteria:**
+- [ ] An individual Codeology officer can log in and act as themselves, not the shared sentinel
+- [ ] Every existing `DEFAULT_ACTOR` call site (8 files as of 2026-07-21 — see `grep -rl DEFAULT_ACTOR src/`) receives a real actor from session context instead
+- [ ] A written fact/note/contact/artifact records who wrote it, traceable back to a specific officer
+
+**Tasks:** not scoped — revisit when this becomes a priority.
 
 ---
 

--- a/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
+++ b/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
@@ -368,7 +368,7 @@ Type: AFK (mostly) · Blocked by: F2
 - [x] B1.2 `get_contact` + `get_organization` tools — alias resolution, `ambiguous` result state, org→contacts listing (~2.5h) · AFK — `src/lib/contacts/resolve.ts` + `src/lib/tools/get-contact.ts` + `src/lib/tools/get-organization.ts`, registered in `memoryRegistry()`
 - [x] B1.3 `create_contact` tool (write_internal) — requires name+role+org, gap-flags missing fields (~1.5h) · AFK — `src/lib/contacts/create.ts` + `src/lib/tools/create-contact.ts`, registered in `memoryRegistry()`
 - [x] B1.4 `outreach_history` migration — relationship timeline, pulled forward from B3 (~1.5h) · AFK — `src/migrations/007_outreach_history.sql`
-- [ ] B1.5 `list_outreach_history` tool (read) (~1h) · AFK
+- [x] B1.5 `list_outreach_history` tool (read) (~1h) · AFK — `src/lib/contacts/outreach.ts` + `src/lib/tools/list-outreach-history.ts`, registered in `memoryRegistry()`
 - [ ] B1.6 Contact Profile Card component (Identity/Relationship/Key Facts/Gaps) (~2h) · AFK
 - [ ] B1.7 Sourcing doctrine update: gather name+role+org on new-connection intake (~1h) · AFK
 - [ ] B1.8 Verify card matches DESIGN.md + uses src/components/ui primitives (~1h) · HITL

--- a/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
+++ b/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
@@ -369,7 +369,7 @@ Type: AFK (mostly) · Blocked by: F2
 - [x] B1.3 `create_contact` tool (write_internal) — requires name+role+org, gap-flags missing fields (~1.5h) · AFK — `src/lib/contacts/create.ts` + `src/lib/tools/create-contact.ts`, registered in `memoryRegistry()`
 - [x] B1.4 `outreach_history` migration — relationship timeline, pulled forward from B3 (~1.5h) · AFK — `src/migrations/007_outreach_history.sql`
 - [x] B1.5 `list_outreach_history` tool (read) (~1h) · AFK — `src/lib/contacts/outreach.ts` + `src/lib/tools/list-outreach-history.ts`, registered in `memoryRegistry()`
-- [ ] B1.6 Contact Profile Card component (Identity/Relationship/Key Facts/Gaps) (~2h) · AFK
+- [x] B1.6 Contact Profile Card component (Identity/Relationship/Key Facts/Gaps) (~2h) · AFK — `src/app/chat/ContactProfileCard.tsx` + `selectContactCard` in `src/app/chat/stream.ts`, wired into `ChatClient.tsx`. Verified via component tests + confirmed `/chat` compiles/loads with no regression; could not drive an end-to-end live render since no model API key is configured locally (see B1.8 for a real design-review pass once one is)
 - [ ] B1.7 Sourcing doctrine update: gather name+role+org on new-connection intake (~1h) · AFK
 - [ ] B1.8 Verify card matches DESIGN.md + uses src/components/ui primitives (~1h) · HITL
 

--- a/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
+++ b/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
@@ -372,6 +372,7 @@ Type: AFK (mostly) · Blocked by: F2
 - [x] B1.6 Contact Profile Card component (Identity/Relationship/Key Facts/Gaps) (~2h) · AFK — `src/app/chat/ContactProfileCard.tsx` + `selectContactCard` in `src/app/chat/stream.ts`, wired into `ChatClient.tsx`. Verified via component tests + confirmed `/chat` compiles/loads with no regression; could not drive an end-to-end live render since no model API key is configured locally (see B1.8 for a real design-review pass once one is)
 - [x] B1.7 Sourcing doctrine update: gather name+role+org on new-connection intake (~1h) · AFK — two new bullets in `SOURCING_DOCTRINE_SECTION` (`src/lib/context.ts`), covering intake and ambiguity
 - [ ] B1.8 Verify card matches DESIGN.md + uses src/components/ui primitives (~1h) · HITL
+- [x] B1.9 phone/email/linkedinUrl/photoUrl on Contact (~2h) · AFK — added 2026-07-21 from B1.8 design-review feedback (room for social/contact links + a profile photo). `src/migrations/008_contact_details.sql`, threaded through `resolve.ts`/`create.ts`/both tools/the wire format (`answer.ts` + `stream.ts`). Auto-populating `photoUrl` from a confirmed LinkedIn match is C3's job, not this task's — these are plain optional fields for now.
 
 ## B2 — Target Personas
 Type: AFK · Blocked by: B1

--- a/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
+++ b/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
@@ -357,11 +357,11 @@ Type: AFK (mostly) · Blocked by: F2
   visually anywhere).
 
 **Acceptance criteria:**
-- [ ] Organizations and Contacts persist and link (an Org can contain Contacts); every Contact has name, role, and org
-- [ ] `get_contact` / `get_organization` return records to the loop and log to the ledger
-- [ ] Two contacts sharing a name/alias never silently merge — `get_contact` returns `ambiguous` with candidates instead
-- [ ] `create_contact` refuses to silently save a partial identity; missing fields are asked for or explicitly flagged as gaps, never dropped
-- [ ] A Contact Profile Card renders identity + relationship timeline + cited facts + gaps in one place
+- [x] Organizations and Contacts persist and link (an Org can contain Contacts) — correction: "every Contact has name, role, and org" as originally worded overstates it; role/org (and now phone/email/linkedinUrl/photoUrl) are optional by design, since a thin record is a gap to fill later, not a blocked write. Only name is required.
+- [x] `get_contact` / `get_organization` return records to the loop and log to the ledger (ledger logging via the existing tool-orchestrator chokepoint, same as every other tool)
+- [x] Two contacts sharing a name/alias never silently merge — `get_contact` returns `ambiguous` with candidates instead
+- [x] `create_contact` refuses to silently save a partial identity; missing fields are asked for or explicitly flagged as gaps, never dropped
+- [x] A Contact Profile Card renders identity + relationship timeline + cited facts + gaps in one place — signed off 2026-07-21 (B1.8)
 
 **Tasks:**
 - [x] B1.1 `organizations` + `contacts` (name, role, org_id) + `contact_aliases` migration (~2h) · AFK — `src/migrations/006_contacts.sql` (TDD, `tests/contacts-migrate.test.ts`)
@@ -371,7 +371,7 @@ Type: AFK (mostly) · Blocked by: F2
 - [x] B1.5 `list_outreach_history` tool (read) (~1h) · AFK — `src/lib/contacts/outreach.ts` + `src/lib/tools/list-outreach-history.ts`, registered in `memoryRegistry()`
 - [x] B1.6 Contact Profile Card component (Identity/Relationship/Key Facts/Gaps) (~2h) · AFK — `src/app/chat/ContactProfileCard.tsx` + `selectContactCard` in `src/app/chat/stream.ts`, wired into `ChatClient.tsx`. Verified via component tests + confirmed `/chat` compiles/loads with no regression; could not drive an end-to-end live render since no model API key is configured locally (see B1.8 for a real design-review pass once one is)
 - [x] B1.7 Sourcing doctrine update: gather name+role+org on new-connection intake (~1h) · AFK — two new bullets in `SOURCING_DOCTRINE_SECTION` (`src/lib/context.ts`), covering intake and ambiguity
-- [ ] B1.8 Verify card matches DESIGN.md + uses src/components/ui primitives (~1h) · HITL
+- [x] B1.8 Verify card matches DESIGN.md + uses src/components/ui primitives (~1h) · HITL — signed off 2026-07-21 after reviewing rendered states (full record, thin/new-connection record) via the dev-preview scratch-page pattern; card uses `Card`/`Tag` primitives throughout, spacing/type scale consistent with the rest of the app
 - [x] B1.9 phone/email/linkedinUrl/photoUrl on Contact (~2h) · AFK — added 2026-07-21 from B1.8 design-review feedback (room for social/contact links + a profile photo). `src/migrations/008_contact_details.sql`, threaded through `resolve.ts`/`create.ts`/both tools/the wire format (`answer.ts` + `stream.ts`). Auto-populating `photoUrl` from a confirmed LinkedIn match is C3's job, not this task's — these are plain optional fields for now.
 
 ## B2 — Target Personas

--- a/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
+++ b/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
@@ -365,7 +365,7 @@ Type: AFK (mostly) · Blocked by: F2
 
 **Tasks:**
 - [x] B1.1 `organizations` + `contacts` (name, role, org_id) + `contact_aliases` migration (~2h) · AFK — `src/migrations/006_contacts.sql` (TDD, `tests/contacts-migrate.test.ts`)
-- [ ] B1.2 `get_contact` + `get_organization` tools — alias resolution, `ambiguous` result state, org→contacts listing (~2.5h) · AFK
+- [x] B1.2 `get_contact` + `get_organization` tools — alias resolution, `ambiguous` result state, org→contacts listing (~2.5h) · AFK — `src/lib/contacts/resolve.ts` + `src/lib/tools/get-contact.ts` + `src/lib/tools/get-organization.ts`, registered in `memoryRegistry()`
 - [ ] B1.3 `create_contact` tool (write_internal) — requires name+role+org, gap-flags missing fields (~1.5h) · AFK
 - [ ] B1.4 `outreach_history` migration — relationship timeline, pulled forward from B3 (~1.5h) · AFK
 - [ ] B1.5 `list_outreach_history` tool (read) (~1h) · AFK

--- a/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
+++ b/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
@@ -370,7 +370,7 @@ Type: AFK (mostly) · Blocked by: F2
 - [x] B1.4 `outreach_history` migration — relationship timeline, pulled forward from B3 (~1.5h) · AFK — `src/migrations/007_outreach_history.sql`
 - [x] B1.5 `list_outreach_history` tool (read) (~1h) · AFK — `src/lib/contacts/outreach.ts` + `src/lib/tools/list-outreach-history.ts`, registered in `memoryRegistry()`
 - [x] B1.6 Contact Profile Card component (Identity/Relationship/Key Facts/Gaps) (~2h) · AFK — `src/app/chat/ContactProfileCard.tsx` + `selectContactCard` in `src/app/chat/stream.ts`, wired into `ChatClient.tsx`. Verified via component tests + confirmed `/chat` compiles/loads with no regression; could not drive an end-to-end live render since no model API key is configured locally (see B1.8 for a real design-review pass once one is)
-- [ ] B1.7 Sourcing doctrine update: gather name+role+org on new-connection intake (~1h) · AFK
+- [x] B1.7 Sourcing doctrine update: gather name+role+org on new-connection intake (~1h) · AFK — two new bullets in `SOURCING_DOCTRINE_SECTION` (`src/lib/context.ts`), covering intake and ambiguity
 - [ ] B1.8 Verify card matches DESIGN.md + uses src/components/ui primitives (~1h) · HITL
 
 ## B2 — Target Personas

--- a/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
+++ b/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
@@ -367,7 +367,7 @@ Type: AFK (mostly) · Blocked by: F2
 - [x] B1.1 `organizations` + `contacts` (name, role, org_id) + `contact_aliases` migration (~2h) · AFK — `src/migrations/006_contacts.sql` (TDD, `tests/contacts-migrate.test.ts`)
 - [x] B1.2 `get_contact` + `get_organization` tools — alias resolution, `ambiguous` result state, org→contacts listing (~2.5h) · AFK — `src/lib/contacts/resolve.ts` + `src/lib/tools/get-contact.ts` + `src/lib/tools/get-organization.ts`, registered in `memoryRegistry()`
 - [x] B1.3 `create_contact` tool (write_internal) — requires name+role+org, gap-flags missing fields (~1.5h) · AFK — `src/lib/contacts/create.ts` + `src/lib/tools/create-contact.ts`, registered in `memoryRegistry()`
-- [ ] B1.4 `outreach_history` migration — relationship timeline, pulled forward from B3 (~1.5h) · AFK
+- [x] B1.4 `outreach_history` migration — relationship timeline, pulled forward from B3 (~1.5h) · AFK — `src/migrations/007_outreach_history.sql`
 - [ ] B1.5 `list_outreach_history` tool (read) (~1h) · AFK
 - [ ] B1.6 Contact Profile Card component (Identity/Relationship/Key Facts/Gaps) (~2h) · AFK
 - [ ] B1.7 Sourcing doctrine update: gather name+role+org on new-connection intake (~1h) · AFK

--- a/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
+++ b/docs/superpowers/plans/2026-06-15-sourcecado-full-agent-stack-task-breakdown.md
@@ -241,23 +241,23 @@ deterministic citation post-check replaces the prose-parity concern.
 - [x] ~~A3.3 Parity harness~~ — **cut** (decision #6)
 - [x] ~~A3.4 Parity review gate~~ — **cut** (decision #6); citation post-check (`src/lib/memory/citations.ts`) is the deterministic guard
 
-## A4 — File/export memory import path — DEFERRED (in-app UI)
-Type: AFK · Blocked by: A1
+## A4 — File/export memory import path
+Type: AFK · Blocked by: A1 · Done: 2026-06-25 (PR #9)
 
 **What to build:** App-side file/export import (roadmap: ingestion is file/export only).
 Imported sources become source records with citations.
 
-> **Deferred (2026-06-25):** the in-app import UI is out of Feature A's reframed scope. The
-> ingest path itself is done via the CLI (`npm run ingest <dir>`, A1.2) with per-file
-> success/skip reasons; only the app upload endpoint + UI remain for a later UI slice.
+> **Correction (2026-07-21):** this was marked deferred earlier the same day (2026-06-25,
+> 14:06) but was actually built later that evening — `df7fd64` (19:28) added the in-memory
+> `ingestFiles` core + `POST /api/memory/import`. The doc was never updated after. Not deferred.
 
 **Acceptance criteria:**
-- [ ] A user can import a file/export from the app and see it become source records (CLI only for now)
+- [x] A user can import a file/export from the app and see it become source records — `POST /api/memory/import`
 - [x] Import surfaces per-file success/skip with reasons (no silent skips) — done in `ingestFolder`
 
 **Tasks:**
-- [ ] A4.1 Import endpoint + source-record creation from upload (~2h) · AFK — deferred (CLI ingest exists)
-- [ ] A4.2 Import result UI with per-file status/skip reasons (~1.5h) · AFK — deferred
+- [x] A4.1 Import endpoint + source-record creation from upload (~2h) · AFK — `src/lib/memory/ingest.ts` (`ingestFiles`) + `src/app/api/memory/import/route.ts`
+- [ ] A4.2 Import result UI with per-file status/skip reasons (~1.5h) · AFK — still no dedicated result UI; route returns per-file status but nothing renders it yet
 
 ## A5 — search_memory tool
 Type: AFK · Blocked by: A2, F5 · Done: 2026-06-25 (PR #8)
@@ -287,22 +287,27 @@ design review.
 **Tasks:**
 - [x] A6.1 Research Chat UI: message list + input + run trigger (~2h) · AFK — reused the F5 `/chat` (ChatClient) against the memory config
 - [x] A6.2 Inline run status + cited answer + gaps render (~1.5h) · AFK — 4-section answer + `invalidCitations` from `/api/agent`
-- [ ] A6.3 Verify Research Chat matches DESIGN.md + uses src/components/ui primitives (~1h) · HITL — **pending** (design review not yet done)
+- [ ] A6.3 Verify Research Chat matches DESIGN.md + uses src/components/ui primitives (~1h) · HITL — **pending**, and now higher-stakes: the undocumented `rt-R1`–`rt-R6` runtime rewrite (2026-07-14/15, PRs #11–#16 — raw-SDK provider adapters, hand-rolled agent loop, tool orchestrator, context/prompt v5, SSE streaming rewire, server-side chat sessions) substantially changed this UI/streaming after this checkbox was written. No design doc exists for that rewrite; review it against DESIGN.md fresh rather than assuming this checkbox's original scope still applies.
 
 ## A7 — Memory management page (add/correct)
-Type: AFK · Blocked by: A3 · A7.1 done: 2026-06-25 (PR #8); A7.2 page deferred
+Type: AFK · Blocked by: A3 · Done: 2026-06-25 (PR #9)
 
 **What to build:** Memory management page to add a memory note and correct existing
 memory (the memory-correction path from `src/`).
 
+> **Correction (2026-07-21):** A7.2 was marked deferred earlier the same day (2026-06-25,
+> 14:06) but shipped later that night — `599792d` (memory sources backend) and `4cfd62b`
+> (23:22, `/memory` page: sources list with archive/restore + add-note) both landed after
+> the doc was written. Not deferred.
+
 **Acceptance criteria:**
 - [x] A user can add a memory note; it becomes retrievable (`add_memory_note` tool — immediately searchable)
 - [x] A user can correct memory; corrections affect future answers (superseding note, no destructive edit)
-- [ ] …from a dedicated **app page** — deferred (tool exists; management UI is a later slice)
+- [x] …from a dedicated **app page** — `src/app/memory/MemoryClient.tsx` (list, archive/restore, add-note)
 
 **Tasks:**
 - [x] A7.1 `add_memory_note` tool + write path (~1.5h) · AFK — `src/lib/tools/add-memory-note.ts` + `src/lib/memory/notes.ts`
-- [ ] A7.2 Memory management page: list + add + correct (~2h) · AFK — **deferred** to a later UI slice
+- [x] A7.2 Memory management page: list + add + correct (~2h) · AFK — `src/app/memory/MemoryClient.tsx` + `src/app/api/memory/sources/*` routes
 
 **FEATURE A DEMO:** ~~import sourcing notes~~ (CLI `npm run ingest`), ask a question in chat,
 get a cited answer with gaps, inspect the run, and correct memory (`add_memory_note`). ✅
@@ -315,19 +320,58 @@ Demonstrated live 2026-06-25 on 3 complex queries.
 Give the agent enough sourcing state to act like a Sourcing Director. Each entity is
 added here (not in a day-1 schema).
 
-## B1 — Organizations & Contacts
-Type: AFK · Blocked by: F2
+## B1 — Organizations & Contacts + identity resolution + Contact Profile Card
+Type: AFK (mostly) · Blocked by: F2
 
-**What to build:** `organizations` and `contacts` schema + read tools (`get_contact`,
-`get_organization`) wired into the harness.
+> **Expanded scope (2026-07-21):** pulled forward and widened beyond the original
+> read-only B1 to deliver a Contact Profile Card — a single readable card showing a
+> person's identity, our relationship with them, key facts, and knowledge gaps, for the
+> consulting/sourcing use case of building on past connections while creating new ones.
+> Pulls `outreach_history` + `list_outreach_history` forward from B3 (see note there);
+> B3's outcome-state-machine and follow-up-sequence tables stay deferred.
+
+**What to build:**
+- `organizations` + `contacts` + `contact_aliases` schema. Contacts require **name, role,
+  and organization** at intake — not name alone — so a company can later be looked up for
+  everyone known there.
+- `get_contact` / `get_organization` read tools with resolution: exact canonical name →
+  exact alias → else return an **ambiguous** result (candidates + distinguishing org/title)
+  rather than guessing. This is a third result state alongside found/not-found, not an
+  error. `get_organization` also lists known contacts at that org.
+- `create_contact` (write_internal tool): the write path for a new connection surfaced in
+  chat. Requires name + role + org (creating the org if new); if the Director gives an
+  incomplete name, the agent asks for the missing field before writing rather than saving a
+  thin record — if the Director explicitly doesn't know a field, it's saved and flagged as
+  a Knowledge Gap rather than blocking. Doctrine addition to `context.ts`'s Sourcing
+  doctrine section.
+- Ambiguity resolution is chat-time only (a human is present to ask). Bulk import (file
+  upload, CSV) has no one to ask mid-file: unambiguous exact matches auto-link, anything
+  ambiguous or unmatched stays unlinked and becomes a Knowledge Gap for later review — no
+  auto-merge, ever. **The review surface for those flagged mentions is an explicit
+  fast-follow, not built in this pass** — revisit once real historical data is actually
+  being imported and the volume of unresolved mentions is known.
+- Contact Profile Card component: renders when `get_contact` resolves a person —
+  **Identity** (name, org, role) · **Relationship** (past-collaborator flag + interaction
+  timeline from `list_outreach_history`) · **Key Facts** (cited, from existing
+  `search_memory`) · **Knowledge Gaps** (existing `gapFacts`, not currently surfaced
+  visually anywhere).
 
 **Acceptance criteria:**
-- [ ] Organizations and Contacts persist and link (an Org can contain Contacts)
+- [ ] Organizations and Contacts persist and link (an Org can contain Contacts); every Contact has name, role, and org
 - [ ] `get_contact` / `get_organization` return records to the loop and log to the ledger
+- [ ] Two contacts sharing a name/alias never silently merge — `get_contact` returns `ambiguous` with candidates instead
+- [ ] `create_contact` refuses to silently save a partial identity; missing fields are asked for or explicitly flagged as gaps, never dropped
+- [ ] A Contact Profile Card renders identity + relationship timeline + cited facts + gaps in one place
 
 **Tasks:**
-- [ ] B1.1 `organizations` + `contacts` migration (~1.5h) · AFK
-- [ ] B1.2 `get_contact` + `get_organization` tools + register (~1.5h) · AFK
+- [x] B1.1 `organizations` + `contacts` (name, role, org_id) + `contact_aliases` migration (~2h) · AFK — `src/migrations/006_contacts.sql` (TDD, `tests/contacts-migrate.test.ts`)
+- [ ] B1.2 `get_contact` + `get_organization` tools — alias resolution, `ambiguous` result state, org→contacts listing (~2.5h) · AFK
+- [ ] B1.3 `create_contact` tool (write_internal) — requires name+role+org, gap-flags missing fields (~1.5h) · AFK
+- [ ] B1.4 `outreach_history` migration — relationship timeline, pulled forward from B3 (~1.5h) · AFK
+- [ ] B1.5 `list_outreach_history` tool (read) (~1h) · AFK
+- [ ] B1.6 Contact Profile Card component (Identity/Relationship/Key Facts/Gaps) (~2h) · AFK
+- [ ] B1.7 Sourcing doctrine update: gather name+role+org on new-connection intake (~1h) · AFK
+- [ ] B1.8 Verify card matches DESIGN.md + uses src/components/ui primitives (~1h) · HITL
 
 ## B2 — Target Personas
 Type: AFK · Blocked by: B1
@@ -342,22 +386,27 @@ Organizations.
 **Tasks:**
 - [ ] B2.1 `target_personas` migration + association (~1.5h) · AFK
 
-## B3 — Outreach History, Outcomes, Follow-Up state
+## B3 — Outreach Outcomes, Follow-Up state
 Type: AFK · Blocked by: B1
 
-**What to build:** `outreach_history`, `outreach_outcomes`, `followup_sequence` state +
-the `list_outreach_history` read tool. Sourcing Lead is a state of a Contact, not a new
-table (per CONTEXT.md).
+> **Note (2026-07-21):** `outreach_history` (migration) and `list_outreach_history` (read
+> tool) were pulled forward into B1.4/B1.5 for the Contact Profile Card's relationship
+> timeline — don't rebuild them here. What's left is the outcome-state-machine and
+> follow-up-sequence scheduling, which is write/state work the card doesn't need.
+
+**What to build:** `outreach_outcomes`, `followup_sequence` state + the write tools.
+Sourcing Lead is a state of a Contact, not a new table (per CONTEXT.md).
 
 **Acceptance criteria:**
-- [ ] Outreach history and outcomes persist against a Contact
+- [ ] Outcomes persist against a Contact's outreach history
 - [ ] Follow-Up Sequence state can be read and updated
-- [ ] `list_outreach_history` returns history to the loop
 
 **Tasks:**
-- [ ] B3.1 `outreach_history` + `outreach_outcomes` migrations (~1.5h) · AFK
+- [ ] ~~B3.1 `outreach_history` migration~~ — done, see B1.4
+- [ ] B3.1b `outreach_outcomes` migration (~1h) · AFK
 - [ ] B3.2 `followup_sequence` state migration (~1h) · AFK
-- [ ] B3.3 `list_outreach_history` + `record_outreach_outcome` + `update_followup_sequence` tools (~2h) · AFK
+- [ ] ~~`list_outreach_history` tool~~ — done, see B1.5
+- [ ] B3.3 `record_outreach_outcome` + `update_followup_sequence` tools (~1.5h) · AFK
 
 ## B4 — Contact / Organization detail page
 Type: HITL · Blocked by: B3

--- a/sourcecado-build-sequence.html
+++ b/sourcecado-build-sequence.html
@@ -315,7 +315,7 @@
       <div class="stat"><div class="n">31</div><div class="l">Slices</div></div>
       <div class="stat"><div class="n">~91</div><div class="l">Tasks · 1–2h ea</div></div>
       <div class="stat"><div class="n">6</div><div class="l">HITL gates</div></div>
-      <div class="stat"><div class="n">11/31</div><div class="l">Slices done</div></div>
+      <div class="stat"><div class="n">12/31</div><div class="l">Slices done</div></div>
       <div class="stat"><div class="n">~2mo</div><div class="l">Original target</div></div>
     </div>
   </header>
@@ -382,11 +382,11 @@
         <div class="rail" style="background:var(--rail-b)">
           <div class="badge">B</div>
           <div class="nm">Sourcing State Model</div>
-          <div class="ph">Act like a director · B1 in progress</div>
+          <div class="ph">Act like a director · B1 done</div>
           <div class="counts"><span><b>5</b></span><span><b>17</b>t</span></div>
         </div>
         <div class="slices">
-          <div class="slice" data-status="partial"><div class="sid">B1</div><div class="sbody"><div class="stitle">Organizations &amp; Contacts + identity + Profile Card <span class="mono" style="color:var(--ink-faint);font-size:11px">· widened 2026-07-21</span></div><div class="sblock"><b>↳</b> F2</div></div><div class="smeta"><span class="status-partial">7/8</span><span class="tag-type hitl">HITL</span></div></div>
+          <div class="slice" data-status="done"><div class="sid">B1</div><div class="sbody"><div class="stitle">Organizations &amp; Contacts + identity + Profile Card <span class="mono" style="color:var(--ink-faint);font-size:11px">· widened 2026-07-21</span></div><div class="sblock"><b>↳</b> F2</div></div><div class="smeta"><span class="status-done">✓ done</span></div></div>
           <div class="slice"><div class="sid">B2</div><div class="sbody"><div class="stitle">Target Personas</div><div class="sblock"><b>↳</b> B1</div></div><div class="smeta"><span class="tasks">1</span><span class="tag-type afk">AFK</span></div></div>
           <div class="slice"><div class="sid">B3</div><div class="sbody"><div class="stitle">Outreach Outcomes / Follow-Up <span class="mono" style="color:var(--ink-faint);font-size:11px">· History moved to B1.4</span></div><div class="sblock"><b>↳</b> B1</div></div><div class="smeta"><span class="tasks">3</span><span class="tag-type afk">AFK</span></div></div>
           <div class="slice"><div class="sid">B4</div><div class="sbody"><div class="stitle">Contact / Organization detail page</div><div class="sblock"><b>↳</b> B3 · <span style="color:var(--hitl)">design</span></div></div><div class="smeta"><span class="tasks">3</span><span class="tag-type hitl">HITL</span></div></div>
@@ -506,7 +506,7 @@ const TASKS = {
   A6:[["A6.1","Research Chat UI: message list + input + run trigger","2h","done"],["A6.2","Inline run status + cited answer + gaps render","1.5h","done"],["A6.3","Chat-layout design review — higher stakes post R1–R6 rewrite","1h","hitl"]],
   A7:[["A7.1","add_memory_note tool + write path","1.5h","done"],["A7.2","Memory management page: list + add + correct","2h","done"]],
 
-  B1:[["B1.1","organizations + contacts + contact_aliases migration","2h","done"],["B1.2","get_contact + get_organization tools + alias resolution + ambiguous state","2.5h","done"],["B1.3","create_contact tool — requires name+role+org, gap-flags missing","1.5h","done"],["B1.4","outreach_history migration (pulled forward from B3)","1.5h","done"],["B1.5","list_outreach_history tool","1h","done"],["B1.6","Contact Profile Card component","2h","done"],["B1.7","Sourcing doctrine: gather name+role+org, ask on ambiguity","1h","done"],["B1.8","Verify card matches DESIGN.md + uses primitives","1h","hitl"]],
+  B1:[["B1.1","organizations + contacts + contact_aliases migration","2h","done"],["B1.2","get_contact + get_organization tools + alias resolution + ambiguous state","2.5h","done"],["B1.3","create_contact tool — requires name+role+org, gap-flags missing","1.5h","done"],["B1.4","outreach_history migration (pulled forward from B3)","1.5h","done"],["B1.5","list_outreach_history tool","1h","done"],["B1.6","Contact Profile Card component","2h","done"],["B1.7","Sourcing doctrine: gather name+role+org, ask on ambiguity","1h","done"],["B1.8","Verify card matches DESIGN.md + uses primitives — signed off","1h","done"],["B1.9","phone/email/linkedinUrl/photoUrl on Contact","2h","done"]],
   B2:[["B2.1","target_personas migration + association","1.5h","afk"]],
   B3:[["B3.1","outreach_history migration — done, see B1.4","1.5h","cut"],["B3.1b","outreach_outcomes migration","1h","afk"],["B3.2","followup_sequence state migration","1h","afk"],["B3.2b","list_outreach_history tool — done, see B1.5","—","cut"],["B3.3","record_outreach_outcome + update_followup_sequence tools","1.5h","afk"]],
   B4:[["B4.1","Detail page data loaders + layout","2h","afk"],["B4.2","History / outcomes / artifacts panels","2h","afk"],["B4.3","Detail-page design review pass","1h","hitl"]],

--- a/sourcecado-build-sequence.html
+++ b/sourcecado-build-sequence.html
@@ -21,6 +21,8 @@
     --afk-wash:#e8f5ef;
     --hitl:#bd6a12;
     --hitl-wash:#fbf0e2;
+    --deferred:#7a828d;
+    --deferred-wash:#eceeef;
     --rail-f:#16191e;
     --rail-a:#2f49c9;
     --rail-b:#0f8aa6;
@@ -28,6 +30,7 @@
     --rail-d:#7a3fb0;
     --rail-e:#b0573f;
     --rail-g:#1d8a64;
+    --rail-h:#5a626d;
   }
   *{box-sizing:border-box;margin:0;padding:0}
   html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}
@@ -63,12 +66,15 @@
   .sub{
     max-width:620px;color:var(--ink-soft);font-size:15.5px;line-height:1.55;
   }
+  .synced{
+    margin-top:10px;font-family:"IBM Plex Mono",monospace;font-size:11px;color:var(--ink-faint);
+  }
   .meta-row{
     display:flex;flex-wrap:wrap;gap:0;margin-top:26px;
     border:1px solid var(--line-strong);border-radius:3px;overflow:hidden;
   }
   .stat{
-    flex:1 1 0;min-width:140px;padding:16px 20px;
+    flex:1 1 0;min-width:130px;padding:16px 20px;
     border-right:1px solid var(--line);
   }
   .stat:last-child{border-right:none}
@@ -77,7 +83,7 @@
 
   /* ---------- Legend ---------- */
   .legend{
-    display:flex;flex-wrap:wrap;gap:22px;align-items:center;
+    display:flex;flex-wrap:wrap;gap:20px;align-items:center;
     margin:20px 0 4px;padding:13px 18px;
     background:#fafbfc;border:1px solid var(--line);border-radius:3px;
     font-size:12.5px;color:var(--ink-soft);
@@ -86,6 +92,7 @@
   .dot{width:9px;height:9px;border-radius:50%;flex:none}
   .dot.afk{background:var(--afk)}
   .dot.hitl{background:var(--hitl)}
+  .dot.deferred{background:var(--deferred)}
   .swatch{font-family:"IBM Plex Mono",monospace;font-size:11px;font-weight:500}
   .legend b{color:var(--ink);font-weight:600}
 
@@ -109,7 +116,9 @@
     border:1px solid var(--line-strong);border-radius:5px;
     background:var(--paper);overflow:hidden;
     box-shadow:0 1px 0 rgba(20,25,30,.02), 0 10px 24px -20px rgba(20,25,30,.35);
+    position:relative;
   }
+  .stage.deferred{border-style:dashed;box-shadow:none}
   .rail{
     padding:24px 22px;color:#fff;position:relative;
     display:flex;flex-direction:column;
@@ -132,6 +141,13 @@
   }
   .rail .counts span{opacity:.9}
   .rail .counts b{font-weight:600}
+  .rail-check{
+    position:absolute;top:20px;right:18px;
+    width:22px;height:22px;border-radius:50%;
+    background:rgba(255,255,255,.16);
+    display:flex;align-items:center;justify-content:center;
+    font-size:12px;font-weight:700;
+  }
 
   .slices{padding:10px 8px}
   .slice{
@@ -140,6 +156,7 @@
   }
   .slice + .slice{border-top:1px solid var(--line)}
   .slice:hover{background:#fafbfc}
+  .slice[data-status="done"] .stitle{color:var(--ink-soft)}
   .sid{
     font-family:"IBM Plex Mono",monospace;font-size:12px;font-weight:600;
     color:var(--ink);width:30px;flex:none;padding-top:1px;
@@ -163,6 +180,17 @@
   }
   .tag-type.afk{background:var(--afk-wash);color:var(--afk)}
   .tag-type.hitl{background:var(--hitl-wash);color:var(--hitl)}
+  .tag-type.deferred{background:var(--deferred-wash);color:var(--deferred)}
+  .status-done{
+    font-family:"IBM Plex Mono",monospace;font-size:10px;font-weight:600;letter-spacing:.06em;
+    padding:3px 9px;border-radius:999px;white-space:nowrap;display:inline-flex;align-items:center;gap:5px;
+    background:var(--afk-wash);color:var(--afk);
+  }
+  .status-partial{
+    font-family:"IBM Plex Mono",monospace;font-size:11px;font-weight:600;
+    padding:3px 9px;border-radius:999px;white-space:nowrap;
+    background:var(--blue-wash);color:var(--blue);
+  }
 
   .demo{
     grid-column:1 / -1;
@@ -212,15 +240,20 @@
     border-bottom:1px dashed var(--line);
   }
   .subtask:last-child{border-bottom:none}
+  .subtask.done .st-title{color:var(--ink-soft)}
+  .subtask.cut .st-title{color:var(--ink-faint);text-decoration:line-through}
   .st-id{font-family:"IBM Plex Mono",monospace;font-size:11.5px;font-weight:600;color:var(--blue);width:40px;flex:none}
+  .subtask.done .st-id{color:var(--afk)}
   .st-title{flex:1;font-size:13.5px;color:var(--ink);line-height:1.4}
   .st-est{font-family:"IBM Plex Mono",monospace;font-size:11px;color:var(--ink-faint);flex:none;width:42px;text-align:right}
   .st-type{
     font-family:"IBM Plex Mono",monospace;font-size:9.5px;font-weight:600;letter-spacing:.05em;
-    padding:2px 6px;border-radius:3px;flex:none;width:42px;text-align:center;
+    padding:2px 6px;border-radius:3px;flex:none;width:46px;text-align:center;
   }
   .st-type.afk{background:var(--afk-wash);color:var(--afk)}
   .st-type.hitl{background:var(--hitl-wash);color:var(--hitl)}
+  .st-type.done{background:var(--afk-wash);color:var(--afk)}
+  .st-type.cut{background:#f1efe8;color:var(--ink-faint)}
   .expand-all{
     margin-left:auto;font-family:"IBM Plex Mono",monospace;font-size:11px;
     background:var(--paper);border:1px solid var(--line-strong);border-radius:999px;
@@ -247,6 +280,8 @@
   .flow > *:nth-child(8){animation-delay:.40s}
   .flow > *:nth-child(9){animation-delay:.45s}
   .flow > *:nth-child(10){animation-delay:.50s}
+  .flow > *:nth-child(11){animation-delay:.55s}
+  .flow > *:nth-child(12){animation-delay:.60s}
   @keyframes rise{from{opacity:0;transform:translateY(14px)}to{opacity:1;transform:none}}
 
   @media (max-width:760px){
@@ -274,19 +309,22 @@
     <div class="kicker">Sourcecado · Full Agent Stack</div>
     <h1>Build&nbsp;Sequence <em>top&#8209;down</em></h1>
     <p class="sub">A minimal spine first, then each capability as its own vertical slice. Schema grows per feature, no big&#8209;bang design. Every task is ~1&ndash;2 hours of engineer&#8209;with&#8209;Claude&#8209;Code work; every slice is demoable on its own.</p>
+    <p class="synced">Regenerated 2026-07-21 from the current task breakdown &mdash; not the 2026-06-15 original.</p>
     <div class="meta-row">
-      <div class="stat"><div class="n">7</div><div class="l">Stages</div></div>
-      <div class="stat"><div class="n">28</div><div class="l">Slices</div></div>
-      <div class="stat"><div class="n">~74</div><div class="l">Tasks · 1–2h ea</div></div>
-      <div class="stat"><div class="n">5</div><div class="l">HITL gates</div></div>
-      <div class="stat"><div class="n">~2mo</div><div class="l">Target</div></div>
+      <div class="stat"><div class="n">8</div><div class="l">Stages (+H deferred)</div></div>
+      <div class="stat"><div class="n">31</div><div class="l">Slices</div></div>
+      <div class="stat"><div class="n">~91</div><div class="l">Tasks · 1–2h ea</div></div>
+      <div class="stat"><div class="n">6</div><div class="l">HITL gates</div></div>
+      <div class="stat"><div class="n">11/31</div><div class="l">Slices done</div></div>
+      <div class="stat"><div class="n">~2mo</div><div class="l">Original target</div></div>
     </div>
   </header>
 
   <div class="legend">
     <div class="grp"><span class="dot afk"></span><b>AFK</b>&nbsp;build &amp; merge, no human gate</div>
     <div class="grp"><span class="dot hitl"></span><b>HITL</b>&nbsp;needs a decision / design review</div>
-    <div class="grp"><span class="swatch" style="color:var(--blue)">[n tasks]</span>&nbsp;1–2h chunks in the slice</div>
+    <div class="grp"><span class="dot deferred"></span><b>Deferred</b>&nbsp;not scheduled</div>
+    <div class="grp"><span class="swatch" style="color:var(--afk)">✓ done</span>&nbsp;/&nbsp;<span class="swatch" style="color:var(--blue)">n/m</span>&nbsp;partial</div>
     <div class="grp"><span class="mono" style="color:var(--ink-faint)">↳ blocked by</span>&nbsp;dependency</div>
     <button class="expand-all" id="toggleAll">▸ expand all</button>
   </div>
@@ -296,17 +334,19 @@
     <!-- FOUNDATION -->
     <div class="stage">
       <div class="rail" style="background:var(--rail-f)">
+        <div class="rail-check">✓</div>
         <div class="badge">F</div>
         <div class="nm">Foundation Cluster</div>
         <div class="ph">The spine · enables all</div>
-        <div class="counts"><span><b>5</b> slices</span><span><b>15</b> tasks</span></div>
+        <div class="counts"><span><b>6</b> slices</span><span><b>22</b> tasks</span></div>
       </div>
       <div class="slices">
-        <div class="slice"><div class="sid">F1</div><div class="sbody"><div class="stitle">App shell runs locally</div><div class="sblock"><b>↳</b> none</div></div><div class="smeta"><span class="tasks">2 tasks</span><span class="tag-type afk">AFK</span></div></div>
-        <div class="slice"><div class="sid">F2</div><div class="sbody"><div class="stitle">Postgres + pgvector available locally</div><div class="sblock"><b>↳</b> none</div></div><div class="smeta"><span class="tasks">3 tasks</span><span class="tag-type afk">AFK</span></div></div>
-        <div class="slice"><div class="sid">F3</div><div class="sbody"><div class="stitle">Model Gateway with usage logging <span class="mono" style="color:var(--ink-faint);font-size:11px">· ADR-0004</span></div><div class="sblock"><b>↳</b> F2</div></div><div class="smeta"><span class="tasks">3 tasks</span><span class="tag-type afk">AFK</span></div></div>
-        <div class="slice"><div class="sid">F4</div><div class="sbody"><div class="stitle">Run Ledger spine <span class="mono" style="color:var(--ink-faint);font-size:11px">· ADR-0002</span></div><div class="sblock"><b>↳</b> F2</div></div><div class="smeta"><span class="tasks">4 tasks</span><span class="tag-type afk">AFK</span></div></div>
-        <div class="slice"><div class="sid">F5</div><div class="sbody"><div class="stitle">Agent Harness ReAct loop + tool registry</div><div class="sblock"><b>↳</b> F3, F4</div></div><div class="smeta"><span class="tasks">3 tasks</span><span class="tag-type afk">AFK</span></div></div>
+        <div class="slice" data-status="done"><div class="sid">F1</div><div class="sbody"><div class="stitle">App shell runs locally</div><div class="sblock"><b>↳</b> none</div></div><div class="smeta"><span class="status-done">✓ done</span></div></div>
+        <div class="slice" data-status="done"><div class="sid">F2</div><div class="sbody"><div class="stitle">Postgres + pgvector available locally</div><div class="sblock"><b>↳</b> none</div></div><div class="smeta"><span class="status-done">✓ done</span></div></div>
+        <div class="slice" data-status="done"><div class="sid">FD</div><div class="sbody"><div class="stitle">Design Foundation (Warm Operator) <span class="mono" style="color:var(--ink-faint);font-size:11px">· inserted 2026-06-18</span></div><div class="sblock"><b>↳</b> F1</div></div><div class="smeta"><span class="status-done">✓ done</span></div></div>
+        <div class="slice" data-status="done"><div class="sid">F3</div><div class="sbody"><div class="stitle">Model Gateway with usage logging <span class="mono" style="color:var(--ink-faint);font-size:11px">· ADR-0004</span></div><div class="sblock"><b>↳</b> F2</div></div><div class="smeta"><span class="status-done">✓ done</span></div></div>
+        <div class="slice" data-status="done"><div class="sid">F4</div><div class="sbody"><div class="stitle">Run Ledger spine <span class="mono" style="color:var(--ink-faint);font-size:11px">· ADR-0002</span></div><div class="sblock"><b>↳</b> F2</div></div><div class="smeta"><span class="status-done">✓ done</span></div></div>
+        <div class="slice" data-status="done"><div class="sid">F5</div><div class="sbody"><div class="stitle">Agent Harness ReAct loop + tool registry</div><div class="sblock"><b>↳</b> F3, F4</div></div><div class="smeta"><span class="status-done">✓ done</span></div></div>
       </div>
       <div class="demo"><span class="pin">demo</span><span>Type a question → harness runs a traced multi-step loop calling the model + echo tool, full trace lands in the Run Ledger. Spine works, nothing sourcing-specific yet.</span></div>
     </div>
@@ -316,21 +356,22 @@
     <!-- A -->
     <div class="stage">
       <div class="rail" style="background:var(--rail-a)">
+        <div class="rail-check">✓</div>
         <div class="badge">A</div>
         <div class="nm">Cited Sourcing Memory Answer</div>
         <div class="ph">Port the brain · highest risk</div>
-        <div class="counts"><span><b>7</b> slices</span><span><b>17</b> tasks</span></div>
+        <div class="counts"><span><b>7</b> slices</span><span><b>15</b> tasks</span></div>
       </div>
       <div class="slices">
-        <div class="slice"><div class="sid">A1</div><div class="sbody"><div class="stitle">Memory schema + ingest → Postgres/pgvector</div><div class="sblock"><b>↳</b> F2</div></div><div class="smeta"><span class="tasks">3 tasks</span><span class="tag-type afk">AFK</span></div></div>
-        <div class="slice"><div class="sid">A2</div><div class="sbody"><div class="stitle">Embeddings + cited retrieval ported <span class="mono" style="color:var(--ink-faint);font-size:11px">· ADR-0001</span></div><div class="sblock"><b>↳</b> A1</div></div><div class="smeta"><span class="tasks">2 tasks</span><span class="tag-type afk">AFK</span></div></div>
-        <div class="slice"><div class="sid">A3</div><div class="sbody"><div class="stitle">Answer logic ported &mdash; with parity test</div><div class="sblock"><b>↳</b> A2 &nbsp;·&nbsp; <span style="color:var(--hitl)">SQLite-vs-Postgres sign-off</span></div></div><div class="smeta"><span class="tasks">4 tasks</span><span class="tag-type hitl">HITL</span></div></div>
-        <div class="slice"><div class="sid">A4</div><div class="sbody"><div class="stitle">File / export memory import path</div><div class="sblock"><b>↳</b> A1</div></div><div class="smeta"><span class="tasks">2 tasks</span><span class="tag-type afk">AFK</span></div></div>
-        <div class="slice"><div class="sid">A5</div><div class="sbody"><div class="stitle">search_memory tool</div><div class="sblock"><b>↳</b> A2, F5</div></div><div class="smeta"><span class="tasks">1 task</span><span class="tag-type afk">AFK</span></div></div>
-        <div class="slice"><div class="sid">A6</div><div class="sbody"><div class="stitle">Research Chat answers from memory</div><div class="sblock"><b>↳</b> A3, A5, F1 &nbsp;·&nbsp; <span style="color:var(--hitl)">chat design review</span></div></div><div class="smeta"><span class="tasks">3 tasks</span><span class="tag-type hitl">HITL</span></div></div>
-        <div class="slice"><div class="sid">A7</div><div class="sbody"><div class="stitle">Memory management page (add / correct)</div><div class="sblock"><b>↳</b> A3</div></div><div class="smeta"><span class="tasks">2 tasks</span><span class="tag-type afk">AFK</span></div></div>
+        <div class="slice" data-status="done"><div class="sid">A1</div><div class="sbody"><div class="stitle">Memory schema + ingest → Postgres/pgvector</div><div class="sblock"><b>↳</b> F2</div></div><div class="smeta"><span class="status-done">✓ done</span></div></div>
+        <div class="slice" data-status="done"><div class="sid">A2</div><div class="sbody"><div class="stitle">Embeddings + cited retrieval ported <span class="mono" style="color:var(--ink-faint);font-size:11px">· ADR-0001</span></div><div class="sblock"><b>↳</b> A1</div></div><div class="smeta"><span class="status-done">✓ done</span></div></div>
+        <div class="slice" data-status="done"><div class="sid">A3</div><div class="sbody"><div class="stitle">Answer logic ported <span class="mono" style="color:var(--ink-faint);font-size:11px">· parity gate cut, model synthesizes prose</span></div><div class="sblock"><b>↳</b> A2</div></div><div class="smeta"><span class="status-done">✓ done</span></div></div>
+        <div class="slice" data-status="partial"><div class="sid">A4</div><div class="sbody"><div class="stitle">File/export memory import path</div><div class="sblock"><b>↳</b> A1</div></div><div class="smeta"><span class="status-partial">1/2</span></div></div>
+        <div class="slice" data-status="done"><div class="sid">A5</div><div class="sbody"><div class="stitle">search_memory tool</div><div class="sblock"><b>↳</b> A2, F5</div></div><div class="smeta"><span class="status-done">✓ done</span></div></div>
+        <div class="slice" data-status="partial"><div class="sid">A6</div><div class="sbody"><div class="stitle">Research Chat answers from memory <span class="mono" style="color:var(--hitl);font-size:11px">· A6.3 higher-stakes now (R1&ndash;R6 rewrite)</span></div><div class="sblock"><b>↳</b> A3, A5, F1</div></div><div class="smeta"><span class="status-partial">2/3</span></div></div>
+        <div class="slice" data-status="done"><div class="sid">A7</div><div class="sbody"><div class="stitle">Memory management page (add / correct)</div><div class="sblock"><b>↳</b> A3</div></div><div class="smeta"><span class="status-done">✓ done</span></div></div>
       </div>
-      <div class="demo"><span class="pin">demo</span><span>Import notes → ask a question in chat → cited answer with gaps → inspect the run → correct memory.</span></div>
+      <div class="demo"><span class="pin">demo</span><span>Import notes → ask a question in chat → cited answer with gaps → inspect the run → correct memory. Demonstrated live 2026-06-25 on 3 complex queries.</span></div>
     </div>
 
     <div class="connector"><div class="ln"></div><div class="tag">splits into 2 lanes</div><div class="chev"></div></div>
@@ -341,13 +382,13 @@
         <div class="rail" style="background:var(--rail-b)">
           <div class="badge">B</div>
           <div class="nm">Sourcing State Model</div>
-          <div class="ph">Act like a director</div>
-          <div class="counts"><span><b>5</b></span><span><b>11</b>t</span></div>
+          <div class="ph">Act like a director · B1 in progress</div>
+          <div class="counts"><span><b>5</b></span><span><b>17</b>t</span></div>
         </div>
         <div class="slices">
-          <div class="slice"><div class="sid">B1</div><div class="sbody"><div class="stitle">Organizations &amp; Contacts</div><div class="sblock"><b>↳</b> F2</div></div><div class="smeta"><span class="tasks">2</span><span class="tag-type afk">AFK</span></div></div>
+          <div class="slice" data-status="partial"><div class="sid">B1</div><div class="sbody"><div class="stitle">Organizations &amp; Contacts + identity + Profile Card <span class="mono" style="color:var(--ink-faint);font-size:11px">· widened 2026-07-21</span></div><div class="sblock"><b>↳</b> F2</div></div><div class="smeta"><span class="status-partial">7/8</span><span class="tag-type hitl">HITL</span></div></div>
           <div class="slice"><div class="sid">B2</div><div class="sbody"><div class="stitle">Target Personas</div><div class="sblock"><b>↳</b> B1</div></div><div class="smeta"><span class="tasks">1</span><span class="tag-type afk">AFK</span></div></div>
-          <div class="slice"><div class="sid">B3</div><div class="sbody"><div class="stitle">Outreach History / Outcomes / Follow-Up</div><div class="sblock"><b>↳</b> B1</div></div><div class="smeta"><span class="tasks">3</span><span class="tag-type afk">AFK</span></div></div>
+          <div class="slice"><div class="sid">B3</div><div class="sbody"><div class="stitle">Outreach Outcomes / Follow-Up <span class="mono" style="color:var(--ink-faint);font-size:11px">· History moved to B1.4</span></div><div class="sblock"><b>↳</b> B1</div></div><div class="smeta"><span class="tasks">3</span><span class="tag-type afk">AFK</span></div></div>
           <div class="slice"><div class="sid">B4</div><div class="sbody"><div class="stitle">Contact / Organization detail page</div><div class="sblock"><b>↳</b> B3 · <span style="color:var(--hitl)">design</span></div></div><div class="smeta"><span class="tasks">3</span><span class="tag-type hitl">HITL</span></div></div>
           <div class="slice"><div class="sid">B5</div><div class="sbody"><div class="stitle">Manual Reply Capture</div><div class="sblock"><b>↳</b> B3</div></div><div class="smeta"><span class="tasks">2</span><span class="tag-type afk">AFK</span></div></div>
         </div>
@@ -357,14 +398,15 @@
           <div class="badge">C</div>
           <div class="nm">Enrichment</div>
           <div class="ph">Provenance + usage</div>
-          <div class="counts"><span><b>2</b></span><span><b>6</b>t</span></div>
+          <div class="counts"><span><b>3</b></span><span><b>12</b>t</span></div>
         </div>
         <div class="slices">
           <div class="slice"><div class="sid">C1</div><div class="sbody"><div class="stitle">Apollo search / enrich tools</div><div class="sblock"><b>↳</b> F5, B1</div></div><div class="smeta"><span class="tasks">3</span><span class="tag-type afk">AFK</span></div></div>
           <div class="slice"><div class="sid">C2</div><div class="sbody"><div class="stitle">Web Enrichment tools (Apify provider)</div><div class="sblock"><b>↳</b> F5, B1</div></div><div class="smeta"><span class="tasks">3</span><span class="tag-type afk">AFK</span></div></div>
+          <div class="slice"><div class="sid">C3</div><div class="sbody"><div class="stitle">Guided contact data-collection workflow <span class="mono" style="color:var(--ink-faint);font-size:11px">· added 2026-07-21</span></div><div class="sblock"><b>↳</b> C1, C2, B1</div></div><div class="smeta"><span class="tasks">6</span><span class="tag-type hitl">HITL</span></div></div>
           <div class="slice" style="opacity:.55"><div class="sid">—</div><div class="sbody"><div class="stitle" style="font-weight:450;color:var(--ink-soft)">No LinkedIn-specific enrichment (out of scope)</div></div></div>
         </div>
-        <div class="demo"><span class="pin">demo</span><span>Research an Org, enrich Contacts with citations, see Apollo/web usage in the Ledger.</span></div>
+        <div class="demo"><span class="pin">demo</span><span>Research an Org, enrich Contacts with citations, see Apollo/web usage in the Ledger, then walk a new connection through guided data collection with a verified LinkedIn photo match.</span></div>
       </div>
     </div>
 
@@ -422,6 +464,22 @@
       <div class="demo"><span class="pin">final</span><span>The full sourcing loop: imported memory → chat/routine run → enrichment → artifacts → review → outcome/feedback → memory update. Dependable and repeatable from a clean DB.</span></div>
     </div>
 
+    <div class="connector"><div class="ln"></div><div class="tag">deferred · not scheduled</div><div class="chev"></div></div>
+
+    <!-- H -->
+    <div class="stage deferred">
+      <div class="rail" style="background:var(--rail-h)">
+        <div class="badge">H</div>
+        <div class="nm">Actor Identity &amp; Attribution</div>
+        <div class="ph">Real per-officer login · added 2026-07-21</div>
+        <div class="counts"><span><b>1</b> slice</span><span>tasks not scoped</span></div>
+      </div>
+      <div class="slices">
+        <div class="slice"><div class="sid">H1</div><div class="sbody"><div class="stitle">Per-officer login &amp; session identity</div><div class="sblock"><b>↳</b> none &mdash; can start anytime, blocks nothing shipped so far</div></div><div class="smeta"><span class="tag-type deferred">DEFERRED</span></div></div>
+      </div>
+      <div class="demo"><span class="pin">why</span><span>Replaces the DEFAULT_ACTOR v1 sentinel (8 call sites today) so create_contact, notes, B3's outcomes, D1's artifact review, G1's feedback, and C3's data-collection workflow can all attribute writes to a real officer instead of one shared identity.</span></div>
+    </div>
+
   </div>
 
   <footer>
@@ -433,28 +491,30 @@
 
 <script>
 const TASKS = {
-  F1:[["F1.1","Scaffold Next.js app shell + base layout / nav","1h","afk"],["F1.2","Add /chat placeholder route + /health route","1h","afk"]],
-  F2:[["F2.1","docker-compose Postgres + pgvector + .env.example","1h","afk"],["F2.2","DB client / access layer + connection config","1h","afk"],["F2.3","Migration runner + baseline migration","1.5h","afk"]],
-  F3:[["F3.1","model_calls migration (task, prompt/version, usage, status, error)","1h","afk"],["F3.2","callModel() with named tasks + prompt/version naming","1.5h","afk"],["F3.3","Structured-output parse + error capture + usage counters","1.5h","afk"]],
-  F4:[["F4.1","runs + run_steps + tool_calls migrations","1.5h","afk"],["F4.2","Run create + step/tool/model logging write path","1.5h","afk"],["F4.3","Run status + error capture on the run","1h","afk"],["F4.4","Run inspector view (read-only trace render)","1.5h","afk"]],
-  F5:[["F5.1","ReAct loop (observation → model → tool → repeat, stop cond.)","2h","afk"],["F5.2","Tool registry + permission classes + class enforcement","1.5h","afk"],["F5.3","echo reference tool + wire loop end-to-end to ledger","1h","afk"]],
+  F1:[["F1.1","Scaffold Next.js app shell + base layout / nav","1h","done"],["F1.2","Add /chat placeholder route + /health route","1h","done"]],
+  F2:[["F2.1","docker-compose Postgres + pgvector + .env.example","1h","done"],["F2.2","DB client / access layer + connection config","1h","done"],["F2.3","Migration runner + baseline migration","1.5h","done"]],
+  FD:[["FD.1","Design tokens + font wiring","1h","done"],["FD.2","UI test infra + Button/StatusPill","1.5h","done"],["FD.3","Input/Toggle/Card/EmptyState","1h","done"],["FD.4","DataTable","1.5h","done"],["FD.5","AppShell","1.5h","done"],["FD.6","F1 retrofit + Sourcecado rename","1h","done"],["FD.7","/styleguide catalog page","1h","done"]],
+  F3:[["F3.1","model_calls migration (task, prompt/version, usage, status, error)","1h","done"],["F3.2","callModel() with named tasks + prompt/version naming","1.5h","done"],["F3.3","Structured-output parse + error capture + usage counters","1.5h","done"]],
+  F4:[["F4.1","runs + run_steps + tool_calls migrations","1.5h","done"],["F4.2","Run create + step/tool/model logging write path","1.5h","done"],["F4.3","Run status + error capture on the run","1h","done"],["F4.4","Run inspector view (read-only trace render)","1.5h","done"]],
+  F5:[["F5.1","ReAct loop (observation → model → tool → repeat, stop cond.)","2h","done"],["F5.2","Tool registry + permission classes + class enforcement","1.5h","done"],["F5.3","echo reference tool + wire loop end-to-end to ledger","1h","done"]],
 
-  A1:[["A1.1","source_records + memory_chunks migration: pgvector + permission cols","1.5h","afk"],["A1.2","Port ingest (source records, content hashing, dedupe)","2h","afk"],["A1.3","Port chunking + citation construction","1.5h","afk"]],
-  A2:[["A2.1","Embedding generation through Model Gateway → pgvector column","2h","afk"],["A2.2","pgvector similarity query with pre-retrieval permission filter","2h","afk"]],
-  A3:[["A3.1","Port intent classification + fact selection","2h","afk"],["A3.2","Port gap-fact handling + no-memory / no-relevant-memory paths","1.5h","afk"],["A3.3","Parity harness: question set + SQLite-vs-Postgres diff report","2h","afk"],["A3.4","Parity review gate + log accepted deltas","1h","hitl"]],
-  A4:[["A4.1","Import endpoint + source-record creation from upload","2h","afk"],["A4.2","Import result UI with per-file status / skip reasons","1.5h","afk"]],
-  A5:[["A5.1","search_memory tool wrapping retrieval + register it","1.5h","afk"]],
-  A6:[["A6.1","Research Chat UI: message list + input + run trigger","2h","afk"],["A6.2","Inline run status + cited answer + gaps render","1.5h","afk"],["A6.3","Chat-layout design review pass","1h","hitl"]],
-  A7:[["A7.1","add_memory_note tool + write path","1.5h","afk"],["A7.2","Memory management page: list + add + correct","2h","afk"]],
+  A1:[["A1.1","source_records + memory_chunks migration: pgvector + permission cols","1.5h","done"],["A1.2","Port ingest (source records, content hashing, dedupe)","2h","done"],["A1.3","Port chunking + citation construction","1.5h","done"]],
+  A2:[["A2.1","Embedding generation through Model Gateway → pgvector column","2h","done"],["A2.2","pgvector similarity query with pre-retrieval permission filter","2h","done"]],
+  A3:[["A3.1","Port intent classification + fact selection","2h","done"],["A3.2","Port gap-fact handling + no-memory / no-relevant-memory paths","1.5h","done"],["A3.3","Parity harness — cut, decision #6","2h","cut"],["A3.4","Parity review gate — cut, decision #6","1h","cut"]],
+  A4:[["A4.1","Import endpoint + source-record creation from upload","2h","done"],["A4.2","Import result UI with per-file status / skip reasons","1.5h","afk"]],
+  A5:[["A5.1","search_memory tool wrapping retrieval + register it","1.5h","done"]],
+  A6:[["A6.1","Research Chat UI: message list + input + run trigger","2h","done"],["A6.2","Inline run status + cited answer + gaps render","1.5h","done"],["A6.3","Chat-layout design review — higher stakes post R1–R6 rewrite","1h","hitl"]],
+  A7:[["A7.1","add_memory_note tool + write path","1.5h","done"],["A7.2","Memory management page: list + add + correct","2h","done"]],
 
-  B1:[["B1.1","organizations + contacts migration","1.5h","afk"],["B1.2","get_contact + get_organization tools + register","1.5h","afk"]],
+  B1:[["B1.1","organizations + contacts + contact_aliases migration","2h","done"],["B1.2","get_contact + get_organization tools + alias resolution + ambiguous state","2.5h","done"],["B1.3","create_contact tool — requires name+role+org, gap-flags missing","1.5h","done"],["B1.4","outreach_history migration (pulled forward from B3)","1.5h","done"],["B1.5","list_outreach_history tool","1h","done"],["B1.6","Contact Profile Card component","2h","done"],["B1.7","Sourcing doctrine: gather name+role+org, ask on ambiguity","1h","done"],["B1.8","Verify card matches DESIGN.md + uses primitives","1h","hitl"]],
   B2:[["B2.1","target_personas migration + association","1.5h","afk"]],
-  B3:[["B3.1","outreach_history + outreach_outcomes migrations","1.5h","afk"],["B3.2","followup_sequence state migration","1h","afk"],["B3.3","list_outreach_history + record_outreach_outcome + update_followup_sequence tools","2h","afk"]],
+  B3:[["B3.1","outreach_history migration — done, see B1.4","1.5h","cut"],["B3.1b","outreach_outcomes migration","1h","afk"],["B3.2","followup_sequence state migration","1h","afk"],["B3.2b","list_outreach_history tool — done, see B1.5","—","cut"],["B3.3","record_outreach_outcome + update_followup_sequence tools","1.5h","afk"]],
   B4:[["B4.1","Detail page data loaders + layout","2h","afk"],["B4.2","History / outcomes / artifacts panels","2h","afk"],["B4.3","Detail-page design review pass","1h","hitl"]],
   B5:[["B5.1","Manual Reply Capture form + write to outcomes / state","1.5h","afk"],["B5.2","Reply → next-action suggestion run trigger","1.5h","afk"]],
 
   C1:[["C1.1","Apollo client + usage tracking plumbing","2h","afk"],["C1.2","search_apollo tool + citation records","1.5h","afk"],["C1.3","enrich_apollo_contact tool + write to Contact with provenance","2h","afk"]],
   C2:[["C2.1","Web provider client (Apify) + usage tracking","2h","afk"],["C2.2","web_enrich_company tool + citations","1.5h","afk"],["C2.3","web_enrich_contact tool + citations","1.5h","afk"]],
+  C3:[["C3.1","Design guided workflow's step sequence + gap-detection logic","2h","hitl"],["C3.2","Candidate surfacing from Apollo/web + identity-confirmation UI","2h","afk"],["C3.3","Field-level provenance write path (value+source+actor+method+time)","2h","afk"],["C3.4","“Data collect” entry points: new-connection + existing-profile","1.5h","afk"],["C3.5","Rework Key Facts to cite originating interaction/source","1.5h","afk"],["C3.6","Verify guided workflow UX matches DESIGN.md","1h","hitl"]],
 
   D1:[["D1.1","artifacts migration + create / revise / save tools","2h","afk"],["D1.2","Artifact panel UI + draft / revise / save flow","2h","afk"],["D1.3","Save-artifact-to-memory path","1h","afk"],["D1.4","Artifact shape + panel design review","1h","hitl"]],
   D2:[["D2.1","Citation checker over artifact claims","2h","afk"],["D2.2","Duplicate Contact check","1.5h","afk"]],
@@ -483,12 +543,12 @@ document.querySelectorAll('.slice').forEach(slice => {
 
   const panel = document.createElement('div');
   panel.className = 'subtasks';
-  panel.innerHTML = '<div class="subhdr">' + rows.length + ' task' + (rows.length>1?'s':'') + ' · ~1–2h each</div>' +
+  panel.innerHTML = '<div class="subhdr">' + rows.length + ' task' + (rows.length>1?'s':'') + '</div>' +
     rows.map(r =>
-      '<div class="subtask">' +
+      '<div class="subtask ' + r[3] + '">' +
         '<span class="st-id">'+r[0]+'</span>' +
         '<span class="st-title">'+r[1]+'</span>' +
-        '<span class="st-est">~'+r[2]+'</span>' +
+        '<span class="st-est">'+(r[2]==='—' ? '' : '~'+r[2])+'</span>' +
         '<span class="st-type '+r[3]+'">'+r[3].toUpperCase()+'</span>' +
       '</div>'
     ).join('');

--- a/src/app/chat/ChatClient.tsx
+++ b/src/app/chat/ChatClient.tsx
@@ -3,10 +3,17 @@
 import { useEffect, useRef, useState } from "react";
 import { EmptyState } from "@/components/ui";
 import { Composer } from "./Composer";
+import { ContactProfileCard } from "./ContactProfileCard";
 import { MessageBubble } from "./MessageBubble";
 import { ReasoningTrace } from "./ReasoningTrace";
 import type { ResumedExchange } from "./resume";
-import { runChat, type AssistantTurn, type ChatMeta, type ConversationTurn } from "./stream";
+import {
+  runChat,
+  selectContactCard,
+  type AssistantTurn,
+  type ChatMeta,
+  type ConversationTurn,
+} from "./stream";
 
 interface Exchange {
   id: number;
@@ -120,7 +127,9 @@ export function ChatClient({ initialExchanges = [] }: { initialExchanges?: Resum
           </div>
         ) : (
           <div className="flex flex-col gap-6">
-            {exchanges.map((e) => (
+            {exchanges.map((e) => {
+              const contactCard = selectContactCard(e.turn.steps);
+              return (
               <div key={e.id} className="flex flex-col gap-2">
                 <MessageBubble role="user">{e.question}</MessageBubble>
                 <div className="flex flex-col gap-2" aria-live="polite">
@@ -133,6 +142,7 @@ export function ChatClient({ initialExchanges = [] }: { initialExchanges?: Resum
                       pendingTool={e.turn.pendingTool}
                     />
                   )}
+                  {contactCard ? <ContactProfileCard {...contactCard} /> : null}
                   {e.errored ? (
                     <div
                       role="alert"
@@ -148,7 +158,8 @@ export function ChatClient({ initialExchanges = [] }: { initialExchanges?: Resum
                   {e.turn.meta ? <MetaFooter meta={e.turn.meta} /> : null}
                 </div>
               </div>
-            ))}
+              );
+            })}
             <div ref={bottomRef} />
           </div>
         )}

--- a/src/app/chat/ContactProfileCard.tsx
+++ b/src/app/chat/ContactProfileCard.tsx
@@ -1,0 +1,66 @@
+import { Card, Tag } from "@/components/ui";
+import type { ContactCardView } from "./stream";
+
+// One card summarizing everything known about a person: identity, our
+// relationship with them (past interactions), key facts, and gaps. A missing
+// role/org or an empty history is shown as a plain gap, not hidden — same
+// "call out what's missing" philosophy as the rest of the memory system.
+export function ContactProfileCard({ contact, history, acceptedFacts, gapFacts }: ContactCardView) {
+  return (
+    <Card className="flex flex-col gap-3" data-testid="contact-profile-card">
+      <div>
+        <div className="text-[15px] font-semibold text-text">{contact.canonicalName}</div>
+        <div className="text-[12px] text-muted">
+          {contact.role ?? "Role not yet known"}
+          {" · "}
+          {contact.organizationName ?? "Organization not yet known"}
+        </div>
+      </div>
+
+      <section>
+        <div className="text-[11px] font-medium uppercase tracking-wide text-muted">Relationship</div>
+        {history.length === 0 ? (
+          <p className="mt-1 text-[12px] text-muted">No recorded interactions yet.</p>
+        ) : (
+          <ul className="mt-1 flex flex-col gap-1">
+            {history.map((entry, i) => (
+              <li key={i} className="flex items-baseline gap-2 text-[12px] text-text">
+                <span className="font-mono text-[11px] text-muted">
+                  {new Date(entry.occurredAt).toLocaleDateString()}
+                </span>
+                {entry.channel ? <Tag>{entry.channel}</Tag> : null}
+                <span>{entry.summary}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {acceptedFacts.length > 0 ? (
+        <section>
+          <div className="text-[11px] font-medium uppercase tracking-wide text-muted">Key facts</div>
+          <ul className="mt-1 flex flex-col gap-1">
+            {acceptedFacts.map((fact, i) => (
+              <li key={i} className="text-[12px] text-text">
+                {fact.subject} {fact.predicate} {fact.object}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      {gapFacts.length > 0 ? (
+        <section>
+          <div className="text-[11px] font-medium uppercase tracking-wide text-warn-tx">Knowledge gaps</div>
+          <ul className="mt-1 flex flex-col gap-1">
+            {gapFacts.map((fact, i) => (
+              <li key={i} className="text-[12px] text-warn-tx">
+                {fact.subject} {fact.predicate} {fact.object}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </Card>
+  );
+}

--- a/src/app/chat/ContactProfileCard.tsx
+++ b/src/app/chat/ContactProfileCard.tsx
@@ -1,21 +1,69 @@
 import { Card, Tag } from "@/components/ui";
-import type { ContactCardView } from "./stream";
+import type { ContactCardView, MemoryFactEntry } from "./stream";
+
+// A fact's subject usually just restates the contact's own name (search_memory
+// facts are subject/predicate/object triples with no notion of "this card's
+// person"), which reads redundantly on a card already headlined by that name.
+// Drop it only on an exact match — a fact about a different entity (an org, a
+// related person) keeps its subject since dropping it there would be wrong,
+// not just repetitive.
+function formatFact(fact: MemoryFactEntry, contactName: string): string {
+  const sameSubject = fact.subject.trim().toLowerCase() === contactName.trim().toLowerCase();
+  return sameSubject ? `${fact.predicate}: ${fact.object}` : `${fact.subject} ${fact.predicate} ${fact.object}`;
+}
+
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  const first = parts[0]?.[0] ?? "";
+  const last = parts.length > 1 ? parts[parts.length - 1][0] : "";
+  return (first + last).toUpperCase();
+}
 
 // One card summarizing everything known about a person: identity, our
 // relationship with them (past interactions), key facts, and gaps. A missing
-// role/org or an empty history is shown as a plain gap, not hidden — same
-// "call out what's missing" philosophy as the rest of the memory system.
+// role/org/phone/email/LinkedIn or an empty history is shown as a plain gap,
+// not hidden — same "call out what's missing" philosophy as the rest of the
+// memory system. photoUrl is a plain field here; auto-populating it from a
+// confirmed LinkedIn match is C3's job, not this component's.
 export function ContactProfileCard({ contact, history, acceptedFacts, gapFacts }: ContactCardView) {
   return (
     <Card className="flex flex-col gap-3" data-testid="contact-profile-card">
-      <div>
-        <div className="text-[15px] font-semibold text-text">{contact.canonicalName}</div>
-        <div className="text-[12px] text-muted">
-          {contact.role ?? "Role not yet known"}
-          {" · "}
-          {contact.organizationName ?? "Organization not yet known"}
+      <div className="flex items-center gap-3">
+        {contact.photoUrl ? (
+          <img
+            src={contact.photoUrl}
+            alt={contact.canonicalName}
+            className="h-11 w-11 flex-none rounded-full object-cover"
+          />
+        ) : (
+          <div className="flex h-11 w-11 flex-none items-center justify-center rounded-full bg-accent-tint text-[13px] font-medium text-accent-deep">
+            {initials(contact.canonicalName)}
+          </div>
+        )}
+        <div>
+          <div className="text-[15px] font-semibold text-text">{contact.canonicalName}</div>
+          <div className="text-[12px] text-muted">
+            {contact.role ?? "Role not yet known"}
+            {" · "}
+            {contact.organizationName ?? "Organization not yet known"}
+          </div>
         </div>
       </div>
+
+      <section>
+        <div className="text-[11px] font-medium uppercase tracking-wide text-muted">Contact</div>
+        <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-[12px]">
+          <span className={contact.phone ? "text-text" : "text-muted"}>{contact.phone ?? "Phone not yet known"}</span>
+          <span className={contact.email ? "text-text" : "text-muted"}>{contact.email ?? "Email not yet known"}</span>
+          {contact.linkedinUrl ? (
+            <a href={contact.linkedinUrl} className="text-accent-deep underline" aria-label="LinkedIn profile">
+              LinkedIn
+            </a>
+          ) : (
+            <span className="text-muted">LinkedIn not yet known</span>
+          )}
+        </div>
+      </section>
 
       <section>
         <div className="text-[11px] font-medium uppercase tracking-wide text-muted">Relationship</div>
@@ -42,7 +90,7 @@ export function ContactProfileCard({ contact, history, acceptedFacts, gapFacts }
           <ul className="mt-1 flex flex-col gap-1">
             {acceptedFacts.map((fact, i) => (
               <li key={i} className="text-[12px] text-text">
-                {fact.subject} {fact.predicate} {fact.object}
+                {formatFact(fact, contact.canonicalName)}
               </li>
             ))}
           </ul>
@@ -55,7 +103,7 @@ export function ContactProfileCard({ contact, history, acceptedFacts, gapFacts }
           <ul className="mt-1 flex flex-col gap-1">
             {gapFacts.map((fact, i) => (
               <li key={i} className="text-[12px] text-warn-tx">
-                {fact.subject} {fact.predicate} {fact.object}
+                {formatFact(fact, contact.canonicalName)}
               </li>
             ))}
           </ul>

--- a/src/app/chat/stream.ts
+++ b/src/app/chat/stream.ts
@@ -8,6 +8,68 @@ export interface ChatStep {
   thought?: string;
   ok: boolean;
   detail: string;
+  // Mirrors ChatStepPart's structured fields (src/lib/memory/answer.ts) —
+  // present only for their respective tool (get_contact/list_outreach_history/
+  // search_memory) and only on a successful, non-ambiguous result.
+  contactCard?: ContactCardData;
+  outreachHistory?: OutreachHistoryEntry[];
+  memoryFacts?: MemoryFactEntry[];
+}
+
+export interface ContactCardData {
+  id: number;
+  canonicalName: string;
+  role: string | null;
+  organizationName: string | null;
+}
+
+export interface OutreachHistoryEntry {
+  occurredAt: string;
+  channel: string | null;
+  summary: string;
+  citation: string | null;
+}
+
+export interface MemoryFactEntry {
+  subject: string;
+  predicate: string;
+  object: string;
+  citation: string | null;
+  status: string;
+}
+
+// A Contact Profile Card's full view model, assembled from up to three
+// separate steps within the same turn: the get_contact step that resolved
+// the person, plus whichever list_outreach_history / search_memory steps
+// also ran in that turn. This is a same-turn heuristic (there is no
+// contactId tag linking a search_memory step to a specific get_contact
+// step) — sound as long as the agent's doctrine is "resolve the person
+// first, then look up their history/facts," which is what B1.7 establishes.
+export interface ContactCardView {
+  contact: ContactCardData;
+  history: OutreachHistoryEntry[];
+  acceptedFacts: MemoryFactEntry[];
+  gapFacts: MemoryFactEntry[];
+}
+
+// Picks the most recent contactCard-bearing step, if any, and merges in the
+// most recent outreachHistory/memoryFacts from the same list of steps.
+// Returns undefined when no get_contact step resolved to a single contact
+// in this turn — the normal case for a non-person question.
+export function selectContactCard(steps: ChatStep[]): ContactCardView | undefined {
+  const contactStep = [...steps].reverse().find((s) => s.contactCard);
+  if (!contactStep?.contactCard) return undefined;
+
+  const historyStep = [...steps].reverse().find((s) => s.outreachHistory);
+  const factsStep = [...steps].reverse().find((s) => s.memoryFacts);
+  const facts = factsStep?.memoryFacts ?? [];
+
+  return {
+    contact: contactStep.contactCard,
+    history: historyStep?.outreachHistory ?? [],
+    acceptedFacts: facts.filter((f) => f.status === "accepted"),
+    gapFacts: facts.filter((f) => f.status !== "accepted"),
+  };
 }
 
 export interface ChatMeta {

--- a/src/app/chat/stream.ts
+++ b/src/app/chat/stream.ts
@@ -21,6 +21,10 @@ export interface ContactCardData {
   canonicalName: string;
   role: string | null;
   organizationName: string | null;
+  phone: string | null;
+  email: string | null;
+  linkedinUrl: string | null;
+  photoUrl: string | null;
 }
 
 export interface OutreachHistoryEntry {

--- a/src/lib/contacts/create.ts
+++ b/src/lib/contacts/create.ts
@@ -1,0 +1,71 @@
+import type { Sql } from "../tools/types";
+import { findOrganizationsByExactName, type ContactSummary, type OrganizationSummary } from "./resolve";
+
+// ---------------------------------------------------------------------------
+// createContact — the write path for a new connection. Only `name` is
+// required at the type/DB level: role and organization are gaps, not
+// blockers, when the caller genuinely doesn't know them (rendered as such on
+// the Contact Profile Card via the null columns themselves — no separate
+// gap-tracking table needed). It is the *doctrine* layer (B1.7's system
+// prompt update) that makes the agent ask the Director for role/org before
+// calling this tool during a live chat; this function must still work when
+// called with just a name (e.g. a future bulk-import path).
+//
+// organizationName resolution never guesses: an exact existing org is
+// reused, a new name creates one, and an ambiguous exact match (two orgs
+// already share that name) refuses to write and asks instead — the same
+// "ask, don't guess" policy as resolveContact/resolveOrganization.
+// ---------------------------------------------------------------------------
+
+export interface CreateContactArgs {
+  name: string;
+  role?: string;
+  organizationName?: string;
+}
+
+export type CreateContactResult =
+  | { status: "created"; contact: ContactSummary }
+  | { status: "ambiguous_organization"; organizationName: string; candidates: OrganizationSummary[] };
+
+export async function createContact(db: Sql, args: CreateContactArgs): Promise<CreateContactResult> {
+  const name = args.name.trim();
+  const role = args.role?.trim() || null;
+  const organizationName = args.organizationName?.trim() || null;
+
+  let organizationId: number | null = null;
+  let resolvedOrganizationName: string | null = null;
+
+  if (organizationName) {
+    const existing = await findOrganizationsByExactName(db, organizationName);
+    if (existing.length > 1) {
+      return { status: "ambiguous_organization", organizationName, candidates: existing };
+    }
+    if (existing.length === 1) {
+      organizationId = existing[0].id;
+      resolvedOrganizationName = existing[0].name;
+    } else {
+      const [created] = await db<{ id: number | string }[]>`
+        INSERT INTO organizations (name) VALUES (${organizationName}) RETURNING id
+      `;
+      organizationId = Number(created.id);
+      resolvedOrganizationName = organizationName;
+    }
+  }
+
+  const [row] = await db<{ id: number | string }[]>`
+    INSERT INTO contacts (canonical_name, role, organization_id)
+    VALUES (${name}, ${role}, ${organizationId})
+    RETURNING id
+  `;
+
+  return {
+    status: "created",
+    contact: {
+      id: Number(row.id),
+      canonicalName: name,
+      role,
+      organizationId,
+      organizationName: resolvedOrganizationName,
+    },
+  };
+}

--- a/src/lib/contacts/create.ts
+++ b/src/lib/contacts/create.ts
@@ -21,6 +21,10 @@ export interface CreateContactArgs {
   name: string;
   role?: string;
   organizationName?: string;
+  phone?: string;
+  email?: string;
+  linkedinUrl?: string;
+  photoUrl?: string;
 }
 
 export type CreateContactResult =
@@ -31,6 +35,10 @@ export async function createContact(db: Sql, args: CreateContactArgs): Promise<C
   const name = args.name.trim();
   const role = args.role?.trim() || null;
   const organizationName = args.organizationName?.trim() || null;
+  const phone = args.phone?.trim() || null;
+  const email = args.email?.trim() || null;
+  const linkedinUrl = args.linkedinUrl?.trim() || null;
+  const photoUrl = args.photoUrl?.trim() || null;
 
   let organizationId: number | null = null;
   let resolvedOrganizationName: string | null = null;
@@ -53,8 +61,8 @@ export async function createContact(db: Sql, args: CreateContactArgs): Promise<C
   }
 
   const [row] = await db<{ id: number | string }[]>`
-    INSERT INTO contacts (canonical_name, role, organization_id)
-    VALUES (${name}, ${role}, ${organizationId})
+    INSERT INTO contacts (canonical_name, role, organization_id, phone, email, linkedin_url, photo_url)
+    VALUES (${name}, ${role}, ${organizationId}, ${phone}, ${email}, ${linkedinUrl}, ${photoUrl})
     RETURNING id
   `;
 
@@ -66,6 +74,10 @@ export async function createContact(db: Sql, args: CreateContactArgs): Promise<C
       role,
       organizationId,
       organizationName: resolvedOrganizationName,
+      phone,
+      email,
+      linkedinUrl,
+      photoUrl,
     },
   };
 }

--- a/src/lib/contacts/outreach.ts
+++ b/src/lib/contacts/outreach.ts
@@ -1,0 +1,37 @@
+import type { Sql } from "../tools/types";
+
+export interface OutreachHistoryEntry {
+  id: number;
+  occurredAt: Date;
+  channel: string | null;
+  summary: string;
+  citation: string | null;
+}
+
+interface OutreachHistoryRow {
+  id: number | string;
+  occurred_at: Date;
+  channel: string | null;
+  summary: string;
+  citation: string | null;
+}
+
+function mapEntry(row: OutreachHistoryRow): OutreachHistoryEntry {
+  return {
+    id: Number(row.id),
+    occurredAt: row.occurred_at,
+    channel: row.channel,
+    summary: row.summary,
+    citation: row.citation,
+  };
+}
+
+export async function listOutreachHistory(db: Sql, contactId: number): Promise<OutreachHistoryEntry[]> {
+  const rows = await db<OutreachHistoryRow[]>`
+    SELECT id, occurred_at, channel, summary, citation
+    FROM outreach_history
+    WHERE contact_id = ${contactId}
+    ORDER BY occurred_at DESC
+  `;
+  return rows.map(mapEntry);
+}

--- a/src/lib/contacts/resolve.ts
+++ b/src/lib/contacts/resolve.ts
@@ -10,6 +10,10 @@ export interface ContactSummary {
   role: string | null;
   organizationId: number | null;
   organizationName: string | null;
+  phone: string | null;
+  email: string | null;
+  linkedinUrl: string | null;
+  photoUrl: string | null;
 }
 
 export type ContactResolution =
@@ -48,6 +52,10 @@ interface ContactRow {
   role: string | null;
   organization_id: number | string | null;
   organization_name: string | null;
+  phone: string | null;
+  email: string | null;
+  linkedin_url: string | null;
+  photo_url: string | null;
 }
 
 function mapContact(row: ContactRow): ContactSummary {
@@ -57,13 +65,17 @@ function mapContact(row: ContactRow): ContactSummary {
     role: row.role,
     organizationId: row.organization_id === null ? null : Number(row.organization_id),
     organizationName: row.organization_name,
+    phone: row.phone,
+    email: row.email,
+    linkedinUrl: row.linkedin_url,
+    photoUrl: row.photo_url,
   };
 }
 
 export async function resolveContact(db: Sql, name: string): Promise<ContactResolution> {
   const trimmed = name.trim();
   const rows = await db<ContactRow[]>`
-    SELECT c.id, c.canonical_name, c.role,
+    SELECT c.id, c.canonical_name, c.role, c.phone, c.email, c.linkedin_url, c.photo_url,
            o.id AS organization_id, o.name AS organization_name
     FROM contacts c
     LEFT JOIN organizations o ON o.id = c.organization_id

--- a/src/lib/contacts/resolve.ts
+++ b/src/lib/contacts/resolve.ts
@@ -1,0 +1,123 @@
+import type { Sql } from "../tools/types";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface ContactSummary {
+  id: number;
+  canonicalName: string;
+  role: string | null;
+  organizationId: number | null;
+  organizationName: string | null;
+}
+
+export type ContactResolution =
+  | { status: "found"; contact: ContactSummary }
+  | { status: "ambiguous"; candidates: ContactSummary[] }
+  | { status: "not_found" };
+
+export interface OrganizationSummary {
+  id: number;
+  name: string;
+  domain: string | null;
+}
+
+export interface OrganizationContact {
+  id: number;
+  canonicalName: string;
+  role: string | null;
+}
+
+export type OrganizationResolution =
+  | { status: "found"; organization: OrganizationSummary; contacts: OrganizationContact[] }
+  | { status: "ambiguous"; candidates: OrganizationSummary[] }
+  | { status: "not_found" };
+
+// ---------------------------------------------------------------------------
+// resolveContact — exact canonical-name or alias match only. No fuzzy/trigram
+// matching: a near-miss with zero exact match is "not_found", not a guess.
+// More than one exact match (shared name, or the same alias on two different
+// people) is "ambiguous" — the caller (harness doctrine) asks which one is
+// meant rather than the tool silently picking one.
+// ---------------------------------------------------------------------------
+
+interface ContactRow {
+  id: number | string;
+  canonical_name: string;
+  role: string | null;
+  organization_id: number | string | null;
+  organization_name: string | null;
+}
+
+function mapContact(row: ContactRow): ContactSummary {
+  return {
+    id: Number(row.id),
+    canonicalName: row.canonical_name,
+    role: row.role,
+    organizationId: row.organization_id === null ? null : Number(row.organization_id),
+    organizationName: row.organization_name,
+  };
+}
+
+export async function resolveContact(db: Sql, name: string): Promise<ContactResolution> {
+  const trimmed = name.trim();
+  const rows = await db<ContactRow[]>`
+    SELECT c.id, c.canonical_name, c.role,
+           o.id AS organization_id, o.name AS organization_name
+    FROM contacts c
+    LEFT JOIN organizations o ON o.id = c.organization_id
+    WHERE lower(c.canonical_name) = lower(${trimmed})
+       OR EXISTS (
+         SELECT 1 FROM contact_aliases a
+         WHERE a.contact_id = c.id AND lower(a.alias) = lower(${trimmed})
+       )
+    ORDER BY c.id
+  `;
+
+  if (rows.length === 0) return { status: "not_found" };
+  if (rows.length === 1) return { status: "found", contact: mapContact(rows[0]) };
+  return { status: "ambiguous", candidates: rows.map(mapContact) };
+}
+
+// ---------------------------------------------------------------------------
+// resolveOrganization — same exact-match-only policy. On a single match,
+// also returns the known contacts at that org (the "who do we know at
+// Company X" lookup).
+// ---------------------------------------------------------------------------
+
+interface OrgRow {
+  id: number | string;
+  name: string;
+  domain: string | null;
+}
+
+function mapOrg(row: OrgRow): OrganizationSummary {
+  return { id: Number(row.id), name: row.name, domain: row.domain };
+}
+
+export async function resolveOrganization(db: Sql, name: string): Promise<OrganizationResolution> {
+  const trimmed = name.trim();
+  const orgs = await db<OrgRow[]>`
+    SELECT id, name, domain FROM organizations
+    WHERE lower(name) = lower(${trimmed})
+    ORDER BY id
+  `;
+
+  if (orgs.length === 0) return { status: "not_found" };
+  if (orgs.length > 1) return { status: "ambiguous", candidates: orgs.map(mapOrg) };
+
+  const organization = mapOrg(orgs[0]);
+  const contactRows = await db<{ id: number | string; canonical_name: string; role: string | null }[]>`
+    SELECT id, canonical_name, role FROM contacts
+    WHERE organization_id = ${organization.id}
+    ORDER BY canonical_name
+  `;
+  const contacts: OrganizationContact[] = contactRows.map((r) => ({
+    id: Number(r.id),
+    canonicalName: r.canonical_name,
+    role: r.role,
+  }));
+
+  return { status: "found", organization, contacts };
+}

--- a/src/lib/contacts/resolve.ts
+++ b/src/lib/contacts/resolve.ts
@@ -96,18 +96,25 @@ function mapOrg(row: OrgRow): OrganizationSummary {
   return { id: Number(row.id), name: row.name, domain: row.domain };
 }
 
-export async function resolveOrganization(db: Sql, name: string): Promise<OrganizationResolution> {
+// Shared by resolveOrganization and createContact — both need "does an org with
+// exactly this name already exist" without duplicating the query/mapping.
+export async function findOrganizationsByExactName(db: Sql, name: string): Promise<OrganizationSummary[]> {
   const trimmed = name.trim();
-  const orgs = await db<OrgRow[]>`
+  const rows = await db<OrgRow[]>`
     SELECT id, name, domain FROM organizations
     WHERE lower(name) = lower(${trimmed})
     ORDER BY id
   `;
+  return rows.map(mapOrg);
+}
+
+export async function resolveOrganization(db: Sql, name: string): Promise<OrganizationResolution> {
+  const orgs = await findOrganizationsByExactName(db, name);
 
   if (orgs.length === 0) return { status: "not_found" };
-  if (orgs.length > 1) return { status: "ambiguous", candidates: orgs.map(mapOrg) };
+  if (orgs.length > 1) return { status: "ambiguous", candidates: orgs };
 
-  const organization = mapOrg(orgs[0]);
+  const organization = orgs[0];
   const contactRows = await db<{ id: number | string; canonical_name: string; role: string | null }[]>`
     SELECT id, canonical_name, role FROM contacts
     WHERE organization_id = ${organization.id}

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -50,6 +50,8 @@ export const SOURCING_DOCTRINE_SECTION: SystemPromptSection = {
     "- When work produces something durable — an outcome, a correction, a relationship fact — record it as a note; chat is not memory.",
     "- When live web evidence contradicts memory about a Contact's current role or company, trust the fresher source, flag the stale memory as a Knowledge Gap, and record the correction.",
     "- Outreach drafts are deliverables for the Director's review — direct, useful, human, and personalized only with professionally relevant facts (a draft that shows off research the Contact didn't share reads as surveillance and loses the reply); sending is always the Director's act.",
+    "- When the Director introduces a new connection, gather their name, role, and organization before recording them as a Contact — ask for whichever of the three is missing rather than saving a thin record silently; if the Director genuinely doesn't know one, save it anyway and let it show as a gap rather than blocking on it.",
+    "- When looking up a Contact or Organization returns more than one match, ask which one is meant before continuing — two people or two organizations sharing a name is genuine ambiguity, and a wrong guess here means acting on, or recording history against, the wrong person.",
   ].join("\n"),
 };
 

--- a/src/lib/memory/answer-config.ts
+++ b/src/lib/memory/answer-config.ts
@@ -2,7 +2,9 @@ import { createToolRegistry } from "../tools/registry";
 import type { ToolRegistry } from "../tools/registry";
 import { searchMemoryTool } from "../tools/search-memory";
 import { addMemoryNoteTool } from "../tools/add-memory-note";
+import { getContactTool } from "../tools/get-contact";
+import { getOrganizationTool } from "../tools/get-organization";
 
 export function memoryRegistry(): ToolRegistry {
-  return createToolRegistry([searchMemoryTool, addMemoryNoteTool]);
+  return createToolRegistry([searchMemoryTool, addMemoryNoteTool, getContactTool, getOrganizationTool]);
 }

--- a/src/lib/memory/answer-config.ts
+++ b/src/lib/memory/answer-config.ts
@@ -4,7 +4,14 @@ import { searchMemoryTool } from "../tools/search-memory";
 import { addMemoryNoteTool } from "../tools/add-memory-note";
 import { getContactTool } from "../tools/get-contact";
 import { getOrganizationTool } from "../tools/get-organization";
+import { createContactTool } from "../tools/create-contact";
 
 export function memoryRegistry(): ToolRegistry {
-  return createToolRegistry([searchMemoryTool, addMemoryNoteTool, getContactTool, getOrganizationTool]);
+  return createToolRegistry([
+    searchMemoryTool,
+    addMemoryNoteTool,
+    getContactTool,
+    getOrganizationTool,
+    createContactTool,
+  ]);
 }

--- a/src/lib/memory/answer-config.ts
+++ b/src/lib/memory/answer-config.ts
@@ -5,6 +5,7 @@ import { addMemoryNoteTool } from "../tools/add-memory-note";
 import { getContactTool } from "../tools/get-contact";
 import { getOrganizationTool } from "../tools/get-organization";
 import { createContactTool } from "../tools/create-contact";
+import { listOutreachHistoryTool } from "../tools/list-outreach-history";
 
 export function memoryRegistry(): ToolRegistry {
   return createToolRegistry([
@@ -13,5 +14,6 @@ export function memoryRegistry(): ToolRegistry {
     getContactTool,
     getOrganizationTool,
     createContactTool,
+    listOutreachHistoryTool,
   ]);
 }

--- a/src/lib/memory/answer.ts
+++ b/src/lib/memory/answer.ts
@@ -87,6 +87,37 @@ export interface ChatStepPart {
   thought?: string;
   ok: boolean;
   detail: string;
+  // The three fields below carry structured data alongside `detail`'s prose
+  // summary, so the Contact Profile Card (B1.6) can render get_contact,
+  // list_outreach_history, and search_memory results from the same step
+  // stream without re-parsing raw tool JSON in the browser. Populated only
+  // for their respective tools; absent for every other tool and for
+  // get_contact results that are ambiguous or not_found.
+  contactCard?: ContactCardPart;
+  outreachHistory?: OutreachHistoryPart[];
+  memoryFacts?: MemoryFactPart[];
+}
+
+export interface ContactCardPart {
+  id: number;
+  canonicalName: string;
+  role: string | null;
+  organizationName: string | null;
+}
+
+export interface OutreachHistoryPart {
+  occurredAt: string;
+  channel: string | null;
+  summary: string;
+  citation: string | null;
+}
+
+export interface MemoryFactPart {
+  subject: string;
+  predicate: string;
+  object: string;
+  citation: string | null;
+  status: string;
 }
 
 export function summarizeStep(event: AgentStepEvent): ChatStepPart {
@@ -96,7 +127,48 @@ export function summarizeStep(event: AgentStepEvent): ChatStepPart {
     thought: event.thought,
     ok: event.ok,
     detail: describeObservation(event),
+    ...extractStructuredData(event),
   };
+}
+
+function extractStructuredData(
+  event: AgentStepEvent
+): Pick<ChatStepPart, "contactCard" | "outreachHistory" | "memoryFacts"> {
+  if (!event.ok) return {};
+  const payload = event.observation.replace(/^Success:\s*/, "");
+
+  if (event.tool === "get_contact") {
+    try {
+      const r = JSON.parse(payload) as { status?: string; contact?: ContactCardPart };
+      if (r.status === "found" && r.contact) return { contactCard: r.contact };
+    } catch {
+      // Malformed payload — no card rather than a crash.
+    }
+    return {};
+  }
+
+  if (event.tool === "list_outreach_history") {
+    try {
+      const entries = JSON.parse(payload) as OutreachHistoryPart[];
+      if (Array.isArray(entries)) return { outreachHistory: entries };
+    } catch {
+      // Malformed payload — no history rather than a crash.
+    }
+    return {};
+  }
+
+  if (event.tool === "search_memory") {
+    try {
+      const r = JSON.parse(payload) as { acceptedFacts?: MemoryFactPart[]; gapFacts?: MemoryFactPart[] };
+      const facts = [...(r.acceptedFacts ?? []), ...(r.gapFacts ?? [])];
+      if (facts.length > 0) return { memoryFacts: facts };
+    } catch {
+      // Malformed payload — no facts rather than a crash.
+    }
+    return {};
+  }
+
+  return {};
 }
 
 function describeObservation(event: AgentStepEvent): string {

--- a/src/lib/memory/answer.ts
+++ b/src/lib/memory/answer.ts
@@ -103,6 +103,10 @@ export interface ContactCardPart {
   canonicalName: string;
   role: string | null;
   organizationName: string | null;
+  phone: string | null;
+  email: string | null;
+  linkedinUrl: string | null;
+  photoUrl: string | null;
 }
 
 export interface OutreachHistoryPart {

--- a/src/lib/tools/create-contact.ts
+++ b/src/lib/tools/create-contact.ts
@@ -3,14 +3,23 @@ import { createContact, type CreateContactResult } from "../contacts/create";
 import type { Tool } from "./types";
 
 export const createContactTool: Tool<
-  { name: string; role?: string; organizationName?: string },
+  {
+    name: string;
+    role?: string;
+    organizationName?: string;
+    phone?: string;
+    email?: string;
+    linkedinUrl?: string;
+    photoUrl?: string;
+  },
   CreateContactResult
 > = {
   name: "create_contact",
   description:
     "Record a new Contact (a new connection). Only name is required; role and organizationName " +
     "should be gathered from the Director before calling this when possible, since a missing field " +
-    "becomes a visible gap on the Contact Profile Card rather than blocking the write. Returns " +
+    "becomes a visible gap on the Contact Profile Card rather than blocking the write. phone, email, " +
+    "linkedinUrl, and photoUrl are also optional and render on the card when known. Returns " +
     "{ status: 'created', contact } or { status: 'ambiguous_organization', candidates } if " +
     "organizationName matches more than one existing Organization, in which case ask which one is " +
     "meant and call again rather than guessing.",
@@ -19,6 +28,10 @@ export const createContactTool: Tool<
     name: z.string().min(1),
     role: z.string().min(1).optional(),
     organizationName: z.string().min(1).optional(),
+    phone: z.string().min(1).optional(),
+    email: z.string().min(1).optional(),
+    linkedinUrl: z.string().min(1).optional(),
+    photoUrl: z.string().min(1).optional(),
   }),
   async execute(args, ctx) {
     return createContact(ctx.db, args);

--- a/src/lib/tools/create-contact.ts
+++ b/src/lib/tools/create-contact.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+import { createContact, type CreateContactResult } from "../contacts/create";
+import type { Tool } from "./types";
+
+export const createContactTool: Tool<
+  { name: string; role?: string; organizationName?: string },
+  CreateContactResult
+> = {
+  name: "create_contact",
+  description:
+    "Record a new Contact (a new connection). Only name is required; role and organizationName " +
+    "should be gathered from the Director before calling this when possible, since a missing field " +
+    "becomes a visible gap on the Contact Profile Card rather than blocking the write. Returns " +
+    "{ status: 'created', contact } or { status: 'ambiguous_organization', candidates } if " +
+    "organizationName matches more than one existing Organization, in which case ask which one is " +
+    "meant and call again rather than guessing.",
+  permissionClass: "write_internal",
+  argsSchema: z.object({
+    name: z.string().min(1),
+    role: z.string().min(1).optional(),
+    organizationName: z.string().min(1).optional(),
+  }),
+  async execute(args, ctx) {
+    return createContact(ctx.db, args);
+  },
+};

--- a/src/lib/tools/get-contact.ts
+++ b/src/lib/tools/get-contact.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+import { resolveContact, type ContactResolution } from "../contacts/resolve";
+import type { Tool } from "./types";
+
+export const getContactTool: Tool<{ name: string }, ContactResolution> = {
+  name: "get_contact",
+  description:
+    "Look up a Contact by name. Returns { status: 'found', contact } on an unambiguous match, " +
+    "{ status: 'ambiguous', candidates } when the name matches more than one Contact (ask which " +
+    "one before continuing), or { status: 'not_found' }. Never guesses between candidates.",
+  permissionClass: "read",
+  argsSchema: z.object({ name: z.string().min(1) }),
+  async execute(args, ctx) {
+    return resolveContact(ctx.db, args.name);
+  },
+};

--- a/src/lib/tools/get-organization.ts
+++ b/src/lib/tools/get-organization.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+import { resolveOrganization, type OrganizationResolution } from "../contacts/resolve";
+import type { Tool } from "./types";
+
+export const getOrganizationTool: Tool<{ name: string }, OrganizationResolution> = {
+  name: "get_organization",
+  description:
+    "Look up an Organization by name. Returns { status: 'found', organization, contacts } with " +
+    "every known Contact at that org on an unambiguous match, { status: 'ambiguous', candidates } " +
+    "when the name matches more than one Organization, or { status: 'not_found' }.",
+  permissionClass: "read",
+  argsSchema: z.object({ name: z.string().min(1) }),
+  async execute(args, ctx) {
+    return resolveOrganization(ctx.db, args.name);
+  },
+};

--- a/src/lib/tools/list-outreach-history.ts
+++ b/src/lib/tools/list-outreach-history.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+import { listOutreachHistory, type OutreachHistoryEntry } from "../contacts/outreach";
+import type { Tool } from "./types";
+
+export const listOutreachHistoryTool: Tool<{ contactId: number }, OutreachHistoryEntry[]> = {
+  name: "list_outreach_history",
+  description:
+    "List a Contact's past interaction timeline (most recent first), given the contactId from a " +
+    "prior get_contact call. Returns an empty array when there is no recorded history yet, not an error.",
+  permissionClass: "read",
+  argsSchema: z.object({ contactId: z.number().int().positive() }),
+  async execute(args, ctx) {
+    return listOutreachHistory(ctx.db, args.contactId);
+  },
+};

--- a/src/migrations/006_contacts.sql
+++ b/src/migrations/006_contacts.sql
@@ -1,0 +1,36 @@
+-- 006_contacts.sql — B1: Organizations & Contacts + identity resolution.
+-- canonical_name is required; role and organization_id are not — a contact created from
+-- a thin mention is a known gap (rendered as such on the Contact Profile Card), not a
+-- blocked write. canonical_name and alias are deliberately NOT unique: two different real
+-- people can share a name, and the same alias can point at two different contacts — that
+-- ambiguity is resolved by get_contact (B1.2), never hidden by a schema constraint.
+
+CREATE TABLE IF NOT EXISTS organizations (
+  id             BIGSERIAL PRIMARY KEY,
+  name           TEXT NOT NULL,
+  domain         TEXT,
+  notes          TEXT,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS contacts (
+  id              BIGSERIAL PRIMARY KEY,
+  canonical_name  TEXT NOT NULL,
+  role            TEXT,
+  organization_id BIGINT REFERENCES organizations(id) ON DELETE SET NULL,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS contact_aliases (
+  id          BIGSERIAL PRIMARY KEY,
+  contact_id  BIGINT NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+  alias       TEXT NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (contact_id, alias)
+);
+
+CREATE INDEX IF NOT EXISTS contacts_organization_idx ON contacts(organization_id);
+CREATE INDEX IF NOT EXISTS contacts_canonical_name_idx ON contacts(lower(canonical_name));
+CREATE INDEX IF NOT EXISTS contact_aliases_alias_idx ON contact_aliases(lower(alias));

--- a/src/migrations/007_outreach_history.sql
+++ b/src/migrations/007_outreach_history.sql
@@ -1,0 +1,17 @@
+-- 007_outreach_history.sql — B1.4: relationship timeline, pulled forward from B3.
+-- A row records one past interaction with a Contact. occurred_at and summary are
+-- required (a history entry without either isn't useful on the profile card);
+-- channel and citation are optional, since a manually recalled conversation may
+-- have neither a clear channel label nor a source document behind it.
+
+CREATE TABLE IF NOT EXISTS outreach_history (
+  id           BIGSERIAL PRIMARY KEY,
+  contact_id   BIGINT NOT NULL REFERENCES contacts(id) ON DELETE CASCADE,
+  occurred_at  TIMESTAMPTZ NOT NULL,
+  channel      TEXT,
+  summary      TEXT NOT NULL,
+  citation     TEXT,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS outreach_history_contact_idx ON outreach_history(contact_id, occurred_at DESC);

--- a/src/migrations/008_contact_details.sql
+++ b/src/migrations/008_contact_details.sql
@@ -1,0 +1,11 @@
+-- 008_contact_details.sql — B1.9: contact detail fields for the Profile Card.
+-- All four are optional, same gap-not-blocker treatment as role/organization_id
+-- in 006_contacts.sql. photo_url is a plain URL for now — auto-populating it
+-- from a confirmed LinkedIn match is C3's job (guided data-collection workflow),
+-- not this migration's.
+
+ALTER TABLE contacts
+  ADD COLUMN IF NOT EXISTS phone        TEXT,
+  ADD COLUMN IF NOT EXISTS email        TEXT,
+  ADD COLUMN IF NOT EXISTS linkedin_url TEXT,
+  ADD COLUMN IF NOT EXISTS photo_url    TEXT;

--- a/tests/chat-stream.test.ts
+++ b/tests/chat-stream.test.ts
@@ -1,5 +1,5 @@
 import { vi } from "vitest";
-import { applyChunk, drainSse, runChat, type AssistantTurn } from "@/app/chat/stream";
+import { applyChunk, drainSse, runChat, selectContactCard, type AssistantTurn, type ChatStep } from "@/app/chat/stream";
 
 const empty: AssistantTurn = { steps: [], answer: "" };
 
@@ -122,5 +122,58 @@ describe("runChat", () => {
     );
     const turn = await runChat("hi", [], () => {});
     expect(turn.answer).toBe("Hi");
+  });
+});
+
+describe("selectContactCard", () => {
+  const contactStep: ChatStep = {
+    index: 1,
+    tool: "get_contact",
+    ok: true,
+    detail: "found",
+    contactCard: { id: 1, canonicalName: "Jane Smith", role: "PM", organizationName: "Acme" },
+  };
+
+  it("returns undefined when no step has a contactCard", () => {
+    expect(selectContactCard([{ index: 1, tool: "search_memory", ok: true, detail: "0 facts, 0 chunks" }])).toBeUndefined();
+  });
+
+  it("returns the contact alone, with empty arrays, when no history/facts steps are present", () => {
+    const view = selectContactCard([contactStep]);
+    expect(view).toEqual({
+      contact: contactStep.contactCard,
+      history: [],
+      acceptedFacts: [],
+      gapFacts: [],
+    });
+  });
+
+  it("merges in outreach history and splits memoryFacts into accepted vs gap by status", () => {
+    const historyStep: ChatStep = {
+      index: 2,
+      tool: "list_outreach_history",
+      ok: true,
+      detail: "1 entry",
+      outreachHistory: [{ occurredAt: "2026-01-01T00:00:00.000Z", channel: "email", summary: "Intro", citation: null }],
+    };
+    const factsStep: ChatStep = {
+      index: 3,
+      tool: "search_memory",
+      ok: true,
+      detail: "2 facts, 0 chunks",
+      memoryFacts: [
+        { subject: "Jane", predicate: "role", object: "PM", citation: "c1", status: "accepted" },
+        { subject: "Jane", predicate: "last_contacted", object: "unknown", citation: null, status: "candidate" },
+      ],
+    };
+
+    const view = selectContactCard([contactStep, historyStep, factsStep]);
+    expect(view?.history).toHaveLength(1);
+    expect(view?.acceptedFacts).toEqual([
+      { subject: "Jane", predicate: "role", object: "PM", citation: "c1", status: "accepted" },
+    ]);
+    expect(view?.gapFacts).toEqual([
+      { subject: "Jane", predicate: "last_contacted", object: "unknown", citation: null, status: "candidate" },
+    ]);
   });
 });

--- a/tests/chat-stream.test.ts
+++ b/tests/chat-stream.test.ts
@@ -131,7 +131,16 @@ describe("selectContactCard", () => {
     tool: "get_contact",
     ok: true,
     detail: "found",
-    contactCard: { id: 1, canonicalName: "Jane Smith", role: "PM", organizationName: "Acme" },
+    contactCard: {
+      id: 1,
+      canonicalName: "Jane Smith",
+      role: "PM",
+      organizationName: "Acme",
+      phone: null,
+      email: null,
+      linkedinUrl: null,
+      photoUrl: null,
+    },
   };
 
   it("returns undefined when no step has a contactCard", () => {

--- a/tests/components/ChatClient.test.tsx
+++ b/tests/components/ChatClient.test.tsx
@@ -4,7 +4,12 @@ import { vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 const { runChatMock } = vi.hoisted(() => ({ runChatMock: vi.fn() }));
-vi.mock("@/app/chat/stream", () => ({ runChat: runChatMock }));
+vi.mock("@/app/chat/stream", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/app/chat/stream")>();
+  // Only runChat is mocked — selectContactCard stays real (it's pure) so
+  // ChatClient's card-selection logic isn't silently skipped in these tests.
+  return { ...actual, runChat: runChatMock };
+});
 
 import { ChatClient } from "@/app/chat/ChatClient";
 

--- a/tests/components/ContactProfileCard.test.tsx
+++ b/tests/components/ContactProfileCard.test.tsx
@@ -5,7 +5,16 @@ import { ContactProfileCard } from "@/app/chat/ContactProfileCard";
 import type { ContactCardView } from "@/app/chat/stream";
 
 const baseView: ContactCardView = {
-  contact: { id: 1, canonicalName: "Jane Smith", role: "PM", organizationName: "Acme Corp" },
+  contact: {
+    id: 1,
+    canonicalName: "Jane Smith",
+    role: "PM",
+    organizationName: "Acme Corp",
+    phone: null,
+    email: null,
+    linkedinUrl: null,
+    photoUrl: null,
+  },
   history: [],
   acceptedFacts: [],
   gapFacts: [],
@@ -22,7 +31,16 @@ describe("ContactProfileCard", () => {
   it("shows a gap indicator instead of hiding missing role/org", () => {
     render(
       <ContactProfileCard
-        contact={{ id: 1, canonicalName: "Thin Record", role: null, organizationName: null }}
+        contact={{
+          id: 1,
+          canonicalName: "Thin Record",
+          role: null,
+          organizationName: null,
+          phone: null,
+          email: null,
+          linkedinUrl: null,
+          photoUrl: null,
+        }}
         history={[]}
         acceptedFacts={[]}
         gapFacts={[]}

--- a/tests/components/ContactProfileCard.test.tsx
+++ b/tests/components/ContactProfileCard.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { ContactProfileCard } from "@/app/chat/ContactProfileCard";
+import type { ContactCardView } from "@/app/chat/stream";
+
+const baseView: ContactCardView = {
+  contact: { id: 1, canonicalName: "Jane Smith", role: "PM", organizationName: "Acme Corp" },
+  history: [],
+  acceptedFacts: [],
+  gapFacts: [],
+};
+
+describe("ContactProfileCard", () => {
+  it("renders identity", () => {
+    render(<ContactProfileCard {...baseView} />);
+    expect(screen.getByText("Jane Smith")).toBeInTheDocument();
+    expect(screen.getByText(/PM/)).toBeInTheDocument();
+    expect(screen.getByText(/Acme Corp/)).toBeInTheDocument();
+  });
+
+  it("shows a gap indicator instead of hiding missing role/org", () => {
+    render(
+      <ContactProfileCard
+        contact={{ id: 1, canonicalName: "Thin Record", role: null, organizationName: null }}
+        history={[]}
+        acceptedFacts={[]}
+        gapFacts={[]}
+      />,
+    );
+    expect(screen.getByText(/Role not yet known/)).toBeInTheDocument();
+    expect(screen.getByText(/Organization not yet known/)).toBeInTheDocument();
+  });
+
+  it("shows a no-history message when there is no recorded interaction", () => {
+    render(<ContactProfileCard {...baseView} />);
+    expect(screen.getByText("No recorded interactions yet.")).toBeInTheDocument();
+  });
+
+  it("renders the relationship timeline when history is present", () => {
+    render(
+      <ContactProfileCard
+        {...baseView}
+        history={[
+          { occurredAt: "2026-01-01T00:00:00.000Z", channel: "email", summary: "First outreach", citation: null },
+        ]}
+      />,
+    );
+    expect(screen.getByText("First outreach")).toBeInTheDocument();
+    expect(screen.getByText("email")).toBeInTheDocument();
+  });
+
+  it("renders key facts and knowledge gaps in separate sections", () => {
+    render(
+      <ContactProfileCard
+        {...baseView}
+        acceptedFacts={[{ subject: "Jane", predicate: "role", object: "PM", citation: "c1", status: "accepted" }]}
+        gapFacts={[{ subject: "Jane", predicate: "last_contacted", object: "unknown", citation: null, status: "candidate" }]}
+      />,
+    );
+    expect(screen.getByText("Key facts")).toBeInTheDocument();
+    expect(screen.getByText("Knowledge gaps")).toBeInTheDocument();
+    expect(screen.getByText(/Jane role PM/)).toBeInTheDocument();
+    expect(screen.getByText(/Jane last_contacted unknown/)).toBeInTheDocument();
+  });
+
+  it("omits the key facts / knowledge gaps sections when there are none", () => {
+    render(<ContactProfileCard {...baseView} />);
+    expect(screen.queryByText("Key facts")).not.toBeInTheDocument();
+    expect(screen.queryByText("Knowledge gaps")).not.toBeInTheDocument();
+  });
+});

--- a/tests/components/ContactProfileCard.test.tsx
+++ b/tests/components/ContactProfileCard.test.tsx
@@ -87,4 +87,60 @@ describe("ContactProfileCard", () => {
     expect(screen.queryByText("Key facts")).not.toBeInTheDocument();
     expect(screen.queryByText("Knowledge gaps")).not.toBeInTheDocument();
   });
+
+  it("drops a fact's subject when it's just restating the contact's own name", () => {
+    render(
+      <ContactProfileCard
+        {...baseView}
+        acceptedFacts={[
+          { subject: "Jane Smith", predicate: "role", object: "Engineering Manager at Acme Corp", citation: "c1", status: "accepted" },
+        ]}
+      />,
+    );
+    expect(screen.getByText(/Engineering Manager at Acme Corp/)).toBeInTheDocument();
+    expect(screen.queryByText(/Jane Smith role/)).not.toBeInTheDocument();
+  });
+
+  it("keeps a fact's subject when it's about someone/something else", () => {
+    render(
+      <ContactProfileCard
+        {...baseView}
+        acceptedFacts={[{ subject: "Acme Corp", predicate: "founded", object: "2015", citation: "c1", status: "accepted" }]}
+      />,
+    );
+    expect(screen.getByText(/Acme Corp founded 2015/)).toBeInTheDocument();
+  });
+
+  it("shows contact details when present, and gap placeholders when missing", () => {
+    render(<ContactProfileCard {...baseView} />);
+    expect(screen.getByText(/Phone not yet known/)).toBeInTheDocument();
+    expect(screen.getByText(/Email not yet known/)).toBeInTheDocument();
+    expect(screen.getByText(/LinkedIn not yet known/)).toBeInTheDocument();
+  });
+
+  it("renders phone, email, and a working LinkedIn link when known", () => {
+    render(
+      <ContactProfileCard
+        {...baseView}
+        contact={{ ...baseView.contact, phone: "555-0100", email: "jane@acme.com", linkedinUrl: "https://linkedin.com/in/janesmith" }}
+      />,
+    );
+    expect(screen.getByText("555-0100")).toBeInTheDocument();
+    expect(screen.getByText("jane@acme.com")).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /linkedin/i });
+    expect(link).toHaveAttribute("href", "https://linkedin.com/in/janesmith");
+  });
+
+  it("renders a photo when photoUrl is set, and initials otherwise", () => {
+    const { rerender } = render(<ContactProfileCard {...baseView} />);
+    expect(screen.getByText("JS")).toBeInTheDocument();
+
+    rerender(
+      <ContactProfileCard
+        {...baseView}
+        contact={{ ...baseView.contact, photoUrl: "https://example.com/jane.jpg" }}
+      />,
+    );
+    expect(screen.getByRole("img", { name: "Jane Smith" })).toHaveAttribute("src", "https://example.com/jane.jpg");
+  });
 });

--- a/tests/contact-details-migrate.test.ts
+++ b/tests/contact-details-migrate.test.ts
@@ -1,0 +1,57 @@
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+
+async function resetContactTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS outreach_history CASCADE`;
+  await db`DROP TABLE IF EXISTS contact_aliases CASCADE`;
+  await db`DROP TABLE IF EXISTS contacts CASCADE`;
+  await db`DROP TABLE IF EXISTS organizations CASCADE`;
+  await db`DELETE FROM schema_migrations WHERE name IN ('006_contacts.sql', '007_outreach_history.sql', '008_contact_details.sql')`;
+  await runMigrations(db);
+}
+
+describe("008 contact_details migration", () => {
+  beforeEach(async () => {
+    await resetContactTables();
+  });
+
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("adds phone, email, linkedin_url, and photo_url to contacts, all optional", async () => {
+    const db = getDb();
+    const [row] = await db<{
+      phone: string | null;
+      email: string | null;
+      linkedin_url: string | null;
+      photo_url: string | null;
+    }[]>`
+      INSERT INTO contacts (canonical_name) VALUES ('Jane Smith')
+      RETURNING phone, email, linkedin_url, photo_url
+    `;
+    expect(row.phone).toBeNull();
+    expect(row.email).toBeNull();
+    expect(row.linkedin_url).toBeNull();
+    expect(row.photo_url).toBeNull();
+  });
+
+  it("stores all four fields when provided", async () => {
+    const db = getDb();
+    const [row] = await db<{
+      phone: string | null;
+      email: string | null;
+      linkedin_url: string | null;
+      photo_url: string | null;
+    }[]>`
+      INSERT INTO contacts (canonical_name, phone, email, linkedin_url, photo_url)
+      VALUES ('Jane Smith', '555-0100', 'jane@acme.com', 'https://linkedin.com/in/janesmith', 'https://example.com/jane.jpg')
+      RETURNING phone, email, linkedin_url, photo_url
+    `;
+    expect(row.phone).toBe("555-0100");
+    expect(row.email).toBe("jane@acme.com");
+    expect(row.linkedin_url).toBe("https://linkedin.com/in/janesmith");
+    expect(row.photo_url).toBe("https://example.com/jane.jpg");
+  });
+});

--- a/tests/contacts-create.test.ts
+++ b/tests/contacts-create.test.ts
@@ -7,7 +7,7 @@ async function resetContactTables(): Promise<void> {
   await db`DROP TABLE IF EXISTS contact_aliases CASCADE`;
   await db`DROP TABLE IF EXISTS contacts CASCADE`;
   await db`DROP TABLE IF EXISTS organizations CASCADE`;
-  await db`DELETE FROM schema_migrations WHERE name = '006_contacts.sql'`;
+  await db`DELETE FROM schema_migrations WHERE name IN ('006_contacts.sql', '007_outreach_history.sql', '008_contact_details.sql')`;
   await runMigrations(db);
 }
 

--- a/tests/contacts-create.test.ts
+++ b/tests/contacts-create.test.ts
@@ -1,0 +1,80 @@
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+import { createContact } from "@/lib/contacts/create";
+
+async function resetContactTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS contact_aliases CASCADE`;
+  await db`DROP TABLE IF EXISTS contacts CASCADE`;
+  await db`DROP TABLE IF EXISTS organizations CASCADE`;
+  await db`DELETE FROM schema_migrations WHERE name = '006_contacts.sql'`;
+  await runMigrations(db);
+}
+
+describe("createContact", () => {
+  beforeEach(async () => {
+    await resetContactTables();
+  });
+
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("creates a contact with only a name — role and org are gaps (null), not blockers", async () => {
+    const result = await createContact(getDb(), { name: "Thin Record" });
+    expect(result.status).toBe("created");
+    if (result.status === "created") {
+      expect(result.contact.canonicalName).toBe("Thin Record");
+      expect(result.contact.role).toBeNull();
+      expect(result.contact.organizationId).toBeNull();
+      expect(result.contact.organizationName).toBeNull();
+    }
+  });
+
+  it("creates a new organization when the named org doesn't exist yet", async () => {
+    const db = getDb();
+    const result = await createContact(db, { name: "Jane Smith", role: "PM", organizationName: "Brand New Co" });
+    expect(result.status).toBe("created");
+    if (result.status === "created") {
+      expect(result.contact.organizationName).toBe("Brand New Co");
+      expect(result.contact.organizationId).not.toBeNull();
+    }
+    const orgs = await db`SELECT count(*) FROM organizations WHERE name = 'Brand New Co'`;
+    expect(Number(orgs[0].count)).toBe(1);
+  });
+
+  it("reuses an existing organization instead of creating a duplicate", async () => {
+    const db = getDb();
+    const [org] = await db<{ id: number }[]>`INSERT INTO organizations (name) VALUES ('Acme Corp') RETURNING id`;
+
+    const result = await createContact(db, { name: "Jane Smith", organizationName: "acme corp" });
+    expect(result.status).toBe("created");
+    if (result.status === "created") {
+      expect(result.contact.organizationId).toBe(Number(org.id));
+    }
+    const orgs = await db`SELECT count(*) FROM organizations WHERE lower(name) = 'acme corp'`;
+    expect(Number(orgs[0].count)).toBe(1);
+  });
+
+  it("refuses to write and returns ambiguous_organization when the org name matches two existing orgs", async () => {
+    const db = getDb();
+    await db`INSERT INTO organizations (name) VALUES ('Acme Corp')`;
+    await db`INSERT INTO organizations (name) VALUES ('Acme Corp')`;
+
+    const result = await createContact(db, { name: "Jane Smith", organizationName: "Acme Corp" });
+    expect(result.status).toBe("ambiguous_organization");
+    if (result.status === "ambiguous_organization") {
+      expect(result.candidates).toHaveLength(2);
+    }
+    const contacts = await db`SELECT count(*) FROM contacts`;
+    expect(Number(contacts[0].count)).toBe(0);
+  });
+
+  it("two contacts of the same name can both be created — no dedup/merge on write", async () => {
+    const db = getDb();
+    await createContact(db, { name: "Jane Smith" });
+    await createContact(db, { name: "Jane Smith" });
+    const rows = await db`SELECT id FROM contacts WHERE canonical_name = 'Jane Smith'`;
+    expect(rows).toHaveLength(2);
+  });
+});

--- a/tests/contacts-create.test.ts
+++ b/tests/contacts-create.test.ts
@@ -31,6 +31,37 @@ describe("createContact", () => {
     }
   });
 
+  it("creates a contact with only a name — phone, email, linkedin, photo are gaps (null) too", async () => {
+    const result = await createContact(getDb(), { name: "Thin Record" });
+    expect(result.status).toBe("created");
+    if (result.status === "created") {
+      expect(result.contact.phone).toBeNull();
+      expect(result.contact.email).toBeNull();
+      expect(result.contact.linkedinUrl).toBeNull();
+      expect(result.contact.photoUrl).toBeNull();
+    }
+  });
+
+  it("stores phone, email, linkedinUrl, and photoUrl when provided", async () => {
+    const db = getDb();
+    const result = await createContact(db, {
+      name: "Jane Smith",
+      phone: "555-0100",
+      email: "jane@acme.com",
+      linkedinUrl: "https://linkedin.com/in/janesmith",
+      photoUrl: "https://example.com/jane.jpg",
+    });
+    expect(result.status).toBe("created");
+    if (result.status === "created") {
+      expect(result.contact.phone).toBe("555-0100");
+      expect(result.contact.email).toBe("jane@acme.com");
+      expect(result.contact.linkedinUrl).toBe("https://linkedin.com/in/janesmith");
+      expect(result.contact.photoUrl).toBe("https://example.com/jane.jpg");
+    }
+    const [row] = await db<{ phone: string | null }[]>`SELECT phone FROM contacts WHERE canonical_name = 'Jane Smith'`;
+    expect(row.phone).toBe("555-0100");
+  });
+
   it("creates a new organization when the named org doesn't exist yet", async () => {
     const db = getDb();
     const result = await createContact(db, { name: "Jane Smith", role: "PM", organizationName: "Brand New Co" });

--- a/tests/contacts-migrate.test.ts
+++ b/tests/contacts-migrate.test.ts
@@ -6,7 +6,7 @@ async function resetContactTables(): Promise<void> {
   await db`DROP TABLE IF EXISTS contact_aliases CASCADE`;
   await db`DROP TABLE IF EXISTS contacts CASCADE`;
   await db`DROP TABLE IF EXISTS organizations CASCADE`;
-  await db`DELETE FROM schema_migrations WHERE name = '006_contacts.sql'`;
+  await db`DELETE FROM schema_migrations WHERE name IN ('006_contacts.sql', '007_outreach_history.sql', '008_contact_details.sql')`;
   await runMigrations(db);
 }
 

--- a/tests/contacts-migrate.test.ts
+++ b/tests/contacts-migrate.test.ts
@@ -1,0 +1,116 @@
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+
+async function resetContactTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS contact_aliases CASCADE`;
+  await db`DROP TABLE IF EXISTS contacts CASCADE`;
+  await db`DROP TABLE IF EXISTS organizations CASCADE`;
+  await db`DELETE FROM schema_migrations WHERE name = '006_contacts.sql'`;
+  await runMigrations(db);
+}
+
+describe("006 contacts migration", () => {
+  beforeEach(async () => {
+    await resetContactTables();
+  });
+
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("creates organizations, contacts, and contact_aliases", async () => {
+    const db = getDb();
+    const result = await db<{ table_name: string }[]>`
+      SELECT table_name FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name IN ('organizations', 'contacts', 'contact_aliases')
+      ORDER BY table_name
+    `;
+    expect(result.map((r) => r.table_name)).toEqual(["contact_aliases", "contacts", "organizations"]);
+  });
+
+  it("contacts.canonical_name is required", async () => {
+    const db = getDb();
+    await expect(
+      db`INSERT INTO contacts (canonical_name) VALUES (${null})`
+    ).rejects.toThrow();
+  });
+
+  it("a contact can be created with only a name — role and organization are optional (gaps, not blockers)", async () => {
+    const db = getDb();
+    const [contact] = await db<{ id: number; role: string | null; organization_id: number | null }[]>`
+      INSERT INTO contacts (canonical_name) VALUES ('Jane Smith') RETURNING id, role, organization_id
+    `;
+    expect(contact.role).toBeNull();
+    expect(contact.organization_id).toBeNull();
+  });
+
+  it("two different contacts may share the same canonical_name (ambiguity is a resolution concern, not a schema constraint)", async () => {
+    const db = getDb();
+    await db`INSERT INTO contacts (canonical_name) VALUES ('Jane Smith')`;
+    await db`INSERT INTO contacts (canonical_name) VALUES ('Jane Smith')`;
+    const rows = await db`SELECT id FROM contacts WHERE canonical_name = 'Jane Smith'`;
+    expect(rows).toHaveLength(2);
+  });
+
+  it("deleting an organization sets contacts.organization_id to NULL, not blocking the delete", async () => {
+    const db = getDb();
+    const [org] = await db<{ id: number }[]>`
+      INSERT INTO organizations (name) VALUES ('Acme Corp') RETURNING id
+    `;
+    const [contact] = await db<{ id: number }[]>`
+      INSERT INTO contacts (canonical_name, organization_id) VALUES ('Jane Smith', ${org.id}) RETURNING id
+    `;
+    await db`DELETE FROM organizations WHERE id = ${org.id}`;
+    const [row] = await db<{ organization_id: number | null }[]>`
+      SELECT organization_id FROM contacts WHERE id = ${contact.id}
+    `;
+    expect(row.organization_id).toBeNull();
+  });
+
+  it("deleting a contact cascades to its aliases", async () => {
+    const db = getDb();
+    const [contact] = await db<{ id: number }[]>`
+      INSERT INTO contacts (canonical_name) VALUES ('Jane Smith') RETURNING id
+    `;
+    await db`INSERT INTO contact_aliases (contact_id, alias) VALUES (${contact.id}, 'Jane')`;
+    await db`DELETE FROM contacts WHERE id = ${contact.id}`;
+    const remaining = await db`SELECT 1 FROM contact_aliases WHERE contact_id = ${contact.id}`;
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("the same alias string can point at two different contacts (ambiguity must be resolvable, not schema-prevented)", async () => {
+    const db = getDb();
+    const [a] = await db<{ id: number }[]>`INSERT INTO contacts (canonical_name) VALUES ('Jane Smith (Acme)') RETURNING id`;
+    const [b] = await db<{ id: number }[]>`INSERT INTO contacts (canonical_name) VALUES ('Jane Smith (Globex)') RETURNING id`;
+    await db`INSERT INTO contact_aliases (contact_id, alias) VALUES (${a.id}, 'Jane')`;
+    await db`INSERT INTO contact_aliases (contact_id, alias) VALUES (${b.id}, 'Jane')`;
+    const rows = await db`SELECT contact_id FROM contact_aliases WHERE alias = 'Jane'`;
+    expect(rows).toHaveLength(2);
+  });
+
+  it("a contact cannot have the same alias recorded twice", async () => {
+    const db = getDb();
+    const [contact] = await db<{ id: number }[]>`
+      INSERT INTO contacts (canonical_name) VALUES ('Jane Smith') RETURNING id
+    `;
+    await db`INSERT INTO contact_aliases (contact_id, alias) VALUES (${contact.id}, 'Jane')`;
+    await expect(
+      db`INSERT INTO contact_aliases (contact_id, alias) VALUES (${contact.id}, 'Jane')`
+    ).rejects.toThrow();
+  });
+
+  it("contacts_organization_idx, contacts_canonical_name_idx, and contact_aliases_alias_idx exist", async () => {
+    const db = getDb();
+    const result = await db<{ indexname: string }[]>`
+      SELECT indexname FROM pg_indexes
+      WHERE schemaname = 'public'
+        AND indexname IN ('contacts_organization_idx', 'contacts_canonical_name_idx', 'contact_aliases_alias_idx')
+    `;
+    expect(result.map((r) => r.indexname).sort()).toEqual([
+      "contact_aliases_alias_idx",
+      "contacts_canonical_name_idx",
+      "contacts_organization_idx",
+    ]);
+  });
+});

--- a/tests/contacts-resolve.test.ts
+++ b/tests/contacts-resolve.test.ts
@@ -7,7 +7,7 @@ async function resetContactTables(): Promise<void> {
   await db`DROP TABLE IF EXISTS contact_aliases CASCADE`;
   await db`DROP TABLE IF EXISTS contacts CASCADE`;
   await db`DROP TABLE IF EXISTS organizations CASCADE`;
-  await db`DELETE FROM schema_migrations WHERE name = '006_contacts.sql'`;
+  await db`DELETE FROM schema_migrations WHERE name IN ('006_contacts.sql', '007_outreach_history.sql', '008_contact_details.sql')`;
   await runMigrations(db);
 }
 

--- a/tests/contacts-resolve.test.ts
+++ b/tests/contacts-resolve.test.ts
@@ -1,0 +1,149 @@
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+import { resolveContact, resolveOrganization } from "@/lib/contacts/resolve";
+
+async function resetContactTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS contact_aliases CASCADE`;
+  await db`DROP TABLE IF EXISTS contacts CASCADE`;
+  await db`DROP TABLE IF EXISTS organizations CASCADE`;
+  await db`DELETE FROM schema_migrations WHERE name = '006_contacts.sql'`;
+  await runMigrations(db);
+}
+
+describe("resolveContact", () => {
+  beforeEach(async () => {
+    await resetContactTables();
+  });
+
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("returns not_found when no contact matches", async () => {
+    const result = await resolveContact(getDb(), "Nobody Here");
+    expect(result).toEqual({ status: "not_found" });
+  });
+
+  it("resolves an exact canonical-name match, case-insensitively, with organization info", async () => {
+    const db = getDb();
+    const [org] = await db<{ id: number }[]>`INSERT INTO organizations (name) VALUES ('Acme Corp') RETURNING id`;
+    await db`INSERT INTO contacts (canonical_name, role, organization_id) VALUES ('Jane Smith', 'Engineering Manager', ${org.id})`;
+
+    const result = await resolveContact(db, "jane smith");
+    expect(result.status).toBe("found");
+    if (result.status === "found") {
+      expect(result.contact.canonicalName).toBe("Jane Smith");
+      expect(result.contact.role).toBe("Engineering Manager");
+      expect(result.contact.organizationName).toBe("Acme Corp");
+    }
+  });
+
+  it("resolves a contact with no role/org — nulls, not an error", async () => {
+    const db = getDb();
+    await db`INSERT INTO contacts (canonical_name) VALUES ('Thin Record')`;
+    const result = await resolveContact(db, "Thin Record");
+    expect(result.status).toBe("found");
+    if (result.status === "found") {
+      expect(result.contact.role).toBeNull();
+      expect(result.contact.organizationId).toBeNull();
+      expect(result.contact.organizationName).toBeNull();
+    }
+  });
+
+  it("resolves via an exact alias match", async () => {
+    const db = getDb();
+    const [contact] = await db<{ id: number }[]>`INSERT INTO contacts (canonical_name) VALUES ('Jane Smith') RETURNING id`;
+    await db`INSERT INTO contact_aliases (contact_id, alias) VALUES (${contact.id}, 'Jane')`;
+
+    const result = await resolveContact(db, "jane");
+    expect(result.status).toBe("found");
+    if (result.status === "found") {
+      expect(result.contact.id).toBe(Number(contact.id));
+    }
+  });
+
+  it("is ambiguous when two contacts share the exact same canonical name", async () => {
+    const db = getDb();
+    await db`INSERT INTO contacts (canonical_name) VALUES ('Jane Smith')`;
+    await db`INSERT INTO contacts (canonical_name) VALUES ('Jane Smith')`;
+
+    const result = await resolveContact(db, "Jane Smith");
+    expect(result.status).toBe("ambiguous");
+    if (result.status === "ambiguous") {
+      expect(result.candidates).toHaveLength(2);
+    }
+  });
+
+  it("is ambiguous when the same alias points at two different contacts, and never silently picks one", async () => {
+    const db = getDb();
+    const [acme] = await db<{ id: number }[]>`INSERT INTO organizations (name) VALUES ('Acme Corp') RETURNING id`;
+    const [globex] = await db<{ id: number }[]>`INSERT INTO organizations (name) VALUES ('Globex') RETURNING id`;
+    const [a] = await db<{ id: number }[]>`
+      INSERT INTO contacts (canonical_name, role, organization_id) VALUES ('Jane Smith', 'PM', ${acme.id}) RETURNING id
+    `;
+    const [b] = await db<{ id: number }[]>`
+      INSERT INTO contacts (canonical_name, role, organization_id) VALUES ('Jane R. Smith', 'Engineer', ${globex.id}) RETURNING id
+    `;
+    await db`INSERT INTO contact_aliases (contact_id, alias) VALUES (${a.id}, 'Jane')`;
+    await db`INSERT INTO contact_aliases (contact_id, alias) VALUES (${b.id}, 'Jane')`;
+
+    const result = await resolveContact(db, "Jane");
+    expect(result.status).toBe("ambiguous");
+    if (result.status === "ambiguous") {
+      const orgNames = result.candidates.map((c) => c.organizationName).sort();
+      expect(orgNames).toEqual(["Acme Corp", "Globex"]);
+    }
+  });
+
+  it("does not fuzzy-match a near-miss with no exact alias or canonical match", async () => {
+    const db = getDb();
+    await db`INSERT INTO contacts (canonical_name) VALUES ('Jane Smith')`;
+    const result = await resolveContact(db, "Jayne Smyth");
+    expect(result).toEqual({ status: "not_found" });
+  });
+});
+
+describe("resolveOrganization", () => {
+  beforeEach(async () => {
+    await resetContactTables();
+  });
+
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("returns not_found when no organization matches", async () => {
+    const result = await resolveOrganization(getDb(), "Nonexistent Inc");
+    expect(result).toEqual({ status: "not_found" });
+  });
+
+  it("resolves an exact name match, case-insensitively, with its known contacts", async () => {
+    const db = getDb();
+    const [org] = await db<{ id: number }[]>`INSERT INTO organizations (name, domain) VALUES ('Acme Corp', 'acme.com') RETURNING id`;
+    await db`INSERT INTO contacts (canonical_name, role, organization_id) VALUES ('Jane Smith', 'PM', ${org.id})`;
+    await db`INSERT INTO contacts (canonical_name, organization_id) VALUES ('Bob Jones', ${org.id})`;
+    // A contact at a different org must not leak into these results.
+    const [other] = await db<{ id: number }[]>`INSERT INTO organizations (name) VALUES ('Globex') RETURNING id`;
+    await db`INSERT INTO contacts (canonical_name, organization_id) VALUES ('Someone Else', ${other.id})`;
+
+    const result = await resolveOrganization(db, "acme corp");
+    expect(result.status).toBe("found");
+    if (result.status === "found") {
+      expect(result.organization.domain).toBe("acme.com");
+      expect(result.contacts.map((c) => c.canonicalName).sort()).toEqual(["Bob Jones", "Jane Smith"]);
+    }
+  });
+
+  it("is ambiguous when two organizations share the exact same name", async () => {
+    const db = getDb();
+    await db`INSERT INTO organizations (name) VALUES ('Acme Corp')`;
+    await db`INSERT INTO organizations (name) VALUES ('Acme Corp')`;
+
+    const result = await resolveOrganization(db, "Acme Corp");
+    expect(result.status).toBe("ambiguous");
+    if (result.status === "ambiguous") {
+      expect(result.candidates).toHaveLength(2);
+    }
+  });
+});

--- a/tests/contacts-resolve.test.ts
+++ b/tests/contacts-resolve.test.ts
@@ -39,6 +39,22 @@ describe("resolveContact", () => {
     }
   });
 
+  it("resolves phone, email, linkedinUrl, and photoUrl alongside the rest", async () => {
+    const db = getDb();
+    await db`
+      INSERT INTO contacts (canonical_name, phone, email, linkedin_url, photo_url)
+      VALUES ('Jane Smith', '555-0100', 'jane@acme.com', 'https://linkedin.com/in/janesmith', 'https://example.com/jane.jpg')
+    `;
+    const result = await resolveContact(db, "Jane Smith");
+    expect(result.status).toBe("found");
+    if (result.status === "found") {
+      expect(result.contact.phone).toBe("555-0100");
+      expect(result.contact.email).toBe("jane@acme.com");
+      expect(result.contact.linkedinUrl).toBe("https://linkedin.com/in/janesmith");
+      expect(result.contact.photoUrl).toBe("https://example.com/jane.jpg");
+    }
+  });
+
   it("resolves a contact with no role/org — nulls, not an error", async () => {
     const db = getDb();
     await db`INSERT INTO contacts (canonical_name) VALUES ('Thin Record')`;
@@ -48,6 +64,10 @@ describe("resolveContact", () => {
       expect(result.contact.role).toBeNull();
       expect(result.contact.organizationId).toBeNull();
       expect(result.contact.organizationName).toBeNull();
+      expect(result.contact.phone).toBeNull();
+      expect(result.contact.email).toBeNull();
+      expect(result.contact.linkedinUrl).toBeNull();
+      expect(result.contact.photoUrl).toBeNull();
     }
   });
 

--- a/tests/context.test.ts
+++ b/tests/context.test.ts
@@ -74,6 +74,13 @@ describe("static sections (v5)", () => {
     // No section carries the deleted identity text.
     expect(STATIC_SECTIONS.some((s) => /sourcing agent with access to team memory/.test(s.body))).toBe(false);
   });
+
+  it("carries B1.7's new-connection intake and ambiguity doctrine", () => {
+    const doctrine = STATIC_SECTIONS.find((s) => s.title === "Sourcing doctrine")!;
+    expect(doctrine.body).toMatch(/name, role, and organization/);
+    expect(doctrine.body).toMatch(/let it show as a gap rather than blocking/);
+    expect(doctrine.body).toMatch(/more than one match, ask which one is meant/);
+  });
 });
 
 describe("buildMemoryIndexSection (postgres)", () => {

--- a/tests/create-contact-tool.test.ts
+++ b/tests/create-contact-tool.test.ts
@@ -7,7 +7,7 @@ async function resetContactTables(): Promise<void> {
   await db`DROP TABLE IF EXISTS contact_aliases CASCADE`;
   await db`DROP TABLE IF EXISTS contacts CASCADE`;
   await db`DROP TABLE IF EXISTS organizations CASCADE`;
-  await db`DELETE FROM schema_migrations WHERE name = '006_contacts.sql'`;
+  await db`DELETE FROM schema_migrations WHERE name IN ('006_contacts.sql', '007_outreach_history.sql', '008_contact_details.sql')`;
   await runMigrations(db);
 }
 

--- a/tests/create-contact-tool.test.ts
+++ b/tests/create-contact-tool.test.ts
@@ -41,4 +41,36 @@ describe("createContactTool", () => {
   it("allows name alone, with role and organizationName omitted", () => {
     expect(() => createContactTool.argsSchema.parse({ name: "Jane Smith" })).not.toThrow();
   });
+
+  it("declares phone, email, linkedinUrl, and photoUrl in its args schema (not just pass-through)", () => {
+    const shape = (createContactTool.argsSchema as unknown as { shape: Record<string, unknown> }).shape;
+    expect(Object.keys(shape).sort()).toEqual([
+      "email",
+      "linkedinUrl",
+      "name",
+      "organizationName",
+      "phone",
+      "photoUrl",
+      "role",
+    ]);
+  });
+
+  it("accepts phone, email, linkedinUrl, and photoUrl and writes them through", async () => {
+    const db = getDb();
+    const result = await createContactTool.execute(
+      {
+        name: "Jane Smith",
+        phone: "555-0100",
+        email: "jane@acme.com",
+        linkedinUrl: "https://linkedin.com/in/janesmith",
+        photoUrl: "https://example.com/jane.jpg",
+      },
+      { db, runId: 0, parentStepId: 0 },
+    );
+    expect(result.status).toBe("created");
+    if (result.status === "created") {
+      expect(result.contact.phone).toBe("555-0100");
+      expect(result.contact.linkedinUrl).toBe("https://linkedin.com/in/janesmith");
+    }
+  });
 });

--- a/tests/create-contact-tool.test.ts
+++ b/tests/create-contact-tool.test.ts
@@ -1,0 +1,44 @@
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+import { createContactTool } from "@/lib/tools/create-contact";
+
+async function resetContactTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS contact_aliases CASCADE`;
+  await db`DROP TABLE IF EXISTS contacts CASCADE`;
+  await db`DROP TABLE IF EXISTS organizations CASCADE`;
+  await db`DELETE FROM schema_migrations WHERE name = '006_contacts.sql'`;
+  await runMigrations(db);
+}
+
+describe("createContactTool", () => {
+  beforeEach(async () => {
+    await resetContactTables();
+  });
+
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("is a write_internal-class tool named create_contact", () => {
+    expect(createContactTool.name).toBe("create_contact");
+    expect(createContactTool.permissionClass).toBe("write_internal");
+  });
+
+  it("creates a contact end-to-end through the tool", async () => {
+    const db = getDb();
+    const result = await createContactTool.execute(
+      { name: "Jane Smith", role: "PM", organizationName: "Acme Corp" },
+      { db, runId: 0, parentStepId: 0 },
+    );
+    expect(result.status).toBe("created");
+  });
+
+  it("rejects an empty name via the args schema", () => {
+    expect(() => createContactTool.argsSchema.parse({ name: "" })).toThrow();
+  });
+
+  it("allows name alone, with role and organizationName omitted", () => {
+    expect(() => createContactTool.argsSchema.parse({ name: "Jane Smith" })).not.toThrow();
+  });
+});

--- a/tests/get-contact-tool.test.ts
+++ b/tests/get-contact-tool.test.ts
@@ -8,7 +8,7 @@ async function resetContactTables(): Promise<void> {
   await db`DROP TABLE IF EXISTS contact_aliases CASCADE`;
   await db`DROP TABLE IF EXISTS contacts CASCADE`;
   await db`DROP TABLE IF EXISTS organizations CASCADE`;
-  await db`DELETE FROM schema_migrations WHERE name = '006_contacts.sql'`;
+  await db`DELETE FROM schema_migrations WHERE name IN ('006_contacts.sql', '007_outreach_history.sql', '008_contact_details.sql')`;
   await runMigrations(db);
 }
 

--- a/tests/get-contact-tool.test.ts
+++ b/tests/get-contact-tool.test.ts
@@ -1,0 +1,69 @@
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+import { getContactTool } from "@/lib/tools/get-contact";
+import { getOrganizationTool } from "@/lib/tools/get-organization";
+
+async function resetContactTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS contact_aliases CASCADE`;
+  await db`DROP TABLE IF EXISTS contacts CASCADE`;
+  await db`DROP TABLE IF EXISTS organizations CASCADE`;
+  await db`DELETE FROM schema_migrations WHERE name = '006_contacts.sql'`;
+  await runMigrations(db);
+}
+
+describe("getContactTool", () => {
+  beforeEach(async () => {
+    await resetContactTables();
+  });
+
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("is a read-class tool named get_contact", () => {
+    expect(getContactTool.name).toBe("get_contact");
+    expect(getContactTool.permissionClass).toBe("read");
+  });
+
+  it("resolves a contact end-to-end through the tool", async () => {
+    const db = getDb();
+    await db`INSERT INTO contacts (canonical_name, role) VALUES ('Jane Smith', 'PM')`;
+
+    const result = await getContactTool.execute(
+      { name: "Jane Smith" },
+      { db, runId: 0, parentStepId: 0 },
+    );
+    expect(result.status).toBe("found");
+  });
+
+  it("rejects an empty name via the args schema", () => {
+    expect(() => getContactTool.argsSchema.parse({ name: "" })).toThrow();
+  });
+});
+
+describe("getOrganizationTool", () => {
+  beforeEach(async () => {
+    await resetContactTables();
+  });
+
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("is a read-class tool named get_organization", () => {
+    expect(getOrganizationTool.name).toBe("get_organization");
+    expect(getOrganizationTool.permissionClass).toBe("read");
+  });
+
+  it("resolves an organization end-to-end through the tool", async () => {
+    const db = getDb();
+    await db`INSERT INTO organizations (name) VALUES ('Acme Corp')`;
+
+    const result = await getOrganizationTool.execute(
+      { name: "Acme Corp" },
+      { db, runId: 0, parentStepId: 0 },
+    );
+    expect(result.status).toBe("found");
+  });
+});

--- a/tests/list-outreach-history-tool.test.ts
+++ b/tests/list-outreach-history-tool.test.ts
@@ -1,0 +1,45 @@
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+import { listOutreachHistoryTool } from "@/lib/tools/list-outreach-history";
+
+async function resetOutreachTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS outreach_history CASCADE`;
+  await db`DROP TABLE IF EXISTS contact_aliases CASCADE`;
+  await db`DROP TABLE IF EXISTS contacts CASCADE`;
+  await db`DROP TABLE IF EXISTS organizations CASCADE`;
+  await db`DELETE FROM schema_migrations WHERE name IN ('006_contacts.sql', '007_outreach_history.sql')`;
+  await runMigrations(db);
+}
+
+describe("listOutreachHistoryTool", () => {
+  beforeEach(async () => {
+    await resetOutreachTables();
+  });
+
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("is a read-class tool named list_outreach_history", () => {
+    expect(listOutreachHistoryTool.name).toBe("list_outreach_history");
+    expect(listOutreachHistoryTool.permissionClass).toBe("read");
+  });
+
+  it("resolves a contact's history end-to-end through the tool", async () => {
+    const db = getDb();
+    const [contact] = await db<{ id: number }[]>`INSERT INTO contacts (canonical_name) VALUES ('Jane Smith') RETURNING id`;
+    await db`INSERT INTO outreach_history (contact_id, occurred_at, summary) VALUES (${contact.id}, now(), 'Intro call')`;
+
+    const result = await listOutreachHistoryTool.execute(
+      { contactId: Number(contact.id) },
+      { db, runId: 0, parentStepId: 0 },
+    );
+    expect(result).toHaveLength(1);
+  });
+
+  it("rejects a non-positive contactId via the args schema", () => {
+    expect(() => listOutreachHistoryTool.argsSchema.parse({ contactId: 0 })).toThrow();
+    expect(() => listOutreachHistoryTool.argsSchema.parse({ contactId: -1 })).toThrow();
+  });
+});

--- a/tests/list-outreach-history-tool.test.ts
+++ b/tests/list-outreach-history-tool.test.ts
@@ -8,7 +8,7 @@ async function resetOutreachTables(): Promise<void> {
   await db`DROP TABLE IF EXISTS contact_aliases CASCADE`;
   await db`DROP TABLE IF EXISTS contacts CASCADE`;
   await db`DROP TABLE IF EXISTS organizations CASCADE`;
-  await db`DELETE FROM schema_migrations WHERE name IN ('006_contacts.sql', '007_outreach_history.sql')`;
+  await db`DELETE FROM schema_migrations WHERE name IN ('006_contacts.sql', '007_outreach_history.sql', '008_contact_details.sql')`;
   await runMigrations(db);
 }
 

--- a/tests/memory-answer.test.ts
+++ b/tests/memory-answer.test.ts
@@ -92,15 +92,21 @@ async function insertFact(
 // ---------------------------------------------------------------------------
 
 describe("memoryRegistry", () => {
-  it("registers both search_memory (read) and add_memory_note (write_internal)", () => {
+  it("registers search_memory, get_contact, get_organization (read) and add_memory_note (write_internal)", () => {
     const registry = memoryRegistry();
     expect(registry.get("search_memory")?.permissionClass).toBe("read");
+    expect(registry.get("get_contact")?.permissionClass).toBe("read");
+    expect(registry.get("get_organization")?.permissionClass).toBe("read");
     expect(registry.get("add_memory_note")?.permissionClass).toBe("write_internal");
     // add_memory_note is only listed once its write_internal class is allowed.
-    expect(registry.list(new Set(["read"])).map((t) => t.name)).toEqual(["search_memory"]);
+    expect(registry.list(new Set(["read"])).map((t) => t.name).sort()).toEqual([
+      "get_contact",
+      "get_organization",
+      "search_memory",
+    ]);
     expect(
       registry.list(new Set(["read", "write_internal"])).map((t) => t.name).sort()
-    ).toEqual(["add_memory_note", "search_memory"]);
+    ).toEqual(["add_memory_note", "get_contact", "get_organization", "search_memory"]);
   });
 });
 

--- a/tests/memory-answer.test.ts
+++ b/tests/memory-answer.test.ts
@@ -92,13 +92,14 @@ async function insertFact(
 // ---------------------------------------------------------------------------
 
 describe("memoryRegistry", () => {
-  it("registers search_memory, get_contact, get_organization (read) and add_memory_note (write_internal)", () => {
+  it("registers search_memory, get_contact, get_organization (read) and add_memory_note, create_contact (write_internal)", () => {
     const registry = memoryRegistry();
     expect(registry.get("search_memory")?.permissionClass).toBe("read");
     expect(registry.get("get_contact")?.permissionClass).toBe("read");
     expect(registry.get("get_organization")?.permissionClass).toBe("read");
     expect(registry.get("add_memory_note")?.permissionClass).toBe("write_internal");
-    // add_memory_note is only listed once its write_internal class is allowed.
+    expect(registry.get("create_contact")?.permissionClass).toBe("write_internal");
+    // write_internal tools are only listed once that class is allowed.
     expect(registry.list(new Set(["read"])).map((t) => t.name).sort()).toEqual([
       "get_contact",
       "get_organization",
@@ -106,7 +107,7 @@ describe("memoryRegistry", () => {
     ]);
     expect(
       registry.list(new Set(["read", "write_internal"])).map((t) => t.name).sort()
-    ).toEqual(["add_memory_note", "get_contact", "get_organization", "search_memory"]);
+    ).toEqual(["add_memory_note", "create_contact", "get_contact", "get_organization", "search_memory"]);
   });
 });
 

--- a/tests/memory-answer.test.ts
+++ b/tests/memory-answer.test.ts
@@ -92,22 +92,31 @@ async function insertFact(
 // ---------------------------------------------------------------------------
 
 describe("memoryRegistry", () => {
-  it("registers search_memory, get_contact, get_organization (read) and add_memory_note, create_contact (write_internal)", () => {
+  it("registers search_memory, get_contact, get_organization, list_outreach_history (read) and add_memory_note, create_contact (write_internal)", () => {
     const registry = memoryRegistry();
     expect(registry.get("search_memory")?.permissionClass).toBe("read");
     expect(registry.get("get_contact")?.permissionClass).toBe("read");
     expect(registry.get("get_organization")?.permissionClass).toBe("read");
+    expect(registry.get("list_outreach_history")?.permissionClass).toBe("read");
     expect(registry.get("add_memory_note")?.permissionClass).toBe("write_internal");
     expect(registry.get("create_contact")?.permissionClass).toBe("write_internal");
     // write_internal tools are only listed once that class is allowed.
     expect(registry.list(new Set(["read"])).map((t) => t.name).sort()).toEqual([
       "get_contact",
       "get_organization",
+      "list_outreach_history",
       "search_memory",
     ]);
     expect(
       registry.list(new Set(["read", "write_internal"])).map((t) => t.name).sort()
-    ).toEqual(["add_memory_note", "create_contact", "get_contact", "get_organization", "search_memory"]);
+    ).toEqual([
+      "add_memory_note",
+      "create_contact",
+      "get_contact",
+      "get_organization",
+      "list_outreach_history",
+      "search_memory",
+    ]);
   });
 });
 

--- a/tests/memory-summarize-step.test.ts
+++ b/tests/memory-summarize-step.test.ts
@@ -40,13 +40,18 @@ describe("summarizeStep", () => {
       tool: "get_contact",
       ok: true,
       observation:
-        'Success: {"status":"found","contact":{"id":1,"canonicalName":"Jane Smith","role":"PM","organizationName":"Acme"}}',
+        'Success: {"status":"found","contact":{"id":1,"canonicalName":"Jane Smith","role":"PM","organizationName":"Acme",' +
+        '"phone":"555-0100","email":"jane@acme.com","linkedinUrl":"https://linkedin.com/in/janesmith","photoUrl":"https://example.com/jane.jpg"}}',
     });
     expect(part.contactCard).toEqual({
       id: 1,
       canonicalName: "Jane Smith",
       role: "PM",
       organizationName: "Acme",
+      phone: "555-0100",
+      email: "jane@acme.com",
+      linkedinUrl: "https://linkedin.com/in/janesmith",
+      photoUrl: "https://example.com/jane.jpg",
     });
   });
 

--- a/tests/memory-summarize-step.test.ts
+++ b/tests/memory-summarize-step.test.ts
@@ -33,4 +33,86 @@ describe("summarizeStep", () => {
     expect(part.detail).toContain("source not allowed");
     expect(part.detail).not.toContain("Error (");
   });
+
+  it("attaches a contactCard for a found get_contact step", () => {
+    const part = summarizeStep({
+      index: 1,
+      tool: "get_contact",
+      ok: true,
+      observation:
+        'Success: {"status":"found","contact":{"id":1,"canonicalName":"Jane Smith","role":"PM","organizationName":"Acme"}}',
+    });
+    expect(part.contactCard).toEqual({
+      id: 1,
+      canonicalName: "Jane Smith",
+      role: "PM",
+      organizationName: "Acme",
+    });
+  });
+
+  it("omits contactCard for an ambiguous or not_found get_contact step", () => {
+    const ambiguous = summarizeStep({
+      index: 1,
+      tool: "get_contact",
+      ok: true,
+      observation: 'Success: {"status":"ambiguous","candidates":[]}',
+    });
+    expect(ambiguous.contactCard).toBeUndefined();
+
+    const notFound = summarizeStep({
+      index: 1,
+      tool: "get_contact",
+      ok: true,
+      observation: 'Success: {"status":"not_found"}',
+    });
+    expect(notFound.contactCard).toBeUndefined();
+  });
+
+  it("attaches outreachHistory for a list_outreach_history step", () => {
+    const part = summarizeStep({
+      index: 1,
+      tool: "list_outreach_history",
+      ok: true,
+      observation:
+        'Success: [{"id":1,"occurredAt":"2026-01-01T00:00:00.000Z","channel":"email","summary":"Intro","citation":null}]',
+    });
+    expect(part.outreachHistory).toHaveLength(1);
+    expect(part.outreachHistory?.[0].summary).toBe("Intro");
+  });
+
+  it("attaches memoryFacts (accepted + gap) for a search_memory step", () => {
+    const part = summarizeStep({
+      index: 1,
+      tool: "search_memory",
+      ok: true,
+      observation:
+        'Success: {"acceptedFacts":[{"subject":"Jane","predicate":"role","object":"PM","citation":"c1","status":"accepted"}],' +
+        '"gapFacts":[{"subject":"Jane","predicate":"last_contacted","object":"unknown","citation":null,"status":"candidate"}],' +
+        '"chunks":[]}',
+    });
+    expect(part.memoryFacts).toHaveLength(2);
+    expect(part.memoryFacts?.map((f) => f.status).sort()).toEqual(["accepted", "candidate"]);
+  });
+
+  it("omits memoryFacts when search_memory returns nothing", () => {
+    const part = summarizeStep({
+      index: 1,
+      tool: "search_memory",
+      ok: true,
+      observation: 'Success: {"acceptedFacts":[],"gapFacts":[],"chunks":[]}',
+    });
+    expect(part.memoryFacts).toBeUndefined();
+  });
+
+  it("attaches no structured data for a failed step, regardless of tool", () => {
+    const part = summarizeStep({
+      index: 1,
+      tool: "get_contact",
+      ok: false,
+      observation: "Error (invalid_args): name is required",
+    });
+    expect(part.contactCard).toBeUndefined();
+    expect(part.outreachHistory).toBeUndefined();
+    expect(part.memoryFacts).toBeUndefined();
+  });
 });

--- a/tests/outreach-history-list.test.ts
+++ b/tests/outreach-history-list.test.ts
@@ -1,0 +1,60 @@
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+import { listOutreachHistory } from "@/lib/contacts/outreach";
+
+async function resetOutreachTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS outreach_history CASCADE`;
+  await db`DROP TABLE IF EXISTS contact_aliases CASCADE`;
+  await db`DROP TABLE IF EXISTS contacts CASCADE`;
+  await db`DROP TABLE IF EXISTS organizations CASCADE`;
+  await db`DELETE FROM schema_migrations WHERE name IN ('006_contacts.sql', '007_outreach_history.sql')`;
+  await runMigrations(db);
+}
+
+describe("listOutreachHistory", () => {
+  beforeEach(async () => {
+    await resetOutreachTables();
+  });
+
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("returns an empty array for a contact with no history", async () => {
+    const db = getDb();
+    const [contact] = await db<{ id: number }[]>`INSERT INTO contacts (canonical_name) VALUES ('Jane Smith') RETURNING id`;
+    const result = await listOutreachHistory(db, Number(contact.id));
+    expect(result).toEqual([]);
+  });
+
+  it("returns entries ordered most-recent-first", async () => {
+    const db = getDb();
+    const [contact] = await db<{ id: number }[]>`INSERT INTO contacts (canonical_name) VALUES ('Jane Smith') RETURNING id`;
+    await db`
+      INSERT INTO outreach_history (contact_id, occurred_at, channel, summary, citation)
+      VALUES
+        (${contact.id}, '2026-01-01', 'email', 'First cold outreach', 'note-1#chunk-1'),
+        (${contact.id}, '2026-05-01', 'call', 'Follow-up call, went well', NULL)
+    `;
+
+    const result = await listOutreachHistory(db, Number(contact.id));
+    expect(result).toHaveLength(2);
+    expect(result[0].summary).toBe("Follow-up call, went well");
+    expect(result[0].citation).toBeNull();
+    expect(result[1].summary).toBe("First cold outreach");
+    expect(result[1].citation).toBe("note-1#chunk-1");
+  });
+
+  it("only returns history for the requested contact, not others", async () => {
+    const db = getDb();
+    const [a] = await db<{ id: number }[]>`INSERT INTO contacts (canonical_name) VALUES ('Jane Smith') RETURNING id`;
+    const [b] = await db<{ id: number }[]>`INSERT INTO contacts (canonical_name) VALUES ('Bob Jones') RETURNING id`;
+    await db`INSERT INTO outreach_history (contact_id, occurred_at, summary) VALUES (${a.id}, now(), 'About Jane')`;
+    await db`INSERT INTO outreach_history (contact_id, occurred_at, summary) VALUES (${b.id}, now(), 'About Bob')`;
+
+    const result = await listOutreachHistory(db, Number(a.id));
+    expect(result).toHaveLength(1);
+    expect(result[0].summary).toBe("About Jane");
+  });
+});

--- a/tests/outreach-history-list.test.ts
+++ b/tests/outreach-history-list.test.ts
@@ -8,7 +8,7 @@ async function resetOutreachTables(): Promise<void> {
   await db`DROP TABLE IF EXISTS contact_aliases CASCADE`;
   await db`DROP TABLE IF EXISTS contacts CASCADE`;
   await db`DROP TABLE IF EXISTS organizations CASCADE`;
-  await db`DELETE FROM schema_migrations WHERE name IN ('006_contacts.sql', '007_outreach_history.sql')`;
+  await db`DELETE FROM schema_migrations WHERE name IN ('006_contacts.sql', '007_outreach_history.sql', '008_contact_details.sql')`;
   await runMigrations(db);
 }
 

--- a/tests/outreach-history-migrate.test.ts
+++ b/tests/outreach-history-migrate.test.ts
@@ -7,7 +7,7 @@ async function resetOutreachTables(): Promise<void> {
   await db`DROP TABLE IF EXISTS contact_aliases CASCADE`;
   await db`DROP TABLE IF EXISTS contacts CASCADE`;
   await db`DROP TABLE IF EXISTS organizations CASCADE`;
-  await db`DELETE FROM schema_migrations WHERE name IN ('006_contacts.sql', '007_outreach_history.sql')`;
+  await db`DELETE FROM schema_migrations WHERE name IN ('006_contacts.sql', '007_outreach_history.sql', '008_contact_details.sql')`;
   await runMigrations(db);
 }
 

--- a/tests/outreach-history-migrate.test.ts
+++ b/tests/outreach-history-migrate.test.ts
@@ -1,0 +1,83 @@
+import { closeDb, getDb } from "@/lib/db";
+import { runMigrations } from "@/lib/migrate";
+
+async function resetOutreachTables(): Promise<void> {
+  const db = getDb();
+  await db`DROP TABLE IF EXISTS outreach_history CASCADE`;
+  await db`DROP TABLE IF EXISTS contact_aliases CASCADE`;
+  await db`DROP TABLE IF EXISTS contacts CASCADE`;
+  await db`DROP TABLE IF EXISTS organizations CASCADE`;
+  await db`DELETE FROM schema_migrations WHERE name IN ('006_contacts.sql', '007_outreach_history.sql')`;
+  await runMigrations(db);
+}
+
+describe("007 outreach_history migration", () => {
+  beforeEach(async () => {
+    await resetOutreachTables();
+  });
+
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("creates outreach_history", async () => {
+    const db = getDb();
+    const result = await db<{ table_name: string }[]>`
+      SELECT table_name FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_name = 'outreach_history'
+    `;
+    expect(result).toHaveLength(1);
+  });
+
+  it("requires contact_id, occurred_at, and summary", async () => {
+    const db = getDb();
+    const [contact] = await db<{ id: number }[]>`INSERT INTO contacts (canonical_name) VALUES ('Jane Smith') RETURNING id`;
+
+    await expect(
+      db`INSERT INTO outreach_history (occurred_at, summary) VALUES (now(), 'x')`
+    ).rejects.toThrow();
+    await expect(
+      db`INSERT INTO outreach_history (contact_id, summary) VALUES (${contact.id}, 'x')`
+    ).rejects.toThrow();
+    await expect(
+      db`INSERT INTO outreach_history (contact_id, occurred_at) VALUES (${contact.id}, now())`
+    ).rejects.toThrow();
+  });
+
+  it("channel and citation are optional", async () => {
+    const db = getDb();
+    const [contact] = await db<{ id: number }[]>`INSERT INTO contacts (canonical_name) VALUES ('Jane Smith') RETURNING id`;
+    const [row] = await db<{ channel: string | null; citation: string | null }[]>`
+      INSERT INTO outreach_history (contact_id, occurred_at, summary)
+      VALUES (${contact.id}, now(), 'Met at a conference')
+      RETURNING channel, citation
+    `;
+    expect(row.channel).toBeNull();
+    expect(row.citation).toBeNull();
+  });
+
+  it("rejects an outreach_history row for a nonexistent contact", async () => {
+    const db = getDb();
+    await expect(
+      db`INSERT INTO outreach_history (contact_id, occurred_at, summary) VALUES (999999, now(), 'x')`
+    ).rejects.toThrow();
+  });
+
+  it("deleting a contact cascades to its outreach history", async () => {
+    const db = getDb();
+    const [contact] = await db<{ id: number }[]>`INSERT INTO contacts (canonical_name) VALUES ('Jane Smith') RETURNING id`;
+    await db`INSERT INTO outreach_history (contact_id, occurred_at, summary) VALUES (${contact.id}, now(), 'Intro call')`;
+    await db`DELETE FROM contacts WHERE id = ${contact.id}`;
+    const remaining = await db`SELECT 1 FROM outreach_history WHERE contact_id = ${contact.id}`;
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("outreach_history_contact_idx exists", async () => {
+    const db = getDb();
+    const result = await db<{ indexname: string }[]>`
+      SELECT indexname FROM pg_indexes
+      WHERE schemaname = 'public' AND indexname = 'outreach_history_contact_idx'
+    `;
+    expect(result).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Ships B1 — Organizations & Contacts, identity resolution, and the Contact Profile Card — widened from its original read-only scope into a full feature after design-review feedback (B1.8).

organizations / contacts / contact_aliases schema, plus outreach_history pulled forward from B3 for the relationship timeline
get_contact / get_organization / create_contact / list_outreach_history tools, registered in the agent's memory registry
Identity resolution never guesses: an exact canonical-name or alias match resolves; two people (or orgs) sharing a name returns ambiguous with candidates instead of silently picking one
create_contact requires a name; role/org/phone/email/LinkedIn/photo are optional — a thin record is a visible gap, not a blocked write
Contact Profile Card: identity + photo, contact details, relationship timeline, cited key facts, and knowledge gaps in one place, wired into Research Chat
Sourcing doctrine updated so the agent gathers name/role/org on a new connection and asks before acting on an ambiguous match
Plan doc (docs/superpowers/plans/2026-06-15-...-task-breakdown.md) and its generated HTML kept in sync throughout, including two new specced-but-deferred items: C3 (a guided, human-verified data-collection workflow) and Stage H (per-officer login/attribution, currently a single shared DEFAULT_ACTOR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added contact profile cards in chat with identity details, contact information, relationship history, key facts, and knowledge gaps.
  * Added contact and organization lookup with clear handling for missing or ambiguous matches.
  * Added contact creation with organization linking and optional phone, email, LinkedIn, and photo details.
  * Added outreach history visibility, including recent interaction timelines.
  * Expanded memory tools to surface structured contact and sourcing information.

* **Documentation**
  * Updated build plans and status visualizations to reflect completed, partial, and deferred work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds organizations, contacts, and contact profiles to the sourcing workflow. The main changes are:

- Contact, organization, alias, detail, and outreach-history schemas.
- Contact creation and exact identity-resolution tools.
- Structured contact data in the chat stream.
- A Contact Profile Card with relationship history, facts, and gaps.
- Expanded tests and updated planning documentation.

<h3>Confidence Score: 4/5</h3>

Concurrent contact creation and multi-contact chat turns can produce incorrect organization and profile data.

- Concurrent writes can create duplicate organization identities.
- A profile card can display one contact's history under another contact's identity.
- The remaining schema, resolution, registry, and presentation changes are coherent.

src/lib/contacts/create.ts, src/migrations/006_contacts.sql, src/app/chat/stream.ts, and src/lib/memory/answer.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/lib/contacts/create.ts | Adds contact and organization creation, but organization reuse has a concurrent check-then-insert race. |
| src/lib/contacts/resolve.ts | Adds exact canonical-name and alias resolution with explicit found, ambiguous, and not-found results. |
| src/app/chat/stream.ts | Builds the profile-card view from tool steps, but can combine data from different contacts. |
| src/lib/memory/answer.ts | Adds structured contact, outreach-history, and memory-fact fields to streamed agent steps. |
| src/app/chat/ContactProfileCard.tsx | Adds the contact identity, details, relationship, facts, and knowledge-gap presentation. |
| src/migrations/006_contacts.sql | Creates organization, contact, and alias tables without an organization identity constraint for concurrent creation. |
| src/migrations/007_outreach_history.sql | Creates contact-scoped outreach history with reverse-chronological indexing. |
| src/lib/memory/answer-config.ts | Registers the new contact and outreach tools in the memory tool registry. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant D as Director
    participant A as Agent
    participant T as Contact tools
    participant DB as PostgreSQL
    participant UI as Research Chat
    D->>A: Ask about a contact
    A->>T: get_contact(name)
    T->>DB: Resolve canonical name or alias
    DB-->>T: Contact result
    A->>T: list_outreach_history(contactId)
    T->>DB: Read relationship history
    A->>T: search_memory(query)
    T-->>UI: Structured contact, history, and facts
    UI-->>D: Render Contact Profile Card
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant D as Director
    participant A as Agent
    participant T as Contact tools
    participant DB as PostgreSQL
    participant UI as Research Chat
    D->>A: Ask about a contact
    A->>T: get_contact(name)
    T->>DB: Resolve canonical name or alias
    DB-->>T: Contact result
    A->>T: list_outreach_history(contactId)
    T->>DB: Read relationship history
    A->>T: search_memory(query)
    T-->>UI: Structured contact, history, and facts
    UI-->>D: Render Contact Profile Card
```

</a>

<sub>Reviews (1): Last reviewed commit: ["docs(plan): mark B1 fully done in the re..."](https://github.com/fisherxz/sourcecado/commit/47f8469d7610e9e011b8d66e4649227f42019398) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46138426)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->