### PR TITLE
R11: pin validated IP + stream-cap web_fetch bodies

### DIFF
--- a/src/lib/tools/web-fetch-http.ts
+++ b/src/lib/tools/web-fetch-http.ts
@@ -1,0 +1,122 @@
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
+import type { IncomingMessage } from "node:http";
+import type { LookupFunction } from "node:net";
+
+// Low-level transport for web_fetch. Split from web-fetch.ts because it answers
+// a different question: web-fetch.ts decides *whether* a URL may be fetched,
+// this decides *how* the bytes arrive. Two things global fetch() cannot do:
+//
+//  1. Pin the connection to an already-validated IP. `fetch` re-resolves the
+//     hostname at connect time, so an attacker-controlled DNS record can return
+//     a public address to our SSRF check and a private one to the socket.
+//  2. Stop reading at a byte limit. `res.text()` buffers the whole body first,
+//     so a size cap applied afterwards bounds the string, not memory.
+
+export interface CappedResponse {
+  status: number;
+  statusText: string;
+  contentType: string | null;
+  location: string | null;
+  text: string;
+  truncated: boolean;
+}
+
+export interface FetchCappedOptions {
+  url: string;
+  /** Pre-validated address to pin the connection to. */
+  address: string;
+  family: number;
+  maxBytes: number;
+  timeoutMs: number;
+}
+
+// Hands the connection the address the caller already validated instead of
+// re-resolving. SNI and certificate validation still use the hostname, so
+// pinning costs no TLS safety — only the address lookup is short-circuited.
+export function pinnedLookup(address: string, family: number): LookupFunction {
+  return (_hostname, options, callback) => {
+    if (options?.all === true) callback(null, [{ address, family }]);
+    else callback(null, address, family);
+  };
+}
+
+function header(res: IncomingMessage, name: string): string | null {
+  const value = res.headers[name];
+  if (value === undefined) return null;
+  return Array.isArray(value) ? (value[0] ?? null) : value;
+}
+
+export function fetchCapped(opts: FetchCappedOptions): Promise<CappedResponse> {
+  const url = new URL(opts.url);
+  const isHttps = url.protocol === "https:";
+  const request = isHttps ? httpsRequest : httpRequest;
+
+  return new Promise<CappedResponse>((resolve, reject) => {
+    let settled = false;
+    const settle = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(deadline);
+      fn();
+    };
+
+    const req = request(
+      {
+        protocol: url.protocol,
+        host: url.hostname, // Host header, SNI, and cert validation all use this
+        port: url.port || (isHttps ? 443 : 80),
+        path: `${url.pathname}${url.search}`,
+        lookup: pinnedLookup(opts.address, opts.family), // ...only the socket is pinned
+      },
+      (res) => {
+        const base = {
+          status: res.statusCode ?? 0,
+          statusText: res.statusMessage ?? "",
+          contentType: header(res, "content-type"),
+          location: header(res, "location"),
+        };
+
+        // Redirect bodies are never used — discard rather than buffer.
+        if (base.status >= 300 && base.status < 400) {
+          res.resume();
+          settle(() => resolve({ ...base, text: "", truncated: false }));
+          return;
+        }
+
+        const chunks: Buffer[] = [];
+        let received = 0;
+        let truncated = false;
+
+        const body = (): string =>
+          Buffer.concat(chunks).subarray(0, opts.maxBytes).toString("utf8");
+
+        res.on("data", (chunk: Buffer) => {
+          if (settled) return;
+          chunks.push(chunk);
+          received += chunk.length;
+          if (received <= opts.maxBytes) return;
+          // Past the cap: kill the connection so the rest of the body is never
+          // transferred. Overshoot is bounded by one socket read (64KB), which
+          // is what lets a body landing exactly on the cap be reported as
+          // complete rather than truncated.
+          truncated = true;
+          req.destroy();
+          settle(() => resolve({ ...base, text: body(), truncated }));
+        });
+
+        res.on("end", () => settle(() => resolve({ ...base, text: body(), truncated })));
+        res.on("error", (err) => settle(() => reject(err)));
+      },
+    );
+
+    const deadline = setTimeout(() => {
+      req.destroy(new Error(`web_fetch: timed out after ${opts.timeoutMs}ms`));
+    }, opts.timeoutMs);
+
+    // Fires for connection failures and for our own destroy() on timeout. A
+    // destroy() after the cap was hit arrives post-settle and is ignored.
+    req.on("error", (err) => settle(() => reject(err)));
+    req.end();
+  });
+}

--- a/src/lib/tools/web-fetch-http.ts
+++ b/src/lib/tools/web-fetch-http.ts
@@ -68,6 +68,17 @@ export function fetchCapped(opts: FetchCappedOptions): Promise<CappedResponse> {
         port: url.port || (isHttps ? 443 : 80),
         path: `${url.pathname}${url.search}`,
         lookup: pinnedLookup(opts.address, opts.family), // ...only the socket is pinned
+        // Ask for no compression. Decompressing would move the byte cap off the
+        // wire and onto the decoded output, which reopens the unbounded-memory
+        // hole this transport exists to close (a 500KB gzip expands to GBs).
+        // Unlike fetch(), http.request sends no Accept-Encoding of its own, so
+        // this is explicit rather than a downgrade.
+        headers: { "accept-encoding": "identity" },
+        // Do not pool. The default global agent keys sockets on host:port and
+        // ignores `lookup`, so a pooled socket could serve a hop that never ran
+        // pinnedLookup — weakening "this connection goes to the address we just
+        // validated" into "…to an address we validated at some point".
+        agent: false,
       },
       (res) => {
         const base = {
@@ -77,10 +88,26 @@ export function fetchCapped(opts: FetchCappedOptions): Promise<CappedResponse> {
           location: header(res, "location"),
         };
 
-        // Redirect bodies are never used — discard rather than buffer.
+        // Redirect bodies are never used. Close the socket rather than draining
+        // it: res.resume() would keep reading in the background after we
+        // resolve, past both the byte cap and the (already cleared) deadline —
+        // and web-fetch.ts allows 5 hops, so one call could leave several
+        // sockets draining.
         if (base.status >= 300 && base.status < 400) {
-          res.resume();
           settle(() => resolve({ ...base, text: "", truncated: false }));
+          req.destroy();
+          return;
+        }
+
+        // A server may compress anyway despite the identity request. Decoding
+        // bytes we cannot decode would hand htmlToText() binary garbage, so
+        // fail loudly instead of returning corrupted "text".
+        const encoding = header(res, "content-encoding");
+        if (encoding && encoding.toLowerCase() !== "identity") {
+          settle(() =>
+            reject(new Error(`web_fetch: refusing ${encoding}-encoded response (identity was requested)`)),
+          );
+          req.destroy();
           return;
         }
 

--- a/src/lib/tools/web-fetch.ts
+++ b/src/lib/tools/web-fetch.ts
@@ -1,9 +1,14 @@
 import { z } from "zod";
 import { lookup } from "node:dns/promises";
+import { fetchCapped } from "./web-fetch-http";
 import type { Tool } from "./types";
 
-export const WEB_FETCH_MAX_CHARS = 500_000;
+// Bytes, not characters: the cap now bounds how much we read off the socket, so
+// it is a real memory bound rather than a slice applied to an already-buffered
+// body.
+export const WEB_FETCH_MAX_BYTES = 500_000;
 const MAX_REDIRECTS = 5;
+const REQUEST_TIMEOUT_MS = 15_000;
 
 export const webFetchArgsSchema = z.object({
   url: z.string().min(1),
@@ -81,8 +86,12 @@ export function isBlockedIp(ip: string): boolean {
 // Resolve a host (dns.lookup echoes a literal IP verbatim, so this covers
 // literal-IP URLs too) and reject if ANY resolved address is non-public.
 // Called on every redirect hop.
-export async function assertPublicHost(hostname: string): Promise<void> {
-  let addrs: Array<{ address: string }>;
+//
+// Returns the address it validated so the caller can pin the connection to it.
+// Without that, the transport re-resolves at connect time and a hostname whose
+// DNS flips between this check and the socket reaches the address we refused.
+export async function assertPublicHost(hostname: string): Promise<{ address: string; family: number }> {
+  let addrs: Array<{ address: string; family: number }>;
   try {
     addrs = await lookup(hostname, { all: true });
   } catch {
@@ -96,6 +105,7 @@ export async function assertPublicHost(hostname: string): Promise<void> {
       throw new Error(`web_fetch: refusing non-public address ${address} for "${hostname}"`);
     }
   }
+  return addrs[0];
 }
 
 export const webFetchTool: Tool<WebFetchArgs, WebFetchResult> = {
@@ -118,36 +128,40 @@ export const webFetchTool: Tool<WebFetchArgs, WebFetchResult> = {
       if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
         throw new Error(`Unsupported URL protocol: ${parsed.protocol} (only http/https allowed)`);
       }
-      await assertPublicHost(parsed.hostname); // re-validated every hop
+      const pinned = await assertPublicHost(parsed.hostname); // re-validated every hop
       finalUrl = parsed.toString();
 
-      const res = await fetch(finalUrl, {
-        redirect: "manual", // follow manually so each hop's host is re-validated
-        signal: AbortSignal.timeout(15_000),
+      // Redirects are followed manually so each hop's host is re-validated, and
+      // each hop connects to its own validated address.
+      const res = await fetchCapped({
+        url: finalUrl,
+        address: pinned.address,
+        family: pinned.family,
+        maxBytes: WEB_FETCH_MAX_BYTES,
+        timeoutMs: REQUEST_TIMEOUT_MS,
       });
 
       if (res.status >= 300 && res.status < 400) {
         if (hop >= MAX_REDIRECTS) {
           throw new Error(`web_fetch: too many redirects (>${MAX_REDIRECTS})`);
         }
-        const location = res.headers.get("location");
-        if (!location) {
+        if (!res.location) {
           throw new Error(`web_fetch: redirect ${res.status} with no Location header`);
         }
-        target = new URL(location, finalUrl).toString();
+        target = new URL(res.location, finalUrl).toString();
         continue;
       }
 
-      if (!res.ok) {
+      if (res.status < 200 || res.status >= 300) {
         throw new Error(`Fetch failed: ${res.status} ${res.statusText}`);
       }
 
-      const contentType = res.headers.get("content-type");
-      const raw = await res.text();
-      const truncated = raw.length > WEB_FETCH_MAX_CHARS;
-      const capped = truncated ? raw.slice(0, WEB_FETCH_MAX_CHARS) : raw;
-
-      return { url: finalUrl, contentType, text: htmlToText(capped), truncated };
+      return {
+        url: finalUrl,
+        contentType: res.contentType,
+        text: htmlToText(res.text),
+        truncated: res.truncated,
+      };
     }
   },
 };

--- a/tests/web-fetch-http.test.ts
+++ b/tests/web-fetch-http.test.ts
@@ -1,0 +1,194 @@
+import { createServer, type Server } from "node:http";
+import { AddressInfo } from "node:net";
+import { fetchCapped, pinnedLookup } from "@/lib/tools/web-fetch-http";
+
+// Transport-level tests. These run against a real loopback HTTP server rather
+// than a mock, because the two things under test — that the connection goes to
+// the pinned address, and that an oversized body is aborted instead of buffered
+// — are properties of the socket, not of our code's control flow. A mock would
+// assert we called something, not that the bytes stopped arriving.
+
+function listen(handler: Parameters<typeof createServer>[1]): Promise<{ server: Server; port: number }> {
+  return new Promise((resolve) => {
+    const server = createServer(handler);
+    server.listen(0, "127.0.0.1", () => {
+      resolve({ server, port: (server.address() as AddressInfo).port });
+    });
+  });
+}
+
+const close = (server: Server) => new Promise<void>((resolve) => server.close(() => resolve()));
+
+describe("pinnedLookup", () => {
+  it("returns the pinned address for any hostname (callback form)", async () => {
+    const result = await new Promise<[unknown, unknown, unknown]>((resolve) => {
+      pinnedLookup("93.184.216.34", 4)("anything.test", {}, (...args) => resolve(args as never));
+    });
+    expect(result).toEqual([null, "93.184.216.34", 4]);
+  });
+
+  it("returns the pinned address in array form when options.all is set", async () => {
+    const result = await new Promise<[unknown, unknown]>((resolve) => {
+      pinnedLookup("93.184.216.34", 4)("anything.test", { all: true }, (...args) => resolve(args as never));
+    });
+    expect(result[0]).toBeNull();
+    expect(result[1]).toEqual([{ address: "93.184.216.34", family: 4 }]);
+  });
+});
+
+describe("fetchCapped", () => {
+  it("connects to the pinned address while keeping the hostname in the Host header", async () => {
+    // The rebinding fix, proven at the transport layer: the URL says
+    // "pinned.test" (which does not resolve at all) and the connection still
+    // lands on our loopback server because the address was pinned.
+    const { server, port } = await listen((req, res) => {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end(`host=${req.headers.host}`);
+    });
+    try {
+      const res = await fetchCapped({
+        url: `http://pinned.test:${port}/page`,
+        address: "127.0.0.1",
+        family: 4,
+        maxBytes: 10_000,
+        timeoutMs: 5_000,
+      });
+      expect(res.status).toBe(200);
+      expect(res.text).toBe(`host=pinned.test:${port}`);
+      expect(res.contentType).toBe("text/plain");
+      expect(res.truncated).toBe(false);
+    } finally {
+      await close(server);
+    }
+  });
+
+  it("aborts an oversized body at the cap instead of buffering it", async () => {
+    let pushed = 0;
+    let clientGone = false;
+    const { server, port } = await listen((_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain" });
+      const chunk = "a".repeat(64 * 1024);
+      const pump = (): void => {
+        // 8MB ceiling so a broken cap fails the test instead of hanging forever.
+        if (clientGone || pushed > 8 * 1024 * 1024) return void res.end();
+        pushed += chunk.length;
+        if (res.write(chunk)) setImmediate(pump);
+        else res.once("drain", pump);
+      };
+      res.on("close", () => { clientGone = true; });
+      pump();
+    });
+    try {
+      const res = await fetchCapped({
+        url: `http://127.0.0.1:${port}/big`,
+        address: "127.0.0.1",
+        family: 4,
+        maxBytes: 100_000,
+        timeoutMs: 5_000,
+      });
+      expect(res.truncated).toBe(true);
+      expect(res.text.length).toBe(100_000);
+      // The point of the fix: the transfer stopped early. Without the abort the
+      // server would have pushed its full 8MB.
+      expect(pushed).toBeLessThan(4 * 1024 * 1024);
+    } finally {
+      await close(server);
+    }
+  });
+
+  it("does not mark a body that lands exactly on the cap as truncated", async () => {
+    const exact = "b".repeat(4096);
+    const { server, port } = await listen((_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end(exact);
+    });
+    try {
+      const res = await fetchCapped({
+        url: `http://127.0.0.1:${port}/exact`,
+        address: "127.0.0.1",
+        family: 4,
+        maxBytes: exact.length,
+        timeoutMs: 5_000,
+      });
+      expect(res.truncated).toBe(false);
+      expect(res.text).toBe(exact);
+    } finally {
+      await close(server);
+    }
+  });
+
+  it("returns a redirect's location without reading its body", async () => {
+    const { server, port } = await listen((_req, res) => {
+      res.writeHead(302, { location: "https://elsewhere.test/next" });
+      res.end("ignored body");
+    });
+    try {
+      const res = await fetchCapped({
+        url: `http://127.0.0.1:${port}/go`,
+        address: "127.0.0.1",
+        family: 4,
+        maxBytes: 10_000,
+        timeoutMs: 5_000,
+      });
+      expect(res.status).toBe(302);
+      expect(res.location).toBe("https://elsewhere.test/next");
+      expect(res.text).toBe("");
+    } finally {
+      await close(server);
+    }
+  });
+
+  it("returns a non-OK status rather than throwing (the caller decides)", async () => {
+    const { server, port } = await listen((_req, res) => {
+      res.writeHead(404, { "content-type": "text/plain" });
+      res.end("nope");
+    });
+    try {
+      const res = await fetchCapped({
+        url: `http://127.0.0.1:${port}/missing`,
+        address: "127.0.0.1",
+        family: 4,
+        maxBytes: 10_000,
+        timeoutMs: 5_000,
+      });
+      expect(res.status).toBe(404);
+      expect(res.statusText).toBe("Not Found");
+    } finally {
+      await close(server);
+    }
+  });
+
+  it("rejects when the connection fails", async () => {
+    const { server, port } = await listen((_req, res) => res.end());
+    await close(server); // nothing is listening on `port` any more
+    await expect(
+      fetchCapped({
+        url: `http://127.0.0.1:${port}/gone`,
+        address: "127.0.0.1",
+        family: 4,
+        maxBytes: 10_000,
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow(/ECONNREFUSED/);
+  });
+
+  it("rejects when the response stalls past the timeout", async () => {
+    const { server, port } = await listen((_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.write("start"); // headers sent, body never completes
+    });
+    try {
+      await expect(
+        fetchCapped({
+          url: `http://127.0.0.1:${port}/stall`,
+          address: "127.0.0.1",
+          family: 4,
+          maxBytes: 10_000,
+          timeoutMs: 300,
+        }),
+      ).rejects.toThrow(/timed out/);
+    } finally {
+      await close(server);
+    }
+  });
+});

--- a/tests/web-fetch-http.test.ts
+++ b/tests/web-fetch-http.test.ts
@@ -1,5 +1,6 @@
 import { createServer, type Server } from "node:http";
 import { AddressInfo } from "node:net";
+import { gzipSync } from "node:zlib";
 import { fetchCapped, pinnedLookup } from "@/lib/tools/web-fetch-http";
 
 // Transport-level tests. These run against a real loopback HTTP server rather
@@ -133,6 +134,84 @@ describe("fetchCapped", () => {
       expect(res.status).toBe(302);
       expect(res.location).toBe("https://elsewhere.test/next");
       expect(res.text).toBe("");
+    } finally {
+      await close(server);
+    }
+  });
+
+  it("closes the socket on a redirect instead of draining its body", async () => {
+    // Without the destroy, res.resume() keeps reading in the background after
+    // the promise settles — past the byte cap and past the cleared deadline.
+    let pushed = 0;
+    let clientGone = false;
+    const { server, port } = await listen((_req, res) => {
+      res.writeHead(302, { location: "https://elsewhere.test/next" });
+      const chunk = "x".repeat(64 * 1024);
+      const pump = (): void => {
+        if (clientGone || pushed > 8 * 1024 * 1024) return void res.end();
+        pushed += chunk.length;
+        if (res.write(chunk)) setImmediate(pump);
+        else res.once("drain", pump);
+      };
+      res.on("close", () => { clientGone = true; });
+      pump();
+    });
+    try {
+      const res = await fetchCapped({
+        url: `http://127.0.0.1:${port}/go`,
+        address: "127.0.0.1",
+        family: 4,
+        maxBytes: 10_000,
+        timeoutMs: 5_000,
+      });
+      expect(res.status).toBe(302);
+      await new Promise((r) => setTimeout(r, 250)); // let a leaked drain accumulate
+      expect(clientGone).toBe(true);
+      expect(pushed).toBeLessThan(4 * 1024 * 1024);
+    } finally {
+      await close(server);
+    }
+  });
+
+  it("requests identity encoding and refuses a compressed response", async () => {
+    // http.request sends no Accept-Encoding of its own and does not decompress,
+    // so an encoded body would reach htmlToText() as binary garbage.
+    let accept: string | undefined;
+    const { server, port } = await listen((req, res) => {
+      accept = req.headers["accept-encoding"];
+      res.writeHead(200, { "content-type": "text/html", "content-encoding": "gzip" });
+      res.end(gzipSync(Buffer.from("<h1>Hello</h1>")));
+    });
+    try {
+      await expect(
+        fetchCapped({
+          url: `http://127.0.0.1:${port}/gz`,
+          address: "127.0.0.1",
+          family: 4,
+          maxBytes: 10_000,
+          timeoutMs: 5_000,
+        }),
+      ).rejects.toThrow(/refusing gzip-encoded response/);
+      expect(accept).toBe("identity");
+    } finally {
+      await close(server);
+    }
+  });
+
+  it("does not reuse pooled sockets between calls to the same host and port", async () => {
+    // The default global agent keys its pool on host:port and ignores `lookup`,
+    // so a reused socket could serve a hop that never ran pinnedLookup.
+    let connections = 0;
+    const { server, port } = await listen((_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("ok");
+    });
+    server.on("connection", () => { connections++; });
+    try {
+      const opts = { address: "127.0.0.1", family: 4, maxBytes: 10_000, timeoutMs: 5_000 };
+      await fetchCapped({ url: `http://127.0.0.1:${port}/one`, ...opts });
+      await fetchCapped({ url: `http://127.0.0.1:${port}/two`, ...opts });
+      expect(connections).toBe(2);
     } finally {
       await close(server);
     }

--- a/tests/web-fetch-tool.test.ts
+++ b/tests/web-fetch-tool.test.ts
@@ -1,6 +1,12 @@
 import { lookup } from "node:dns/promises";
 import { getDb } from "@/lib/db";
-import { htmlToText, isBlockedIp, webFetchTool, WEB_FETCH_MAX_CHARS } from "@/lib/tools/web-fetch";
+import { fetchCapped } from "@/lib/tools/web-fetch-http";
+import {
+  htmlToText,
+  isBlockedIp,
+  webFetchTool,
+  WEB_FETCH_MAX_BYTES,
+} from "@/lib/tools/web-fetch";
 
 // SSRF guard resolves hosts via dns.lookup — mock it so execute() tests never
 // touch real DNS. Default: every host resolves to a public address; SSRF tests
@@ -9,15 +15,28 @@ vi.mock("node:dns/promises", () => ({ lookup: vi.fn() }));
 const lookupMock = vi.mocked(lookup);
 const PUBLIC = [{ address: "93.184.216.34", family: 4 }];
 
+// The transport is mocked here so these tests cover the guard and the redirect
+// loop. The transport's own behaviour (pinning, byte cap) is covered against a
+// real socket in web-fetch-http.test.ts.
+vi.mock("@/lib/tools/web-fetch-http", () => ({ fetchCapped: vi.fn() }));
+const fetchMock = vi.mocked(fetchCapped);
+
+const ok = (text: string, contentType: string | null = "text/html", truncated = false) => ({
+  status: 200,
+  statusText: "OK",
+  contentType,
+  location: null,
+  text,
+  truncated,
+});
+
 const ctx = () => ({ db: getDb(), runId: 0, parentStepId: 0 });
 
 describe("webFetchTool", () => {
   beforeEach(() => {
     lookupMock.mockReset();
     lookupMock.mockResolvedValue(PUBLIC as never);
-  });
-  afterEach(() => {
-    vi.unstubAllGlobals();
+    fetchMock.mockReset();
   });
 
   it("is an enrich-class tool named web_fetch", () => {
@@ -61,12 +80,46 @@ describe("webFetchTool", () => {
 
   it("refuses a host that resolves to a non-public address (SSRF)", async () => {
     lookupMock.mockResolvedValue([{ address: "169.254.169.254", family: 4 }] as never);
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
     await expect(webFetchTool.execute({ url: "https://metadata.evil.test/" }, ctx())).rejects.toThrow(
       /non-public address 169\.254\.169\.254/,
     );
     expect(fetchMock).not.toHaveBeenCalled(); // blocked before any network call
+  });
+
+  it("hands the transport the address it validated, not the hostname (DNS-rebinding pin)", async () => {
+    // The guard resolves once; that exact address must be what the connection
+    // uses. If the transport were left to re-resolve, a hostname whose DNS flips
+    // to 169.254.169.254 between validation and connect would reach the metadata
+    // service — the TOCTOU window PR #18 left open.
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }] as never);
+    fetchMock.mockResolvedValue(ok("<p>hi</p>"));
+
+    await webFetchTool.execute({ url: "https://rebind.test/page" }, ctx());
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toMatchObject({
+      url: "https://rebind.test/page",
+      address: "93.184.216.34",
+      family: 4,
+    });
+  });
+
+  it("pins each redirect hop to that hop's own validated address", async () => {
+    lookupMock
+      .mockResolvedValueOnce([{ address: "93.184.216.34", family: 4 }] as never)
+      .mockResolvedValueOnce([{ address: "8.8.8.8", family: 4 }] as never);
+    fetchMock
+      .mockResolvedValueOnce({
+        status: 302, statusText: "Found", contentType: null,
+        location: "https://second.test/landing", text: "", truncated: false,
+      })
+      .mockResolvedValueOnce(ok("<p>done</p>"));
+
+    const result = await webFetchTool.execute({ url: "https://first.test/go" }, ctx());
+
+    expect(result.text).toBe("done");
+    expect(fetchMock.mock.calls[0][0]).toMatchObject({ url: "https://first.test/go", address: "93.184.216.34" });
+    expect(fetchMock.mock.calls[1][0]).toMatchObject({ url: "https://second.test/landing", address: "8.8.8.8" });
   });
 
   it("re-validates on redirect and refuses a redirect to a private address (SSRF)", async () => {
@@ -74,42 +127,40 @@ describe("webFetchTool", () => {
     lookupMock
       .mockResolvedValueOnce(PUBLIC as never)
       .mockResolvedValueOnce([{ address: "169.254.169.254", family: 4 }] as never);
-    const fetchMock = vi.fn().mockResolvedValueOnce({
-      status: 302,
-      statusText: "Found",
-      headers: { get: (h: string) => (h === "location" ? "http://169.254.169.254/latest/meta-data/" : null) },
+    fetchMock.mockResolvedValueOnce({
+      status: 302, statusText: "Found", contentType: null,
+      location: "http://169.254.169.254/latest/meta-data/", text: "", truncated: false,
     });
-    vi.stubGlobal("fetch", fetchMock);
+
     await expect(webFetchTool.execute({ url: "https://redir.test/go" }, ctx())).rejects.toThrow(
       /non-public address 169\.254\.169\.254/,
     );
-    expect(fetchMock).toHaveBeenCalledTimes(1); // second hop refused before fetch
+    expect(fetchMock).toHaveBeenCalledTimes(1); // second hop refused before connecting
+  });
+
+  it("throws a clean error on a redirect with no Location header", async () => {
+    fetchMock.mockResolvedValue({
+      status: 302, statusText: "Found", contentType: null,
+      location: null, text: "", truncated: false,
+    });
+    await expect(webFetchTool.execute({ url: "https://example.com/go" }, ctx())).rejects.toThrow(
+      /redirect 302 with no Location/,
+    );
   });
 
   it("throws a clean error on too many redirects", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        status: 302,
-        statusText: "Found",
-        headers: { get: (h: string) => (h === "location" ? "https://example.com/next" : null) },
-      }),
-    );
+    fetchMock.mockResolvedValue({
+      status: 302, statusText: "Found", contentType: null,
+      location: "https://example.com/next", text: "", truncated: false,
+    });
     await expect(webFetchTool.execute({ url: "https://example.com/start" }, ctx())).rejects.toThrow(
       /too many redirects/,
     );
   });
 
   it("fetches a page and returns HTML-stripped text with the content type", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        statusText: "OK",
-        headers: { get: () => "text/html; charset=utf-8" },
-        text: async () => "<html><body><h1>Hi</h1><script>evil()</script><p>World</p></body></html>",
-      }),
+    fetchMock.mockResolvedValue(
+      ok("<html><body><h1>Hi</h1><script>evil()</script><p>World</p></body></html>", "text/html; charset=utf-8"),
     );
 
     const result = await webFetchTool.execute({ url: "https://example.com/page" }, ctx());
@@ -120,61 +171,38 @@ describe("webFetchTool", () => {
     expect(result.url).toBe("https://example.com/page");
   });
 
-  it("caps oversized responses and marks them truncated", async () => {
-    const big = "a".repeat(WEB_FETCH_MAX_CHARS + 1000);
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        statusText: "OK",
-        headers: { get: () => "text/plain" },
-        text: async () => big,
-      }),
-    );
+  it("passes the byte cap to the transport and surfaces its truncation flag", async () => {
+    fetchMock.mockResolvedValue(ok("a".repeat(1000), "text/plain", true));
 
     const result = await webFetchTool.execute({ url: "https://example.com/big" }, ctx());
 
+    expect(fetchMock.mock.calls[0][0]).toMatchObject({ maxBytes: WEB_FETCH_MAX_BYTES });
     expect(result.truncated).toBe(true);
-    expect(result.text.length).toBeLessThanOrEqual(WEB_FETCH_MAX_CHARS);
   });
 
   it("throws a clean error on a non-OK response", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({ ok: false, status: 404, statusText: "Not Found", headers: { get: () => null } }),
-    );
+    fetchMock.mockResolvedValue({
+      status: 404, statusText: "Not Found", contentType: null,
+      location: null, text: "nope", truncated: false,
+    });
     await expect(webFetchTool.execute({ url: "https://example.com/missing" }, ctx())).rejects.toThrow(
       /Fetch failed: 404/,
     );
   });
 
-  it("throws a clean error when fetch itself rejects (network failure)", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("ENOTFOUND example.com")));
-    await expect(webFetchTool.execute({ url: "https://example.com/page" }, ctx())).rejects.toThrow(/ENOTFOUND/);
-  });
-
-  it("throws a clean error when reading the response body fails", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        statusText: "OK",
-        headers: { get: () => "text/html" },
-        text: async () => {
-          throw new Error("stream aborted");
-        },
-      }),
-    );
-    await expect(webFetchTool.execute({ url: "https://example.com/page" }, ctx())).rejects.toThrow(/stream aborted/);
+  it("propagates a transport failure", async () => {
+    fetchMock.mockRejectedValue(new Error("ECONNREFUSED 93.184.216.34:443"));
+    await expect(webFetchTool.execute({ url: "https://example.com/page" }, ctx())).rejects.toThrow(/ECONNREFUSED/);
   });
 
   it.skipIf(!process.env.SOURCECADO_RUN_LIVE_SMOKE)(
     "live: fetches a real page and strips its HTML",
     async () => {
-      const real = await vi.importActual<typeof import("node:dns/promises")>("node:dns/promises");
-      lookupMock.mockImplementation(real.lookup as never);
+      const realDns = await vi.importActual<typeof import("node:dns/promises")>("node:dns/promises");
+      const realTransport =
+        await vi.importActual<typeof import("@/lib/tools/web-fetch-http")>("@/lib/tools/web-fetch-http");
+      lookupMock.mockImplementation(realDns.lookup as never);
+      fetchMock.mockImplementation(realTransport.fetchCapped);
       const result = await webFetchTool.execute({ url: "https://example.com" }, ctx());
       expect(result.text).toMatch(/Example Domain/i);
     },


### PR DESCRIPTION
Closes the two threads PR #18 left **NEEDS-HUMAN**: finding **#2** (DNS-rebinding TOCTOU) and finding **#3** (response cap applied after full buffering).

## Scope change

R11 originally bundled a per-run spend ceiling with these two fixes. **The ceiling was split out** to `docs/superpowers/plans/2026-08-04-ticket-enrich-spend-ceiling.md` and now sits with J3/J4, where its consumers are. Short version: Apollo isn't live, the `enrich` permission class is already the gate, and the ceiling protects an autonomous path that doesn't exist yet. Its design is fully settled in that ticket, so it's deferred rather than re-opened. This PR is the security half only.

## No new dependency

PR #18 concluded the pin required `undici` — a runbook stop-condition. It doesn't. `https.request` accepts a `lookup` option that reaches `tls.connect`, pinning the socket to a chosen address while **SNI and certificate validation still use the hostname**.

Verified by spike before writing any code, against a self-signed `CN=pinned.test` cert served on `127.0.0.1`:

| Check | Result |
|---|---|
| `lookup` pins the TCP connection | connected to 127.0.0.1, `Host: pinned.test` preserved |
| HTTPS pinned **and** cert validated for `CN=pinned.test` | TLS validated |
| `req.destroy()` at the cap halts transfer | 262KB received; server stopped at 590KB instead of sending 40MB |

The byte cap forces a stream regardless, so both findings collapse into one transport rewrite.

## Changes

- **new `src/lib/tools/web-fetch-http.ts`** — `fetchCapped()` + `pinnedLookup()`. Streams the body and destroys the request past the cap. Overshoot is bounded by one 64KB socket read, which is what lets a body landing exactly on the cap report as complete rather than truncated.
- **`assertPublicHost()` now returns the address it validated**, so every redirect hop connects to its own checked address instead of re-resolving.
- **`WEB_FETCH_MAX_CHARS` → `WEB_FETCH_MAX_BYTES`** — it now bounds memory, not just the resulting string.

The split is along a real seam: `web-fetch.ts` decides *whether* a URL may be fetched; `web-fetch-http.ts` decides *how* the bytes arrive.

## Testing

`tests/web-fetch-http.test.ts` runs against a **real loopback HTTP server, not a mock** — that the bytes stop arriving is a property of the socket, and a mock would only assert we called something. It covers pinning (a URL for `pinned.test`, which doesn't resolve at all, still lands on the local server), the abort-at-cap, the exactly-at-cap boundary, redirects, non-OK, connection failure, and timeout.

`tests/web-fetch-tool.test.ts` keeps the guard and redirect-loop coverage with the transport mocked, plus two new tests asserting the validated address is what reaches the transport on every hop. Live smoke against real HTTPS passes with `SOURCECADO_RUN_LIVE_SMOKE=1`.

## Gate

| | |
|---|---|
| Suite | **430 passed**, 78 failed, 1 skipped |
| Failures | all 78 pre-existing `better-sqlite3` bindings failures in the legacy CLI stack (**R10's scope**) — identical to the branch baseline, zero new |
| `tsc --noEmit` | clean |
| `npm run build` | clean |
| `npm run lint` | clean (only the pre-existing `embed.ts` warning) |

Branched off `main` @ `372d613` (R7), so this does **not** include PR #20. No migration in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened web fetching against DNS rebinding by pinning connections to validated addresses while preserving hostname verification.
* **Bug Fixes**
  * Added request timeouts and safer handling for redirects, connection failures, and non-success responses.
  * Limited response sizes during download, stopping oversized responses early and reporting truncation.
* **Improvements**
  * Web fetch results now provide more reliable response metadata, content handling, and truncation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces web_fetch’s global Fetch transport with a pinned-address, streaming Node HTTP(S) implementation to close DNS-rebinding and full-body-buffering gaps.
- Returns the DNS address validated by the SSRF guard and pins every redirect hop to that address.
- Adds a byte-capped transport with request timeouts and socket-level tests.
- Preserves manual redirect validation while moving response handling into web-fetch-http.ts.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until redirect transfers remain bounded and encoded HTTP response bodies are decoded before being returned as visible text.

The new transport correctly pins validated addresses and caps ordinary bodies, but a streaming redirect can outlive the cleared deadline indefinitely, while compressed responses are interpreted as raw UTF-8 and produce corrupted tool output.

**Files Needing Attention:** src/lib/tools/web-fetch-http.ts

<details open><summary><h3>Security Review</h3></summary>

The address pinning closes the intended DNS-rebinding window, but redirect responses can bypass both transfer limits: settling immediately cancels the timeout while res.resume() continues draining an attacker-controlled body in the background. **How this was verified:** The redirect branch was traced through settle(), which clears the deadline without reaching either request-destruction path.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/tools/web-fetch-http.ts | Introduces address-pinned streaming transport, but redirect bodies escape timeout/cap enforcement and encoded response bodies are not decoded. |
| src/lib/tools/web-fetch.ts | Integrates per-hop DNS pinning and byte-capped fetching while retaining protocol, SSRF, redirect, and status checks. |
| tests/web-fetch-http.test.ts | Adds useful socket-level coverage for pinning, limits, boundaries, and timeout behavior, but only tests finite uncompressed redirect bodies. |
| tests/web-fetch-tool.test.ts | Updates tool-level mocks and verifies that each redirect hop receives its independently validated address. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Caller-provided URL] --> B[Resolve and validate all addresses]
  B --> C[Select validated address]
  C --> D[fetchCapped pins socket lookup]
  D --> E{Response status}
  E -->|2xx| F[Stream body with byte cap and timeout]
  F --> G[Decode text and strip HTML]
  E -->|3xx| H[Read Location and validate next hop]
  H --> C
  E -->|Other| I[Return fetch error]
```

<sub>Reviews (1): Last reviewed commit: ["fix(rt-R11): pin validated IP + stream-c..."](https://github.com/fisherxz/sourcecado/commit/502e06d925c70290ff7abf83d4603e5edbdfe34c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50212645)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->