### PR TITLE
fix(apollo): map apollo_search_people to the fields Apollo actually returns

### DIFF
--- a/src/lib/tools/apollo.ts
+++ b/src/lib/tools/apollo.ts
@@ -38,12 +38,22 @@ export const apolloSearchPeopleArgsSchema = z
   });
 export type ApolloSearchPeopleArgs = z.infer<typeof apolloSearchPeopleArgsSchema>;
 
+// Shape verified live against mixed_people/api_search on 2026-08-04 (50
+// records). Search deliberately withholds contact detail on this plan: no
+// `name`, `email`, or `linkedin_url` is ever sent — the last name arrives
+// obfuscated ("Do***e") and email/phone reduce to existence signals. Reading
+// fields Apollo does not send is what this shape replaces; do not add them back.
 export interface ApolloPersonSummary {
-  name: string | null;
+  apolloId: string | null;
+  firstName: string | null;
+  lastNameObfuscated: string | null;
   title: string | null;
   organizationName: string | null;
-  linkedinUrl: string | null;
-  email: string | null;
+  hasEmail: boolean;
+  // Apollo sends a string here, not a boolean: "Yes" or "Maybe: please request
+  // direct dial via people/bulk_match". Passed through verbatim — collapsing
+  // "Maybe" into false would assert an absence Apollo never claimed.
+  directPhoneStatus: string | null;
 }
 
 export interface ApolloSearchPeopleResult {
@@ -52,18 +62,22 @@ export interface ApolloSearchPeopleResult {
 
 interface ApolloSearchResponse {
   people?: Array<{
-    name?: string;
+    id?: string;
+    first_name?: string;
+    last_name_obfuscated?: string | null;
     title?: string;
+    has_email?: boolean;
+    has_direct_phone?: string;
     organization?: { name?: string };
-    linkedin_url?: string;
-    email?: string;
   }>;
 }
 
 export const apolloSearchPeopleTool: Tool<ApolloSearchPeopleArgs, ApolloSearchPeopleResult> = {
   name: "apollo_search_people",
   description:
-    "Search for people at a target organization via Apollo. Provide organizationName and/or personTitles.",
+    "Search for people at a target organization via Apollo. Provide organizationName and/or personTitles. " +
+    "Returns who exists and their titles only — no email and no full last name. To reach someone, resolve " +
+    "their full name first (web_search / web_fetch), then call apollo_enrich_contact for a verified email.",
   permissionClass: "enrich",
   argsSchema: apolloSearchPeopleArgsSchema,
   async execute(args) {
@@ -75,11 +89,13 @@ export const apolloSearchPeopleTool: Tool<ApolloSearchPeopleArgs, ApolloSearchPe
     })) as ApolloSearchResponse;
 
     const people: ApolloPersonSummary[] = (data.people ?? []).map((p) => ({
-      name: p.name ?? null,
+      apolloId: p.id ?? null,
+      firstName: p.first_name ?? null,
+      lastNameObfuscated: p.last_name_obfuscated ?? null,
       title: p.title ?? null,
       organizationName: p.organization?.name ?? null,
-      linkedinUrl: p.linkedin_url ?? null,
-      email: p.email ?? null,
+      hasEmail: p.has_email ?? false,
+      directPhoneStatus: p.has_direct_phone ?? null,
     }));
     return { people };
   },

--- a/tests/apollo-tools.test.ts
+++ b/tests/apollo-tools.test.ts
@@ -38,6 +38,12 @@ describe("apollo tools", () => {
       ).rejects.toThrow(/APOLLO_API_KEY/);
     });
 
+    // Fixture shape captured live from POST /api/v1/mixed_people/api_search on
+    // 2026-08-04 (50 records). Every key, type, and value below is one Apollo
+    // actually sends — including has_direct_phone being a string ("Yes" or
+    // "Maybe: ...") rather than a boolean, and last_name_obfuscated being
+    // nullable. Only the person identities are swapped out. The endpoint sends
+    // no `name`, `email`, or `linkedin_url` on this plan.
     it("returns mapped people on a successful Apollo response", async () => {
       process.env.APOLLO_API_KEY = "test-key";
       const fetchMock = vi.fn().mockResolvedValue({
@@ -45,13 +51,38 @@ describe("apollo tools", () => {
         status: 200,
         statusText: "OK",
         json: async () => ({
+          total_entries: 3402,
           people: [
             {
-              name: "Jane Doe",
+              id: "55d725d1f3e5bb49f90024ff",
+              first_name: "Jane",
+              last_name_obfuscated: "Do***e",
               title: "VP Eng",
+              last_refreshed_at: "2026-07-14T15:24:06.101+00:00",
+              has_email: true,
+              has_city: true,
+              has_state: true,
+              has_country: true,
+              has_direct_phone: "Yes",
+              organization: {
+                name: "Acme",
+                has_industry: true,
+                has_phone: false,
+                has_city: true,
+              },
+            },
+            {
+              id: "54a5d4697468693442c7e1ab",
+              first_name: "Robert",
+              last_name_obfuscated: null,
+              title: "Strategic Partnerships",
+              last_refreshed_at: "2026-06-02T10:11:12.000+00:00",
+              has_email: false,
+              has_city: true,
+              has_state: true,
+              has_country: true,
+              has_direct_phone: "Maybe: please request direct dial via people/bulk_match",
               organization: { name: "Acme" },
-              linkedin_url: "https://linkedin.com/in/janedoe",
-              email: "jane@acme.com",
             },
           ],
         }),
@@ -65,17 +96,60 @@ describe("apollo tools", () => {
 
       expect(result.people).toEqual([
         {
-          name: "Jane Doe",
+          apolloId: "55d725d1f3e5bb49f90024ff",
+          firstName: "Jane",
+          lastNameObfuscated: "Do***e",
           title: "VP Eng",
           organizationName: "Acme",
-          linkedinUrl: "https://linkedin.com/in/janedoe",
-          email: "jane@acme.com",
+          hasEmail: true,
+          directPhoneStatus: "Yes",
+        },
+        {
+          apolloId: "54a5d4697468693442c7e1ab",
+          firstName: "Robert",
+          lastNameObfuscated: null,
+          title: "Strategic Partnerships",
+          organizationName: "Acme",
+          hasEmail: false,
+          directPhoneStatus: "Maybe: please request direct dial via people/bulk_match",
         },
       ]);
       expect(fetchMock).toHaveBeenCalledWith(
         "https://api.apollo.io/api/v1/mixed_people/api_search",
         expect.objectContaining({ method: "POST" }),
       );
+    });
+
+    // Both assertions here are exact-match: a re-added `email` or `linkedinUrl`
+    // member — the bug this ticket fixes — fails them.
+    it("degrades to nulls when Apollo omits fields on a person", async () => {
+      process.env.APOLLO_API_KEY = "test-key";
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          json: async () => ({ total_entries: 1, people: [{}] }),
+        }),
+      );
+
+      const result = await apolloSearchPeopleTool.execute(
+        { organizationName: "Acme" },
+        { db: getDb(), runId: 0, parentStepId: 0 },
+      );
+
+      expect(result.people).toEqual([
+        {
+          apolloId: null,
+          firstName: null,
+          lastNameObfuscated: null,
+          title: null,
+          organizationName: null,
+          hasEmail: false,
+          directPhoneStatus: null,
+        },
+      ]);
     });
 
     it("throws a clean error when fetch itself rejects (network failure)", async () => {


### PR DESCRIPTION
Ticket: `docs/superpowers/plans/2026-08-04-ticket-apollo-search-field-mapping.md`

## Problem

`mixed_people/api_search` never sends `name`, `email`, or `linkedin_url` on our Apollo plan. Three of the five mapped fields on `ApolloPersonSummary` were therefore structurally always `null` — every search result came back near-empty, and the tests were green on the wrong mapping for two weeks because the fixtures were written from the same assumption as the code.

## Fix

`ApolloPersonSummary` now carries only what Apollo sends:

| field | source |
|---|---|
| `apolloId` | `id` |
| `firstName` | `first_name` |
| `lastNameObfuscated` | `last_name_obfuscated` (nullable) |
| `title` | `title` |
| `organizationName` | `organization.name` |
| `hasEmail` | `has_email` |
| `directPhoneStatus` | `has_direct_phone` |

`email` and `linkedinUrl` are gone from the search result type entirely.

## Deviation from the ticket, found by re-probing

Re-verified live against 50 records on 2026-08-04 rather than trusting the ticket text. Two corrections:

- **`has_direct_phone` is a string, never a boolean.** Observed values: `"Yes"` (37/50) and `"Maybe: please request direct dial via people/bulk_match"` (13/50). No negative value observed at all. Shipped as `directPhoneStatus: string | null`, verbatim — a `hasDirectPhone: boolean` would have to collapse "Maybe" into `false`, asserting an absence Apollo never claimed. That is the same class of error as the bug being fixed.
- **`last_name_obfuscated` is nullable** (1/50).

`has_email` *is* a real boolean, true and false both observed.

## Tests

`tests/apollo-tools.test.ts` fixtures rewritten from the captured response — every key, type, and value vocabulary is one Apollo actually sends, with only the person identities swapped out (no scraped contact data committed). Both assertions are exact-match, so a re-added always-null member fails them. Verified red against the old mapping before the fix.

## Also changed

The tool description now tells the agent search yields no email and no full last name, so it routes `apollo_search_people` → `web_search`/`web_fetch` (resolve full name) → `apollo_enrich_contact` (verified email) instead of assuming search alone produces contactable people.

## Verification

- `npm test` — 73 files, 500 passed / 2 skipped
- `npm run typecheck` — clean
- `npm run lint` — clean (one pre-existing warning in `embed.ts`, untouched)
- `npm run build` — clean

`apollo_enrich_contact` is unchanged; its mapping was already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates Apollo people-search results to reflect the fields actually returned by `mixed_people/api_search`.
- Replaces unavailable contact fields with Apollo ID, first name, obfuscated last name, email availability, and direct-phone status.
- Clarifies the search-to-enrichment workflow in the tool description.
- Reworks fixtures and exact-match assertions around the observed Apollo response shape.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The revised result shape has no field-level repository consumers, remains compatible with generic tool-result serialization, and is covered by exact mapping tests.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/tools/apollo.ts | Aligns the people-search response interface, mapping, and tool guidance with Apollo’s observed payload. |
| tests/apollo-tools.test.ts | Replaces inaccurate fixtures and adds exact assertions for populated and omitted Apollo fields. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(apollo): map apollo\_search\_people to..."](https://github.com/fisherxz/sourcecado/commit/3589cd00fa8841144c57802b7975657d61648504) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50250983)</sub>

<!-- /greptile_comment -->