### PR TITLE
test(apollo): add a live shape smoke for apollo_search_people

### DIFF
--- a/tests/apollo-tools.test.ts
+++ b/tests/apollo-tools.test.ts
@@ -183,6 +183,33 @@ describe("apollo tools", () => {
         ),
       ).rejects.toThrow(/Unexpected token/);
     });
+
+    // The fixtures above are captured from a real response, so they start out
+    // correct — and then rot silently the day Apollo changes the contract.
+    // Only a real call catches that. Gated on the explicit SOURCECADO_RUN_LIVE_SMOKE
+    // opt-in because each run spends an Apollo credit; .env.local carries
+    // APOLLO_API_KEY for the DB suites, so key presence is not the right gate.
+    it.skipIf(!process.env.SOURCECADO_RUN_LIVE_SMOKE)(
+      "live: search still returns the fields we map (opt-in via SOURCECADO_RUN_LIVE_SMOKE)",
+      async () => {
+        const result = await apolloSearchPeopleTool.execute(
+          { organizationName: "Anthropic", limit: 2 },
+          { db: getDb(), runId: 0, parentStepId: 0 },
+        );
+
+        expect(result.people.length).toBeGreaterThan(0);
+        for (const person of result.people) {
+          expect(typeof person.apolloId).toBe("string");
+          expect(person.apolloId).not.toBe("");
+          expect(typeof person.firstName).toBe("string");
+          expect(typeof person.organizationName).toBe("string");
+          expect(typeof person.hasEmail).toBe("boolean");
+          // Apollo sends this as a status string, not a boolean. If it ever
+          // becomes one, directPhoneStatus is the wrong shape and this fails.
+          expect(typeof person.directPhoneStatus).not.toBe("boolean");
+        }
+      },
+    );
   });
 
   describe("apolloEnrichContactTool", () => {


### PR DESCRIPTION
**Rescoped.** #27 landed the same ticket while this branch was in flight, and its fix is better than mine on the point that matters: `has_direct_phone` also comes back as `"Maybe: please request direct dial via people/bulk_match"`, not just `"Yes"`. Its 50-record capture caught that; my 2-record capture didn't. My version normalized to a boolean, which would have collapsed `"Maybe"` into `false` — asserting an absence Apollo never claimed. Main's `directPhoneStatus` passthrough is correct, so I took main's `apollo.ts` wholesale and dropped my mapping entirely.

I also dropped my key-absence test: main's `toEqual` exact-match assertions already fail on a re-added `email` or `linkedinUrl` member, so it was duplicate coverage.

## What's left

One test, 27 lines. #27 rebuilt the fixtures from a real capture — correct, and the right call — but a copied fixture only *starts out* correct. It rots silently the day Apollo changes the contract, and nothing in the suite would notice. The ticket's own stated lesson is that a mock nobody re-checks proves nothing; that applies to a captured mock too, just on a longer fuse.

This adds a call to real Apollo asserting the mapped fields are still populated, including that `directPhoneStatus` is still a status string rather than a boolean. Gated on `SOURCECADO_RUN_LIVE_SMOKE`, matching `web-search-tool.test.ts:105` and `web-fetch-tool.test.ts` — key presence is deliberately not the gate, since `.env.local` carries `APOLLO_API_KEY` for the DB suites and each run spends a credit.

## Verification

- `npm test` — 74 files, 516 passed, 3 skipped (the smoke skips by default)
- `SOURCECADO_RUN_LIVE_SMOKE=1 npx vitest run tests/apollo-tools.test.ts` — 14/14 against live Apollo, confirming main's shape holds
- `npx tsc --noEmit` clean. Test-only diff, so no build re-run beyond what main's CI covers.

## Known gap

The `person_titles` **request** param is still unverified against the live API — every capture so far used `q_organization_name`. It either works or silently over-broadens. Separate bug, worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an optional live smoke test that validates people-search results, including identity, organization, email, and direct-phone information.
  * The test runs only when explicitly enabled; otherwise, it is skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->