### PR TITLE
fix(agent-loop): return partial work when the step budget runs out

### DIFF
--- a/docs/superpowers/plans/2026-08-04-ticket-loop-step-budget-partial-answer.md
+++ b/docs/superpowers/plans/2026-08-04-ticket-loop-step-budget-partial-answer.md
@@ -1,0 +1,163 @@
+# Ticket — Exhausting the step budget returns nothing
+
+Date: 2026-08-04
+Found by: code read during the 2026-08-04 agent probe
+Est: 0.5
+
+## Problem
+
+`src/lib/agent-loop.ts:158` ends a step-exhausted run like this:
+
+```ts
+return { status: "failed", messages, stopReason: lastStopReason, steps: maxSteps };
+```
+
+No `finalText`. An agent that ran 8 steps of real research — searched memory,
+queried Apollo, fetched pages — hands back **nothing at all**. Not a summary, not
+partial findings, not a statement of what it was doing when it ran out.
+
+Every other exit path in the loop produces something. This one silently discards
+the whole run.
+
+## Second problem: the ceiling is low — and is the wrong instrument
+
+```ts
+const DEFAULT_MAX_STEPS = 8;
+```
+
+One step is one LLM turn. The chain a real sourcing task needs — memory search,
+Apollo search, web search, web fetch, Apollo enrich, then write — spends 5-6
+turns before the first word of the deliverable. Eight leaves almost no room for
+a retry, a refinement, or a second contact.
+
+**There are two constants, not one.** `agent-loop.ts:16` and `harness.ts:71`.
+Harness always passes its value down, so `harness.ts:71` is the effective ceiling
+for every chat run and `agent-loop.ts:16` only binds direct `runAgentLoop`
+callers (tests today). Changing one and not the other is a live foot-gun.
+
+## Evidence
+
+The 2026-08-04 probe used 2 of 8 steps, so the ceiling was not what broke that
+run. This is a latent defect, not the observed one — but it will bite the moment
+`2026-08-04-ticket-agent-tool-chaining.md` lands and the agent actually starts
+chaining. Fixing the chain without fixing this trades a template for a blank.
+
+### What the reference implementations do
+
+Checked 2026-08-04 against `Good-Examples/claude-code-main` and
+`GitHub2026/openclaw`. **Neither imposes a default step ceiling on its main
+agent loop.**
+
+Claude Code:
+
+- `maxTurns?: number` is optional with no default (`QueryEngine.ts:146`). The
+  check is `if (maxTurns && nextTurnCount > maxTurns)` (`query.ts:1705`) —
+  undefined means the `while (true)` loop runs until the model stops calling
+  tools.
+- `--max-turns` is `.hideHelp()`'d and its own description says *"only works with
+  `--print`"* (`main.tsx:976`). It is a headless-scripting affordance, not the
+  interactive agent's governor.
+- Registered on the next line is the actual cost control: `--max-budget-usd`,
+  checked at `QueryEngine.ts:972` (`getTotalCost() >= maxBudgetUsd` →
+  `error_max_budget_usd`). `attachments.ts:3846` injects
+  `{ used, total, remaining }` into the model's context each turn, so the agent
+  sees its runway shrink and wraps up itself rather than being cut off blind.
+- Subagents take an optional `maxTurns` from agent frontmatter
+  (`loadAgentsDir.ts:89`) — opt-in, still no default.
+
+openclaw imposes no step ceiling on its own loop. Its `maxTurns` occurrences are
+xAI's internal search config (`types.tools.ts:648`), an agent-to-agent ping-pong
+deadlock guard that also hands the model an explicit stop token
+(`sessions-send-helpers.ts:101-103`), and relaying `cli_max_turns` out of the
+Claude Code subprocess it drives.
+
+Sourcecado's unconditional `DEFAULT_MAX_STEPS = 8` on every chat run is out of
+line with both.
+
+## Decisions
+
+Settled 2026-08-04 with Fisher, after the reference read above.
+
+1. **Keep a ceiling, but demote it to a runaway backstop: 50.** Not "remove
+   entirely" and not a tuned product number like 20. A tuned number is just a
+   smaller version of the same wrong control — it still ends legitimate runs, and
+   any value picked today is a guess. 50 sits far above any real sourcing chain,
+   so it stops being the thing that ends real work, while still capping a
+   pathological tool-call cycle burning model tokens. Set **both** constants.
+
+2. **Why not remove it entirely.** Claude Code can run unbounded partly because
+   it auto-compacts (`autoCompactTracking` threaded through `query.ts` state).
+   Sourcecado has no compaction — `runAgentLoop` appends to `messages[]` forever.
+   An unbounded loop here does not run until it is done; it runs until the
+   provider rejects the transcript on context length, which surfaces as
+   `stopReason: "error"` — a hard failure, not a graceful stop. Revisit removing
+   the backstop only once compaction exists.
+
+3. **The spend ceiling does not subsume this.** Worth stating because it is the
+   natural assumption: `2026-08-04-ticket-enrich-spend-ceiling.md` decision 4 is
+   *soft-deny, do not kill the run* — a budget-exhausted agent gets
+   `Error (budget_exhausted)` and answers from what it has, so the run still ends
+   `succeeded` through the normal path. It never truncates. That makes the step
+   backstop (and abort) the **only** ways a run ends mid-chain, so the truncated
+   path built here is not shared machinery with the budget work.
+
+4. **Signal truncation with a distinct status,** threaded
+   `AgentLoopResult` → `RunAgentResult` → `MemoryAnswer` → the stream's `meta`:
+
+   ```ts
+   status: "succeeded" | "truncated" | "failed"
+   ```
+
+   The ticket's requirement is that a caller can tell "ran out of room, here is
+   what I have" from "the model errored"; a boolean flag riding alongside
+   `status: "failed"` leaves `/api/agent` returning 500 and the ledger recording
+   a failure for a run that produced usable output.
+
+5. **Partial text is the last assistant text, verbatim,** with a synthetic
+   fallback line when that turn was pure `tool_use` and carries no text. Rejected
+   the alternative (one extra tools-disabled synthesis turn) because at a 50-step
+   backstop the run is already pathological — spending another LLM turn to
+   prettify a runaway is the wrong trade. Reconsider if the backstop is ever
+   lowered back into everyday range.
+
+## Notes for implementation
+
+- **The citation scrub is the trap.** `src/lib/memory/answer.ts:75` gates on
+  `result.status === "succeeded" && answer !== undefined`. Populating `finalText`
+  on the truncated path without widening this condition ships partial text to the
+  user **unscrubbed**, invented citations included. Widen the gate; do not just
+  change the loop's return.
+- `/api/agent` (`route.ts:20`) maps `status !== "succeeded"` to **HTTP 500**.
+  `truncated` must return 200 — a truncated answer is a result, not a server
+  error.
+- `/api/agent/stream` (`route.ts:91-101`) falls to `writer.answerEnd()` when
+  `result.answer` is undefined. In `ChatClient.tsx`, `errored` is only set on a
+  *transport* failure (line 95), so today a step-exhausted run renders as a
+  completed exchange with an **empty answer bubble** and a small grey "failed" in
+  the meta footer. That is the "silently dropped" this ticket names.
+- `harness.ts:165-168` routes every non-`succeeded` result through
+  `describeLoopFailure` → `failRunStep` + `failRun`. A truncated run should
+  `finishRun` with its output plus a truncation marker; it produced work.
+- The stream route's `withCheckedAnswer` (`route.ts:120`) no-ops when `answer` is
+  undefined — once truncated runs carry text, it starts applying to them, which is
+  correct but currently untested.
+- Existing tests encode the old behavior and must be rewritten, not deleted:
+  `tests/agent-loop.test.ts:267` asserts `status === "failed"` on exhaustion;
+  `tests/harness.test.ts:129-146` asserts the ledger gets
+  `errorType: "max_steps_exceeded"`.
+- Steal from Claude Code later, not now: injecting remaining-runway into the
+  model's context (`attachments.ts:3846`) is the mechanism that makes a ceiling
+  steer rather than guillotine. It belongs with the spend ceiling, where the
+  agent can act on it.
+
+## Done when
+
+- A run that exhausts its steps returns usable text plus a `truncated` status
+  distinguishable from a hard failure, proven by test.
+- Both `DEFAULT_MAX_STEPS` constants (`agent-loop.ts:16`, `harness.ts:71`) are 50,
+  documented in-file as a runaway backstop rather than a product limit.
+- Truncated partial text passes through the citation scrub, proven by a test that
+  would fail if the `answer.ts:75` gate were left as-is.
+- `/api/agent` returns 200 with the partial answer for a truncated run.
+- The truncated answer renders in chat as text the user can read, with a visible
+  "ran out of steps" signal — not an empty bubble.

--- a/src/app/api/agent/route.ts
+++ b/src/app/api/agent/route.ts
@@ -16,8 +16,10 @@ export async function POST(request: Request) {
     const db = getDb();
     const actor = await requireActor();
     const result = await answerWithMemory(db, { question, actor, history });
+    // A truncated run is a result, not a server error: it carries a real partial
+    // answer, and 500 would put that work out of reach of any HTTP client.
     return NextResponse.json(result, {
-      status: result.status === "succeeded" ? 200 : 500,
+      status: result.status === "failed" ? 500 : 200,
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : "agent run failed";

--- a/src/app/api/agent/stream/route.ts
+++ b/src/app/api/agent/stream/route.ts
@@ -48,6 +48,12 @@ export async function POST(request: Request) {
     // registry, gate on any tool_start.
     let searchCalledSoFar = false;
     let streamedLive = false;
+    // Exactly what reached the client live. answerFlush *appends* (it writes
+    // another text-delta, which the client concatenates), so any text flushed
+    // that already streamed renders twice. A truncated run's partial answer is
+    // frequently the pre-search narration verbatim, which makes this the common
+    // case rather than an edge one.
+    let streamedText = "";
 
     const result = await answerWithMemory(db, {
       question,
@@ -68,6 +74,7 @@ export async function POST(request: Request) {
           if (event.name === "search_memory") searchCalledSoFar = true;
         } else if (event.type === "llm" && event.event.type === "text_delta" && !searchCalledSoFar) {
           writer.answerDelta(event.event.delta);
+          streamedText += event.event.delta;
           streamedLive = true;
         }
       },
@@ -91,7 +98,20 @@ export async function POST(request: Request) {
     if (streamedLive && !searchCalledSoFar) {
       writer.answerEnd();
     } else if (result.answer) {
-      writer.answerFlush(result.answer);
+      // Send only what the client has not already seen. When the checked answer
+      // begins with the live-streamed prefix, that prefix is dropped and just the
+      // gated tail is flushed; when nothing streamed, `streamedText` is "" and
+      // this is the whole answer, exactly as before. An answer that no longer
+      // starts with what streamed (e.g. citation scrubbing rewrote the prefix)
+      // is flushed whole — the corrected text is worth the visible repeat.
+      const unsent = result.answer.startsWith(streamedText)
+        ? result.answer.slice(streamedText.length)
+        : result.answer;
+      if (unsent) {
+        writer.answerFlush(unsent);
+      } else {
+        writer.answerEnd();
+      }
     } else {
       // Run ended with no authoritative answer (e.g. failed mid-stream after a
       // search_memory gated further live streaming): close any answer part that

--- a/src/app/chat/ChatClient.tsx
+++ b/src/app/chat/ChatClient.tsx
@@ -141,9 +141,19 @@ export function ChatClient({ initialExchanges = [] }: { initialExchanges?: Resum
                       {e.turn.answer}
                     </div>
                   ) : e.turn.answer ? (
-                    <MessageBubble role="assistant">
-                      <span className="whitespace-pre-wrap">{e.turn.answer}</span>
-                    </MessageBubble>
+                    <>
+                      {/* Sits above the answer so "incomplete" is read before the
+                          text itself. The parent is already an aria-live region,
+                          so no nested role is needed. */}
+                      {e.turn.meta?.status === "truncated" ? (
+                        <div className="rounded-[8px] bg-warn-bg px-3 py-2 text-[13px] text-warn-tx">
+                          Ran out of steps — this answer is incomplete. Ask a follow-up to continue.
+                        </div>
+                      ) : null}
+                      <MessageBubble role="assistant">
+                        <span className="whitespace-pre-wrap">{e.turn.answer}</span>
+                      </MessageBubble>
+                    </>
                   ) : null}
                   {e.turn.meta ? <MetaFooter meta={e.turn.meta} /> : null}
                 </div>

--- a/src/app/chat/stream.ts
+++ b/src/app/chat/stream.ts
@@ -12,7 +12,7 @@ export interface ChatStep {
 
 export interface ChatMeta {
   runId: number;
-  status: "succeeded" | "failed";
+  status: "succeeded" | "truncated" | "failed";
   steps: number;
   invalidCitations: string[];
 }

--- a/src/lib/agent-loop.ts
+++ b/src/lib/agent-loop.ts
@@ -13,7 +13,14 @@ import type { MemoryActor } from "./memory/actor";
 
 export type { ToolExecutionResult } from "./tools/orchestrator";
 
-const DEFAULT_MAX_STEPS = 8;
+// A runaway backstop, NOT a product limit — neither Claude Code nor openclaw
+// bounds its main agent loop by turn count. Spend belongs to the per-run ceiling
+// (docs/superpowers/plans/2026-08-04-ticket-enrich-spend-ceiling.md); 50 sits far
+// above any real sourcing chain, so it only catches a pathological tool cycle.
+// Not removed outright because this loop has no context compaction: unbounded, it
+// would end on a provider context-length rejection rather than on finishing.
+// Exported so harness.ts shares the value — the two copies used to drift.
+export const DEFAULT_MAX_STEPS = 50;
 
 export interface AgentLoopInput {
   messages: LlmMessage[];
@@ -36,8 +43,12 @@ export type AgentLoopEvent =
   | { type: "tool_end"; id: string; name: string; result: ToolExecutionResult };
 
 export interface AgentLoopResult {
-  status: "succeeded" | "failed";
+  // "truncated" = ran out of steps with work in hand. Deliberately distinct from
+  // "failed": the caller must be able to tell "here is what I have" from "the
+  // model errored", and only the former should reach the user as an answer.
+  status: "succeeded" | "truncated" | "failed";
   messages: LlmMessage[];
+  // Always set for "succeeded" and "truncated"; absent for "failed".
   finalText?: string;
   stopReason: StopReason;
   steps: number;
@@ -90,11 +101,7 @@ export async function runAgentLoop(input: AgentLoopInput): Promise<AgentLoopResu
     lastStopReason = outcome.stopReason;
 
     if (outcome.stopReason === "end") {
-      const finalText = outcome.message.content
-        .filter((block): block is Extract<(typeof outcome.message.content)[number], { type: "text" }> => block.type === "text")
-        .map((block) => block.text)
-        .join("");
-      return { status: "succeeded", messages, finalText, stopReason: "end", steps: step };
+      return { status: "succeeded", messages, finalText: assistantText(outcome.message), stopReason: "end", steps: step };
     }
 
     if (outcome.stopReason !== "tool_use") {
@@ -155,7 +162,38 @@ export async function runAgentLoop(input: AgentLoopInput): Promise<AgentLoopResu
     messages.push({ role: "tool_result", content: resultBlocks });
   }
 
-  return { status: "failed", messages, stopReason: lastStopReason, steps: maxSteps };
+  // Out of steps mid-chain. The run did real work — carry the model's own last
+  // words out as the answer rather than discarding the whole transcript. No
+  // extra synthesis turn: at this ceiling the run is already pathological, so
+  // spending another model call to tidy it up is the wrong trade. The fallback
+  // matters: an empty finalText would reproduce the blank-answer bug this fixes.
+  return {
+    status: "truncated",
+    messages,
+    finalText:
+      lastAssistantText(messages) ||
+      `[Ran out of steps: stopped after ${maxSteps} model turns without producing an answer.]`,
+    stopReason: lastStopReason,
+    steps: maxSteps,
+  };
+}
+
+function assistantText(message: LlmMessage): string {
+  if (message.role !== "assistant") return "";
+  return message.content
+    .filter((block): block is Extract<(typeof message.content)[number], { type: "text" }> => block.type === "text")
+    .map((block) => block.text)
+    .join("");
+}
+
+// The model may have spent its last turns on bare tool calls with no narration,
+// leaving nothing to carry forward. Returns "" in that case; callers substitute.
+function lastAssistantText(messages: LlmMessage[]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const text = assistantText(messages[i]).trim();
+    if (text) return text;
+  }
+  return "";
 }
 
 async function drain(

--- a/src/lib/harness.ts
+++ b/src/lib/harness.ts
@@ -1,7 +1,7 @@
 import { getDb } from "./db";
 import { failRun, failRunStep, finishRun, finishRunStep, startRun, startRunStep } from "./ledger";
 import { ModelGatewayError } from "./model-gateway";
-import { runAgentLoop, type AgentLoopEvent } from "./agent-loop";
+import { DEFAULT_MAX_STEPS, runAgentLoop, type AgentLoopEvent } from "./agent-loop";
 import type { LlmAdapter, LlmMessage } from "./llm/types";
 import type { ToolRegistry } from "./tools/registry";
 import type { PermissionClass, Sql } from "./tools/types";
@@ -59,7 +59,8 @@ export interface RunAgentInput {
 
 export interface RunAgentResult {
   runId: number;
-  status: "succeeded" | "failed";
+  // "truncated" carries a usable partial answer — see AgentLoopResult.status.
+  status: "succeeded" | "truncated" | "failed";
   answer?: string;
   steps: number;
   // Additive: the full transcript produced by this run (AgentLoopResult.messages),
@@ -68,7 +69,6 @@ export interface RunAgentResult {
 }
 
 const DEFAULT_ALLOWED: PermissionClass[] = ["read", "reason"];
-const DEFAULT_MAX_STEPS = 8;
 // Fallback system message when no `instructions` is supplied. R4's context
 // assembly passes its full sectioned prompt through `instructions` instead of
 // this repo needing another call site change.
@@ -153,16 +153,27 @@ export async function runAgent(input: RunAgentInput): Promise<RunAgentResult> {
       onEvent,
     });
 
-    if (result.status === "succeeded") {
-      await finishRunStep(db, {
-        runStepId: agentStep.id,
-        output: { answer: result.finalText, steps: result.steps },
-      });
-      await finishRun(db, { runId: run.id, output: { answer: result.finalText, steps: result.steps } });
-      return { runId: run.id, status: "succeeded", answer: result.finalText, steps: result.steps, messages: result.messages };
+    // A truncated run produced work, so it finishes rather than fails — but the
+    // ledger output carries `truncated` so a trace reader (and any later
+    // quality pass) can tell a complete answer from a cut-off one.
+    if (result.status === "succeeded" || result.status === "truncated") {
+      const output = {
+        answer: result.finalText,
+        steps: result.steps,
+        ...(result.status === "truncated" ? { truncated: true } : {}),
+      };
+      await finishRunStep(db, { runStepId: agentStep.id, output });
+      await finishRun(db, { runId: run.id, output });
+      return {
+        runId: run.id,
+        status: result.status,
+        answer: result.finalText,
+        steps: result.steps,
+        messages: result.messages,
+      };
     }
 
-    const { errorType, errorMessage } = describeLoopFailure(result.stopReason, maxSteps);
+    const { errorType, errorMessage } = describeLoopFailure(result.stopReason);
     await failRunStep(db, { runStepId: agentStep.id, errorType, errorMessage });
     await failRun(db, { runId: run.id, errorType, errorMessage });
     return { runId: run.id, status: "failed", steps: result.steps, messages: result.messages };
@@ -180,15 +191,11 @@ export async function runAgent(input: RunAgentInput): Promise<RunAgentResult> {
   }
 }
 
-function describeLoopFailure(
-  stopReason: string,
-  maxSteps: number
-): { errorType: string; errorMessage: string } {
+// Step exhaustion no longer lands here — it returns `truncated` and finishes the
+// run — so there is deliberately no "tool_use" branch.
+function describeLoopFailure(stopReason: string): { errorType: string; errorMessage: string } {
   if (stopReason === "aborted") {
     return { errorType: "aborted", errorMessage: "Agent run was aborted." };
-  }
-  if (stopReason === "tool_use") {
-    return { errorType: "max_steps_exceeded", errorMessage: `Agent did not finish within ${maxSteps} steps.` };
   }
   if (stopReason === "max_tokens") {
     return { errorType: "max_tokens_exceeded", errorMessage: "Agent loop stopped: model hit its max token limit." };

--- a/src/lib/memory/answer.ts
+++ b/src/lib/memory/answer.ts
@@ -11,7 +11,8 @@ import type { MemoryActor } from "@/lib/memory/actor";
 
 export interface MemoryAnswer {
   runId: number;
-  status: "succeeded" | "failed";
+  // "truncated" carries a usable partial answer — see AgentLoopResult.status.
+  status: "succeeded" | "truncated" | "failed";
   answer?: string;
   steps: number;
   invalidCitations: string[];
@@ -39,6 +40,10 @@ export interface AnswerWithMemoryInput {
   // Test seam: injected LlmAdapter, forwarded to runAgent. Mirrors
   // RunAgentInput.adapter; production callers never set it.
   adapter?: LlmAdapter;
+  // Test seam: forwarded to runAgent.maxSteps. Production callers leave it unset
+  // and get DEFAULT_MAX_STEPS; tests use it to reach the truncated path without
+  // driving 50 real turns.
+  maxSteps?: number;
 }
 
 // One agent run over team memory: the ReAct harness plus the citation post-check
@@ -73,11 +78,15 @@ export async function answerWithMemory(db: Sql, input: AnswerWithMemoryInput): P
     onAgentLoopEvent: input.onAgentLoopEvent,
     signal: input.signal,
     adapter: input.adapter,
+    maxSteps: input.maxSteps,
   });
 
   let answer = result.answer;
   let invalidCitations: string[] = [];
-  if (result.status === "succeeded" && answer !== undefined) {
+  // Every status that carries text must be checked. Gating on "succeeded" alone
+  // would ship a truncated run's partial answer to the user with its citations
+  // unverified — the same text, none of the scrubbing.
+  if ((result.status === "succeeded" || result.status === "truncated") && answer !== undefined) {
     const trace = await getRunTrace(db, result.runId);
     const checked = verifyAnswerCitations(trace, answer);
     answer = checked.answer;

--- a/tests/agent-loop.test.ts
+++ b/tests/agent-loop.test.ts
@@ -40,6 +40,19 @@ async function* finalTurn(answer: string): AsyncGenerator<LlmStreamEvent> {
   yield { type: "turn_end", stopReason: "end", usage: { inputTokens: 5, outputTokens: 3, totalTokens: 8 } };
 }
 
+// A turn that narrates before calling a tool — the realistic shape of a chained
+// run, and the one that leaves usable partial work behind when steps run out.
+async function* narratedToolCallTurn(
+  text: string,
+  toolName: string,
+  args: unknown
+): AsyncGenerator<LlmStreamEvent> {
+  yield { type: "text_delta", delta: text };
+  yield { type: "tool_call_start", id: "call-1", name: toolName };
+  yield { type: "tool_call_end", id: "call-1", name: toolName, input: args };
+  yield { type: "turn_end", stopReason: "tool_use", usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } };
+}
+
 async function seedAgentStep() {
   const db = getDb();
   const run = await startRun(db, { runType: "agent_chat", title: "t", input: {} });
@@ -264,7 +277,7 @@ describe("runAgentLoop", () => {
     });
   });
 
-  it("fails the run when maxSteps is exceeded, reporting the last real stopReason", async () => {
+  it("truncates rather than fails when maxSteps is exceeded, handing back the last assistant text", async () => {
     const { db, runId, parentStepId } = await seedAgentStep();
     const registry = createToolRegistry([echoTool]);
 
@@ -276,12 +289,39 @@ describe("runAgentLoop", () => {
       db,
       runId,
       parentStepId,
+      adapter: sequentialAdapter([
+        () => narratedToolCallTurn("Found 2 candidates so far.", "echo", { text: "again" }),
+      ]),
+    });
+
+    // "truncated", not "failed": the run produced real work, and a caller must be
+    // able to tell "ran out of room" from "the model errored".
+    expect(result.status).toBe("truncated");
+    expect(result.stopReason).toBe("tool_use");
+    expect(result.steps).toBe(3);
+    expect(result.finalText).toBe("Found 2 candidates so far.");
+  });
+
+  it("substitutes a readable notice when the exhausted run left no assistant text", async () => {
+    const { db, runId, parentStepId } = await seedAgentStep();
+    const registry = createToolRegistry([echoTool]);
+
+    const result = await runAgentLoop({
+      messages: [{ role: "system", content: "sys" }, { role: "user", content: "loop forever" }],
+      registry,
+      allowed: ALLOWED,
+      maxSteps: 3,
+      db,
+      runId,
+      parentStepId,
+      // Every turn is a bare tool call — no text block anywhere to carry forward.
       adapter: sequentialAdapter([() => toolCallTurn("echo", { text: "again" })]),
     });
 
-    expect(result.status).toBe("failed");
-    expect(result.stopReason).toBe("tool_use");
-    expect(result.steps).toBe(3);
+    expect(result.status).toBe("truncated");
+    // Never empty: an empty finalText reproduces the blank-bubble bug this fixes.
+    expect(result.finalText).toBeTruthy();
+    expect(result.finalText).toContain("3");
   });
 
   it("converts a streamAgentTurn throw into a synthetic assistant message and stops with stopReason 'error'", async () => {

--- a/tests/agent-route.test.ts
+++ b/tests/agent-route.test.ts
@@ -53,6 +53,24 @@ describe("POST /api/agent", () => {
     await expect(res.json()).resolves.toMatchObject({ runId: 9, status: "failed" });
   });
 
+  it("returns 200 with the partial answer when the run is truncated", async () => {
+    // A truncated run is a result, not a server error — 500 would make the
+    // partial work unreachable to any HTTP client.
+    runAgentMock.mockResolvedValue({
+      runId: 12,
+      status: "truncated",
+      answer: "Found 2 candidates; ran out of steps before verifying emails.",
+      steps: 50,
+    });
+    const res = await POST(postRequest({ question: "source me 5 people" }));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      runId: 12,
+      status: "truncated",
+      answer: "Found 2 candidates; ran out of steps before verifying emails.",
+    });
+  });
+
   it("returns invalidCitations in the response body", async () => {
     runAgentMock.mockResolvedValue({ runId: 7, status: "succeeded", answer: "hi", steps: 1 });
     const res = await POST(postRequest({ question: "echo hi" }));

--- a/tests/agent-stream-route.test.ts
+++ b/tests/agent-stream-route.test.ts
@@ -135,6 +135,55 @@ describe("POST /api/agent/stream", () => {
     expect(body).toContain("truncated");
   });
 
+  it("does not re-flush a truncated run's text that already streamed live", async () => {
+    // Narration streams live (no search yet), search_memory then gates further
+    // streaming, and the run runs out of steps carrying that same narration as
+    // its partial answer. Flushing it whole would render it twice in the chat.
+    runAgentMock.mockImplementation(
+      async (input: { onAgentLoopEvent?: (e: unknown) => unknown }) => {
+        await input.onAgentLoopEvent?.({ type: "llm", event: { type: "text_delta", delta: "Found 2 candidates. " } });
+        await input.onAgentLoopEvent?.({ type: "tool_start", id: "call-1", name: "search_memory", input: {} });
+        return {
+          runId: 14,
+          status: "truncated",
+          answer: "Found 2 candidates. ",
+          steps: 50,
+          messages: STUB_MESSAGES,
+        };
+      }
+    );
+
+    const body = await readAll(await POST(postRequest({ question: "source me 5 people" })));
+
+    expect((body.match(/Found 2 candidates\./g) ?? []).length).toBe(1);
+    // The answer part is still closed exactly once.
+    expect((body.match(/"type":"text-end"/g) ?? []).length).toBe(1);
+  });
+
+  it("flushes only the part of a truncated answer that was never streamed", async () => {
+    // Same path, but the model produced more text after the search gate closed.
+    // The gated tail must reach the client without repeating the live prefix.
+    runAgentMock.mockImplementation(
+      async (input: { onAgentLoopEvent?: (e: unknown) => unknown }) => {
+        await input.onAgentLoopEvent?.({ type: "llm", event: { type: "text_delta", delta: "Found 2 candidates. " } });
+        await input.onAgentLoopEvent?.({ type: "tool_start", id: "call-1", name: "search_memory", input: {} });
+        return {
+          runId: 15,
+          status: "truncated",
+          answer: "Found 2 candidates. Still verifying emails.",
+          steps: 50,
+          messages: STUB_MESSAGES,
+        };
+      }
+    );
+
+    const body = await readAll(await POST(postRequest({ question: "source me 5 people" })));
+
+    expect((body.match(/Found 2 candidates\./g) ?? []).length).toBe(1);
+    expect(body).toContain("Still verifying emails.");
+    expect((body.match(/"type":"text-end"/g) ?? []).length).toBe(1);
+  });
+
   it("closes the open answer text part when the run fails after narration streamed and a search fired", async () => {
     // Regression for the mixed live-then-search failure path: pre-search
     // narration opens the "answer" text part (answerStarted), search_memory then

--- a/tests/agent-stream-route.test.ts
+++ b/tests/agent-stream-route.test.ts
@@ -116,6 +116,25 @@ describe("POST /api/agent/stream", () => {
     expect(body).toContain("failed");
   });
 
+  it("flushes a truncated run's partial answer and marks it truncated in meta", async () => {
+    // The stream route is the production path — a truncated run must arrive as
+    // readable text plus a status the UI can render a notice from.
+    runAgentMock.mockResolvedValue({
+      runId: 13,
+      status: "truncated",
+      answer: "Found 2 candidates; ran out of steps before verifying emails.",
+      steps: 50,
+      messages: STUB_MESSAGES,
+    });
+    const res = await POST(postRequest({ question: "source me 5 people" }));
+    expect(res.status).toBe(200);
+    const body = await readAll(res);
+
+    expect(body).toContain("Found 2 candidates");
+    expect(body).toContain("data-meta");
+    expect(body).toContain("truncated");
+  });
+
   it("closes the open answer text part when the run fails after narration streamed and a search fired", async () => {
     // Regression for the mixed live-then-search failure path: pre-search
     // narration opens the "answer" text part (answerStarted), search_memory then

--- a/tests/components/ChatClient.test.tsx
+++ b/tests/components/ChatClient.test.tsx
@@ -53,6 +53,34 @@ describe("ChatClient", () => {
     );
   });
 
+  it("renders a truncated run's partial answer alongside a visible out-of-steps notice", async () => {
+    let resolveRun: (turn: unknown) => void = () => {};
+    runChatMock.mockImplementation((_q: string, _h: unknown, onUpdate?: (t: unknown) => void) => {
+      if (!onUpdate) return Promise.resolve({ steps: [], answer: "" });
+      return new Promise((resolve) => {
+        resolveRun = resolve;
+      });
+    });
+
+    render(<ChatClient />);
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "source me 5 people" } });
+    fireEvent.submit(screen.getByRole("textbox"));
+
+    resolveRun({
+      steps: [{ index: 1, tool: "apollo_search_people", ok: true, detail: "done" }],
+      answer: "Found 2 candidates at Anthropic; still verifying emails.",
+      meta: { runId: 12, status: "truncated", steps: 50, invalidCitations: [] },
+    });
+
+    // The partial work is readable text, not a blank bubble.
+    await waitFor(() =>
+      expect(screen.getByText(/Found 2 candidates at Anthropic/)).toBeInTheDocument()
+    );
+    // ...and the user is told it is incomplete rather than being left to assume
+    // this is the whole answer.
+    expect(screen.getByText(/ran out of steps/i)).toBeInTheDocument();
+  });
+
   it("settles to an error state (no live row, composer re-enabled) when the stream fails", async () => {
     // Guard the teardown no-arg call (vitest cleanup) so only the real run rejects.
     runChatMock.mockImplementation((_q: string, _h: unknown, onUpdate?: (t: unknown) => void) =>

--- a/tests/harness.test.ts
+++ b/tests/harness.test.ts
@@ -38,6 +38,17 @@ async function* finalTurn(answer: string): AsyncGenerator<LlmStreamEvent> {
   yield { type: "turn_end", stopReason: "end", usage: { inputTokens: 5, outputTokens: 3, totalTokens: 8 } };
 }
 
+async function* narratedToolCallTurn(
+  text: string,
+  toolName: string,
+  args: unknown
+): AsyncGenerator<LlmStreamEvent> {
+  yield { type: "text_delta", delta: text };
+  yield { type: "tool_call_start", id: "call-1", name: toolName };
+  yield { type: "tool_call_end", id: "call-1", name: toolName, input: args };
+  yield { type: "turn_end", stopReason: "tool_use", usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } };
+}
+
 const ALLOWED = new Set<Tool["permissionClass"]>(["read", "reason"]);
 
 describe("runAgent", () => {
@@ -126,10 +137,12 @@ describe("runAgent", () => {
     });
   });
 
-  it("fails the run when maxSteps is exceeded", async () => {
+  it("truncates the run when maxSteps is exceeded, returning the partial answer", async () => {
     const db = getDb();
     const registry = createToolRegistry([echoTool]);
-    const adapter = sequentialAdapter([() => toolCallTurn("echo", { text: "again" })]);
+    const adapter = sequentialAdapter([
+      () => narratedToolCallTurn("Checked memory; still verifying emails.", "echo", { text: "again" }),
+    ]);
 
     const result = await runAgent({
       question: "loop forever",
@@ -139,11 +152,16 @@ describe("runAgent", () => {
       adapter,
     });
 
-    expect(result.status).toBe("failed");
+    expect(result.status).toBe("truncated");
     expect(result.steps).toBe(3);
+    expect(result.answer).toBe("Checked memory; still verifying emails.");
+
+    // The run produced work, so the ledger records it as finished with a
+    // truncation marker rather than as a failure.
     const trace = await getRunTrace(db, result.runId);
-    expect(trace?.status).toBe("failed");
-    expect(trace?.errorType).toBe("max_steps_exceeded");
+    expect(trace?.status).toBe("succeeded");
+    expect(trace?.errorType).toBeNull();
+    expect(trace?.output).toMatchObject({ truncated: true, steps: 3 });
   });
 
   it("feeds a tool execution error back and lets the model recover", async () => {

--- a/tests/memory-answer.test.ts
+++ b/tests/memory-answer.test.ts
@@ -366,6 +366,17 @@ async function* finalTurn(answer: string): AsyncGenerator<LlmStreamEvent> {
   yield { type: "turn_end", stopReason: "end", usage: { inputTokens: 5, outputTokens: 3, totalTokens: 8 } };
 }
 
+async function* narratedToolCallTurn(
+  text: string,
+  toolName: string,
+  args: unknown
+): AsyncGenerator<LlmStreamEvent> {
+  yield { type: "text_delta", delta: text };
+  yield { type: "tool_call_start", id: "call-1", name: toolName };
+  yield { type: "tool_call_end", id: "call-1", name: toolName, input: args };
+  yield { type: "turn_end", stopReason: "tool_use", usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } };
+}
+
 describe("search_memory agentic flow (mock provider + postgres)", () => {
   let savedApiKey: string | undefined;
 
@@ -547,5 +558,53 @@ describe("answerWithMemory add_memory_note (mock provider + postgres)", () => {
     `;
     expect(notes).toHaveLength(1);
     expect(notes[0].title).toBe("Acme intro call");
+  });
+
+  // Regression guard for the gate at answer.ts. It used to read
+  // `status === "succeeded" && answer !== undefined`, which would let a
+  // truncated run's partial text reach the user with its citations unchecked.
+  it("runs the citation post-check on a truncated run's partial answer", async () => {
+    const db = getDb();
+    const srcId = await insertSource(db, "src-trunc-test");
+    await grantRead(db, DEFAULT_ACTOR, "src-trunc-test");
+    const chunkId = await insertChunk(db, {
+      sourceRecordId: srcId,
+      text: "Dana responded to sourcing outreach",
+      citation: "src-trunc-test#chunk-1",
+    });
+    await insertFact(db, {
+      subject: "Dana",
+      predicate: "status",
+      object: "responded",
+      status: "accepted",
+      sourceRecordId: srcId,
+      sourceChunkId: chunkId,
+    });
+
+    const adapter = sequentialAdapter([
+      () => toolCallTurn("search_memory", { query: "who responded" }),
+      // Narrates a real citation alongside an invented one, then calls another
+      // tool — so the run is still mid-chain when it runs out of steps.
+      () =>
+        narratedToolCallTurn(
+          "So far: Dana responded src-trunc-test#chunk-1 and ghost#chunk-99. Checking more.",
+          "search_memory",
+          { query: "anyone else" }
+        ),
+    ]);
+
+    const result = await answerWithMemory(db, {
+      question: "who responded?",
+      actor: DEFAULT_ACTOR,
+      adapter,
+      maxSteps: 2,
+    });
+
+    expect(result.status).toBe("truncated");
+    expect(result.answer).toBeTruthy();
+    expect(result.invalidCitations).toContain("ghost#chunk-99");
+    expect(result.answer).not.toContain("ghost#chunk-99");
+    // The real citation survives the scrub.
+    expect(result.answer).toContain("src-trunc-test#chunk-1");
   });
 });


### PR DESCRIPTION
Fixes the defect in `docs/superpowers/plans/2026-08-04-ticket-loop-step-budget-partial-answer.md` (ticket included in this PR).

## The bug

`runAgentLoop` ended a step-exhausted run with `status: "failed"` and no `finalText`. An agent that had searched memory, queried Apollo, and fetched pages handed back **nothing** — `/api/agent` returned 500, and the chat UI rendered a completed exchange with an empty answer bubble and a small grey "failed". Every other exit path in the loop produces something; this one discarded the whole run.

## The fix

Exhaustion now returns a distinct **`truncated`** status carrying the last assistant text (or a readable notice when the run was all bare tool calls — never an empty string), threaded through `harness` → `answerWithMemory` → both agent routes → the chat `meta`.

- A truncated run **finishes** in the ledger with `truncated: true` in its output rather than failing — it produced work.
- `/api/agent` returns 200 for it; only `failed` is a 500.
- The chat shows the partial answer with a warn-token notice above it: *"Ran out of steps — this answer is incomplete. Ask a follow-up to continue."*

**The trap this had to avoid:** the citation post-check in `memory/answer.ts` gated on `status === "succeeded"`. Populating `finalText` without widening it would have shipped partial answers with their citations **unverified** — same text, none of the scrubbing. The gate now admits `truncated`, pinned by a regression test that fails against the old condition.

## Step ceiling: 8 → 50

Also exports `DEFAULT_MAX_STEPS` from `agent-loop.ts` so `harness.ts` imports it. There were two independent copies and only harness's was ever reachable from a chat run — a live drift foot-gun.

50 is a **runaway backstop, not a product limit**. Checked against the reference implementations:

- **Claude Code**: `maxTurns?: number` is optional with no default (`QueryEngine.ts:146`); the check is `if (maxTurns && ...)` (`query.ts:1705`), so the interactive loop is unbounded. `--max-turns` is hidden and documented *"only works with --print"*. The real cost control is `--max-budget-usd` (`QueryEngine.ts:972`), with remaining budget injected into the model's context each turn (`attachments.ts:3846`) so the agent steers itself.
- **openclaw**: no ceiling on its own agent loop.

Per-run spend is the right instrument — see `2026-08-04-ticket-enrich-spend-ceiling.md`. The ceiling isn't removed outright because this loop has **no context compaction**: unbounded, it would end on a provider context-length rejection rather than on finishing. Revisit once compaction exists.

Note that the spend ceiling will **not** subsume this path — its settled design is *soft-deny, don't kill the run*, so a budget-exhausted run still ends `succeeded`. Step exhaustion and abort remain the only mid-chain endings.

## Verification

```
npm test          → 74 files, 521 passed | 3 skipped
npm run typecheck → clean
npm run build     → ✓ Compiled successfully, 15/15 static pages
```

Tests were written first and confirmed red before implementing. 5 net new tests covering: truncated status + partial text, the empty-text fallback, the ledger finish-with-marker, the citation scrub on a truncated answer, the 200 from `/api/agent`, the stream route's flush + meta, and the chat notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes step-budget exhaustion from a failed, empty result into a citation-checked truncated answer and raises the shared runaway ceiling to 50.
- Adds the `truncated` status throughout the agent loop, harness, memory answer, HTTP routes, stream metadata, and chat UI.
- Finishes truncated ledger runs with an explicit marker and returns their partial answer over HTTP.
- Adds regression coverage for fallback text, citation scrubbing, routing, persistence, streaming, and UI presentation.

<h3>Confidence Score: 4/5</h3>

The streaming duplication should be fixed before merging because a reachable truncated search run can display repeated answer text.

When narration is streamed before a search begins, the truncated path can later flush the complete earlier assistant message, and the client blindly appends it to the existing text.

**Files Needing Attention:** src/lib/agent-loop.ts and src/app/api/agent/stream/route.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/lib/agent-loop.ts | Adds the shared 50-step ceiling and truncated result construction, but selecting a full earlier assistant message can duplicate its already-streamed prefix. |
| src/app/api/agent/stream/route.ts | Existing live-versus-flush behavior makes the newly returned truncated text overlap with narration emitted before search activation. |
| src/lib/harness.ts | Propagates truncated results and records them as completed ledger runs with a truncation marker. |
| src/lib/memory/answer.ts | Extends citation verification to truncated answers before they reach API consumers. |
| src/app/chat/ChatClient.tsx | Adds a clear warning above partial answers when stream metadata reports truncation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(agent-loop): return partial work whe..."](https://github.com/fisherxz/sourcecado/commit/f16ddf722e99ed37f711a356e4d107390cbe5db4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50266259)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Partial answers are now preserved when an agent reaches its step limit.
  * Truncated runs return a distinct status while remaining successful responses.
  * Chat displays an inline notice when an answer is incomplete.
  * Streaming responses avoid duplicated text and preserve partial output.
  * Citations in truncated answers continue to be validated and cleaned up.

* **Bug Fixes**
  * Prevented step-limit results from appearing as empty failures or server errors.
  * Added fallback messaging when no assistant text is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->