### PR TITLE
Symphony wiring: add docs/symphony-smoke.md

### DIFF
--- a/docs/symphony-smoke.md
+++ b/docs/symphony-smoke.md
@@ -1,0 +1,4 @@
+# Symphony smoke
+
+This file proves Symphony can clone Sourcecado, edit it, and open a PR.
+Safe to delete.


### PR DESCRIPTION
Adds the requested Symphony smoke marker.

Refs #31