### PR TITLE
feat(spring): person file, send, board, and pickup

### DIFF
--- a/desktop/coworker/brief.py
+++ b/desktop/coworker/brief.py
@@ -1,0 +1,34 @@
+"""Project the living brief from a person file and its ledger."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from coworker.people import SOURCES
+
+
+def build_brief(person: dict[str, Any], events: list[dict[str, Any]]) -> dict[str, Any]:
+    name = " ".join(
+        part for part in (person.get("first_name"), person.get("last_name")) if part
+    )
+    bits = [name] if name else []
+    if person.get("title"):
+        bits.append(str(person["title"]))
+    who = ", ".join(bits)
+    if person.get("company"):
+        who = f"{who} at {person['company']}" if who else str(person["company"])
+    missing: list[str] = []
+    if not person.get("email"):
+        missing.append("email")
+    present = {str(event.get("source")) for event in events}
+    if "gmail" not in present:
+        missing.append("mail")
+    sources = [source for source in SOURCES if source in present]
+    learned = [str(event.get("summary")) for event in events if event.get("summary")]
+    return {
+        "who": who,
+        "why": person.get("target") or "",
+        "learned": learned,
+        "missing": missing,
+        "sources": sources,
+    }

--- a/desktop/coworker/connectors/google_oauth.py
+++ b/desktop/coworker/connectors/google_oauth.py
@@ -1,7 +1,7 @@
 """Google OAuth — one identity, incremental scopes.
 
-Tokens never go in the prompt. Send is in the Gmail grant so later send
-can reuse this login; the tool catalog still has no gmail_send.
+Tokens never go in the prompt. Send is in the Gmail grant. gmail_send asks
+before users.drafts.send.
 """
 
 from __future__ import annotations

--- a/desktop/coworker/gmail.py
+++ b/desktop/coworker/gmail.py
@@ -67,6 +67,7 @@ class GmailClient(Protocol):
     sends: list[dict[str, Any]]
 
     def create_draft(self, *, to: str, subject: str, body: str) -> dict[str, Any]: ...
+    def send(self, *, draft_id: str) -> dict[str, Any]: ...
 
 
 class FakeGmail:
@@ -91,9 +92,9 @@ class FakeGmail:
             "sent": False,
         }
 
-    def send(self, *args: Any, **kwargs: Any) -> None:
-        self.sends.append({"args": args, "kwargs": kwargs})
-        raise GmailError("gmail_draft never sends")
+    def send(self, *, draft_id: str) -> dict[str, Any]:
+        self.sends.append({"draft_id": draft_id})
+        return {"id": f"msg_{len(self.sends)}", "draft_id": draft_id, "sent": True}
 
     def search(self, query: str, max_results: int = 10) -> dict[str, Any]:
         return {"messages": []}
@@ -121,6 +122,11 @@ class MissingGmail:
             "Gmail is not connected. Click Connect Gmail in the window first."
         )
 
+    def send(self, *, draft_id: str) -> dict[str, Any]:
+        raise GmailError(
+            "Gmail is not connected. Click Connect Gmail in the window first."
+        )
+
 
 def _raw_message(*, to: str, subject: str, body: str) -> str:
     msg = EmailMessage()
@@ -131,7 +137,7 @@ def _raw_message(*, to: str, subject: str, body: str) -> str:
 
 
 class GmailApi:
-    """Live Gmail drafts. No send()."""
+    """Live Gmail drafts and send-by-draft-id."""
 
     drafts: list[dict[str, Any]]
     sends: list[dict[str, Any]]
@@ -228,6 +234,20 @@ class GmailApi:
             "sent": False,
         }
         self.drafts.append(item)
+        return item
+
+    def send(self, *, draft_id: str) -> dict[str, Any]:
+        data = self._request(
+            "post",
+            f"{DRAFTS_URL}/send",
+            headers={"Content-Type": "application/json"},
+            json={"id": draft_id},
+        ) or {}
+        message_id = str(data.get("id") or "")
+        if not message_id:
+            raise GmailError("Gmail did not return a sent message id.")
+        item = {"id": message_id, "draft_id": draft_id, "sent": True}
+        self.sends.append(item)
         return item
 
     def search(self, query: str, max_results: int = 10) -> dict[str, Any]:

--- a/desktop/coworker/ledger.py
+++ b/desktop/coworker/ledger.py
@@ -132,6 +132,18 @@ def event_from_tool(
             },
             tool=name,
         )
+    if name == "gmail_send":
+        return _event(
+            source="gmail",
+            kind="send",
+            summary=f"Sent draft {result.get('draft_id') or arguments.get('draft_id') or ''}".strip(),
+            payload={
+                "draft_id": result.get("draft_id") or arguments.get("draft_id"),
+                "id": result.get("id"),
+                "sent": True,
+            },
+            tool=name,
+        )
     if name == "drive_search":
         files = [
             {"id": row.get("id"), "name": row.get("name")}

--- a/desktop/coworker/ledger.py
+++ b/desktop/coworker/ledger.py
@@ -1,0 +1,255 @@
+"""Map Club tool results into person-file ledger events."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from coworker.people import PersonStore
+
+_NOT_FILED = frozenset(
+    {
+        "now",
+        "remember",
+        "memory_update",
+        "memory_forget",
+        "load_skill",
+        "apollo_search_people",
+    }
+)
+_MCP_WRITE = re.compile(r"write|create|delete|update", re.I)
+
+
+def _event(
+    *,
+    source: str,
+    kind: str,
+    summary: str,
+    payload: dict[str, Any],
+    tool: str,
+) -> dict[str, Any]:
+    return {
+        "source": source,
+        "kind": kind,
+        "summary": summary,
+        "payload": payload,
+        "tool": tool,
+    }
+
+
+def _source_for(name: str) -> str | None:
+    if name.startswith("gmail_"):
+        return "gmail"
+    if name.startswith("drive_"):
+        return "drive"
+    if name.startswith("calendar_"):
+        return "calendar"
+    if name == "apollo_enrich_contact":
+        return "apollo"
+    if name.startswith("mcp__granola__"):
+        return "granola"
+    if name in {"web_search", "web_fetch"}:
+        return "web"
+    return None
+
+
+def _granola_write(name: str) -> bool:
+    if not name.startswith("mcp__granola__"):
+        return False
+    last = name.rsplit("__", 1)[-1]
+    return bool(_MCP_WRITE.search(last))
+
+
+def _error_event(name: str, result: dict[str, Any]) -> dict[str, Any] | None:
+    source = _source_for(name)
+    if source is None:
+        return None
+    detail = str(result.get("error") or "unknown error")
+    if name.startswith("mcp__granola__"):
+        label = "Granola " + name.rsplit("__", 1)[-1].replace("_", " ")
+    else:
+        parts = name.split("_")
+        label = parts[0].capitalize() + (" " + " ".join(parts[1:]) if len(parts) > 1 else "")
+    return _event(
+        source=source,
+        kind="error",
+        summary=f"{label} failed",
+        payload={"detail": detail},
+        tool=name,
+    )
+
+
+def event_from_tool(
+    name: str,
+    arguments: dict[str, Any],
+    result: dict[str, Any],
+    *,
+    ok: bool,
+) -> dict[str, Any] | None:
+    """kwargs for PersonStore.append_event except person_id / actor / session / run."""
+    if name in _NOT_FILED or _granola_write(name):
+        return None
+    if not ok:
+        return _error_event(name, result)
+    if name == "gmail_search":
+        messages = result.get("messages") or []
+        ids = [
+            str(row.get("id"))
+            for row in messages
+            if isinstance(row, dict) and row.get("id")
+        ]
+        query = str(arguments.get("query") or "")
+        return _event(
+            source="gmail",
+            kind="mail",
+            summary=f"Searched Gmail for {query!r} ({len(ids)})",
+            payload={"query": query, "ids": ids},
+            tool=name,
+        )
+    if name == "gmail_read":
+        return _event(
+            source="gmail",
+            kind="mail",
+            summary=f"Read mail {result.get('subject') or result.get('id') or ''}".strip(),
+            payload={
+                "id": result.get("id"),
+                "from": result.get("from"),
+                "subject": result.get("subject"),
+                "date": result.get("date"),
+            },
+            tool=name,
+        )
+    if name == "gmail_draft":
+        return _event(
+            source="gmail",
+            kind="draft",
+            summary=f"Drafted mail to {result.get('to') or arguments.get('to') or ''}".strip(),
+            payload={
+                "draft_id": result.get("id"),
+                "to": result.get("to"),
+                "subject": result.get("subject"),
+                "sent": False,
+            },
+            tool=name,
+        )
+    if name == "drive_search":
+        files = [
+            {"id": row.get("id"), "name": row.get("name")}
+            for row in (result.get("files") or [])
+            if isinstance(row, dict)
+        ]
+        query = str(arguments.get("query") or "")
+        return _event(
+            source="drive",
+            kind="file",
+            summary=f"Searched Drive for {query!r} ({len(files)})",
+            payload={"query": query, "files": files},
+            tool=name,
+        )
+    if name == "drive_read":
+        return _event(
+            source="drive",
+            kind="file",
+            summary=f"Read Drive file {result.get('name') or result.get('id') or ''}".strip(),
+            payload={"id": result.get("id"), "name": result.get("name")},
+            tool=name,
+        )
+    if name == "calendar_list":
+        events = result.get("events") or []
+        count = len(events) if isinstance(events, list) else 0
+        return _event(
+            source="calendar",
+            kind="event",
+            summary=f"Listed {count} calendar events",
+            payload={"count": count},
+            tool=name,
+        )
+    if name in {"calendar_create", "calendar_update"}:
+        action = "Created" if name == "calendar_create" else "Updated"
+        return _event(
+            source="calendar",
+            kind="event",
+            summary=f"{action} calendar event {result.get('summary') or result.get('id') or ''}".strip(),
+            payload={"id": result.get("id"), "summary": result.get("summary")},
+            tool=name,
+        )
+    if name == "apollo_enrich_contact":
+        return _event(
+            source="apollo",
+            kind="enrich",
+            summary=f"Enriched {result.get('name') or 'contact'}",
+            payload={
+                "name": result.get("name"),
+                "title": result.get("title"),
+                "organizationName": result.get("organizationName"),
+                "email": result.get("email"),
+            },
+            tool=name,
+        )
+    if name.startswith("mcp__granola__"):
+        return _event(
+            source="granola",
+            kind="meeting",
+            summary=f"Read meeting notes {result.get('title') or result.get('id') or ''}".strip(),
+            payload={"id": result.get("id"), "title": result.get("title")},
+            tool=name,
+        )
+    if name == "web_search":
+        rows = result.get("results") or []
+        urls = [
+            str(row.get("url"))
+            for row in rows
+            if isinstance(row, dict) and row.get("url")
+        ]
+        query = str(arguments.get("query") or "")
+        return _event(
+            source="web",
+            kind="search",
+            summary=f"Searched the web for {query!r} ({len(urls)})",
+            payload={"query": query, "count": len(urls), "urls": urls},
+            tool=name,
+        )
+    if name == "web_fetch":
+        return _event(
+            source="web",
+            kind="fetch",
+            summary=f"Fetched {result.get('title') or result.get('url') or arguments.get('url') or ''}".strip(),
+            payload={
+                "url": result.get("url") or arguments.get("url"),
+                "title": result.get("title"),
+            },
+            tool=name,
+        )
+    return None
+
+
+def record_tool_on_person(
+    people: PersonStore,
+    session_id: str,
+    name: str,
+    arguments: dict[str, Any] | None,
+    result: dict[str, Any],
+    *,
+    ok: bool,
+) -> None:
+    """Bind a one-person keep to this session, then file connector events on the bound person."""
+    if name == "people_keep" and ok:
+        kept = result.get("kept") or []
+        if len(kept) == 1:
+            person_id = kept[0].get("person_id") if isinstance(kept[0], dict) else None
+            if person_id:
+                people.bind_session(session_id, str(person_id))
+        return
+    if not ok and str(result.get("error") or "") == "denied by user":
+        return
+    person_id = people.person_for_session(session_id)
+    if not person_id:
+        return
+    event = event_from_tool(name, arguments or {}, result, ok=ok)
+    if event is None:
+        return
+    people.append_event(person_id, session_id=session_id, **event)
+    if ok and event.get("kind") == "draft":
+        person = people.get(person_id)
+        if person is not None and person.get("sequence_state") is None:
+            people.set_sequence(person_id, "open", actor="assistant")

--- a/desktop/coworker/people.py
+++ b/desktop/coworker/people.py
@@ -1,0 +1,378 @@
+"""Person files — one sqlite db, separate from conversation store."""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import threading
+import uuid
+from pathlib import Path
+from typing import Any
+
+_SID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+SEQUENCE_STATES = ("open", "in_conversation", "done")
+ACTORS = ("director", "assistant")
+SOURCES = (
+    "apollo",
+    "gmail",
+    "calendar",
+    "drive",
+    "web",
+    "granola",
+    "sourcecado",
+)
+
+
+def _new_person_id() -> str:
+    return "per_" + uuid.uuid4().hex
+
+
+def _new_event_id() -> str:
+    return "evt_" + uuid.uuid4().hex
+
+
+class PersonStore:
+    def __init__(self, base_dir: str | Path) -> None:
+        self.base = Path(base_dir).expanduser()
+        self.base.mkdir(parents=True, exist_ok=True)
+        self.db_path = self.base / "people.db"
+        self._lock = threading.RLock()
+        self._conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS people (
+                person_id TEXT PRIMARY KEY,
+                apollo_id TEXT UNIQUE,
+                first_name TEXT,
+                last_name TEXT,
+                title TEXT,
+                company TEXT,
+                email TEXT,
+                linkedin_url TEXT,
+                phone TEXT,
+                sequence_state TEXT,
+                target TEXT,
+                handoff_who TEXT,
+                handoff_wanted TEXT,
+                handoff_happened TEXT,
+                handoff_they_want TEXT,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE IF NOT EXISTS events (
+                event_id TEXT PRIMARY KEY,
+                person_id TEXT NOT NULL,
+                source TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                summary TEXT NOT NULL,
+                payload TEXT NOT NULL DEFAULT '{}',
+                actor TEXT NOT NULL,
+                session_id TEXT,
+                run_id TEXT,
+                tool TEXT,
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE IF NOT EXISTS session_people (
+                session_id TEXT PRIMARY KEY,
+                person_id TEXT NOT NULL
+            );
+            """
+        )
+        self._conn.commit()
+
+    def _person_dict(self, row: sqlite3.Row | None) -> dict[str, Any] | None:
+        if row is None:
+            return None
+        return dict(row)
+
+    def keep_from_apollo(
+        self,
+        *,
+        apollo_id: str | None,
+        first_name: str | None,
+        last_name_obfuscated: str | None,
+        title: str | None,
+        company: str | None,
+        target: str | None = None,
+    ) -> dict[str, Any]:
+        apollo = (apollo_id or "").strip() or None
+        cleaned_target = (target or "").strip() or None
+        with self._lock:
+            existing = None
+            if apollo is not None:
+                existing = self._conn.execute(
+                    "SELECT * FROM people WHERE apollo_id = ?",
+                    (apollo,),
+                ).fetchone()
+            if existing is not None:
+                self._conn.execute(
+                    """
+                    UPDATE people SET
+                        first_name = ?,
+                        last_name = ?,
+                        title = ?,
+                        company = ?,
+                        target = COALESCE(?, target),
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE person_id = ?
+                    """,
+                    (
+                        first_name,
+                        last_name_obfuscated,
+                        title,
+                        company,
+                        cleaned_target,
+                        existing["person_id"],
+                    ),
+                )
+                self._conn.commit()
+                row = self._conn.execute(
+                    "SELECT * FROM people WHERE person_id = ?",
+                    (existing["person_id"],),
+                ).fetchone()
+            else:
+                pid = _new_person_id()
+                self._conn.execute(
+                    """
+                    INSERT INTO people (
+                        person_id, apollo_id, first_name, last_name, title, company, target
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        pid,
+                        apollo,
+                        first_name,
+                        last_name_obfuscated,
+                        title,
+                        company,
+                        cleaned_target,
+                    ),
+                )
+                self._conn.commit()
+                row = self._conn.execute(
+                    "SELECT * FROM people WHERE person_id = ?",
+                    (pid,),
+                ).fetchone()
+        person = self._person_dict(row)
+        assert person is not None
+        return person
+
+    def get_by_apollo_id(self, apollo_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM people WHERE apollo_id = ?",
+                (apollo_id,),
+            ).fetchone()
+        return self._person_dict(row)
+
+    def get(self, person_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM people WHERE person_id = ?",
+                (person_id,),
+            ).fetchone()
+        return self._person_dict(row)
+
+    def set_sequence(self, person_id: str, state: str, *, actor: str) -> dict[str, Any]:
+        if state not in SEQUENCE_STATES:
+            raise ValueError(f"invalid sequence state {state}")
+        if actor not in ACTORS:
+            raise ValueError(f"invalid actor {actor}")
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM people WHERE person_id = ?",
+                (person_id,),
+            ).fetchone()
+            if row is None:
+                raise ValueError("unknown person")
+            self._conn.execute(
+                """
+                UPDATE people SET sequence_state = ?, updated_at = CURRENT_TIMESTAMP
+                WHERE person_id = ?
+                """,
+                (state, person_id),
+            )
+            self._conn.execute(
+                """
+                INSERT INTO events (
+                    event_id, person_id, source, kind, summary, payload, actor
+                ) VALUES (?, ?, 'sourcecado', 'state', ?, ?, ?)
+                """,
+                (
+                    _new_event_id(),
+                    person_id,
+                    f"Moved to {state.replace('_', ' ')}",
+                    json.dumps({"state": state}),
+                    actor,
+                ),
+            )
+            self._conn.commit()
+            row = self._conn.execute(
+                "SELECT * FROM people WHERE person_id = ?",
+                (person_id,),
+            ).fetchone()
+        person = self._person_dict(row)
+        assert person is not None
+        return person
+
+    def list_board(self) -> dict[str, list[dict[str, Any]]]:
+        board: dict[str, list[dict[str, Any]]] = {state: [] for state in SEQUENCE_STATES}
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT * FROM people
+                WHERE sequence_state IS NOT NULL
+                ORDER BY updated_at DESC, person_id
+                """
+            ).fetchall()
+        for row in rows:
+            person = self._person_dict(row)
+            assert person is not None
+            board[person["sequence_state"]].append(person)
+        return board
+
+    def _event_dict(self, row: sqlite3.Row) -> dict[str, Any]:
+        item = dict(row)
+        raw = item.get("payload") or "{}"
+        item["payload"] = json.loads(raw) if isinstance(raw, str) else raw
+        return item
+
+    def append_event(
+        self,
+        person_id: str,
+        *,
+        source: str,
+        kind: str,
+        summary: str,
+        payload: dict[str, Any] | None = None,
+        actor: str = "assistant",
+        session_id: str | None = None,
+        run_id: str | None = None,
+        tool: str | None = None,
+    ) -> dict[str, Any]:
+        if source not in SOURCES:
+            raise ValueError(f"invalid source {source}")
+        if actor not in ACTORS:
+            raise ValueError(f"invalid actor {actor}")
+        if not summary.strip():
+            raise ValueError("summary is required")
+        with self._lock:
+            exists = self._conn.execute(
+                "SELECT 1 FROM people WHERE person_id = ?",
+                (person_id,),
+            ).fetchone()
+            if exists is None:
+                raise ValueError("unknown person")
+            event_id = _new_event_id()
+            self._conn.execute(
+                """
+                INSERT INTO events (
+                    event_id, person_id, source, kind, summary, payload,
+                    actor, session_id, run_id, tool
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event_id,
+                    person_id,
+                    source,
+                    kind,
+                    summary.strip(),
+                    json.dumps(payload or {}),
+                    actor,
+                    session_id,
+                    run_id,
+                    tool,
+                ),
+            )
+            self._conn.execute(
+                "UPDATE people SET updated_at = CURRENT_TIMESTAMP WHERE person_id = ?",
+                (person_id,),
+            )
+            self._conn.commit()
+            row = self._conn.execute(
+                "SELECT * FROM events WHERE event_id = ?",
+                (event_id,),
+            ).fetchone()
+        return self._event_dict(row)
+
+    def timeline(self, person_id: str) -> list[dict[str, Any]]:
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT * FROM events
+                WHERE person_id = ?
+                ORDER BY rowid ASC
+                """,
+                (person_id,),
+            ).fetchall()
+        return [self._event_dict(row) for row in rows]
+
+    def bind_session(self, session_id: str, person_id: str) -> None:
+        sid = (session_id or "").strip()
+        if not sid or not _SID_RE.fullmatch(sid) or ".." in sid:
+            raise ValueError("invalid session id")
+        with self._lock:
+            exists = self._conn.execute(
+                "SELECT 1 FROM people WHERE person_id = ?",
+                (person_id,),
+            ).fetchone()
+            if exists is None:
+                raise ValueError("unknown person")
+            self._conn.execute(
+                """
+                INSERT INTO session_people (session_id, person_id) VALUES (?, ?)
+                ON CONFLICT(session_id) DO UPDATE SET person_id = excluded.person_id
+                """,
+                (sid, person_id),
+            )
+            self._conn.commit()
+
+    def person_for_session(self, session_id: str) -> str | None:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT person_id FROM session_people WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return str(row["person_id"])
+
+    def set_handoff(
+        self,
+        person_id: str,
+        *,
+        who: str,
+        wanted: str,
+        happened: str,
+        they_want: str,
+    ) -> dict[str, Any]:
+        with self._lock:
+            exists = self._conn.execute(
+                "SELECT 1 FROM people WHERE person_id = ?",
+                (person_id,),
+            ).fetchone()
+            if exists is None:
+                raise ValueError("unknown person")
+            self._conn.execute(
+                """
+                UPDATE people SET
+                    handoff_who = ?,
+                    handoff_wanted = ?,
+                    handoff_happened = ?,
+                    handoff_they_want = ?,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE person_id = ?
+                """,
+                (who, wanted, happened, they_want, person_id),
+            )
+            self._conn.commit()
+            row = self._conn.execute(
+                "SELECT * FROM people WHERE person_id = ?",
+                (person_id,),
+            ).fetchone()
+        person = self._person_dict(row)
+        assert person is not None
+        return person

--- a/desktop/coworker/people.py
+++ b/desktop/coworker/people.py
@@ -111,10 +111,10 @@ class PersonStore:
                 self._conn.execute(
                     """
                     UPDATE people SET
-                        first_name = ?,
-                        last_name = ?,
-                        title = ?,
-                        company = ?,
+                        first_name = COALESCE(?, first_name),
+                        last_name = COALESCE(?, last_name),
+                        title = COALESCE(?, title),
+                        company = COALESCE(?, company),
                         target = COALESCE(?, target),
                         updated_at = CURRENT_TIMESTAMP
                     WHERE person_id = ?
@@ -167,6 +167,57 @@ class PersonStore:
                 (apollo_id,),
             ).fetchone()
         return self._person_dict(row)
+
+    def apply_enrichment(
+        self,
+        person_id: str,
+        *,
+        name: str | None = None,
+        title: str | None = None,
+        company: str | None = None,
+        email: str | None = None,
+        linkedin_url: str | None = None,
+        phone: str | None = None,
+    ) -> dict[str, Any] | None:
+        first_name = None
+        last_name = None
+        if name:
+            parts = str(name).split(None, 1)
+            first_name = parts[0]
+            last_name = parts[1] if len(parts) > 1 else None
+        with self._lock:
+            exists = self._conn.execute(
+                "SELECT 1 FROM people WHERE person_id = ?",
+                (person_id,),
+            ).fetchone()
+            if exists is None:
+                return None
+            self._conn.execute(
+                """
+                UPDATE people SET
+                    first_name = COALESCE(?, first_name),
+                    last_name = COALESCE(?, last_name),
+                    title = COALESCE(?, title),
+                    company = COALESCE(?, company),
+                    email = COALESCE(?, email),
+                    linkedin_url = COALESCE(?, linkedin_url),
+                    phone = COALESCE(?, phone),
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE person_id = ?
+                """,
+                (
+                    first_name,
+                    last_name,
+                    title,
+                    company,
+                    email,
+                    linkedin_url,
+                    phone,
+                    person_id,
+                ),
+            )
+            self._conn.commit()
+        return self.get(person_id)
 
     def get(self, person_id: str) -> dict[str, Any] | None:
         with self._lock:

--- a/desktop/coworker/permissions.py
+++ b/desktop/coworker/permissions.py
@@ -23,11 +23,13 @@ AUTO = frozenset(
         "drive_search",
         "drive_read",
         "calendar_list",
+        "web_search",
     }
 )
 ASK = frozenset(
     {
         "gmail_draft",
+        "gmail_send",
         "apollo_enrich_contact",
         "calendar_create",
         "calendar_update",

--- a/desktop/coworker/permissions.py
+++ b/desktop/coworker/permissions.py
@@ -16,6 +16,7 @@ AUTO = frozenset(
         "memory_update",
         "memory_forget",
         "apollo_search_people",
+        "people_keep",
         "load_skill",
         "gmail_search",
         "gmail_read",

--- a/desktop/coworker/server.py
+++ b/desktop/coworker/server.py
@@ -68,22 +68,29 @@ MAX_STEPS = 8
 KERNEL = (
     "Tools: now (America/Los_Angeles clock, auto), remember / memory_update / "
     "memory_forget (auto), load_skill (auto), gmail_search / gmail_read (auto), "
-    "gmail_draft (ask; creates a draft and never sends), drive_search / drive_read (auto, readonly), "
+    "gmail_draft (ask), gmail_send (ask; sends a reviewed draft after Allow), "
+    "drive_search / drive_read (auto, readonly), "
     "calendar_list (auto; upcoming from now unless a time range is given), "
     "calendar_create / calendar_update (ask, no delete), "
     "apollo_search_people (no emails), people_keep (auto; file curated search "
     "rows after the director chooses, do not invent the target), "
     "apollo_enrich_contact "
-    "(ask). MCP tools are named mcp__server__tool. Do not invent the time, tool "
+    "(ask), web_search (auto). MCP tools are named mcp__server__tool. Do not invent the time, tool "
     "results, emails, or memories. Do not claim you sent or drafted unless the "
-    "matching tool ran and was allowed."
+    "matching tool ran and was allowed. Do not send without Allow."
 )
+
+
+_PERSON_FILE_EVENT_CAP = 12
 
 
 def system_prompt(
     store: ConversationStore,
     persona: Persona | None = None,
     skills: SkillLoader | None = None,
+    *,
+    people: PersonStore | None = None,
+    session_id: str | None = None,
 ) -> str:
     identity = persona.body if persona is not None else KERNEL
     parts = [identity, KERNEL]
@@ -113,6 +120,21 @@ def system_prompt(
         catalog = catalog_text(skills)
         if catalog:
             parts.append(catalog)
+    if people is not None and session_id:
+        person_id = people.person_for_session(session_id)
+        person = people.get(person_id) if person_id else None
+        if person is not None:
+            events = people.timeline(person_id)
+            brief = build_brief(person, events)
+            recent = events[-_PERSON_FILE_EVENT_CAP:]
+            learned_lines = [str(event.get("summary") or "") for event in recent if event.get("summary")]
+            parts.append(
+                "Person file:\n"
+                f"who: {brief['who']}\n"
+                f"why: {brief['why']}\n"
+                f"learned:\n" + ("\n".join(f"- {line}" for line in learned_lines) or "-") + "\n"
+                f"missing: {', '.join(brief['missing'])}"
+            )
     return "\n\n".join(parts)
 
 
@@ -227,6 +249,7 @@ def create_app(
     app.state.drive = drive_from_secrets(app.state.secrets, http=http)
     app.state.calendar = calendar_from_secrets(app.state.secrets, http=http)
     app.state.apollo_key = apollo_key if apollo_key is not None else os.environ.get("APOLLO_API_KEY")
+    app.state.tavily_key = os.environ.get("TAVILY_API_KEY")
     app.state.public_url = public_url or "http://127.0.0.1:8765"
     app.state.oauth_state = ""
     app.state.skills = SkillLoader([BUILTIN_SKILLS, Path(root) / "skills"])
@@ -267,6 +290,7 @@ def create_app(
                     "calendar": app.state.calendar,
                     "http": app.state.http,
                     "apollo_key": app.state.apollo_key,
+                    "tavily_key": app.state.tavily_key,
                     "skills": app.state.skills,
                     "mcp": app.state.mcp,
                     "people": app.state.people,
@@ -388,6 +412,7 @@ def create_app(
             calendar=app.state.calendar,
             http=app.state.http,
             apollo_key=app.state.apollo_key,
+            tavily_key=app.state.tavily_key,
             skills=app.state.skills,
             mcp=app.state.mcp,
             people=app.state.people,
@@ -616,6 +641,23 @@ def create_app(
             )
         return HTMLResponse("<p>Gmail connected. You can close this tab and go back to Sourcecado.</p>")
 
+    @app.get("/v1/board")
+    def board_get():
+        return app.state.people.list_board()
+
+    @app.post("/v1/people/{person_id}/sequence")
+    async def people_sequence(person_id: str, request: Request):
+        payload = await request.json()
+        state = str(payload.get("state") or "")
+        actor = str(payload.get("actor") or "director")
+        if app.state.people.get(person_id) is None:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        try:
+            person = app.state.people.set_sequence(person_id, state, actor=actor)
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        return {"person": person}
+
     @app.get("/v1/people/{person_id}")
     def people_get(person_id: str):
         person = app.state.people.get(person_id)
@@ -714,6 +756,7 @@ def create_app(
                         "calendar": app.state.calendar,
                         "http": app.state.http,
                         "apollo_key": app.state.apollo_key,
+                        "tavily_key": app.state.tavily_key,
                         "skills": app.state.skills,
                         "mcp": app.state.mcp,
                         "people": app.state.people,

--- a/desktop/coworker/server.py
+++ b/desktop/coworker/server.py
@@ -41,6 +41,8 @@ from coworker.gmail import gmail_from_secrets
 from coworker.inbox import Inbox
 from coworker.mcp import FakeMcp, LiveMcp, write_default_mcp_json
 from coworker.mcp_oauth import McpOAuth
+from coworker.brief import build_brief
+from coworker.people import PersonStore
 from coworker.persona import ManifestError, Persona, load_persona
 from coworker.skills import BUILTIN_SKILLS, SkillLoader, catalog_text
 from coworker.permissions import decide
@@ -69,7 +71,9 @@ KERNEL = (
     "gmail_draft (ask; creates a draft and never sends), drive_search / drive_read (auto, readonly), "
     "calendar_list (auto; upcoming from now unless a time range is given), "
     "calendar_create / calendar_update (ask, no delete), "
-    "apollo_search_people (no emails), apollo_enrich_contact "
+    "apollo_search_people (no emails), people_keep (auto; file curated search "
+    "rows after the director chooses, do not invent the target), "
+    "apollo_enrich_contact "
     "(ask). MCP tools are named mcp__server__tool. Do not invent the time, tool "
     "results, emails, or memories. Do not claim you sent or drafted unless the "
     "matching tool ran and was allowed."
@@ -117,6 +121,22 @@ def state_dir() -> Path:
     if override:
         return Path(override).expanduser()
     return Path.home() / ".config" / "club"
+
+
+_SECRET_EVENT_KEYS = frozenset(
+    {"access_token", "refresh_token", "authorization", "api_key", "token"}
+)
+
+
+def _public_event(event: dict[str, Any]) -> dict[str, Any]:
+    payload = event.get("payload") or {}
+    if isinstance(payload, dict):
+        payload = {
+            key: value
+            for key, value in payload.items()
+            if key.lower() not in _SECRET_EVENT_KEYS
+        }
+    return {**event, "payload": payload}
 
 
 def _origin_allowed(origin: str | None) -> bool:
@@ -183,6 +203,7 @@ def create_app(
     app.state.provider = provider_from_env() if provider is _UNSET else provider
     root = state if state is not None else state_dir()
     app.state.store = ConversationStore(root)
+    app.state.people = PersonStore(root)
     app.state.secrets = SecretStore(Path(root) / "secrets.json")
     store = app.state.store
     if store.open_session_id() is None:
@@ -248,6 +269,7 @@ def create_app(
                     "apollo_key": app.state.apollo_key,
                     "skills": app.state.skills,
                     "mcp": app.state.mcp,
+                    "people": app.state.people,
                 },
                 emit=None,
                 wait_permission=None,
@@ -368,6 +390,7 @@ def create_app(
             apollo_key=app.state.apollo_key,
             skills=app.state.skills,
             mcp=app.state.mcp,
+            people=app.state.people,
         )
         app.state.tool_results[item_id] = (ok, result)
         return {"ok": ok, "item": resolved, "result": result}
@@ -593,6 +616,18 @@ def create_app(
             )
         return HTMLResponse("<p>Gmail connected. You can close this tab and go back to Sourcecado.</p>")
 
+    @app.get("/v1/people/{person_id}")
+    def people_get(person_id: str):
+        person = app.state.people.get(person_id)
+        if person is None:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        timeline = [_public_event(event) for event in app.state.people.timeline(person_id)]
+        return {
+            "person": person,
+            "brief": build_brief(person, timeline),
+            "timeline": timeline,
+        }
+
     @app.get("/v1/sessions")
     def sessions_list():
         store = app.state.store
@@ -681,6 +716,7 @@ def create_app(
                         "apollo_key": app.state.apollo_key,
                         "skills": app.state.skills,
                         "mcp": app.state.mcp,
+                        "people": app.state.people,
                         "_tool_results": app.state.tool_results,
                     },
                     emit=ws.send_json,

--- a/desktop/coworker/tools.py
+++ b/desktop/coworker/tools.py
@@ -12,6 +12,7 @@ from typing import Any
 from zoneinfo import ZoneInfo
 
 from coworker.apollo import MISSING_KEY, enrich_contact, search_people
+from coworker.web import MISSING_KEY as TAVILY_MISSING, search_web
 from coworker.gmail import GmailError, MissingGmail
 from coworker.people import PersonStore
 from coworker.store import ConversationStore
@@ -77,6 +78,26 @@ MEMORY_UPDATE_SCHEMA: dict[str, Any] = {
                 },
             },
             "required": ["memory_id", "content"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+WEB_SEARCH_SCHEMA: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "web_search",
+        "description": (
+            "Search the public web. Returns titles, URLs, and snippets. "
+            "Use for cited research. Not a gate on drafting."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "max_results": {"type": "integer"},
+            },
+            "required": ["query"],
             "additionalProperties": False,
         },
     },
@@ -273,6 +294,28 @@ CALENDAR_UPDATE_SCHEMA: dict[str, Any] = {
     },
 }
 
+GMAIL_SEND_SCHEMA: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "gmail_send",
+        "description": (
+            "Send an existing Gmail draft by id. Fisher must Allow first. "
+            "Use after a draft was created and reviewed. Does not create a new message."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "draft_id": {
+                    "type": "string",
+                    "description": "The Gmail draft id to send.",
+                }
+            },
+            "required": ["draft_id"],
+            "additionalProperties": False,
+        },
+    },
+}
+
 GMAIL_DRAFT_SCHEMA: dict[str, Any] = {
     "type": "function",
     "function": {
@@ -340,6 +383,7 @@ OPENAI_TOOLS = [
     GMAIL_SEARCH_SCHEMA,
     GMAIL_READ_SCHEMA,
     GMAIL_DRAFT_SCHEMA,
+    GMAIL_SEND_SCHEMA,
     DRIVE_SEARCH_SCHEMA,
     DRIVE_READ_SCHEMA,
     CALENDAR_LIST_SCHEMA,
@@ -349,6 +393,7 @@ OPENAI_TOOLS = [
     PEOPLE_KEEP_SCHEMA,
     APOLLO_ENRICH_SCHEMA,
     LOAD_SKILL_SCHEMA,
+    WEB_SEARCH_SCHEMA,
 ]
 
 
@@ -381,6 +426,8 @@ def execute(
     skills: Any = None,
     mcp: Any = None,
     people: PersonStore | None = None,
+    session_id: str | None = None,
+    tavily_key: str | None = None,
 ) -> tuple[bool, dict[str, Any]]:
     args = arguments or {}
     if name == "now":
@@ -484,6 +531,21 @@ def execute(
         result = dict(result)
         result["sent"] = False
         return True, result
+    if name == "gmail_send":
+        draft_id = str(args.get("draft_id") or "").strip()
+        if not draft_id:
+            return False, {"error": "draft_id is required"}
+        client = gmail if gmail is not None else MissingGmail()
+        try:
+            result = client.send(draft_id=draft_id)
+        except GmailError as exc:
+            return False, {"error": str(exc)}
+        except Exception as exc:
+            return False, {"error": str(exc)}
+        result = dict(result)
+        result["sent"] = True
+        result["draft_id"] = draft_id
+        return True, result
     if name in {"remember", "memory_update", "memory_forget"}:
         if store is None:
             return False, {"error": "memory store missing"}
@@ -525,7 +587,14 @@ def execute(
                     person_titles=list(titles) if titles else None,
                     limit=int(args.get("limit") or 10),
                 )
-            return True, enrich_contact(
+            person_id = str(args.get("person_id") or "") or None
+            if person_id is None and people is not None and session_id:
+                person_id = people.person_for_session(session_id)
+            if not person_id:
+                return False, {"error": "Bind a person before enriching."}
+            if people is not None and people.get(person_id) is None:
+                return False, {"error": "unknown person"}
+            result = enrich_contact(
                 http=client,
                 api_key=apollo_key,
                 email=str(args.get("email") or "") or None,
@@ -533,6 +602,17 @@ def execute(
                 last_name=str(args.get("lastName") or "") or None,
                 organization_name=str(args.get("organizationName") or "") or None,
             )
+            if people is not None:
+                people.apply_enrichment(
+                    person_id,
+                    name=result.get("name"),
+                    title=result.get("title"),
+                    company=result.get("organizationName"),
+                    email=result.get("email"),
+                    linkedin_url=result.get("linkedinUrl"),
+                    phone=result.get("phone"),
+                )
+            return True, result
         except Exception as exc:
             return False, {"error": str(exc)}
     if name == "people_keep":
@@ -565,4 +645,22 @@ def execute(
                 }
             )
         return True, {"kept": kept}
+    if name == "web_search":
+        if not tavily_key:
+            return False, {"error": TAVILY_MISSING}
+        query = str(args.get("query") or "").strip()
+        if not query:
+            return False, {"error": "query is required"}
+        from coworker.apollo import LiveHttp
+
+        client = http if http is not None else LiveHttp()
+        try:
+            return True, search_web(
+                http=client,
+                api_key=tavily_key,
+                query=query,
+                max_results=int(args.get("max_results") or 5),
+            )
+        except Exception as exc:
+            return False, {"error": str(exc)}
     return False, {"error": f"unknown tool {name}"}

--- a/desktop/coworker/tools.py
+++ b/desktop/coworker/tools.py
@@ -13,6 +13,7 @@ from zoneinfo import ZoneInfo
 
 from coworker.apollo import MISSING_KEY, enrich_contact, search_people
 from coworker.gmail import GmailError, MissingGmail
+from coworker.people import PersonStore
 from coworker.store import ConversationStore
 
 TZ = ZoneInfo("America/Los_Angeles")
@@ -96,6 +97,34 @@ APOLLO_SEARCH_SCHEMA: dict[str, Any] = {
                 "personTitles": {"type": "array", "items": {"type": "string"}},
                 "limit": {"type": "integer"},
             },
+            "additionalProperties": False,
+        },
+    },
+}
+
+PEOPLE_KEEP_SCHEMA: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "people_keep",
+        "description": (
+            "File curated Apollo search rows into person files. Use after "
+            "apollo_search_people when the director names who to keep. "
+            "Does not enrich and does not send. Never invent the target."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "people": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": "Apollo search rows to keep.",
+                },
+                "target": {
+                    "type": "string",
+                    "description": "Why the director wants to write these people.",
+                },
+            },
+            "required": ["people"],
             "additionalProperties": False,
         },
     },
@@ -317,6 +346,7 @@ OPENAI_TOOLS = [
     CALENDAR_CREATE_SCHEMA,
     CALENDAR_UPDATE_SCHEMA,
     APOLLO_SEARCH_SCHEMA,
+    PEOPLE_KEEP_SCHEMA,
     APOLLO_ENRICH_SCHEMA,
     LOAD_SKILL_SCHEMA,
 ]
@@ -350,6 +380,7 @@ def execute(
     apollo_key: str | None = None,
     skills: Any = None,
     mcp: Any = None,
+    people: PersonStore | None = None,
 ) -> tuple[bool, dict[str, Any]]:
     args = arguments or {}
     if name == "now":
@@ -504,4 +535,34 @@ def execute(
             )
         except Exception as exc:
             return False, {"error": str(exc)}
+    if name == "people_keep":
+        if people is None:
+            return False, {"error": "people store missing"}
+        rows = args.get("people") or []
+        if not isinstance(rows, list):
+            return False, {"error": "people must be a list"}
+        target = str(args.get("target") or "").strip() or None
+        kept: list[dict[str, Any]] = []
+        for row in rows:
+            if not isinstance(row, dict):
+                return False, {"error": "people rows must be objects"}
+            person = people.keep_from_apollo(
+                apollo_id=str(row.get("apolloId") or "") or None,
+                first_name=row.get("firstName"),
+                last_name_obfuscated=row.get("lastNameObfuscated"),
+                title=row.get("title"),
+                company=row.get("organizationName"),
+                target=target,
+            )
+            kept.append(
+                {
+                    "person_id": person["person_id"],
+                    "apollo_id": person["apollo_id"],
+                    "first_name": person["first_name"],
+                    "last_name": person["last_name"],
+                    "title": person["title"],
+                    "company": person["company"],
+                }
+            )
+        return True, {"kept": kept}
     return False, {"error": f"unknown tool {name}"}

--- a/desktop/coworker/turn.py
+++ b/desktop/coworker/turn.py
@@ -135,7 +135,13 @@ async def run_turn(
         store.replace_all(sid, loaded)
     sys_content = ""
     if system_prompt_fn is not None:
-        sys_content = system_prompt_fn(store, persona, skills)
+        sys_content = system_prompt_fn(
+            store,
+            persona,
+            skills,
+            people=execute_kwargs.get("people"),
+            session_id=sid,
+        )
     history: list[dict[str, Any]] = [{"role": "system", "content": sys_content}] + loaded
     # Caller already appended the user message in WS; scheduler has not.
     if not (loaded and loaded[-1].get("role") == "user" and loaded[-1].get("content") == text):
@@ -240,13 +246,20 @@ async def run_turn(
                 )
                 try:
                     kw = {k: v for k, v in execute_kwargs.items() if not k.startswith("_")}
+                    kw["session_id"] = sid
                     ok, result = execute(call.name, call.arguments, **kw)
                 except Exception as exc:
                     ok, result = False, {"error": str(exc)}
                 if call.name in {"remember", "memory_update", "memory_forget"} and system_prompt_fn:
                     history[0] = {
                         "role": "system",
-                        "content": system_prompt_fn(store, persona, skills),
+                        "content": system_prompt_fn(
+                            store,
+                            persona,
+                            skills,
+                            people=execute_kwargs.get("people"),
+                            session_id=sid,
+                        ),
                     }
                 await _emit(
                     {

--- a/desktop/coworker/turn.py
+++ b/desktop/coworker/turn.py
@@ -6,6 +6,7 @@ import json
 from typing import Any, Awaitable, Callable
 
 from coworker.inbox import Inbox
+from coworker.ledger import record_tool_on_person
 from coworker.permissions import decide
 from coworker.provider import ToolCall
 from coworker.store import ConversationStore
@@ -77,6 +78,19 @@ def _tool_result_message(call: ToolCall, payload: dict[str, Any]) -> dict[str, A
         "tool_call_id": call.id,
         "content": json.dumps(payload),
     }
+
+
+def _record_person_file(
+    sid: str,
+    call: ToolCall,
+    ok: bool,
+    result: dict[str, Any],
+    execute_kwargs: dict,
+) -> None:
+    people = execute_kwargs.get("people")
+    if people is None:
+        return
+    record_tool_on_person(people, sid, call.name, call.arguments, result, ok=ok)
 
 
 def _persist_closed(store: ConversationStore, sid: str, history: list[dict[str, Any]]) -> None:
@@ -168,6 +182,7 @@ async def run_turn(
                     denied = _tool_result_message(call, result)
                     history.append(denied)
                     store.append(sid, denied)
+                    _record_person_file(sid, call, False, result, execute_kwargs)
                     continue
                 if gate.needs_user:
                     inbox.park(call.name, call.arguments, item_id=call.id)
@@ -197,6 +212,7 @@ async def run_turn(
                         )
                         history.append(_tool_result_message(call, result))
                         store.append(sid, _tool_result_message(call, result))
+                        _record_person_file(sid, call, ok, result, execute_kwargs)
                         continue
                     if choice == "deny":
                         result = {"error": "denied by user"}
@@ -212,6 +228,7 @@ async def run_turn(
                         denied = _tool_result_message(call, result)
                         history.append(denied)
                         store.append(sid, denied)
+                        _record_person_file(sid, call, False, result, execute_kwargs)
                         continue
                 await _emit(
                     {
@@ -243,6 +260,7 @@ async def run_turn(
                 tool_result = _tool_result_message(call, result)
                 history.append(tool_result)
                 store.append(sid, tool_result)
+                _record_person_file(sid, call, ok, result, execute_kwargs)
         else:
             await _emit({"type": "error", "message": f"Stopped after {MAX_STEPS} tool steps."})
             return {"status": "stopped", "text": last_text}

--- a/desktop/coworker/web.py
+++ b/desktop/coworker/web.py
@@ -1,0 +1,37 @@
+"""Public web search via Tavily. Fake HTTP in tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+SEARCH_URL = "https://api.tavily.com/search"
+MISSING_KEY = "TAVILY_API_KEY is not configured."
+
+
+def search_web(
+    *,
+    http: Any,
+    api_key: str,
+    query: str,
+    max_results: int = 5,
+) -> dict[str, Any]:
+    data = http.post(
+        SEARCH_URL,
+        headers={
+            "content-type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+        },
+        json={"query": query, "max_results": max(1, min(int(max_results), 10))},
+    )
+    results = []
+    for row in (data or {}).get("results") or []:
+        if not isinstance(row, dict):
+            continue
+        results.append(
+            {
+                "title": row.get("title") or "",
+                "url": row.get("url") or "",
+                "snippet": row.get("content") or "",
+            }
+        )
+    return {"results": results}

--- a/desktop/surfaces/gui/postcss.config.js
+++ b/desktop/surfaces/gui/postcss.config.js
@@ -1,0 +1,1 @@
+export default { plugins: [] };

--- a/desktop/surfaces/gui/src/App.tsx
+++ b/desktop/surfaces/gui/src/App.tsx
@@ -1,4 +1,6 @@
 import { FormEvent, useEffect, useRef, useState } from "react";
+import { BoardView } from "./Board";
+import { PersonFileView } from "./PersonFile";
 import {
   connectGmail,
   createSession,
@@ -32,6 +34,23 @@ import {
   type Settings,
   type StoredMessage,
 } from "./api";
+
+type Route =
+  | { kind: "chat" }
+  | { kind: "board" }
+  | { kind: "people"; id: string };
+
+function parseHash(hash: string): Route {
+  if (hash === "#/board") return { kind: "board" };
+  if (hash.startsWith("#/people/") && hash.length > "#/people/".length) {
+    try {
+      return { kind: "people", id: decodeURIComponent(hash.slice("#/people/".length)) };
+    } catch {
+      return { kind: "chat" };
+    }
+  }
+  return { kind: "chat" };
+}
 
 type Item =
   | { kind: "user"; id: number; text: string }
@@ -74,6 +93,17 @@ export function App() {
   const chatRef = useRef<ReturnType<typeof openChat> | null>(null);
   const liveId = useRef<number | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
+  const [route, setRoute] = useState<Route>(() =>
+    typeof window === "undefined" ? { kind: "chat" } : parseHash(window.location.hash)
+  );
+
+  useEffect(() => {
+    function onHash() {
+      setRoute(parseHash(window.location.hash));
+    }
+    window.addEventListener("hashchange", onHash);
+    return () => window.removeEventListener("hashchange", onHash);
+  }, []);
 
   useEffect(() => {
     if (!hasToken()) {
@@ -242,6 +272,7 @@ export function App() {
   }
 
   async function onNewChat() {
+    window.location.hash = "";
     const created = await createSession();
     setSessionId(created.id);
     setItems([]);
@@ -250,6 +281,7 @@ export function App() {
   }
 
   async function onOpenSession(id: string) {
+    window.location.hash = "";
     const conv = await getSession(id);
     setSessionId(id);
     const restored = itemsFromMessages(conv.messages);
@@ -282,6 +314,9 @@ export function App() {
         <button type="button" className="strip-btn" onClick={() => onNewChat().catch((err: unknown) => setBanner(err instanceof Error ? err.message : String(err)))}>
           New chat
         </button>
+        <a className={`session-row ${route.kind === "board" ? "active" : ""}`} href="#/board">
+          Board
+        </a>
         <nav className="session-list">
           {sessions.map((row) => (
             <button
@@ -313,12 +348,17 @@ export function App() {
         </p>
       </header>
 
+      {route.kind === "board" ? (
+        <BoardView />
+      ) : route.kind === "people" ? (
+        <PersonFileView personId={route.id} />
+      ) : (
       <section className="transcript" aria-live="polite">
         {items.length === 0 && (
           <p className="empty">
             {persona?.id === "sourcing"
               ? "Sourcing on duty. Shortlists, drafts for review, why-now."
-              : "Generic buddy on duty. Ask, remember, draft (never send)."}
+              : "Generic buddy on duty. Ask, remember, draft, send with Allow."}
           </p>
         )}
         {items.map((item) =>
@@ -335,18 +375,24 @@ export function App() {
             </article>
           ) : item.kind === "approval" ? (
             <article key={item.id} className={`approval-card ${item.resolved ? "resolved" : "pending"}`}>
-              <p className="tool-name">{item.name}</p>
-              <p className="tool-result">{formatArgs(item.arguments)}</p>
+              <p className="tool-name">{approvalTitle(item)}</p>
+              <p className="tool-result">{approvalBody(item)}</p>
               <p className="approval-reason">{item.reason}</p>
               {item.resolved ? (
-                <p className="approval-resolved">{item.resolved === "allow" ? "allowed" : "denied"}</p>
+                <p className="approval-resolved">
+                  {item.resolved === "allow"
+                    ? item.name === "gmail_send"
+                      ? "sent"
+                      : "allowed"
+                    : "denied"}
+                </p>
               ) : (
                 <div className="approval-actions">
                   <button type="button" className="deny" onClick={() => onApprove(item.id, "deny")}>
                     Deny
                   </button>
                   <button type="button" className="allow" onClick={() => onApprove(item.id, "allow")}>
-                    Allow
+                    {item.name === "gmail_send" || item.name === "gmail_draft" ? "Allow once" : "Allow"}
                   </button>
                 </div>
               )}
@@ -359,6 +405,7 @@ export function App() {
         )}
         <div ref={bottomRef} />
       </section>
+      )}
 
       <aside className="connector-strip">
         <p>
@@ -563,6 +610,7 @@ export function App() {
 
       {banner && <p className="status warn">{banner}</p>}
 
+      {route.kind === "chat" && (
       <form className="composer" onSubmit={onSubmit}>
         <textarea
           value={draft}
@@ -581,9 +629,36 @@ export function App() {
           Send
         </button>
       </form>
+      )}
       </div>
     </main>
   );
+}
+
+function strArg(args: Record<string, unknown>, key: string): string {
+  const value = args[key];
+  return typeof value === "string" ? value : "";
+}
+
+function approvalTitle(item: Extract<Item, { kind: "approval" }>): string {
+  if (item.name === "gmail_draft") return "Gmail draft";
+  if (item.name === "gmail_send") return "Send Gmail draft";
+  return item.name;
+}
+
+function approvalBody(item: Extract<Item, { kind: "approval" }>): string {
+  if (item.name === "gmail_draft") {
+    const to = strArg(item.arguments, "to");
+    const subject = strArg(item.arguments, "subject");
+    const body = strArg(item.arguments, "body");
+    const preview = body.length > 240 ? `${body.slice(0, 240)}…` : body;
+    return [to && `To ${to}`, subject, preview, "Not sent"].filter(Boolean).join("\n");
+  }
+  if (item.name === "gmail_send") {
+    const draftId = strArg(item.arguments, "draft_id");
+    return [draftId && `Draft ${draftId}`, "This will send the reviewed draft."].filter(Boolean).join("\n");
+  }
+  return formatArgs(item.arguments);
 }
 
 function formatResult(result: Record<string, unknown> | undefined): string {
@@ -596,6 +671,7 @@ function formatResult(result: Record<string, unknown> | undefined): string {
   if (result.updated === true) return `updated #${result.id}`;
   if (result.forgotten === true) return `forgot #${result.id}`;
   if (result.drafted === true) return `draft ${result.id} · not sent`;
+  if (result.sent === true) return `sent ${result.draft_id || result.id || ""}`.trim();
   if (Array.isArray(result.people)) return `${result.people.length} people`;
   return JSON.stringify(result);
 }

--- a/desktop/surfaces/gui/src/Board.tsx
+++ b/desktop/surfaces/gui/src/Board.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react";
+
+import { getBoard, type Board, type BoardPerson } from "./api";
+
+function label(person: BoardPerson): string {
+  const name = [person.first_name, person.last_name].filter(Boolean).join(" ");
+  const job = [person.title, person.company].filter(Boolean).join(" · ");
+  return job ? `${name || "Unknown"} · ${job}` : name || "Unknown";
+}
+
+function Bucket({
+  title,
+  people,
+}: {
+  title: string;
+  people: BoardPerson[];
+}) {
+  return (
+    <section className="board-bucket">
+      <h2>{title}</h2>
+      {people.length === 0 ? (
+        <p className="empty">None</p>
+      ) : (
+        people.map((person) => (
+          <a key={person.person_id} className="board-row" href={`#/people/${person.person_id}`}>
+            {label(person)}
+          </a>
+        ))
+      )}
+    </section>
+  );
+}
+
+export function BoardView() {
+  const [board, setBoard] = useState<Board | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getBoard()
+      .then(setBoard)
+      .catch((err: unknown) => setError(err instanceof Error ? err.message : String(err)));
+  }, []);
+
+  const empty =
+    board &&
+    board.open.length === 0 &&
+    board.in_conversation.length === 0 &&
+    board.done.length === 0;
+
+  return (
+    <div className="route-page">
+      <h1>Board</h1>
+      {error ? <p className="empty">{error}</p> : null}
+      {empty ? <p className="empty">No one in motion.</p> : null}
+      {board && !empty ? (
+        <div className="board-grid">
+          <Bucket title="Open" people={board.open} />
+          <Bucket title="In conversation" people={board.in_conversation} />
+          <Bucket title="Done" people={board.done} />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/desktop/surfaces/gui/src/PersonFile.tsx
+++ b/desktop/surfaces/gui/src/PersonFile.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react";
+
+import { getPerson, setPersonSequence, type PersonFile } from "./api";
+
+const STATES = [
+  { id: "open", label: "Open" },
+  { id: "in_conversation", label: "In conversation" },
+  { id: "done", label: "Done" },
+];
+
+export function PersonFileView({ personId }: { personId: string }) {
+  const [file, setFile] = useState<PersonFile | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getPerson(personId)
+      .then(setFile)
+      .catch((err: unknown) => setError(err instanceof Error ? err.message : String(err)));
+  }, [personId]);
+
+  async function move(state: string) {
+    await setPersonSequence(personId, state);
+    setFile(await getPerson(personId));
+  }
+
+  if (error) {
+    return (
+      <div className="route-page">
+        <h1>Person</h1>
+        <p className="empty">{error}</p>
+      </div>
+    );
+  }
+  if (!file) {
+    return (
+      <div className="route-page">
+        <h1>Person</h1>
+        <p className="empty">Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="route-page">
+      <p className="eyebrow">
+        <a href="#/board">Board</a>
+      </p>
+      <h1>{file.brief.who || "Person"}</h1>
+      <p>{file.brief.why}</p>
+      <p className="eyebrow">Missing: {file.brief.missing.join(", ") || "none"}</p>
+      <p className="eyebrow">Sources: {file.brief.sources.join(", ") || "none"}</p>
+      <div className="approval-actions">
+        {STATES.map((state) => (
+          <button
+            key={state.id}
+            type="button"
+            className={file.person.sequence_state === state.id ? "allow" : "strip-btn"}
+            onClick={() => move(state.id).catch((err: unknown) => setError(err instanceof Error ? err.message : String(err)))}
+          >
+            {state.label}
+          </button>
+        ))}
+      </div>
+      <h2>Learned</h2>
+      {file.brief.learned.length === 0 ? (
+        <p className="empty">Nothing filed yet.</p>
+      ) : (
+        <ul>
+          {file.brief.learned.map((line) => (
+            <li key={line}>{line}</li>
+          ))}
+        </ul>
+      )}
+      <h2>Timeline</h2>
+      {file.timeline.map((event) => (
+        <article key={event.event_id} className="tool-card">
+          <p className="tool-name">
+            {event.source} · {event.kind}
+          </p>
+          <p className="tool-result">{event.summary}</p>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/desktop/surfaces/gui/src/api.ts
+++ b/desktop/surfaces/gui/src/api.ts
@@ -120,6 +120,66 @@ export async function renameSession(id: string, title: string): Promise<{ id: st
   return res.json();
 }
 
+export type BoardPerson = {
+  person_id: string;
+  first_name: string | null;
+  last_name: string | null;
+  title: string | null;
+  company: string | null;
+  sequence_state: string | null;
+};
+
+export type Board = {
+  open: BoardPerson[];
+  in_conversation: BoardPerson[];
+  done: BoardPerson[];
+};
+
+export type PersonFile = {
+  person: BoardPerson & Record<string, unknown>;
+  brief: {
+    who: string;
+    why: string;
+    learned: string[];
+    missing: string[];
+    sources: string[];
+  };
+  timeline: Array<{
+    event_id: string;
+    source: string;
+    kind: string;
+    summary: string;
+    payload: Record<string, unknown>;
+  }>;
+};
+
+export async function getBoard(): Promise<Board> {
+  const res = await get("/v1/board");
+  if (!res.ok) throw new Error(`board ${res.status}`);
+  return res.json();
+}
+
+export async function getPerson(id: string): Promise<PersonFile> {
+  const res = await get(`/v1/people/${encodeURIComponent(id)}`);
+  if (!res.ok) throw new Error(`person ${res.status}`);
+  return res.json();
+}
+
+export async function setPersonSequence(
+  id: string,
+  state: string,
+  actor = "director"
+): Promise<{ person: BoardPerson }> {
+  const res = await fetch(`${httpBase()}/v1/people/${encodeURIComponent(id)}/sequence`, {
+    method: "POST",
+    headers: { "X-Club-Token": apiToken(), "Content-Type": "application/json" },
+    body: JSON.stringify({ state, actor }),
+  });
+  const body = await res.json();
+  if (!res.ok) throw new Error(body.error || `sequence ${res.status}`);
+  return body;
+}
+
 export async function getConversation(): Promise<Conversation> {
   const res = await get("/v1/conversation");
   if (!res.ok) throw new Error(`conversation ${res.status}`);

--- a/desktop/surfaces/gui/src/styles.css
+++ b/desktop/surfaces/gui/src/styles.css
@@ -73,6 +73,53 @@ body,
   background: var(--accent-tint);
 }
 
+a.session-row {
+  text-decoration: none;
+  display: block;
+}
+
+.route-page {
+  flex: 1;
+  overflow: auto;
+}
+
+.route-page h1 {
+  margin: 0 0 12px;
+  font-size: 24px;
+  font-weight: 600;
+}
+
+.route-page h2 {
+  margin: 20px 0 8px;
+  font-size: 18px;
+  font-weight: 500;
+}
+
+.board-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.board-bucket {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+}
+
+.board-row {
+  display: block;
+  padding: 8px 10px;
+  border-radius: 6px;
+  color: var(--text);
+  text-decoration: none;
+}
+
+.board-row:hover {
+  background: var(--raised);
+}
+
 .main {
   flex: 1;
   min-width: 0;

--- a/desktop/tests/test_apollo.py
+++ b/desktop/tests/test_apollo.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from coworker.apollo import MATCH_URL, SEARCH_URL, FakeHttp, LiveHttp, search_people
+from coworker.people import PersonStore
 from coworker.tools import execute
 
 
@@ -41,7 +42,7 @@ def test_apollo_search_does_not_invent_emails():
     assert http.calls[0]["headers"]["x-api-key"] == "test-key"
 
 
-def test_apollo_enrich_returns_contact():
+def test_apollo_enrich_returns_contact(tmp_path):
     http = FakeHttp(
         {
             MATCH_URL: {
@@ -56,16 +57,28 @@ def test_apollo_enrich_returns_contact():
             }
         }
     )
+    people = PersonStore(tmp_path)
+    person = people.keep_from_apollo(
+        apollo_id="tim",
+        first_name="Tim",
+        last_name_obfuscated="Z",
+        title="CEO",
+        company="Apollo",
+    )
+    people.bind_session("sess-tim", person["person_id"])
     ok, result = execute(
         "apollo_enrich_contact",
         {"firstName": "Tim", "lastName": "Zheng", "organizationName": "Apollo"},
         http=http,
         apollo_key="test-key",
+        people=people,
+        session_id="sess-tim",
     )
     assert ok is True
     assert result["name"] == "Tim Zheng"
     assert result["email"] == "tim@apollo.io"
     assert result["organizationName"] == "Apollo.io"
+    assert people.get(person["person_id"])["email"] == "tim@apollo.io"
 
 
 def test_apollo_missing_key_fails_clearly():

--- a/desktop/tests/test_bound_turn.py
+++ b/desktop/tests/test_bound_turn.py
@@ -1,5 +1,6 @@
 import asyncio
 
+from coworker.apollo import MATCH_URL, FakeHttp
 from coworker.gmail import FakeGmail
 from coworker.inbox import Inbox
 from coworker.people import PersonStore
@@ -344,3 +345,190 @@ def test_denied_draft_does_not_open_sequence(tmp_path):
     assert [row["kind"] for row in people.timeline(ada["person_id"]) if row["kind"] == "draft"] == []
     assert gmail.drafts == []
     assert gmail.sends == []
+
+
+def _enrich_http():
+    return FakeHttp(
+        {
+            MATCH_URL: {
+                "person": {
+                    "name": "Ada Lovelace",
+                    "title": "Founder",
+                    "organization": {"name": "Analytic"},
+                    "linkedin_url": "https://linkedin.com/in/ada",
+                    "email": "ada@analytic.example",
+                    "phone_numbers": [{"raw_number": "+1 555"}],
+                }
+            }
+        }
+    )
+
+
+def _enrich_call():
+    return ToolCall(
+        id="enrich_1",
+        name="apollo_enrich_contact",
+        arguments={
+            "firstName": "Ada",
+            "lastName": "Lovelace",
+            "organizationName": "Analytic",
+        },
+    )
+
+
+def test_allowed_enrich_writes_email_on_bound_person(tmp_path):
+    people = PersonStore(tmp_path)
+    _keep(tmp_path, people, "sess-ada", _ada())
+    fake = FakeProvider(
+        steps=[
+            {"tool_calls": [_enrich_call()]},
+            {"deltas": ("Got the email.",)},
+        ]
+    )
+    _run(
+        tmp_path=tmp_path,
+        sid="sess-ada",
+        text="enrich Ada",
+        provider=fake,
+        people=people,
+        wait="allow",
+        http=_enrich_http(),
+        apollo_key="test-key",
+    )
+    ada = people.get_by_apollo_id("ada")
+    assert ada is not None
+    assert ada["email"] == "ada@analytic.example"
+    kinds = [row["kind"] for row in people.timeline(ada["person_id"])]
+    assert "enrich" in kinds
+
+
+def test_denied_enrich_does_not_store_email(tmp_path):
+    people = PersonStore(tmp_path)
+    _keep(tmp_path, people, "sess-ada", _ada())
+    fake = FakeProvider(
+        steps=[
+            {"tool_calls": [_enrich_call()]},
+            {"deltas": ("Okay.",)},
+        ]
+    )
+    _run(
+        tmp_path=tmp_path,
+        sid="sess-ada",
+        text="enrich Ada",
+        provider=fake,
+        people=people,
+        wait="deny",
+        http=_enrich_http(),
+        apollo_key="test-key",
+    )
+    ada = people.get_by_apollo_id("ada")
+    assert ada is not None
+    assert ada["email"] is None
+
+
+def test_unbound_enrich_fails_closed(tmp_path):
+    from coworker.tools import execute
+
+    people = PersonStore(tmp_path)
+    http = _enrich_http()
+    ok, result = execute(
+        "apollo_enrich_contact",
+        {
+            "firstName": "Ada",
+            "lastName": "Lovelace",
+            "organizationName": "Analytic",
+        },
+        people=people,
+        http=http,
+        apollo_key="test-key",
+        session_id="sess-other",
+    )
+    assert ok is False
+    assert "bind" in result["error"].lower() or "person" in result["error"].lower()
+    assert people.get_by_apollo_id("ada") is None
+    assert people.list_board() == {"open": [], "in_conversation": [], "done": []}
+    assert http.calls == []
+
+
+def test_gmail_send_asks_and_execute_sends_draft():
+    from coworker.permissions import decide
+    from coworker.tools import execute
+
+    assert decide("gmail_send").needs_user is True
+    gmail = FakeGmail()
+    gmail.create_draft(to="ada@analytic.example", subject="Dinner", body="Join us")
+    ok, result = execute("gmail_send", {"draft_id": "draft_1"}, gmail=gmail)
+    assert ok is True
+    assert result["sent"] is True
+    assert result["draft_id"] == "draft_1"
+    assert gmail.sends == [{"draft_id": "draft_1"}]
+
+
+def test_allowed_send_files_on_bound_person(tmp_path):
+    people = PersonStore(tmp_path)
+    _keep(tmp_path, people, "sess-ada", _ada())
+    gmail = FakeGmail()
+    gmail.create_draft(to="ada@analytic.example", subject="Dinner", body="Join us")
+    fake = FakeProvider(
+        steps=[
+            {
+                "tool_calls": [
+                    ToolCall(id="send_1", name="gmail_send", arguments={"draft_id": "draft_1"})
+                ]
+            },
+            {"deltas": ("Sent.",)},
+        ]
+    )
+    _run(
+        tmp_path=tmp_path,
+        sid="sess-ada",
+        text="send it",
+        provider=fake,
+        people=people,
+        gmail=gmail,
+        wait="allow",
+    )
+    ada = people.get_by_apollo_id("ada")
+    assert ada is not None
+    sends = [row for row in people.timeline(ada["person_id"]) if row["kind"] == "send"]
+    assert len(sends) == 1
+    assert sends[0]["payload"]["sent"] is True
+    assert gmail.sends == [{"draft_id": "draft_1"}]
+
+
+def test_denied_send_does_not_send(tmp_path):
+    people = PersonStore(tmp_path)
+    _keep(tmp_path, people, "sess-ada", _ada())
+    gmail = FakeGmail()
+    gmail.create_draft(to="ada@analytic.example", subject="Dinner", body="Join us")
+    fake = FakeProvider(
+        steps=[
+            {
+                "tool_calls": [
+                    ToolCall(id="send_1", name="gmail_send", arguments={"draft_id": "draft_1"})
+                ]
+            },
+            {"deltas": ("Okay.",)},
+        ]
+    )
+    _run(
+        tmp_path=tmp_path,
+        sid="sess-ada",
+        text="send it",
+        provider=fake,
+        people=people,
+        gmail=gmail,
+        wait="deny",
+    )
+    ada = people.get_by_apollo_id("ada")
+    assert ada is not None
+    assert [row["kind"] for row in people.timeline(ada["person_id"]) if row["kind"] == "send"] == []
+    assert gmail.sends == []
+
+
+def test_kernel_says_send_requires_allow():
+    from coworker.server import KERNEL
+
+    assert "gmail_send" in KERNEL
+    assert "Allow" in KERNEL
+    assert "never sends" not in KERNEL

--- a/desktop/tests/test_bound_turn.py
+++ b/desktop/tests/test_bound_turn.py
@@ -1,0 +1,346 @@
+import asyncio
+
+from coworker.gmail import FakeGmail
+from coworker.inbox import Inbox
+from coworker.people import PersonStore
+from coworker.provider import FakeProvider, ToolCall
+from coworker.store import ConversationStore
+from coworker.tools import OPENAI_TOOLS
+from coworker.turn import run_turn
+
+
+def _alyssa() -> dict:
+    return {
+        "apolloId": "abc123",
+        "firstName": "Alyssa",
+        "lastNameObfuscated": "W***n",
+        "title": "Partner",
+        "organizationName": "Codeology",
+    }
+
+
+def _run(*, tmp_path, sid, text, provider, people, gmail=None, drive=None, wait=None, http=None, apollo_key=None):
+    conv = ConversationStore(tmp_path)
+
+    async def _wait(_call_id: str) -> str:
+        return wait or "allow"
+
+    return asyncio.run(
+        run_turn(
+            text=text,
+            sid=sid,
+            store=conv,
+            provider=provider,
+            persona=None,
+            skills=None,
+            inbox=Inbox(conv),
+            openai_tools=OPENAI_TOOLS,
+            execute_kwargs={
+                "people": people,
+                "gmail": gmail,
+                "drive": drive,
+                "http": http,
+                "apollo_key": apollo_key,
+            },
+            wait_permission=_wait if wait is not None else None,
+        )
+    )
+
+
+def test_keep_one_person_binds_that_session_only(tmp_path):
+    people = PersonStore(tmp_path)
+    fake = FakeProvider(
+        steps=[
+            {
+                "tool_calls": [
+                    ToolCall(
+                        id="keep_1",
+                        name="people_keep",
+                        arguments={"people": [_alyssa()], "target": "dinner"},
+                    )
+                ]
+            },
+            {"deltas": ("Kept Alyssa.",)},
+        ]
+    )
+    _run(
+        tmp_path=tmp_path,
+        sid="sess-a",
+        text="keep Alyssa",
+        provider=fake,
+        people=people,
+    )
+    person_id = people.person_for_session("sess-a")
+    assert person_id is not None
+    assert people.get(person_id)["first_name"] == "Alyssa"
+    assert people.person_for_session("sess-b") is None
+
+
+def _ada() -> dict:
+    return {
+        "apolloId": "ada",
+        "firstName": "Ada",
+        "lastNameObfuscated": "L",
+        "title": "Founder",
+        "organizationName": "Analytic",
+    }
+
+
+def _alonzo() -> dict:
+    return {
+        "apolloId": "alonzo",
+        "firstName": "Alonzo",
+        "lastNameObfuscated": "C",
+        "title": "Professor",
+        "organizationName": "Princeton",
+    }
+
+
+class _SearchGmail:
+    def search(self, query: str, max_results: int = 10) -> dict:
+        return {
+            "messages": [
+                {"id": "m1", "from": "ada@analytic.example", "subject": "Hello"}
+            ]
+        }
+
+
+def _keep(tmp_path, people, sid, row):
+    fake = FakeProvider(
+        steps=[
+            {
+                "tool_calls": [
+                    ToolCall(
+                        id="keep_1",
+                        name="people_keep",
+                        arguments={"people": [row]},
+                    )
+                ]
+            },
+            {"deltas": ("Kept.",)},
+        ]
+    )
+    _run(tmp_path=tmp_path, sid=sid, text="keep", provider=fake, people=people)
+
+
+def test_bound_gmail_search_files_on_ada_not_alonzo(tmp_path):
+    people = PersonStore(tmp_path)
+    _keep(tmp_path, people, "sess-ada", _ada())
+    _keep(tmp_path, people, "sess-alonzo", _alonzo())
+    fake = FakeProvider(
+        steps=[
+            {
+                "tool_calls": [
+                    ToolCall(
+                        id="search_1",
+                        name="gmail_search",
+                        arguments={"query": "from:ada"},
+                    )
+                ]
+            },
+            {"deltas": ("Found mail.",)},
+        ]
+    )
+    _run(
+        tmp_path=tmp_path,
+        sid="sess-ada",
+        text="search mail",
+        provider=fake,
+        people=people,
+        gmail=_SearchGmail(),
+    )
+    ada = people.get_by_apollo_id("ada")
+    alonzo = people.get_by_apollo_id("alonzo")
+    assert ada is not None and alonzo is not None
+    kinds = [row["kind"] for row in people.timeline(ada["person_id"])]
+    assert "mail" in kinds
+    assert people.timeline(alonzo["person_id"]) == []
+
+
+def test_unbound_gmail_search_does_not_file(tmp_path):
+    people = PersonStore(tmp_path)
+    _keep(tmp_path, people, "sess-ada", _ada())
+    ada = people.get_by_apollo_id("ada")
+    assert ada is not None
+    fake = FakeProvider(
+        steps=[
+            {
+                "tool_calls": [
+                    ToolCall(
+                        id="search_1",
+                        name="gmail_search",
+                        arguments={"query": "from:ada"},
+                    )
+                ]
+            },
+            {"deltas": ("Found mail.",)},
+        ]
+    )
+    _run(
+        tmp_path=tmp_path,
+        sid="sess-other",
+        text="search mail",
+        provider=fake,
+        people=people,
+        gmail=_SearchGmail(),
+    )
+    assert people.person_for_session("sess-other") is None
+    assert people.timeline(ada["person_id"]) == []
+
+
+def test_bound_failed_drive_read_files_error(tmp_path):
+    people = PersonStore(tmp_path)
+    _keep(tmp_path, people, "sess-ada", _ada())
+    fake = FakeProvider(
+        steps=[
+            {
+                "tool_calls": [
+                    ToolCall(
+                        id="read_1",
+                        name="drive_read",
+                        arguments={"file_id": "d1"},
+                    )
+                ]
+            },
+            {"deltas": ("Drive is down.",)},
+        ]
+    )
+    _run(
+        tmp_path=tmp_path,
+        sid="sess-ada",
+        text="read the deck",
+        provider=fake,
+        people=people,
+        drive=None,
+    )
+    ada = people.get_by_apollo_id("ada")
+    assert ada is not None
+    timeline = people.timeline(ada["person_id"])
+    assert [row["kind"] for row in timeline] == ["error"]
+    assert timeline[0]["source"] == "drive"
+    assert people.get(ada["person_id"]) is not None
+
+
+def test_keep_two_people_does_not_bind(tmp_path):
+    people = PersonStore(tmp_path)
+    fake = FakeProvider(
+        steps=[
+            {
+                "tool_calls": [
+                    ToolCall(
+                        id="keep_2",
+                        name="people_keep",
+                        arguments={"people": [_ada(), _alonzo()]},
+                    )
+                ]
+            },
+            {"deltas": ("Kept two.",)},
+        ]
+    )
+    _run(
+        tmp_path=tmp_path,
+        sid="sess-a",
+        text="keep both",
+        provider=fake,
+        people=people,
+    )
+    assert people.person_for_session("sess-a") is None
+    assert people.get_by_apollo_id("ada") is not None
+    assert people.get_by_apollo_id("alonzo") is not None
+
+
+def _draft_call():
+    return ToolCall(
+        id="draft_1",
+        name="gmail_draft",
+        arguments={
+            "to": "ada@analytic.example",
+            "subject": "Dinner",
+            "body": "Would you join the research dinner?",
+        },
+    )
+
+
+def test_allowed_draft_opens_sequence_and_does_not_send(tmp_path):
+    people = PersonStore(tmp_path)
+    _keep(tmp_path, people, "sess-ada", _ada())
+    gmail = FakeGmail()
+    fake = FakeProvider(
+        steps=[
+            {"tool_calls": [_draft_call()]},
+            {"deltas": ("Draft is ready.",)},
+        ]
+    )
+    _run(
+        tmp_path=tmp_path,
+        sid="sess-ada",
+        text="write Ada",
+        provider=fake,
+        people=people,
+        gmail=gmail,
+        wait="allow",
+    )
+    ada = people.get_by_apollo_id("ada")
+    assert ada is not None
+    assert ada["sequence_state"] == "open"
+    assert [row["person_id"] for row in people.list_board()["open"]] == [ada["person_id"]]
+    drafts = [row for row in people.timeline(ada["person_id"]) if row["kind"] == "draft"]
+    assert len(drafts) == 1
+    assert drafts[0]["payload"]["to"] == "ada@analytic.example"
+    assert drafts[0]["payload"]["subject"] == "Dinner"
+    assert drafts[0]["payload"]["draft_id"] == "draft_1"
+    assert drafts[0]["payload"]["sent"] is False
+    assert gmail.sends == []
+    assert len(gmail.drafts) == 1
+
+
+def test_draft_does_not_reset_in_conversation(tmp_path):
+    people = PersonStore(tmp_path)
+    _keep(tmp_path, people, "sess-ada", _ada())
+    ada = people.get_by_apollo_id("ada")
+    assert ada is not None
+    people.set_sequence(ada["person_id"], "in_conversation", actor="director")
+    fake = FakeProvider(
+        steps=[
+            {"tool_calls": [_draft_call()]},
+            {"deltas": ("Draft is ready.",)},
+        ]
+    )
+    _run(
+        tmp_path=tmp_path,
+        sid="sess-ada",
+        text="write again",
+        provider=fake,
+        people=people,
+        gmail=FakeGmail(),
+        wait="allow",
+    )
+    assert people.get(ada["person_id"])["sequence_state"] == "in_conversation"
+
+
+def test_denied_draft_does_not_open_sequence(tmp_path):
+    people = PersonStore(tmp_path)
+    _keep(tmp_path, people, "sess-ada", _ada())
+    gmail = FakeGmail()
+    fake = FakeProvider(
+        steps=[
+            {"tool_calls": [_draft_call()]},
+            {"deltas": ("Okay.",)},
+        ]
+    )
+    _run(
+        tmp_path=tmp_path,
+        sid="sess-ada",
+        text="write Ada",
+        provider=fake,
+        people=people,
+        gmail=gmail,
+        wait="deny",
+    )
+    ada = people.get_by_apollo_id("ada")
+    assert ada is not None
+    assert ada["sequence_state"] is None
+    assert people.list_board()["open"] == []
+    assert [row["kind"] for row in people.timeline(ada["person_id"]) if row["kind"] == "draft"] == []
+    assert gmail.drafts == []
+    assert gmail.sends == []

--- a/desktop/tests/test_brief.py
+++ b/desktop/tests/test_brief.py
@@ -1,0 +1,45 @@
+from coworker.brief import build_brief
+from coworker.people import PersonStore
+
+
+def test_apollo_only_brief_names_who_and_missing(tmp_path):
+    store = PersonStore(tmp_path)
+    person = store.keep_from_apollo(
+        apollo_id="abc123",
+        first_name="Alyssa",
+        last_name_obfuscated="W***n",
+        title="Partner",
+        company="Codeology",
+        target="club research dinner",
+    )
+    brief = build_brief(person, [])
+    assert "Alyssa" in brief["who"]
+    assert "Partner" in brief["who"]
+    assert "Codeology" in brief["who"]
+    assert brief["why"] == "club research dinner"
+    assert brief["sources"] == []
+    missing = " ".join(brief["missing"]).lower()
+    assert "email" in missing or "mail" in missing
+
+
+def test_brief_keeps_all_sources_when_calendar_is_absent(tmp_path):
+    store = PersonStore(tmp_path)
+    person = store.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+        target="research dinner",
+    )
+    pid = person["person_id"]
+    store.append_event(pid, source="apollo", kind="enrich", summary="Enriched Ada", payload={"email": "ada@analytic.example"})
+    store.append_event(pid, source="gmail", kind="mail", summary="Read mail from Ada")
+    store.append_event(pid, source="drive", kind="file", summary="Read deck")
+    store.append_event(pid, source="granola", kind="meeting", summary="Meeting notes")
+    brief = build_brief(store.get(pid), store.timeline(pid))
+    assert brief["sources"] == ["apollo", "gmail", "drive", "granola"]
+    assert "calendar" not in brief["sources"]
+    assert brief["learned"]
+    assert "Enriched Ada" in brief["learned"]
+    assert "Read deck" in brief["learned"]

--- a/desktop/tests/test_gmail.py
+++ b/desktop/tests/test_gmail.py
@@ -174,7 +174,7 @@ def test_gmail_api_posts_to_drafts_never_send(tmp_path):
     assert DRAFTS_URL in http.calls[0]["url"]
     assert "send" not in http.calls[0]["url"]
     assert "send" not in str(http.calls)
-    assert not hasattr(GmailApi, "send") or not callable(getattr(api, "send", None))
+    assert api.sends == []
 
 
 def test_gmail_api_http_403_raises_gmail_error(tmp_path):
@@ -455,6 +455,7 @@ def test_gmail_search_is_auto_and_draft_still_asks():
     assert decide("gmail_read").needs_user is False
     assert decide("gmail_draft").needs_user is True
     assert decide("gmail_send").allowed is False
+    assert decide("gmail_send").needs_user is True
 
 
 def test_gmail_search_execute_fake_http(tmp_path):

--- a/desktop/tests/test_ledger.py
+++ b/desktop/tests/test_ledger.py
@@ -1,0 +1,348 @@
+from coworker.ledger import event_from_tool
+
+
+def test_clock_and_memory_tools_are_not_filed():
+    for name in (
+        "now",
+        "remember",
+        "memory_update",
+        "memory_forget",
+        "load_skill",
+    ):
+        assert event_from_tool(name, {}, {"ok": True}, ok=True) is None
+
+
+def test_apollo_search_is_not_filed():
+    event = event_from_tool(
+        "apollo_search_people",
+        {"organizationName": "Codeology", "personTitles": ["Partner"]},
+        {
+            "people": [
+                {
+                    "apolloId": "abc123",
+                    "firstName": "Alyssa",
+                    "lastNameObfuscated": "W***n",
+                    "title": "Partner",
+                    "organizationName": "Codeology",
+                    "hasEmail": True,
+                }
+            ]
+        },
+        ok=True,
+    )
+    assert event is None
+
+
+def test_gmail_search_files_as_mail():
+    event = event_from_tool(
+        "gmail_search",
+        {"query": "from:ada"},
+        {
+            "messages": [
+                {
+                    "id": "m1",
+                    "from": "ada@analytic.example",
+                    "subject": "Hello",
+                }
+            ]
+        },
+        ok=True,
+    )
+    assert event is not None
+    assert event["source"] == "gmail"
+    assert event["kind"] == "mail"
+    assert event["tool"] == "gmail_search"
+    assert "from:ada" in event["summary"]
+    assert "1" in event["summary"]
+    assert event["payload"]["query"] == "from:ada"
+    assert event["payload"]["ids"] == ["m1"]
+    assert "body" not in event["payload"]
+    assert "messages" not in event["payload"]
+
+
+def test_gmail_read_files_as_mail_without_body():
+    event = event_from_tool(
+        "gmail_read",
+        {"message_id": "m1"},
+        {
+            "id": "m1",
+            "from": "ada@analytic.example",
+            "to": "fisher@example.com",
+            "subject": "Hello",
+            "date": "Mon, 1 Jan 2026",
+            "snippet": "Hi Fisher",
+            "body": "Hi Fisher, long body that must not be filed.",
+            "sent": False,
+        },
+        ok=True,
+    )
+    assert event is not None
+    assert event["source"] == "gmail"
+    assert event["kind"] == "mail"
+    assert event["tool"] == "gmail_read"
+    assert event["payload"] == {
+        "id": "m1",
+        "from": "ada@analytic.example",
+        "subject": "Hello",
+        "date": "Mon, 1 Jan 2026",
+    }
+    assert "body" not in event["payload"]
+
+
+def test_gmail_draft_files_as_unsent_draft():
+    event = event_from_tool(
+        "gmail_draft",
+        {
+            "to": "ada@analytic.example",
+            "subject": "Dinner",
+            "body": "Would you join?",
+        },
+        {
+            "id": "draft_1",
+            "to": "ada@analytic.example",
+            "subject": "Dinner",
+            "drafted": True,
+            "sent": False,
+        },
+        ok=True,
+    )
+    assert event is not None
+    assert event["source"] == "gmail"
+    assert event["kind"] == "draft"
+    assert event["tool"] == "gmail_draft"
+    assert event["payload"] == {
+        "draft_id": "draft_1",
+        "to": "ada@analytic.example",
+        "subject": "Dinner",
+        "sent": False,
+    }
+
+
+def test_drive_search_and_read_file_as_file():
+    search = event_from_tool(
+        "drive_search",
+        {"query": "research dinner"},
+        {
+            "files": [
+                {"id": "d1", "name": "Dinner notes", "mimeType": "application/pdf"},
+                {"id": "d2", "name": "Deck"},
+            ]
+        },
+        ok=True,
+    )
+    assert search is not None
+    assert search["source"] == "drive"
+    assert search["kind"] == "file"
+    assert search["tool"] == "drive_search"
+    assert search["payload"]["query"] == "research dinner"
+    assert search["payload"]["files"] == [
+        {"id": "d1", "name": "Dinner notes"},
+        {"id": "d2", "name": "Deck"},
+    ]
+    read = event_from_tool(
+        "drive_read",
+        {"file_id": "d1"},
+        {
+            "id": "d1",
+            "name": "Dinner notes",
+            "mimeType": "application/pdf",
+            "content": "secret file body",
+            "truncated": False,
+        },
+        ok=True,
+    )
+    assert read is not None
+    assert read["source"] == "drive"
+    assert read["kind"] == "file"
+    assert read["payload"] == {"id": "d1", "name": "Dinner notes"}
+    assert "content" not in read["payload"]
+
+
+def test_calendar_list_create_update_file_as_event():
+    listed = event_from_tool(
+        "calendar_list",
+        {},
+        {
+            "events": [
+                {"id": "e1", "summary": "Catch up"},
+                {"id": "e2", "summary": "Dinner"},
+            ]
+        },
+        ok=True,
+    )
+    assert listed is not None
+    assert listed["source"] == "calendar"
+    assert listed["kind"] == "event"
+    assert listed["tool"] == "calendar_list"
+    assert listed["payload"]["count"] == 2
+    created = event_from_tool(
+        "calendar_create",
+        {"summary": "Dinner", "start": "2026-09-01T18:00:00", "end": "2026-09-01T19:00:00"},
+        {"id": "e3", "summary": "Dinner", "htmlLink": "https://calendar.google.com/event?eid=e3"},
+        ok=True,
+    )
+    assert created is not None
+    assert created["payload"] == {"id": "e3", "summary": "Dinner"}
+    updated = event_from_tool(
+        "calendar_update",
+        {"event_id": "e3", "summary": "Dinner (moved)"},
+        {"id": "e3", "summary": "Dinner (moved)"},
+        ok=True,
+    )
+    assert updated is not None
+    assert updated["kind"] == "event"
+    assert updated["payload"] == {"id": "e3", "summary": "Dinner (moved)"}
+
+
+def test_apollo_enrich_files_email_without_api_key():
+    event = event_from_tool(
+        "apollo_enrich_contact",
+        {
+            "firstName": "Alyssa",
+            "lastName": "Wilson",
+            "organizationName": "Codeology",
+        },
+        {
+            "name": "Alyssa Wilson",
+            "title": "Partner",
+            "organizationName": "Codeology",
+            "linkedinUrl": "https://linkedin.com/in/alyssa",
+            "email": "alyssa@codeology.example",
+            "phone": None,
+        },
+        ok=True,
+    )
+    assert event is not None
+    assert event["source"] == "apollo"
+    assert event["kind"] == "enrich"
+    assert event["tool"] == "apollo_enrich_contact"
+    assert event["payload"]["email"] == "alyssa@codeology.example"
+    assert event["payload"]["name"] == "Alyssa Wilson"
+    assert event["payload"]["title"] == "Partner"
+    assert event["payload"]["organizationName"] == "Codeology"
+    assert "api_key" not in event["payload"]
+
+
+def test_granola_mcp_read_files_as_meeting():
+    event = event_from_tool(
+        "mcp__granola__get_note",
+        {"id": "n1"},
+        {"id": "n1", "title": "Catch up with Ada", "transcript": "long note body"},
+        ok=True,
+    )
+    assert event is not None
+    assert event["source"] == "granola"
+    assert event["kind"] == "meeting"
+    assert event["tool"] == "mcp__granola__get_note"
+    assert event["payload"] == {"id": "n1", "title": "Catch up with Ada"}
+    assert "transcript" not in event["payload"]
+    assert (
+        event_from_tool(
+            "mcp__granola__create_note",
+            {"title": "nope"},
+            {"id": "n2"},
+            ok=True,
+        )
+        is None
+    )
+
+
+def test_failed_drive_read_files_as_error():
+    event = event_from_tool(
+        "drive_read",
+        {"file_id": "d1"},
+        {"error": "Drive is not connected."},
+        ok=False,
+    )
+    assert event is not None
+    assert event["source"] == "drive"
+    assert event["kind"] == "error"
+    assert event["tool"] == "drive_read"
+    assert "Drive" in event["summary"]
+    assert "not connected" in event["summary"].lower() or "Drive" in event["summary"]
+    assert event["payload"]["detail"] == "Drive is not connected."
+    assert event["summary"] != "Drive is not connected."
+
+
+def test_web_search_and_fetch_have_stable_shape():
+    search = event_from_tool(
+        "web_search",
+        {"query": "Analytic Engines Ada"},
+        {
+            "results": [
+                {"title": "Ada Lovelace", "url": "https://example.com/ada"},
+                {"title": "Analytic", "url": "https://example.com/analytic"},
+            ]
+        },
+        ok=True,
+    )
+    assert search is not None
+    assert search["source"] == "web"
+    assert search["kind"] == "search"
+    assert search["tool"] == "web_search"
+    assert search["payload"]["query"] == "Analytic Engines Ada"
+    assert search["payload"]["count"] == 2
+    assert search["payload"]["urls"] == [
+        "https://example.com/ada",
+        "https://example.com/analytic",
+    ]
+    fetch = event_from_tool(
+        "web_fetch",
+        {"url": "https://example.com/ada"},
+        {"url": "https://example.com/ada", "title": "Ada Lovelace", "text": "long page"},
+        ok=True,
+    )
+    assert fetch is not None
+    assert fetch["source"] == "web"
+    assert fetch["kind"] == "fetch"
+    assert fetch["payload"]["url"] == "https://example.com/ada"
+    assert fetch["payload"]["title"] == "Ada Lovelace"
+    assert "text" not in fetch["payload"]
+
+
+def test_payloads_do_not_include_tokens():
+    event = event_from_tool(
+        "drive_read",
+        {"file_id": "d1"},
+        {
+            "id": "d1",
+            "name": "Dinner notes",
+            "access_token": "ya29.secret",
+            "refresh_token": "1//secret",
+            "Authorization": "Bearer ya29.secret",
+        },
+        ok=True,
+    )
+    assert event is not None
+    blob = str(event["payload"])
+    assert "ya29" not in blob
+    assert "1//secret" not in blob
+    assert "Bearer" not in blob
+    assert "access_token" not in event["payload"]
+    assert "refresh_token" not in event["payload"]
+    assert "Authorization" not in event["payload"]
+
+
+def test_mapper_output_is_legal_for_person_timeline(tmp_path):
+    from coworker.people import PersonStore
+
+    event = event_from_tool(
+        "gmail_search",
+        {"query": "from:ada"},
+        {"messages": [{"id": "m1"}]},
+        ok=True,
+    )
+    assert event is not None
+    store = PersonStore(tmp_path)
+    person = store.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+    )
+    store.append_event(person["person_id"], actor="assistant", **event)
+    timeline = store.timeline(person["person_id"])
+    assert timeline[0]["source"] == "gmail"
+    assert timeline[0]["kind"] == "mail"
+    assert timeline[0]["payload"]["ids"] == ["m1"]

--- a/desktop/tests/test_people.py
+++ b/desktop/tests/test_people.py
@@ -1,0 +1,201 @@
+import pytest
+
+from coworker.people import PersonStore
+
+
+def test_keeping_apollo_row_files_person_without_email(tmp_path):
+    store = PersonStore(tmp_path)
+    person = store.keep_from_apollo(
+        apollo_id="abc123",
+        first_name="Alyssa",
+        last_name_obfuscated="W***n",
+        title="Partner",
+        company="Codeology",
+        target="club research dinner",
+    )
+    loaded = store.get(person["person_id"])
+    assert loaded is not None
+    assert loaded["apollo_id"] == "abc123"
+    assert loaded["first_name"] == "Alyssa"
+    assert loaded["last_name"] == "W***n"
+    assert loaded["title"] == "Partner"
+    assert loaded["company"] == "Codeology"
+    assert loaded["target"] == "club research dinner"
+    assert loaded["email"] is None
+    assert loaded["sequence_state"] is None
+    restarted = PersonStore(tmp_path)
+    assert restarted.get(person["person_id"])["email"] is None
+    assert restarted.get(person["person_id"])["first_name"] == "Alyssa"
+
+
+def test_keeping_same_apollo_id_updates_instead_of_forking(tmp_path):
+    store = PersonStore(tmp_path)
+    first = store.keep_from_apollo(
+        apollo_id="abc123",
+        first_name="Alyssa",
+        last_name_obfuscated="W***n",
+        title="Partner",
+        company="Codeology",
+    )
+    second = store.keep_from_apollo(
+        apollo_id="abc123",
+        first_name="Alyssa",
+        last_name_obfuscated="Wilson",
+        title="General Partner",
+        company="Codeology",
+        target="follow up",
+    )
+    assert second["person_id"] == first["person_id"]
+    loaded = PersonStore(tmp_path).get_by_apollo_id("abc123")
+    assert loaded is not None
+    assert loaded["person_id"] == first["person_id"]
+    assert loaded["title"] == "General Partner"
+    assert loaded["target"] == "follow up"
+    assert loaded["last_name"] == "Wilson"
+    assert loaded["email"] is None
+    assert store.get(first["person_id"])["title"] == "General Partner"
+
+
+def _ada(store: PersonStore) -> dict:
+    return store.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L***e",
+        title="Founder",
+        company="Analytic",
+    )
+
+
+def test_person_with_no_sequence_is_not_on_the_board(tmp_path):
+    store = PersonStore(tmp_path)
+    _ada(store)
+    assert store.list_board() == {"open": [], "in_conversation": [], "done": []}
+
+
+def test_moving_person_to_open_puts_them_on_the_board(tmp_path):
+    store = PersonStore(tmp_path)
+    person = _ada(store)
+    updated = store.set_sequence(person["person_id"], "open", actor="director")
+    assert updated["sequence_state"] == "open"
+    board = store.list_board()
+    assert [row["person_id"] for row in board["open"]] == [person["person_id"]]
+    assert board["in_conversation"] == []
+    assert board["done"] == []
+    restarted = PersonStore(tmp_path)
+    assert [row["person_id"] for row in restarted.list_board()["open"]] == [
+        person["person_id"]
+    ]
+
+
+def test_unknown_sequence_actor_or_person_is_rejected(tmp_path):
+    store = PersonStore(tmp_path)
+    person = _ada(store)
+    with pytest.raises(ValueError, match="sequence"):
+        store.set_sequence(person["person_id"], "won", actor="director")
+    with pytest.raises(ValueError, match="actor"):
+        store.set_sequence(person["person_id"], "open", actor="crm")
+    with pytest.raises(ValueError, match="unknown person"):
+        store.set_sequence("per_" + "0" * 32, "open", actor="assistant")
+    assert store.list_board() == {"open": [], "in_conversation": [], "done": []}
+    assert store.get(person["person_id"])["sequence_state"] is None
+
+
+def _alonzo(store: PersonStore) -> dict:
+    return store.keep_from_apollo(
+        apollo_id="alonzo",
+        first_name="Alonzo",
+        last_name_obfuscated="C",
+        title="Professor",
+        company="Princeton",
+    )
+
+
+def test_gmail_event_on_ada_does_not_show_up_on_alonzo(tmp_path):
+    store = PersonStore(tmp_path)
+    ada = _ada(store)
+    alonzo = _alonzo(store)
+    first = store.append_event(
+        ada["person_id"],
+        source="gmail",
+        kind="mail",
+        summary="Read mail from Ada",
+        payload={"message_id": "m1"},
+        actor="assistant",
+        tool="gmail_read",
+        session_id="sess1",
+    )
+    store.append_event(
+        ada["person_id"],
+        source="drive",
+        kind="file",
+        summary="Read deck",
+        payload={"file_id": "d1"},
+        actor="assistant",
+        tool="drive_read",
+    )
+    store.append_event(
+        alonzo["person_id"],
+        source="granola",
+        kind="meeting",
+        summary="Meeting notes",
+        payload={"title": "catch up"},
+        actor="assistant",
+        tool="mcp__granola__get_note",
+    )
+    timeline = store.timeline(ada["person_id"])
+    assert [row["kind"] for row in timeline] == ["mail", "file"]
+    assert timeline[0]["event_id"] == first["event_id"]
+    assert timeline[0]["source"] == "gmail"
+    assert timeline[0]["payload"] == {"message_id": "m1"}
+    assert timeline[0]["session_id"] == "sess1"
+    assert all(row["person_id"] == ada["person_id"] for row in timeline)
+    alonzo_timeline = PersonStore(tmp_path).timeline(alonzo["person_id"])
+    assert [row["kind"] for row in alonzo_timeline] == ["meeting"]
+
+
+def test_hubspot_is_not_a_source(tmp_path):
+    store = PersonStore(tmp_path)
+    person = _ada(store)
+    with pytest.raises(ValueError, match="source"):
+        store.append_event(
+            person["person_id"],
+            source="hubspot",
+            kind="deal",
+            summary="nope",
+            actor="assistant",
+        )
+    assert store.timeline(person["person_id"]) == []
+
+
+def test_session_can_be_rebound_to_a_different_person(tmp_path):
+    store = PersonStore(tmp_path)
+    ada = _ada(store)
+    alonzo = _alonzo(store)
+    store.bind_session("chat-1", ada["person_id"])
+    assert store.person_for_session("chat-1") == ada["person_id"]
+    store.bind_session("chat-1", alonzo["person_id"])
+    assert store.person_for_session("chat-1") == alonzo["person_id"]
+    assert store.person_for_session("chat-2") is None
+    with pytest.raises(ValueError, match="unknown person"):
+        store.bind_session("chat-1", "per_" + "0" * 32)
+    restarted = PersonStore(tmp_path)
+    assert restarted.person_for_session("chat-1") == alonzo["person_id"]
+
+
+def test_handoff_four_fields_survive_get(tmp_path):
+    store = PersonStore(tmp_path)
+    person = _ada(store)
+    updated = store.set_handoff(
+        person["person_id"],
+        who="Ada, founder at Analytic",
+        wanted="Invite her to the research dinner",
+        happened="Drafted, not sent",
+        they_want="She asked about student builders",
+    )
+    assert updated["handoff_who"] == "Ada, founder at Analytic"
+    assert updated["handoff_wanted"] == "Invite her to the research dinner"
+    assert updated["handoff_happened"] == "Drafted, not sent"
+    assert updated["handoff_they_want"] == "She asked about student builders"
+    loaded = PersonStore(tmp_path).get(person["person_id"])
+    assert loaded is not None
+    assert loaded["handoff_they_want"] == "She asked about student builders"

--- a/desktop/tests/test_people.py
+++ b/desktop/tests/test_people.py
@@ -56,6 +56,52 @@ def test_keeping_same_apollo_id_updates_instead_of_forking(tmp_path):
     assert store.get(first["person_id"])["title"] == "General Partner"
 
 
+def test_keeping_a_thinner_apollo_row_does_not_blank_the_person_file(tmp_path):
+    store = PersonStore(tmp_path)
+    kept = store.keep_from_apollo(
+        apollo_id="abc123",
+        first_name="Alyssa",
+        last_name_obfuscated="W***n",
+        title="Partner",
+        company="Codeology",
+        target="club research dinner",
+    )
+    again = store.keep_from_apollo(
+        apollo_id="abc123",
+        first_name="Alyssa",
+        last_name_obfuscated=None,
+        title=None,
+        company=None,
+    )
+    assert again["person_id"] == kept["person_id"]
+    assert again["last_name"] == "W***n"
+    assert again["title"] == "Partner"
+    assert again["company"] == "Codeology"
+    assert again["target"] == "club research dinner"
+
+
+def test_blank_apollo_fields_count_as_missing_not_as_a_value(tmp_path):
+    store = PersonStore(tmp_path)
+    store.keep_from_apollo(
+        apollo_id="abc123",
+        first_name="Alyssa",
+        last_name_obfuscated="W***n",
+        title="Partner",
+        company="Codeology",
+    )
+    again = store.keep_from_apollo(
+        apollo_id="abc123",
+        first_name="  ",
+        last_name_obfuscated="",
+        title="",
+        company="   ",
+    )
+    assert again["first_name"] == "Alyssa"
+    assert again["last_name"] == "W***n"
+    assert again["title"] == "Partner"
+    assert again["company"] == "Codeology"
+
+
 def _ada(store: PersonStore) -> dict:
     return store.keep_from_apollo(
         apollo_id="ada",

--- a/desktop/tests/test_people_api.py
+++ b/desktop/tests/test_people_api.py
@@ -1,0 +1,77 @@
+from fastapi.testclient import TestClient
+
+from coworker.provider import FakeProvider
+from coworker.server import TOKEN_HEADER, create_app
+
+TOKEN = "test-token-people"
+
+
+def _app(tmp_path):
+    return create_app(token=TOKEN, state=tmp_path, provider=FakeProvider())
+
+
+def test_get_person_returns_brief_and_timeline(tmp_path):
+    app = _app(tmp_path)
+    person = app.state.people.keep_from_apollo(
+        apollo_id="abc123",
+        first_name="Alyssa",
+        last_name_obfuscated="W***n",
+        title="Partner",
+        company="Codeology",
+        target="club research dinner",
+    )
+    app.state.people.append_event(
+        person["person_id"],
+        source="gmail",
+        kind="mail",
+        summary="Read mail from Alyssa",
+        payload={"id": "m1"},
+    )
+    res = TestClient(app).get(
+        f"/v1/people/{person['person_id']}",
+        headers={TOKEN_HEADER: TOKEN},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["person"]["person_id"] == person["person_id"]
+    assert body["person"]["first_name"] == "Alyssa"
+    assert "Alyssa" in body["brief"]["who"]
+    assert body["brief"]["why"] == "club research dinner"
+    assert body["timeline"][0]["kind"] == "mail"
+    assert body["timeline"][0]["summary"] == "Read mail from Alyssa"
+
+
+def test_get_unknown_person_is_404(tmp_path):
+    res = TestClient(_app(tmp_path)).get(
+        f"/v1/people/per_{'0' * 32}",
+        headers={TOKEN_HEADER: TOKEN},
+    )
+    assert res.status_code == 404
+
+
+def test_get_person_does_not_leak_access_token(tmp_path):
+    app = _app(tmp_path)
+    person = app.state.people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+    )
+    app.state.people.append_event(
+        person["person_id"],
+        source="drive",
+        kind="file",
+        summary="Read deck",
+        payload={"id": "d1", "access_token": "ya29.secret", "name": "Deck"},
+    )
+    res = TestClient(app).get(
+        f"/v1/people/{person['person_id']}",
+        headers={TOKEN_HEADER: TOKEN},
+    )
+    assert res.status_code == 200
+    blob = res.text
+    assert "ya29.secret" not in blob
+    assert "access_token" not in blob
+    assert res.json()["timeline"][0]["payload"]["name"] == "Deck"
+    assert res.json()["timeline"][0]["payload"]["id"] == "d1"

--- a/desktop/tests/test_people_api.py
+++ b/desktop/tests/test_people_api.py
@@ -75,3 +75,63 @@ def test_get_person_does_not_leak_access_token(tmp_path):
     assert "access_token" not in blob
     assert res.json()["timeline"][0]["payload"]["name"] == "Deck"
     assert res.json()["timeline"][0]["payload"]["id"] == "d1"
+
+
+def test_empty_board_is_three_empty_lists(tmp_path):
+    body = TestClient(_app(tmp_path)).get("/v1/board", headers={TOKEN_HEADER: TOKEN}).json()
+    assert body == {"open": [], "in_conversation": [], "done": []}
+    blob = str(body)
+    assert "amount" not in blob
+    assert "pipeline" not in blob
+    assert "deal" not in blob
+
+
+def test_board_lists_open_person_and_move(tmp_path):
+    app = _app(tmp_path)
+    person = app.state.people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+    )
+    app.state.people.set_sequence(person["person_id"], "open", actor="assistant")
+    client = TestClient(app)
+    board = client.get("/v1/board", headers={TOKEN_HEADER: TOKEN}).json()
+    assert [row["person_id"] for row in board["open"]] == [person["person_id"]]
+    moved = client.post(
+        f"/v1/people/{person['person_id']}/sequence",
+        headers={TOKEN_HEADER: TOKEN},
+        json={"state": "in_conversation", "actor": "director"},
+    )
+    assert moved.status_code == 200
+    assert moved.json()["person"]["sequence_state"] == "in_conversation"
+    board = client.get("/v1/board", headers={TOKEN_HEADER: TOKEN}).json()
+    assert board["open"] == []
+    assert [row["person_id"] for row in board["in_conversation"]] == [person["person_id"]]
+    kinds = [row["kind"] for row in app.state.people.timeline(person["person_id"])]
+    assert "state" in kinds
+
+
+def test_board_move_rejects_invalid_state_and_unknown_person(tmp_path):
+    app = _app(tmp_path)
+    person = app.state.people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+    )
+    client = TestClient(app)
+    bad = client.post(
+        f"/v1/people/{person['person_id']}/sequence",
+        headers={TOKEN_HEADER: TOKEN},
+        json={"state": "won", "actor": "director"},
+    )
+    assert bad.status_code == 400
+    missing = client.post(
+        f"/v1/people/per_{'0' * 32}/sequence",
+        headers={TOKEN_HEADER: TOKEN},
+        json={"state": "open", "actor": "director"},
+    )
+    assert missing.status_code == 404

--- a/desktop/tests/test_people_keep.py
+++ b/desktop/tests/test_people_keep.py
@@ -1,0 +1,118 @@
+from coworker.people import PersonStore
+from coworker.tools import execute
+
+
+def _alyssa() -> dict:
+    return {
+        "apolloId": "abc123",
+        "firstName": "Alyssa",
+        "lastNameObfuscated": "W***n",
+        "title": "Partner",
+        "organizationName": "Codeology",
+        "hasEmail": True,
+    }
+
+
+def test_keep_one_apollo_row_files_person_without_email(tmp_path):
+    people = PersonStore(tmp_path)
+    ok, result = execute(
+        "people_keep",
+        {"people": [_alyssa()], "target": "club research dinner"},
+        people=people,
+    )
+    assert ok is True
+    kept = result["kept"]
+    assert len(kept) == 1
+    assert "email" not in kept[0]
+    person = people.get(kept[0]["person_id"])
+    assert person is not None
+    assert person["first_name"] == "Alyssa"
+    assert person["last_name"] == "W***n"
+    assert person["title"] == "Partner"
+    assert person["company"] == "Codeology"
+    assert person["target"] == "club research dinner"
+    assert person["email"] is None
+    assert person["sequence_state"] is None
+
+
+def test_keep_same_apollo_id_twice_does_not_fork(tmp_path):
+    people = PersonStore(tmp_path)
+    first = execute(
+        "people_keep",
+        {"people": [_alyssa()]},
+        people=people,
+    )[1]["kept"][0]
+    ok, result = execute(
+        "people_keep",
+        {
+            "people": [
+                {
+                    **_alyssa(),
+                    "title": "General Partner",
+                    "lastNameObfuscated": "Wilson",
+                }
+            ],
+            "target": "follow up",
+        },
+        people=people,
+    )
+    assert ok is True
+    assert len(result["kept"]) == 1
+    assert result["kept"][0]["person_id"] == first["person_id"]
+    loaded = people.get_by_apollo_id("abc123")
+    assert loaded is not None
+    assert loaded["person_id"] == first["person_id"]
+    assert loaded["title"] == "General Partner"
+    assert loaded["email"] is None
+
+
+def test_keep_two_rows_returns_two_person_ids(tmp_path):
+    people = PersonStore(tmp_path)
+    ok, result = execute(
+        "people_keep",
+        {
+            "people": [
+                _alyssa(),
+                {
+                    "apolloId": "ada",
+                    "firstName": "Ada",
+                    "lastNameObfuscated": "L***e",
+                    "title": "Founder",
+                    "organizationName": "Analytic",
+                },
+            ]
+        },
+        people=people,
+    )
+    assert ok is True
+    ids = [row["person_id"] for row in result["kept"]]
+    assert len(ids) == 2
+    assert len(set(ids)) == 2
+    for row in result["kept"]:
+        assert "email" not in row
+        stored = people.get(row["person_id"])
+        assert stored is not None
+        assert stored["email"] is None
+
+
+def test_keep_empty_list_succeeds(tmp_path):
+    people = PersonStore(tmp_path)
+    ok, result = execute("people_keep", {"people": []}, people=people)
+    assert ok is True
+    assert result["kept"] == []
+
+
+def test_people_keep_is_auto():
+    from coworker.permissions import decide
+
+    decision = decide("people_keep")
+    assert decision.allowed is True
+    assert decision.needs_user is False
+
+
+def test_kernel_tells_model_to_keep_after_search():
+    from coworker.server import KERNEL
+
+    assert "people_keep" in KERNEL
+    assert "search" in KERNEL.lower()
+    assert "invent the target" in KERNEL.lower() or "do not invent" in KERNEL.lower()

--- a/desktop/tests/test_person_prompt.py
+++ b/desktop/tests/test_person_prompt.py
@@ -1,0 +1,102 @@
+from coworker.people import PersonStore
+from coworker.server import system_prompt
+from coworker.store import ConversationStore
+
+
+def test_bound_prompt_includes_ada_not_alonzo(tmp_path):
+    conv = ConversationStore(tmp_path)
+    people = PersonStore(tmp_path)
+    ada = people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+        target="research dinner",
+    )
+    alonzo = people.keep_from_apollo(
+        apollo_id="alonzo",
+        first_name="Alonzo",
+        last_name_obfuscated="C",
+        title="Professor",
+        company="Princeton",
+    )
+    people.bind_session("sess-ada", ada["person_id"])
+    people.append_event(
+        ada["person_id"],
+        source="gmail",
+        kind="mail",
+        summary="Read mail from Ada",
+    )
+    people.append_event(
+        alonzo["person_id"],
+        source="granola",
+        kind="meeting",
+        summary="Secret Alonzo notes",
+    )
+    prompt = system_prompt(conv, people=people, session_id="sess-ada")
+    assert "Person file:" in prompt
+    assert "Ada" in prompt
+    assert "Read mail from Ada" in prompt
+    assert "Alonzo" not in prompt
+    assert "Secret Alonzo notes" not in prompt
+
+
+def test_unbound_prompt_has_no_person_file(tmp_path):
+    conv = ConversationStore(tmp_path)
+    people = PersonStore(tmp_path)
+    people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+    )
+    prompt = system_prompt(conv, people=people, session_id="sess-other")
+    assert "Person file:" not in prompt
+
+
+def test_long_timeline_keeps_newest_summaries(tmp_path):
+    conv = ConversationStore(tmp_path)
+    people = PersonStore(tmp_path)
+    ada = people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+    )
+    people.bind_session("sess-ada", ada["person_id"])
+    for i in range(20):
+        people.append_event(
+            ada["person_id"],
+            source="gmail",
+            kind="mail",
+            summary=f"mail-{i}",
+        )
+    prompt = system_prompt(conv, people=people, session_id="sess-ada")
+    assert "mail-19" in prompt
+    assert "mail-0" not in prompt
+
+
+def test_prompt_does_not_include_access_token(tmp_path):
+    conv = ConversationStore(tmp_path)
+    people = PersonStore(tmp_path)
+    ada = people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+    )
+    people.bind_session("sess-ada", ada["person_id"])
+    people.append_event(
+        ada["person_id"],
+        source="drive",
+        kind="file",
+        summary="Read deck",
+        payload={"access_token": "ya29.secret"},
+    )
+    prompt = system_prompt(conv, people=people, session_id="sess-ada")
+    assert "ya29.secret" not in prompt
+    assert "access_token" not in prompt

--- a/desktop/tests/test_web_search.py
+++ b/desktop/tests/test_web_search.py
@@ -1,0 +1,98 @@
+from coworker.apollo import FakeHttp
+from coworker.people import PersonStore
+from coworker.tools import execute
+from coworker.web import SEARCH_URL
+
+
+def test_web_search_returns_title_and_url():
+    http = FakeHttp(
+        {
+            SEARCH_URL: {
+                "results": [
+                    {
+                        "title": "Ada Lovelace",
+                        "url": "https://example.com/ada",
+                        "content": "mathematician",
+                    },
+                    {
+                        "title": "Analytic",
+                        "url": "https://example.com/analytic",
+                        "content": "engines",
+                    },
+                ]
+            }
+        }
+    )
+    ok, result = execute(
+        "web_search",
+        {"query": "Ada Lovelace"},
+        http=http,
+        tavily_key="tvly-test",
+    )
+    assert ok is True
+    assert result["results"][0]["title"] == "Ada Lovelace"
+    assert result["results"][0]["url"] == "https://example.com/ada"
+    assert http.calls[0]["headers"]["Authorization"] == "Bearer tvly-test"
+
+
+def test_web_search_missing_key_is_clear_error():
+    ok, result = execute("web_search", {"query": "Ada"})
+    assert ok is False
+    assert "TAVILY_API_KEY" in result["error"]
+
+
+def test_bound_web_search_files_web_source(tmp_path):
+    import asyncio
+
+    from coworker.inbox import Inbox
+    from coworker.provider import FakeProvider, ToolCall
+    from coworker.store import ConversationStore
+    from coworker.tools import OPENAI_TOOLS
+    from coworker.turn import run_turn
+
+    people = PersonStore(tmp_path)
+    person = people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+    )
+    people.bind_session("sess-ada", person["person_id"])
+    conv = ConversationStore(tmp_path)
+    http = FakeHttp(
+        {
+            SEARCH_URL: {
+                "results": [
+                    {"title": "Ada", "url": "https://example.com/ada", "content": "bio"}
+                ]
+            }
+        }
+    )
+    fake = FakeProvider(
+        steps=[
+            {
+                "tool_calls": [
+                    ToolCall(id="w1", name="web_search", arguments={"query": "Ada"})
+                ]
+            },
+            {"deltas": ("Found a page.",)},
+        ]
+    )
+    asyncio.run(
+        run_turn(
+            text="search the web",
+            sid="sess-ada",
+            store=conv,
+            provider=fake,
+            persona=None,
+            skills=None,
+            inbox=Inbox(conv),
+            openai_tools=OPENAI_TOOLS,
+            execute_kwargs={"people": people, "http": http, "tavily_key": "tvly-test"},
+        )
+    )
+    timeline = people.timeline(person["person_id"])
+    assert timeline[0]["source"] == "web"
+    assert timeline[0]["kind"] == "search"
+    assert timeline[0]["payload"]["urls"] == ["https://example.com/ada"]

--- a/docs/superpowers/plans/2026-08-25-sd-01-person-file-store.md
+++ b/docs/superpowers/plans/2026-08-25-sd-01-person-file-store.md
@@ -1,0 +1,96 @@
+# SD-01 Person file store
+
+Worktree: `/Users/fisher/Documents/GitHub2026/sc-spring`  
+Branch: `feat/sourcing-director-spring`  
+Spec: `docs/superpowers/specs/2026-08-25-sourcecado-sourcing-director-spring.md`  
+Tickets: `docs/superpowers/plans/2026-08-25-sourcing-director-spring-tickets.md`
+
+## Goal
+
+A sourcing person can be filed, retrieved, moved on a three-bucket board, given a timeline, bound to a chat session, and handed off. No HTTP. No tools. No GUI.
+
+## How to build
+
+TDD. One failing test at a public seam, then only enough code to pass it. Do not write the whole test file first. Do not query sqlite, `._conn`, or private helpers. A second `PersonStore` on the same `tmp_path` is how you prove persistence.
+
+New files only: `desktop/coworker/people.py`, `desktop/tests/test_people.py`. Do not touch `store.py` or `desktop/surfaces/gui/`.
+
+## Seams
+
+Confirm these before coding. Tests live only here.
+
+| Seam | Public API | Behavior under test |
+|---|---|---|
+| File | `keep_from_apollo` → `get` / `get_by_apollo_id` | Apollo candidate becomes a retrievable person. No email. Re-keep of the same Apollo id is the same person. |
+| Board | `set_sequence` → `list_board` | Unworked people are off the board. Open / In conversation / Done are the only buckets. |
+| Ledger | `append_event` → `timeline` | Events stick to one person, oldest first, and reject unknown sources. |
+| Bind | `bind_session` → `person_for_session` | A chat session points at one person. Re-bind replaces. |
+| Handoff | `set_handoff` → `get` | Four fields round-trip: who, wanted, happened, they_want. |
+
+Persistence is not a sixth seam. After any write, construct a new `PersonStore(tmp_path)` and read through the same API.
+
+## Interface
+
+```python
+PersonStore(base_dir)  # people.db under base_dir, never club.db
+
+keep_from_apollo(*, apollo_id, first_name, last_name_obfuscated, title, company, target=None) -> person
+get(person_id) -> person | None
+get_by_apollo_id(apollo_id) -> person | None
+set_sequence(person_id, state, *, actor) -> person   # actor is director | assistant
+list_board() -> {"open": [...], "in_conversation": [...], "done": [...]}
+append_event(person_id, *, source, kind, summary, payload=None, actor="assistant", session_id=None, run_id=None, tool=None) -> event
+timeline(person_id) -> list[event]
+bind_session(session_id, person_id) -> None
+person_for_session(session_id) -> person_id | None
+set_handoff(person_id, *, who, wanted, happened, they_want) -> person
+```
+
+Person keys: `person_id`, `apollo_id`, `first_name`, `last_name`, `title`, `company`, `email`, `linkedin_url`, `phone`, `sequence_state`, `target`, `handoff_who`, `handoff_wanted`, `handoff_happened`, `handoff_they_want`, `created_at`, `updated_at`.
+
+`email` / `linkedin_url` / `phone` exist so later tickets do not migrate. `keep_from_apollo` leaves them unset.
+
+Event keys: `event_id`, `person_id`, `source`, `kind`, `summary`, `payload`, `actor`, `session_id`, `run_id`, `tool`, `created_at`. `payload` is a dict.
+
+Sources: `apollo`, `gmail`, `calendar`, `drive`, `web`, `granola`, `sourcecado`.  
+Sequence: `open`, `in_conversation`, `done`.  
+Actor: `director`, `assistant`.
+
+Company is a string on the person. No company table.
+
+## Vertical slices
+
+Work top to bottom. Each slice is one test name, then the code to make it pass, then the next.
+
+1. **Keeping an Apollo row files a person without an email.**  
+   Keep Alyssa / Partner / Codeology. `get` returns that identity. `email` is `None`. `sequence_state` is `None`.
+
+2. **Keeping the same Apollo id updates the file instead of forking.**  
+   Second keep with a new title and target. `get_by_apollo_id` returns the original `person_id`. Title and target are the new values. Still no email.
+
+3. **A person with no sequence is not on the board.**  
+   `list_board()` is three empty lists.
+
+4. **Moving a person to open puts them on the board.**  
+   `set_sequence(..., "open", actor="director")`. Board `open` contains that person. Other buckets empty.
+
+5. **Unknown sequence, actor, or person is rejected.**  
+   `won`, `crm`, and a made-up id raise `ValueError`. Board unchanged.
+
+6. **A Gmail event on Ada does not show up on Alonzo.**  
+   Append mail then file on Ada, meeting on Alonzo. Ada's timeline is mail then file. Alonzo's is meeting. Payload round-trips as a dict.
+
+7. **HubSpot is not a source.**  
+   `append_event(..., source="hubspot")` raises `ValueError`.
+
+8. **A session can be rebound to a different person.**  
+   Bind chat-1 to Ada, then to Alonzo. `person_for_session("chat-1")` is Alonzo. Unknown session is `None`. Unknown person raises.
+
+9. **Handoff four fields survive get.**  
+   Set who / wanted / happened / they_want. `get` returns the same four strings.
+
+After each slice: `cd desktop && .venv/bin/pytest tests/test_people.py -q`. After the last slice: full `pytest -q`.
+
+## Not in this ticket
+
+HTTP, `people_keep`, enrich, send, brief projection, turn wiring, GUI, `ConversationStore` tables.

--- a/docs/superpowers/plans/2026-08-25-sd-02-person-ledger.md
+++ b/docs/superpowers/plans/2026-08-25-sd-02-person-ledger.md
@@ -1,0 +1,91 @@
+# SD-02 Connector ledger contract
+
+Worktree: `/Users/fisher/Documents/GitHub2026/sc-spring`  
+Depends: SD-01  
+Spec: person file is the log from Apollo, Gmail, Calendar, Drive, web research, and meeting notes. Not an email summary.
+
+## Goal
+
+Given a Club tool name, arguments, and result, produce a ledger event or nothing. SD-04 will persist it. This ticket does not open sqlite and does not edit `turn.py`.
+
+## How to build
+
+TDD. One tool mapping per cycle. Tests call `event_from_tool` only. Fixtures are literals copied from the real tool return shapes in `gmail.py`, `drive.py`, `calendar.py`, `apollo.py`, and Granola MCP reads. Do not mock those modules.
+
+New files: `desktop/coworker/ledger.py`, `desktop/tests/test_ledger.py`.
+
+## Seams
+
+| Seam | Public API | Behavior under test |
+|---|---|---|
+| Mapper | `event_from_tool(name, arguments, result, *, ok) -> dict \| None` | File-worthy tools become `{source, kind, summary, payload, tool}`. Everything else is `None`. |
+
+`append_event` is not this ticket's seam. After a few mappings work, one integration test may call `PersonStore.append_event(**mapping, person_id=...)` then `timeline`, to prove the mapper dict is legal. That is optional and comes last.
+
+## Interface
+
+```python
+def event_from_tool(
+    name: str,
+    arguments: dict,
+    result: dict,
+    *,
+    ok: bool,
+) -> dict | None:
+    """kwargs for PersonStore.append_event except person_id / actor / session / run.
+    None = do not file.
+    """
+```
+
+Returned dict keys: `source`, `kind`, `summary`, `payload`, `tool`.  
+`summary` is a short human sentence. Raw HTTP text belongs in `payload.detail` on failures, never in `summary`.  
+Payloads never include `access_token`, `refresh_token`, `Authorization`, or API keys.
+
+Sources already locked in SD-01: `apollo`, `gmail`, `calendar`, `drive`, `web`, `granola`, `sourcecado`.
+
+## Vertical slices
+
+1. **Clock and memory tools are not filed.**  
+   `now`, `remember`, `memory_update`, `memory_forget`, `load_skill` → `None`.
+
+2. **Apollo search is not filed.**  
+   Candidates are not people until keep (SD-03). `apollo_search_people` → `None`.
+
+3. **A Gmail search files as gmail / mail.**  
+   Args `{query: "from:ada"}`, result `{messages: [{id, from, subject}]}`.  
+   Summary names the query and the count. Payload has `query` and `ids`. No message bodies.
+
+4. **A Gmail read files as gmail / mail.**  
+   Result shape from `GmailApi.read`: `id`, `from`, `subject`, `date`.  
+   Payload has those identifiers. Do not put the full `body` in the default payload.
+
+5. **A Gmail draft files as gmail / draft with sent false.**  
+   Result `{id, to, subject, drafted: True, sent: False}`.  
+   Payload has `draft_id`, `to`, `subject`, `sent: False`.
+
+6. **Drive search and read file as drive / file.**  
+   Search payload: query + file ids/names. Read payload: file id + name. Not the full `content`.
+
+7. **Calendar list / create / update file as calendar / event.**  
+   List: count. Create/update: event id + summary.
+
+8. **Apollo enrich files as apollo / enrich.**  
+   Payload may include `email` (this is the point of enrich) plus name/title/company. No API key.
+
+9. **Granola MCP reads file as granola / meeting.**  
+   Any `mcp__granola__*` name that is not a write. Payload keeps id/title if present, not a raw dump.
+
+10. **A failed Drive read files as kind error.**  
+    `ok=False`, result `{error: "Drive is not connected."}`.  
+    Summary is plain language. `payload.detail` has the error string.
+
+11. **Web search and fetch have a stable shape even though Club has no tool yet.**  
+    `web_search` / `web_fetch` when `ok` → `source: web`, kind `search` or `fetch`.  
+    Payload: query/url plus result count or title. SD-11 must not change these keys.
+
+12. **Secrets do not leak.**  
+    If `result` contains `access_token` or a Bearer header, the returned payload does not.
+
+## Not in this ticket
+
+`run_turn` wiring, `people_keep`, actual web tool, GUI.

--- a/docs/superpowers/plans/2026-08-25-sd-03-to-11-sidecar.md
+++ b/docs/superpowers/plans/2026-08-25-sd-03-to-11-sidecar.md
@@ -1,0 +1,234 @@
+# SD-03 through SD-11 — sidecar plans
+
+TDD for every ticket: one failing test at the named seam, then the code. No GUI. No edits in `/Users/fisher/Documents/GitHub2026/Sourcecado`.
+
+Shared verify: `cd desktop && .venv/bin/pytest -q`.
+
+---
+
+## SD-03 Keep people from Apollo search
+
+**Depends:** SD-01  
+**Goal:** After Apollo search, the director curates. The assistant files the kept rows. Search still returns no emails. Keep does not enrich and does not open a sequence.
+
+### Seams
+
+| Seam | Public API | Behavior |
+|---|---|---|
+| Tool | `execute("people_keep", {people, target})` | Apollo search rows become person files. Same `apolloId` does not fork. Result has `person_id`s and no email. |
+| Permission | `decide("people_keep")` | AUTO. |
+
+Do not test by reading sqlite. Prove through `PersonStore.get` / `get_by_apollo_id` after execute.
+
+### Vertical slices
+
+1. Keep one Apollo search row. Person exists. `email` is `None`. `sequence_state` is `None`.
+2. Keep the same `apolloId` twice. One person. Title can update.
+3. Keep two rows. Two person ids in the tool result. Neither has email.
+4. Empty `people` list succeeds with an empty kept list. No crash.
+5. `decide("people_keep")` is allowed and does not need the user.
+6. KERNEL mentions keep-after-search and not inventing the target.
+
+`people_keep` belongs in `OPENAI_TOOLS`. Bind-on-keep is SD-04.
+
+---
+
+## SD-04 Write the ledger from a bound turn
+
+**Depends:** SD-02, SD-03  
+**Goal:** If this chat is about a person, connector results land on that file.
+
+### Seams
+
+| Seam | Public API | Behavior |
+|---|---|---|
+| Bind | `people_keep` of **one** person, then `person_for_session(sid)` | That session is now about that person. Keep of many does not guess. |
+| Turn | `run_turn` with FakeProvider + FakeGmail/Drive | After a bound Gmail/Drive/Calendar/Granola/enrich tool, `timeline(person)` has the mapped event. Unbound turns write nothing. |
+
+Edit `turn.py` and `tools.py` in this worktree only. Do not import UI/UX event-spine code.
+
+### Vertical slices
+
+1. Keep one person in session A. Session A is bound. Session B is not.
+2. Bound session runs `gmail_search`. Ada's timeline has a gmail/mail event. Alonzo's does not.
+3. Unbound session runs `gmail_search`. No people and no events appear.
+4. Bound session Drive read fails. Timeline has kind `error`. Person still exists.
+5. Keep two people in an unbound session. Neither bind is set.
+
+---
+
+## SD-05 Living brief and pickup API
+
+**Depends:** SD-02  
+**Goal:** Pickup payload: identity, sequence, brief, handoff, timeline. The brief is the sourced picture from every connector, not the last email.
+
+### Seams
+
+| Seam | Public API | Behavior |
+|---|---|---|
+| Brief | `build_brief(person, events) -> dict` | `{who, why, learned, missing, sources}`. Sources are the connector names that actually contributed. |
+| HTTP | `GET /v1/people/{id}` with Club token | `{person, brief, timeline}`. 404 unknown. No tokens in the body. |
+
+`build_brief` is pure. HTTP tests use `TestClient` like the rest of Club.
+
+### Vertical slices
+
+1. Apollo-only person: `who` uses name/title/company. `missing` can mention email or mail. `sources` is `["apollo"]` if an apollo event exists, else empty until events exist.
+2. Apollo + Gmail + Drive + Granola events: `sources` names those four. `learned` is non-empty. A missing Calendar does not drop Drive.
+3. `GET /v1/people/{id}` returns person + brief + timeline for a kept person.
+4. Unknown id is 404.
+5. A forged `access_token` in an event payload does not appear in the HTTP body.
+
+The brief becomes a "working" object when the first draft lands (SD-06). This ticket still projects from whatever events exist.
+
+---
+
+## SD-06 Draft onto a person and open the sequence
+
+**Depends:** SD-04, SD-05  
+**Goal:** Allowed `gmail_draft` on a bound person files the draft, opens the sequence if unset, and does not send.
+
+### Seams
+
+| Seam | Public API | Behavior |
+|---|---|---|
+| Turn | Allow `gmail_draft` on a bound session | Person `sequence_state` is `open` if it was unset. Timeline has gmail/draft, `sent: false`. `FakeGmail.sends` is empty. |
+| Deny | Deny the same call | No sequence change. No successful draft event. |
+
+### Vertical slices
+
+1. Bound person, no sequence, allow draft → `open` and on the board. Draft event has recipient, subject, draft id, `sent: False`.
+2. Person already `in_conversation`. Another draft does not reset to `open`.
+3. Deny draft. Sequence stays unset. Timeline has no `kind == "draft"` success.
+4. `FakeGmail.sends == []`.
+
+---
+
+## SD-07 Director-driven enrich onto the file
+
+**Depends:** SD-04  
+**Goal:** Enrich writes a real email onto one person after Allow. It does not create a person. It does not enrich a list.
+
+### Seams
+
+| Seam | Public API | Behavior |
+|---|---|---|
+| Turn | Allow `apollo_enrich_contact` on a bound person | `get(person).email` is the enriched address. Ledger `apollo` / `enrich`. |
+| Closed | Enrich with no bound person | Tool fails. No new person. |
+
+Use `FakeHttp`. No live Apollo.
+
+### Vertical slices
+
+1. Bound person, allow enrich with FakeHttp person email. Email stored. Event filed.
+2. Deny enrich. Email stays `None`.
+3. Unbound enrich fails closed. `list_board` still empty. No extra person from `get_by_apollo_id` unless they were already kept.
+
+---
+
+## SD-08 Approve-to-send the reviewed draft
+
+**Depends:** SD-06  
+**Goal:** `gmail_send` sends an existing draft after Allow. This replaces drafts-only.
+
+OAuth already has send. Today `FakeGmail.send` raises and `GmailApi` has no send method.
+
+### Seams
+
+| Seam | Public API | Behavior |
+|---|---|---|
+| Permission | `decide("gmail_send")` | ASK. |
+| Execute | `execute("gmail_send", {draft_id})` with FakeGmail | After allow-path tests: draft is sent, result `sent: true`. Deny does not send. |
+| Turn | Bound person, allow send | Ledger `gmail` / `send`. |
+
+Send the draft id (`users.drafts.send` on the live client). Do not invent a second compose path.
+
+### Vertical slices
+
+1. `decide("gmail_send").needs_user is True`.
+2. FakeGmail: `create_draft` then `send(draft_id)` records the send and does not raise.
+3. `execute` after that returns `sent: True`. `sends` is length 1.
+4. Bound allow-send turn files `kind == "send"` on that person.
+5. Deny: `sends` stays empty. No send event.
+6. KERNEL says send requires Allow. It no longer says drafts never send.
+
+---
+
+## SD-09 Board API
+
+**Depends:** SD-06  
+**Goal:** Three buckets over HTTP. Not Scheduled. No HubSpot fields.
+
+### Seams
+
+| Seam | Public API | Behavior |
+|---|---|---|
+| List | `GET /v1/board` | `{open, in_conversation, done}`. Empty is empty lists. |
+| Move | `POST /v1/people/{id}/sequence` `{state, actor}` | Person moves. Timeline has sourcecado/state. Invalid state 400. Unknown person 404. |
+
+### Vertical slices
+
+1. Empty board JSON.
+2. After SD-06-style open person, they appear under `open`.
+3. Move to `in_conversation` as `director`. GET board reflects it. Timeline has the state event.
+4. `"won"` is 400. Unknown id is 404.
+5. Response has no `amount`, `pipeline`, or `deal`.
+
+---
+
+## SD-10 Chat against the person file
+
+**Depends:** SD-05, SD-04  
+**Goal:** Bound chat sees the brief and recent timeline. Pickup is: open the file, then talk.
+
+### Seams
+
+| Seam | Public API | Behavior |
+|---|---|---|
+| Prompt | `system_prompt(...)` with a bound session | Contains who/why/learned/missing and event summaries for that person only. |
+| Unbound | Same function, no bind | No person-file section. |
+
+Prove with the prompt string. Do not inspect model weights. FakeProvider turn can assert the system message.
+
+### Vertical slices
+
+1. Bound Ada session prompt includes Ada's name and a filed Gmail summary. It does not include Alonzo.
+2. Unbound prompt has no "person file" / brief block.
+3. Long timeline is truncated. Newest summaries remain.
+4. Prompt has no `access_token`.
+
+---
+
+## SD-11 Web research tool that writes the ledger
+
+**Depends:** SD-02 (mapper already names `web`)  
+**Goal:** Club can search the public web and file it on a bound person. Cited web is welcome in the brief. It is not a gate on drafting.
+
+Club has no web tool today. Copy the hosted search *job*, not the Next.js module.
+
+### Seams
+
+| Seam | Public API | Behavior |
+|---|---|---|
+| Tool | `execute("web_search", {query})` | Titles, URLs, snippets. Missing key is a tool error. |
+| Ledger | Bound turn + Fake HTTP | `timeline` has `source == "web"`. Keys match SD-02 slice 11. |
+
+Live smoke skip-gated. Default tests fake HTTP.
+
+### Vertical slices
+
+1. Fake search returns two hits. Result has title+url for each.
+2. Missing key → `ok=False`, clear error, no crash.
+3. Bound session files `web` / `search` with count and URLs.
+4. Unbound session does not create a person.
+
+SSRF: if `web_fetch` ships in this ticket, copy the hosted fail-closed host checks. If that is too large, search-only is enough for this spring and fetch waits.
+
+---
+
+## GUI (do not draft further until DU merges)
+
+SD-12 Board + person routes after DU-02.  
+SD-13 Draft/send card after DU-12 and SD-08.
+
+Do not start those in this worktree while `feat/club-desktop` still owns the shell.

--- a/docs/superpowers/plans/2026-08-25-sourcing-director-spring-tickets.md
+++ b/docs/superpowers/plans/2026-08-25-sourcing-director-spring-tickets.md
@@ -1,0 +1,463 @@
+# Sourcecado Sourcing Director Spring — Ticket Proposal
+
+**Status:** Draft for implementation planning on 2026-08-25  
+**Spec:** `docs/superpowers/specs/2026-08-25-sourcecado-sourcing-director-spring.md`  
+**Worktree:** `/Users/fisher/Documents/GitHub2026/sc-spring` on `feat/sourcing-director-spring`  
+**Scope:** Club sidecar domain under `desktop/coworker/` and `desktop/tests/`. GUI tickets are listed and blocked. Do not edit `desktop/surfaces/gui/` in this pass.
+
+The June 8 OS design is prior art, not this product. It is an earlier version with the wrong scope. Borrow identity, citations, and a durable record of work. Do not rebuild the weekly packet, ranked shortlist, or drafts-only Gmail product.
+
+Local Club is the proving ground. The destination is real sourcing officers as soon as the job works. Shared login is still not this spring. Do not shape the domain as Fisher's personal EA.
+
+## Settled approach
+
+Chat is home. The person file is the product object. The board is how the assistant reports.
+
+A **person file** is the comprehensive context layer for one person we may work. It is not an email thread. It is the ledger of everything Sourcecado learned from the connectors a sourcing director actually uses:
+
+- Apollo
+- Gmail
+- Calendar
+- Google Drive
+- web research
+- meeting notes (Granola)
+
+A later officer opens that file, reads the log plus a short handoff, then chats against it.
+
+A **sequence** is a person we are working. Company is a tag on that person. Do not call it a deal. States: Open → In conversation → Done.
+
+**Send** is approve-to-send in Sourcecado. That replaces drafts-only for this spring. Send the reviewed Gmail draft. Do not create-and-send behind the director's back.
+
+**Enrich** is manual and director-driven. Search never returns emails. Getting a real address spends Apollo credits on purpose, one person at a time.
+
+## Why this split
+
+The spec's use cases are the source of truth. Locked conditions are constraints, not the backlog.
+
+`ConversationStore` / `store.py` / `turn.py` / `server.py` are merge-conflict hotspots with the parallel UI/UX pass on `feat/club-desktop`. As of 2026-08-25 that pass has **done** DU-01–06, DU-15, and DU-17, still uncommitted on `feat/club-desktop`. Remaining DU-07–14, DU-16, DU-18–19 are presentation, Scheduled, and cleanup. They do not block sidecar SD-01–11.
+
+SD-01 and SD-02 add new files only. Later tickets may touch `tools.py`, `permissions.py`, `gmail.py`, and `turn.py` in this worktree. They must not edit GUI sources while DU-07–14 / DU-16 are in that tree.
+
+Club already has Apollo search/enrich, Gmail search/read/draft, Drive, Calendar, and Granola MCP. It has no person store, no ledger, no board, no `gmail_send`, and no web research tool.
+
+## Story map
+
+| Story | Officer outcome |
+|---|---|
+| U1 Intake | Name a target, get Apollo people, keep the ones worth a file. |
+| U2 Send | Draft from Apollo fields plus the target, enrich on purpose, send from Sourcecado. |
+| U3 Motion | See Open / In conversation / Done without reconstructing Gmail. |
+| U4 Brief | Walk into the room with the living brief, not a fresh research project. |
+| U5 Pickup | Open the person file, see the full log and handoff, then chat. |
+
+## Dispatch rules
+
+1. Give each agent exactly one SD ticket and this document plus the spec.
+2. Implement test-first in `desktop/tests/`. Run `cd desktop && .venv/bin/pytest -q` after every ticket.
+3. Work only in `/Users/fisher/Documents/GitHub2026/sc-spring`. Do not edit `/Users/fisher/Documents/GitHub2026/Sourcecado`.
+4. Do not edit `desktop/surfaces/gui/` until SD-12 / SD-13. The shell (DU-02) already exists. SD-12 still waits on person/board APIs. SD-13 still waits on DU-12. Do not start GUI in this worktree while the other tree still owns `route.ts` / `GlobalRail.tsx` for DU-16.
+5. Do not add tables to `ConversationStore`. Person data lives in `people.db` via `coworker/people.py`.
+6. Do not add assistant-ui, shadcn, Tailwind, or React 19.
+7. Do not invent HubSpot objects, auto-send, auto-enrich, or a weekly ranking run.
+8. Ledger payloads never include OAuth tokens, API keys, or raw Authorization headers.
+
+## Dependency graph
+
+```text
+SD-01 person file store
+   ├─> SD-02 ledger contract ──> SD-04 turn wiring ──> SD-06 draft opens sequence ──> SD-08 send
+   │         │                         │                         │
+   │         │                         ├─> SD-07 enrich          └─> SD-09 board API
+   │         │                         │
+   │         └─> SD-11 web research    └─> SD-05 brief + pickup API ──> SD-10 chat against the file
+   │
+   └─> SD-03 keep from Apollo ─────────┘
+
+SD-12 board/person GUI  (DU-02 is done; wait on SD-05 / SD-09, and do not fight DU-16 for the rail)
+SD-13 draft/send GUI    (after DU-12 and SD-08; send backend is not waiting on DU-12)
+```
+
+## Ticket index
+
+| ID | Title | Type | Blocked by | Stories |
+|---|---|---|---|---|
+| SD-01 | Person file store | AFK | None | U3, U5 |
+| SD-02 | Connector ledger contract | AFK | SD-01 | U4, U5 |
+| SD-03 | Keep people from Apollo search | AFK | SD-01 | U1 |
+| SD-04 | Write the ledger from a bound turn | AFK | SD-02, SD-03 | U4, U5 |
+| SD-05 | Living brief and pickup API | AFK | SD-02 | U4, U5 |
+| SD-06 | Draft onto a person and open the sequence | AFK | SD-04, SD-05 | U2, U3, U4 |
+| SD-07 | Director-driven enrich onto the file | AFK | SD-04 | U2 |
+| SD-08 | Approve-to-send the reviewed draft | AFK | SD-06 | U2 |
+| SD-09 | Board API | AFK | SD-06 | U3 |
+| SD-10 | Chat against the person file | AFK | SD-05 | U4, U5 |
+| SD-11 | Web research tool that writes the ledger | AFK | SD-02 | U4, U5 |
+| SD-12 | Board and person surfaces | AFK | DU-02, SD-05, SD-09 | U3, U5 |
+| SD-13 | Draft and send domain UI | AFK | DU-12, SD-08 | U2 |
+
+## Ticket bodies
+
+### SD-01: Person file store
+
+**Type:** AFK  
+**User stories:** U3, U5  
+**Plan:** `docs/superpowers/plans/2026-08-25-sd-01-person-file-store.md`
+
+#### What to build
+
+A sidecar-owned person file in a new sqlite database `people.db`, separate from `club.db`. Create, fetch, and update a person from an Apollo candidate without storing an email. Support sequence state, an append-only ledger, session binding, and a four-field handoff.
+
+This ticket is the file. It does not add HTTP, tools, or GUI.
+
+#### Acceptance criteria
+
+- [ ] `PersonStore` lives in `desktop/coworker/people.py` and writes `people.db` under the Club base dir.
+- [ ] `keep_from_apollo` is idempotent on `apollo_id`, stores no email, and leaves `sequence_state` unset.
+- [ ] Company is a string tag on the person. There is no company table.
+- [ ] `set_sequence` only accepts `open`, `in_conversation`, `done` and writes a ledger event.
+- [ ] `list_board` returns those three buckets and omits people with no sequence.
+- [ ] `append_event` accepts sources `apollo`, `gmail`, `calendar`, `drive`, `web`, `granola`, `sourcecado` and rejects anything else.
+- [ ] `timeline` returns that person's events oldest-first and never another person's.
+- [ ] `bind_session` / `person_for_session` are 1:1. Binding a session to a second person replaces the first.
+- [ ] Handoff fields are `who`, `wanted`, `happened`, `they_want`.
+- [ ] `cd desktop && .venv/bin/pytest -q` stays green.
+
+#### Blocked by
+
+None. Start immediately in this worktree.
+
+### SD-02: Connector ledger contract
+
+**Type:** AFK  
+**User stories:** U4, U5  
+**Plan:** `docs/superpowers/plans/2026-08-25-sd-02-person-ledger.md`  
+TDD seams and slices live in that file.
+
+#### What to build
+
+A pure mapper from Club tool name + arguments + result into a ledger event. The living brief is this log, not an email summary. Cover Apollo, Gmail, Calendar, Drive, web research, and Granola meeting notes even when the current turn is not yet wired.
+
+Do not call `PersonStore.append_event` from `turn.py` in this ticket.
+
+#### Acceptance criteria
+
+- [ ] `event_from_tool` in `desktop/coworker/ledger.py` returns `None` for tools that are not file-worthy (`now`, `remember`, `memory_*`, `load_skill`, `apollo_search_people`).
+- [ ] Successful `gmail_search`, `gmail_read`, `gmail_draft`, `drive_search`, `drive_read`, `calendar_list`, `calendar_create`, `calendar_update`, `apollo_enrich_contact`, and `mcp__granola__*` reads produce a typed event with `source`, `kind`, `summary`, `payload`, and `tool`.
+- [ ] Failed tools that are file-worthy produce an event with `kind` `error` and a plain-language summary. Raw transport errors stay in `payload.detail`, not the summary.
+- [ ] Web research has a stable shape for `web_search` / `web_fetch` so SD-11 does not redesign the contract.
+- [ ] Payloads never include tokens, API keys, or Authorization headers.
+- [ ] Mapper unit tests do not open sqlite.
+
+#### Blocked by
+
+- SD-01
+
+### SD-03: Keep people from Apollo search
+
+**Type:** AFK  
+**User stories:** U1  
+**Plan:** `docs/superpowers/plans/2026-08-25-sd-03-to-11-sidecar.md` (SD-03 through SD-11)
+
+#### What to build
+
+A `people_keep` tool the assistant can call after `apollo_search_people`. The director named the target. The assistant searched. The director curated. This tool files the kept rows.
+
+Search stays auto and still returns no emails. Keep does not enrich and does not open a sequence.
+
+#### Acceptance criteria
+
+- [ ] `people_keep` is AUTO. It takes `people` (Apollo search rows) and optional `target`.
+- [ ] Each row becomes a person file via `keep_from_apollo`. Duplicates of the same `apolloId` do not fork files.
+- [ ] The tool result lists `person_id` plus the stored identity fields. No email field.
+- [ ] KERNEL / persona copy tells the model to search, then keep, and never to invent the target.
+- [ ] Pytest covers keep, idempotent re-keep, empty list, and missing Apollo fields.
+
+#### Blocked by
+
+- SD-01
+
+### SD-04: Write the ledger from a bound turn
+
+**Type:** AFK  
+**User stories:** U4, U5
+
+#### What to build
+
+After a successful or failed tool execute in `run_turn`, if the session is bound to a person, append the SD-02 event to that file. Binding happens when the turn keeps a person, drafts to a person, or the session was already bound.
+
+This ticket may edit `turn.py` and `tools.py` in this worktree only. Do not take UI/UX event-spine changes from the other tree.
+
+#### Acceptance criteria
+
+- [ ] A bound session's Gmail/Drive/Calendar/Granola/Apollo-enrich results land on that person and only that person.
+- [ ] Unbound sessions do not create people or ledger rows, except `people_keep` which creates files and binds if a single person is kept into an unbound session that was already bound, or leaves binding to an explicit later bind.
+- [ ] `people_keep` of one person binds that session to that person. Keep of many people does not guess a bind.
+- [ ] Switching sessions cannot append to the wrong person.
+- [ ] Pytest covers bound vs unbound, two people, and a failed Drive read that still records an error event.
+
+#### Blocked by
+
+- SD-02
+- SD-03
+
+### SD-05: Living brief and pickup API
+
+**Type:** AFK  
+**User stories:** U4, U5
+
+#### What to build
+
+Project the living brief from the ledger. Serve the pickup payload: identity, sequence, brief, handoff, timeline.
+
+The brief starts as a product object when the first draft lands (SD-06). This ticket builds the projection and `GET /v1/people/{id}` so pickup is readable before the GUI exists.
+
+The brief is not "the last email." It is a short, sourced picture of who they are, why we are writing, what we have already learned from every connector, and what is still missing.
+
+#### Acceptance criteria
+
+- [ ] `build_brief(person, events) -> dict` returns `who`, `why`, `learned`, `missing`, and `sources` (the connector names that contributed).
+- [ ] A person with only Apollo identity has a thin brief and `missing` that can name email, mail, notes, or files.
+- [ ] A person with Apollo + Gmail + Drive + Granola events names those sources and does not drop the successful ones when another source is absent.
+- [ ] `GET /v1/people/{id}` returns `{ person, brief, timeline }` and 404s for unknown ids.
+- [ ] Response never includes connector tokens or secrets.
+- [ ] Auth is the existing Club token header.
+
+#### Blocked by
+
+- SD-02
+
+### SD-06: Draft onto a person and open the sequence
+
+**Type:** AFK  
+**User stories:** U2, U3, U4
+
+#### What to build
+
+When `gmail_draft` is allowed for a bound person (or an explicit `person_id`), attach the draft to the file, set sequence to `open` if it was unset, and seed the living brief.
+
+Draft still asks. Draft still does not send.
+
+#### Acceptance criteria
+
+- [ ] Allowed draft on a person with no sequence moves them to `open` and onto the board.
+- [ ] A second draft does not reset `in_conversation` or `done` back to `open`.
+- [ ] Ledger has a `gmail` / `draft` event with recipient, subject, draft id, and `sent: false`.
+- [ ] Denied draft writes no person state change and no successful draft event.
+- [ ] Pytest uses `FakeGmail`. `gmail.sends` stays empty.
+
+#### Blocked by
+
+- SD-04
+- SD-05
+
+### SD-07: Director-driven enrich onto the file
+
+**Type:** AFK  
+**User stories:** U2
+
+#### What to build
+
+`apollo_enrich_contact` writes the real email onto the bound person after Allow. It still asks. It still spends credits only when allowed. It does not enrich a list.
+
+#### Acceptance criteria
+
+- [ ] Enrich without a bound person or `person_id` fails closed with a clear error. It does not create a new person.
+- [ ] Allowed enrich stores `email` on the person and a ledger `apollo` / `enrich` event.
+- [ ] Denied enrich does not store an email.
+- [ ] Search results still have no email field.
+- [ ] Pytest uses `FakeHttp`. No live Apollo.
+
+#### Blocked by
+
+- SD-04
+
+### SD-08: Approve-to-send the reviewed draft
+
+**Type:** AFK  
+**User stories:** U2
+
+#### What to build
+
+Add `gmail_send`. It sends an existing Gmail draft by id after Allow. This replaces the drafts-only guardrail for this spring.
+
+OAuth already has `gmail.send`. `FakeGmail.send` currently raises. Change that in tests. Live client calls Gmail `users.drafts.send`.
+
+#### Acceptance criteria
+
+- [ ] `gmail_send` is ASK. Unknown `gmail_send` without the new permission entry must not silently auto-run.
+- [ ] Allow sends the draft, records `sent: true`, and writes a ledger `gmail` / `send` event.
+- [ ] Deny does not send.
+- [ ] Missing draft id or unbound person fails visibly.
+- [ ] KERNEL no longer says drafts never send. It says send requires Allow.
+- [ ] Pytest: FakeGmail records the send; live client is fake-HTTP only.
+
+#### Blocked by
+
+- SD-06
+
+### SD-09: Board API
+
+**Type:** AFK  
+**User stories:** U3
+
+#### What to build
+
+`GET /v1/board` returns Open / In conversation / Done. `POST /v1/people/{id}/sequence` moves a person. The director or the assistant can move them. This is not Scheduled.
+
+#### Acceptance criteria
+
+- [ ] Board lists only people with a sequence.
+- [ ] Move is idempotent and writes a `sourcecado` / `state` ledger event with actor.
+- [ ] Invalid state is 400. Unknown person is 404.
+- [ ] Waiting / empty board is `{ "open": [], "in_conversation": [], "done": [] }`, not an error.
+- [ ] No HubSpot fields (amount, stage, pipeline, close date).
+
+#### Blocked by
+
+- SD-06
+
+### SD-10: Chat against the person file
+
+**Type:** AFK  
+**User stories:** U4, U5
+
+#### What to build
+
+When a session is bound to a person, the system prompt includes the living brief and a bounded recent timeline. Pickup is: open the file, then talk.
+
+This is how a later officer uses the ledger. Do not dump raw JSON payloads into the prompt.
+
+#### Acceptance criteria
+
+- [ ] Bound session prompt contains who / why / learned / missing and recent event summaries.
+- [ ] Unbound sessions do not mention a person file.
+- [ ] Prompt size is capped. Oldest timeline rows drop first.
+- [ ] Prompt contains no tokens, emails of unrelated people, or other persons' events.
+- [ ] Pytest asserts prompt contents with a FakeProvider turn.
+
+#### Blocked by
+
+- SD-05
+
+### SD-11: Web research tool that writes the ledger
+
+**Type:** AFK  
+**User stories:** U4, U5
+
+#### What to build
+
+Club has no web research tool today. Add `web_search` (and `web_fetch` if the hosted SSRF guard can be copied without dragging in the Next.js tree) so the person file can cite the public web.
+
+The mapper in SD-02 already names the source `web`. This ticket adds the tool, AUTO for search, and ledger writes through SD-04.
+
+#### Acceptance criteria
+
+- [ ] Search returns titles, URLs, and snippets. No scraping of LinkedIn as a v1 path.
+- [ ] Bound-session search appends a `web` / `search` event with result count and URLs.
+- [ ] SSRF rules from the hosted `web_fetch` work are copied, not ignored, if fetch ships.
+- [ ] Missing Tavily/key is a clear tool error, not a crash.
+- [ ] Live smoke is skip-gated. Default pytest uses fakes.
+
+#### Blocked by
+
+- SD-02
+
+### SD-12: Board and person surfaces
+
+**Type:** AFK  
+**User stories:** U3, U5
+
+#### What to build
+
+Add `#/board` and `#/people/:id` to the Warm Operator rail after the UI/UX shell (DU-02) has merged. Board is three buckets. Person page is the pickup file: handoff, brief, timeline.
+
+Do not start this ticket in parallel with the UI/UX pass.
+
+#### Acceptance criteria
+
+- [ ] Rail lists Board above Scheduled. Chat remains the default home.
+- [ ] Board restore and refresh work. Empty state is "no one in motion."
+- [ ] Person route survives refresh. Brief panel can sit beside chat once the shell exists.
+- [ ] No new visual system. `DESIGN.md` Warm Operator only.
+- [ ] Do not restyle assistant-ui. That belongs to the other pass.
+
+#### Blocked by
+
+- DU-02 (done, still uncommitted on `feat/club-desktop`)
+- SD-05
+- SD-09
+- Coordinate rail edit with DU-16 (Scheduled is still open)
+
+### SD-13: Draft and send domain UI
+
+**Type:** AFK  
+**User stories:** U2
+
+#### What to build
+
+Extend the DU-12 Gmail draft card with Allow-to-send. Until DU-12 lands, officers can still send via the approval inbox from SD-08.
+
+#### Acceptance criteria
+
+- [ ] Draft card still shows recipient, subject, body, and Not sent until send succeeds.
+- [ ] Send is Allow once. Deny does not send.
+- [ ] After send, the card is a sent receipt, not a draft.
+- [ ] No approve-to-send in the UI/UX tree before this ticket.
+
+#### Blocked by
+
+- DU-12 merged
+- SD-08
+
+## Parallel execution lanes
+
+### Lane A: file and ledger
+
+`SD-01 -> SD-02 -> SD-04 -> {SD-06, SD-07} -> SD-08`
+
+Keep this sequential once turn wiring starts. SD-01 and SD-02 are file-only and safe.
+
+### Lane B: intake and board
+
+`SD-03` after SD-01. `SD-09` after SD-06. `SD-05` after SD-02 can overlap SD-03.
+
+### Lane C: chat pickup and web
+
+`SD-10` after SD-05. `SD-11` after SD-02; merge before expecting web rows in the brief.
+
+### Lane D: GUI
+
+Nothing until DU-02 / DU-12 merge. Then SD-12 and SD-13.
+
+## Recommended launch order
+
+1. SD-01, then SD-02. These only add files.
+2. SD-03 and SD-05 in parallel after SD-01 / SD-02.
+3. SD-04, then SD-06 and SD-07.
+4. SD-08 and SD-09 after SD-06.
+5. SD-10 after SD-05 and SD-04.
+6. SD-11 whenever after SD-02; earlier is better for the brief.
+7. SD-12 / SD-13 only after the UI/UX shell and draft card exist.
+
+## Explicitly not in this spring
+
+- Team tenancy and hosted shared login.
+- Auto-send and auto-enrich.
+- Sourcecado sending follow-ups on its own.
+- HubSpot deals, amounts, forecasts, pipelines.
+- Weekly autonomous ranking as the product.
+- LinkedIn / Apify v2.
+- Calendar delete, Drive writes, Granola writes.
+- Chat polish, assistant-ui, queue/cancel. That is the other pass.
+- Editing `feat/club-desktop` uncommitted GUI work.
+
+## Merge caution
+
+`feat/sourcing-director-spring` branched from committed Club `fec5700`. The UI/UX pass is uncommitted on `feat/club-desktop`. Prefer adding files. When a ticket must edit `turn.py` or `server.py`, rebase onto UI/UX only after that pass has merged those files, or keep the spring edits small and listed in the PR.
+
+## Approval questions
+
+1. Is `people.db` beside `club.db` the right isolation, versus tables inside `club.db` through a second module?
+2. Should `people_keep` of a single person bind the current chat, or is bind always explicit?
+3. Is SD-11 (Club web search) in this spring, or do we record web only after a later tool lands?
+4. Should SD-08 send via Gmail `users.drafts.send` (reuse the draft) as planned, or `users.messages.send`?

--- a/docs/superpowers/specs/2026-08-25-sourcecado-sourcing-director-spring.md
+++ b/docs/superpowers/specs/2026-08-25-sourcecado-sourcing-director-spring.md
@@ -1,0 +1,135 @@
+# Sourcecado as the sourcing director's assistant
+
+Date: 2026-08-25
+Status: Draft for review
+Spring: the next product pass after the operator window
+Supersedes as product shape: the "Monday packet / ranked shortlist" framing from the 2026-08-25 gap pass. The 2026-06-08 OS design still holds as the long-term club brain. This doc is what Sourcecado is *for*.
+
+**How to read this.** The product is the sourcing director's job, done with an assistant. Use cases are the source of truth. Surfaces exist because those use cases need a place to live. If you are implementing, start from the job and the scenes. Do not start from the locked conditions at the bottom. Those are constraints on the use cases, not a backlog.
+
+---
+
+## The job
+
+A Codeology sourcing director sends a lot of email. The work is outbound: find the right people, write something that is actually for them, send it, then be a human in the relationship.
+
+The email has to be good. Not a blast. Title, company, and why we are writing are enough to start. After it is sent, the job is human: the meeting, the follow-up conversation, the project. The assistant's job around that is context, prep, and memory. If we land a project with a team, the next officer should be able to open that person and see what happened, what they want, and where it stands.
+
+That is the whole product. Everything else is how we make that job easier.
+
+---
+
+## The product
+
+Sourcecado is an executive assistant that reports to the sourcing director.
+
+The director is the principal. Sourcecado does the gathering, the drafting, the tracking, and the filing. The director decides who is worth writing, what gets sent, and what happens in the room.
+
+They talk to the assistant in chat. That is home. They check the assistant's operating picture on a dashboard in the rail. They open a person when they need the file.
+
+Sourcecado is not a generic coworker that happens to have Gmail. It is not a weekly ranking engine. It is not HubSpot. It is the assistant for this one job.
+
+This spring it is Fisher's assistant on his machine. The file is written so another officer could read it later. Shared login is not this spring.
+
+---
+
+## Use cases
+
+These are the work. If a change does not make one of these easier, it is not this product.
+
+### 1. Start outreach for a target
+
+The director has a reason to write people: a theme, a kind of company, a role, a club need. They tell the assistant. The assistant searches Apollo and comes back with people to consider, each with the context it already has. The director curates. Sourcecado does not invent the target. The director does not have to live in Apollo.
+
+### 2. Send a lot of tailored email
+
+The volume is real. The quality bar is "this was written for you," not "this was generated." For a new person, Apollo fields plus the target are enough to draft. The director reviews the draft in Sourcecado and sends from Sourcecado. Nothing goes out without that click.
+
+Getting a real email address spends Apollo credits. The director does that on purpose, one person at a time. Sourcecado does not enrich a list in the background.
+
+### 3. Keep work in motion
+
+Outreach is not one email and a prayer. Each person we are working is a sequence. The assistant keeps the picture of what is open, what is in conversation, and what is done, so the director is not reconstructing it from Gmail search.
+
+Follow-ups, "what did we last say," and "is this still alive" are the assistant's job. The conversation itself stays human.
+
+### 4. Walk into the room prepared
+
+Context is not a research project we run before a meeting. It is the living brief that starts when we first draft that person and thickens as mail, notes, and files show up. Meeting prep is that brief, ready, not a separate deliverable the director has to remember to ask for.
+
+### 5. Leave a file someone else can pick up
+
+When the work is done, or when a project lands, the next person should not start from zero. The person file is the full thread of what we know: mail, Drive, meeting notes, and the rest, plus a short handoff of who they are, what we wanted, what happened, and what they want. That is how sourcing survives officer turnover.
+
+---
+
+## How a day feels
+
+The director opens Sourcecado and is in the thread with the assistant.
+
+They can say the target and get people back. They can say "write this one" and get a draft. They can say "what do I need for this conversation" and the brief is already on the person.
+
+When they want the operating picture, they open the dashboard: who is queued to write, which sequences are in conversation, what is done. It is the EA putting the board on the table for the principal. It is not a CRM they have to live in.
+
+When they need the record, they open the person. A small panel of the same brief sits beside whatever they are doing, so they do not have to leave the work to remember who this is.
+
+They never send from a spreadsheet. They never lose the thread because it lived in someone's inbox.
+
+---
+
+## What stays human
+
+Sending the first judgment: this person, this message, now.
+
+The meeting.
+
+The relationship after they reply.
+
+Sourcecado can draft the follow-up and keep the file. Sourcecado does not become the person in the room.
+
+---
+
+## What this spring is for
+
+Make the assistant real for that job, for Fisher, on Sourcecado.
+
+At the end of the spring, a director can name a target, get people, draft from what Apollo already knows, enrich a person when they choose to, send from Sourcecado, see that person on the board as a sequence, and open a file that will still make sense when someone else reads it.
+
+The operator window in flight stays the conversation home. The dashboard is how the assistant reports. Do not flip the product to "dashboard-first" and do not treat chat polish as the spring.
+
+Later springs, not this one: other directors on the same brain, Sourcecado sending follow-ups on its own, Sourcecado enriching a queue on its own.
+
+---
+
+## What we are not building
+
+A generic personal assistant.
+
+A 25-app coworker.
+
+A HubSpot clone (deals, amounts, forecasts, pipelines). HubSpot is only a reference for "there is a live piece of work, with a person, with a history."
+
+A weekly autonomous ranking run as the product.
+
+Auto-send. Auto-enrich.
+
+Team tenancy and hosted shared login.
+
+---
+
+## Locked conditions
+
+These are true. They are not the outline of the work. They exist so an implementation pass does not re-litigate the job.
+
+- Chat is home. The operating board is a destination in the rail.
+- A sequence is a person we are working. A company is how we tag that person, not a separate kind of work item. Do not call it a deal.
+- Sequences move Open → In conversation → Done. Three buckets. The director or the assistant moves them.
+- Intake is Apollo search from a target the director named.
+- A draft may be queued from Apollo fields and the target. Cited web research is welcome in the brief. It is not a gate on drafting.
+- Enrich is manual and director-driven.
+- Send is approve-to-send in Sourcecado. That replaces the old drafts-only guardrail for this spring.
+- The person file is the timeline of related Gmail, Drive, notes, and the rest, plus a handoff summary.
+- The living brief exists from the first draft. Meeting prep is that brief.
+- This spring is local, one operator.
+
+The OS work that makes those use cases trustworthy (storing the people and sequences, attaching search and mail to the file, a durable record of what Sourcecado did, permission on enrich and send) is in service of the job above. It is not a separate product.


### PR DESCRIPTION
## Terms

- **Person file:** sidecar record for one person plus their ledger.
- **Sequence:** a person we are working. Open, In conversation, Done.
- **Keep:** `people_keep` files curated Apollo rows. No enrich. No send.
- **Club:** local desktop sidecar and window under `desktop/`.

## Result

| Before | After |
|---|---|
| Apollo search vanished after the turn. | Keep files people in `people.db`. Same Apollo id does not fork. |
| No send tool. Drafts never sent. | `gmail_send` asks, then sends the reviewed draft id. |
| No operating picture. | `GET /v1/board` and `#/board` with three buckets. |
| Pickup was sqlite. | `GET /v1/people/{id}` and `#/people/:id` with brief and timeline. |
| Chat did not see the file. | Bound sessions inject who / why / learned / missing. |
| No Club web search. | `web_search` (Tavily) files `web` events on the bound person. |

Tickets SD-01 through SD-13.

## How it was verified

```
cd desktop && .venv/bin/pytest -q
```

209 passed, 1 skipped.

Club GUI: `npx vite build` from `desktop/surfaces/gui`.

## Not in this PR

- The parallel UI/UX pass on `feat/club-desktop` (assistant-ui, DU-07–19). This branch is off committed Club `fec5700`. Rebase before combining with uncommitted DU work.
- Team login. Auto-send. Auto-enrich. LinkedIn/Apify.
- DU-12 Gmail artifact polish in the new shell. This PR adds Allow once / Not sent on the existing Club approval card.

## Manual check

Run Club from `/Users/fisher/Documents/GitHub2026/sc-spring/desktop`. Keep one person, allow a draft, open Board, open the person.

```
curl -s -H "X-Club-Token: $(tr -d '\n' < ~/.config/club/sidecar-8765.token)" \
  http://127.0.0.1:8765/v1/board
```