### PR TITLE
fix(people): do not blank a person file on a thinner keep

### DIFF
--- a/desktop/coworker/people.py
+++ b/desktop/coworker/people.py
@@ -25,6 +25,10 @@ SOURCES = (
 )
 
 
+def _clean(value: str | None) -> str | None:
+    return (value or "").strip() or None
+
+
 def _new_person_id() -> str:
     return "per_" + uuid.uuid4().hex
 
@@ -98,8 +102,12 @@ class PersonStore:
         company: str | None,
         target: str | None = None,
     ) -> dict[str, Any]:
-        apollo = (apollo_id or "").strip() or None
-        cleaned_target = (target or "").strip() or None
+        apollo = _clean(apollo_id)
+        first_name = _clean(first_name)
+        last_name_obfuscated = _clean(last_name_obfuscated)
+        title = _clean(title)
+        company = _clean(company)
+        cleaned_target = _clean(target)
         with self._lock:
             existing = None
             if apollo is not None:

--- a/desktop/tests/test_people_keep.py
+++ b/desktop/tests/test_people_keep.py
@@ -35,6 +35,33 @@ def test_keep_one_apollo_row_files_person_without_email(tmp_path):
     assert person["sequence_state"] is None
 
 
+def test_keep_row_with_missing_apollo_fields_keeps_what_the_file_has(tmp_path):
+    people = PersonStore(tmp_path)
+    ok, first = execute(
+        "people_keep",
+        {"people": [_alyssa()], "target": "club research dinner"},
+        people=people,
+    )
+    assert ok is True
+    person_id = first["kept"][0]["person_id"]
+
+    ok, again = execute(
+        "people_keep",
+        {"people": [{"apolloId": "abc123", "firstName": "Alyssa"}]},
+        people=people,
+    )
+    assert ok is True
+    assert again["kept"][0]["person_id"] == person_id
+    assert again["kept"][0]["title"] == "Partner"
+    assert again["kept"][0]["company"] == "Codeology"
+
+    person = people.get(person_id)
+    assert person["last_name"] == "W***n"
+    assert person["title"] == "Partner"
+    assert person["company"] == "Codeology"
+    assert person["target"] == "club research dinner"
+
+
 def test_keep_same_apollo_id_twice_does_not_fork(tmp_path):
     people = PersonStore(tmp_path)
     first = execute(

--- a/desktop/tests/test_people_keep.py
+++ b/desktop/tests/test_people_keep.py
@@ -35,7 +35,7 @@ def test_keep_one_apollo_row_files_person_without_email(tmp_path):
     assert person["sequence_state"] is None
 
 
-def test_keep_row_with_missing_apollo_fields_keeps_what_the_file_has(tmp_path):
+def test_keep_row_with_blank_apollo_fields_keeps_what_the_file_has(tmp_path):
     people = PersonStore(tmp_path)
     ok, first = execute(
         "people_keep",
@@ -47,7 +47,17 @@ def test_keep_row_with_missing_apollo_fields_keeps_what_the_file_has(tmp_path):
 
     ok, again = execute(
         "people_keep",
-        {"people": [{"apolloId": "abc123", "firstName": "Alyssa"}]},
+        {
+            "people": [
+                {
+                    "apolloId": "abc123",
+                    "firstName": "Alyssa",
+                    "lastNameObfuscated": "",
+                    "title": "",
+                    "organizationName": "   ",
+                }
+            ]
+        },
         people=people,
     )
     assert ok is True


### PR DESCRIPTION
## Terms

- **Keep:** `people_keep` files curated Apollo search rows onto a person file.
- **Blank field:** a keep row that sends `title`, `organizationName`, or `lastNameObfuscated` as an empty or whitespace-only string.

## Result

| Before | After |
|---|---|
| A keep row with a blank `title`, `organizationName`, or `lastNameObfuscated` overwrote the filed value with that blank. | A blank counts as "not supplied". Only non-empty values update the file. |

## Correction to the stated cause

The first version of this description said a keep with only `apolloId` and `firstName` cleared title, company, last name, and target. That is wrong. #33 already shipped the `COALESCE` fix that handles omitted fields.

Measured on base commit `8ed9cb7`, through the tool layer:

```
keep with only apolloId+firstName -> {'last_name': 'W***n', 'title': 'Partner', 'company': 'Codeology', 'target': 'club research dinner'}
keep with blank strings           -> {'last_name': '', 'title': '', 'company': '   ', 'target': 'club research dinner'}
```

Only the second line is a bug. This PR fixes that line.

## The base branch is red without this

#33 merged `test_blank_apollo_fields_count_as_missing_not_as_a_value` but not the code that makes it pass. On `feat/club-desktop` at `8ed9cb7`:

```
1 failed, 210 passed, 1 skipped
```

CI never runs the desktop pytest suite. `.github/workflows/ci.yml` runs `npm run lint`, `npm run typecheck`, and `npm test` only. The green check on this PR does not cover this change, and it did not catch the red test on #33.

## How it was verified

```
cd desktop && .venv/bin/pytest -q
```

`212 passed, 1 skipped`.

The new test was checked red first. Copied onto base-commit `people.py` it fails with `assert '' == 'Partner'`.

## Not in this PR

- CI still does not run the desktop pytest suite. That gap is real and is not closed here.
- `apply_enrichment` has the same blank-string hole. No live path reaches it, because `apollo.py` maps every enrich field through `or None` first.
- A non-string field now raises. `{"title": 123}` returns `AttributeError: 'int' object has no attribute 'strip'`. The turn loop catches it and hands the model an error.
- UI/UX pass on the dirty `feat/club-desktop` checkout.
- Send, board, or brief changes.

## Why now

Blank fields from a model-authored keep row should not wipe a person file. Apollo itself cannot send them. Both `search_people` and `enrich_contact` map every field through `or None`. The model re-serializing a search row into `people_keep` arguments is the one path that can.
