### PR TITLE
fix(desktop): contain unsafe Drive source content

### DIFF
--- a/desktop/coworker/drive.py
+++ b/desktop/coworker/drive.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from coworker.apollo import HttpError
@@ -22,6 +23,67 @@ EXPORT = {
     "application/vnd.google-apps.spreadsheet": "text/csv",
     "application/vnd.google-apps.presentation": "text/plain",
 }
+_CREDENTIAL_PREFIX = (
+    r"(?P<prefix>[\"']?(?:[A-Za-z][A-Za-z0-9]*[_-])*"
+    r"(?:api[\s_-]*key|access[\s_-]*token|auth[\s_-]*token|secret|password|"
+    r"private[\s_-]*key)[\"']?\s*[:=]\s*)"
+)
+_QUOTED_CREDENTIAL_ASSIGNMENT_RE = re.compile(
+    _CREDENTIAL_PREFIX + r"(?P<quote>[\"'])(?P<value>[^\r\n]*?)(?P=quote)",
+    re.IGNORECASE | re.MULTILINE,
+)
+_UNQUOTED_CREDENTIAL_ASSIGNMENT_RE = re.compile(
+    _CREDENTIAL_PREFIX + r"(?P<value>[^\s\"']+)",
+    re.IGNORECASE | re.MULTILINE,
+)
+_PRIVATE_KEY_BLOCK_RE = re.compile(
+    r"-----BEGIN (?:(?:RSA|EC|DSA|OPENSSH) )?PRIVATE KEY-----.*?"
+    r"-----END (?:(?:RSA|EC|DSA|OPENSSH) )?PRIVATE KEY-----",
+    re.IGNORECASE | re.DOTALL,
+)
+_LEGAL_NAME_RE = re.compile(
+    r"\b(?:nda|non[ -]?disclosure|agreement|contract|statement of work|sow)\b",
+    re.IGNORECASE,
+)
+_LEGAL_BODY_RE = re.compile(
+    r"\b(?:non[ -]?disclosure agreement|statement of work|this agreement|"
+    r"agreement between|terms and conditions)\b",
+    re.IGNORECASE,
+)
+
+
+def _redact_credentials(text: str) -> tuple[str, int]:
+    redaction_count = 0
+
+    def redact_private_key(_match: re.Match[str]) -> str:
+        nonlocal redaction_count
+        redaction_count += 1
+        return "[REDACTED PRIVATE KEY]"
+
+    def redact_assignment(match: re.Match[str]) -> str:
+        nonlocal redaction_count
+        redaction_count += 1
+        quote = match.groupdict().get("quote") or ""
+        return f"{match.group('prefix')}{quote}[REDACTED]{quote}"
+
+    safe = _PRIVATE_KEY_BLOCK_RE.sub(redact_private_key, text)
+    safe = _QUOTED_CREDENTIAL_ASSIGNMENT_RE.sub(redact_assignment, safe)
+    safe = _UNQUOTED_CREDENTIAL_ASSIGNMENT_RE.sub(redact_assignment, safe)
+    return safe, redaction_count
+
+
+def _legal_source_safety(name: str, text: str) -> dict[str, Any] | None:
+    if not (_LEGAL_NAME_RE.search(name) or _LEGAL_BODY_RE.search(text[:4000])):
+        return None
+    reasons: list[str] = []
+    if "codeology" in name.lower() and "berkeley consulting" in text.lower():
+        reasons.append("unexpected_recipient_berkeley_consulting")
+    return {
+        "legal_document": True,
+        "ready_to_use": False,
+        "status": "party_mismatch" if reasons else "unverified",
+        "reasons": reasons,
+    }
 
 
 class DriveApi:
@@ -65,13 +127,21 @@ class DriveApi:
             content = self._request("get", f"{FILES_URL}/{file_id}", params={"alt": "media"})
         text = content if isinstance(content, str) else str(content or "")
         truncated = len(text) > max_chars
-        return {
+        safe_text, redaction_count = _redact_credentials(text)
+        name = str(meta.get("name") or "")
+        result = {
             "id": str(meta.get("id") or file_id),
             "name": meta.get("name"),
             "mimeType": mime,
-            "content": text[:max_chars],
+            "content": safe_text[:max_chars],
             "truncated": truncated,
+            "sensitive_content_redacted": redaction_count > 0,
+            "redaction_count": redaction_count,
         }
+        source_safety = _legal_source_safety(name, safe_text)
+        if source_safety is not None:
+            result["source_safety"] = source_safety
+        return result
 
     def _require(self) -> None:
         if not has_scope(load_google(self.secrets), DRIVE_SCOPE):

--- a/desktop/coworker/drive.py
+++ b/desktop/coworker/drive.py
@@ -25,7 +25,7 @@ EXPORT = {
 }
 _CREDENTIAL_PREFIX = (
     r"(?P<prefix>[\"']?(?:[A-Za-z][A-Za-z0-9]*[_-])*"
-    r"(?:api[\s_-]*key|access[\s_-]*token|auth[\s_-]*token|secret|password|"
+    r"(?:api[\s_-]*key|access[\s_-]*token|auth[\s_-]*token|token|secret|password|"
     r"private[\s_-]*key)[\"']?\s*[:=]\s*)"
 )
 _QUOTED_CREDENTIAL_ASSIGNMENT_RE = re.compile(
@@ -37,8 +37,8 @@ _UNQUOTED_CREDENTIAL_ASSIGNMENT_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 _PRIVATE_KEY_BLOCK_RE = re.compile(
-    r"-----BEGIN (?:(?:RSA|EC|DSA|OPENSSH) )?PRIVATE KEY-----.*?"
-    r"-----END (?:(?:RSA|EC|DSA|OPENSSH) )?PRIVATE KEY-----",
+    r"-----BEGIN (?:(?:RSA|EC|DSA|OPENSSH|ENCRYPTED) )?PRIVATE KEY-----.*?"
+    r"-----END (?:(?:RSA|EC|DSA|OPENSSH|ENCRYPTED) )?PRIVATE KEY-----",
     re.IGNORECASE | re.DOTALL,
 )
 _LEGAL_NAME_RE = re.compile(
@@ -105,16 +105,25 @@ class DriveApi:
                 "fields": "files(id,name,mimeType,modifiedTime,size,webViewLink)",
             },
         ) or {}
-        files = [
-            {
-                "id": row.get("id"),
-                "name": row.get("name"),
-                "mimeType": row.get("mimeType"),
-                "modifiedTime": row.get("modifiedTime"),
-            }
-            for row in data.get("files") or []
-        ]
-        return {"files": files}
+        files = []
+        redaction_count = 0
+        for row in data.get("files") or []:
+            raw_name = row.get("name")
+            safe_name, name_redaction_count = _redact_credentials(str(raw_name or ""))
+            redaction_count += name_redaction_count
+            files.append(
+                {
+                    "id": row.get("id"),
+                    "name": safe_name if raw_name is not None else None,
+                    "mimeType": row.get("mimeType"),
+                    "modifiedTime": row.get("modifiedTime"),
+                }
+            )
+        return {
+            "files": files,
+            "sensitive_content_redacted": redaction_count > 0,
+            "redaction_count": redaction_count,
+        }
 
     def read(self, file_id: str, max_chars: int = 20000) -> dict[str, Any]:
         self._require()
@@ -128,17 +137,20 @@ class DriveApi:
         text = content if isinstance(content, str) else str(content or "")
         truncated = len(text) > max_chars
         safe_text, redaction_count = _redact_credentials(text)
-        name = str(meta.get("name") or "")
+        raw_name = meta.get("name")
+        name = str(raw_name or "")
+        safe_name, name_redaction_count = _redact_credentials(name)
+        redaction_count += name_redaction_count
         result = {
             "id": str(meta.get("id") or file_id),
-            "name": meta.get("name"),
+            "name": safe_name if raw_name is not None else None,
             "mimeType": mime,
             "content": safe_text[:max_chars],
             "truncated": truncated,
             "sensitive_content_redacted": redaction_count > 0,
             "redaction_count": redaction_count,
         }
-        source_safety = _legal_source_safety(name, safe_text)
+        source_safety = _legal_source_safety(safe_name, safe_text)
         if source_safety is not None:
             result["source_safety"] = source_safety
         return result

--- a/desktop/coworker/server.py
+++ b/desktop/coworker/server.py
@@ -95,7 +95,10 @@ KERNEL = (
     "apollo_enrich_contact "
     "(ask), web_search (auto). MCP tools are named mcp__server__tool. Do not invent the time, tool "
     "results, emails, or memories. Do not claim you sent or drafted unless the "
-    "matching tool ran and was allowed. Do not send without Allow."
+    "matching tool ran and was allowed. Do not send without Allow. Legal templates "
+    "are source evidence, not ready-to-use agreements. If source_safety.ready_to_use "
+    "is false, verify every named party, date, term, and approval status; record a "
+    "knowledge gap and do not adapt or recommend the document as ready to use."
 )
 
 

--- a/desktop/tests/test_drive.py
+++ b/desktop/tests/test_drive.py
@@ -50,6 +50,32 @@ def test_drive_search_fake_http(tmp_path):
     assert "/upload" not in str(http.calls)
 
 
+def test_drive_search_redacts_credentials_in_filenames(tmp_path):
+    raw_secret = "apollo_search_filename_secret_1234567890"
+    secrets = SecretStore(tmp_path / "secrets.json")
+    save_google(secrets, {"refresh_token": "rt", "access_token": "at", "scopes": [DRIVE_SCOPE]})
+    http = FakeHttp(
+        {
+            FILES_URL: {
+                "files": [
+                    {
+                        "id": "f1",
+                        "name": f"APOLLO_API_KEY={raw_secret}",
+                        "mimeType": "text/plain",
+                    }
+                ]
+            }
+        }
+    )
+
+    out = DriveApi(secrets, http=http, client_id="cid", client_secret="sec").search("Apollo")
+
+    assert raw_secret not in json.dumps(out)
+    assert out["files"][0]["name"] == "APOLLO_API_KEY=[REDACTED]"
+    assert out["sensitive_content_redacted"] is True
+    assert out["redaction_count"] == 1
+
+
 def test_drive_read_exports_google_doc(tmp_path):
     secrets = SecretStore(tmp_path / "secrets.json")
     save_google(secrets, {"refresh_token": "rt", "access_token": "at", "scopes": [DRIVE_SCOPE]})
@@ -68,6 +94,8 @@ def test_drive_read_exports_google_doc(tmp_path):
     "source",
     [
         "APOLLO_API_KEY=apollo_live_1234567890",
+        "TOKEN=generic_token_value_1234567890",
+        "GITHUB_TOKEN=github_token_value_1234567890",
         "access token: ya29.example_access_token_123456",
         "secret = internal_secret_value_123456",
         "password: example_password_value_123456",
@@ -105,6 +133,32 @@ def test_drive_read_redacts_private_key_blocks(tmp_path):
         "-----BEGIN PRIVATE KEY-----\n"
         "private-key-material-that-must-never-leave-the-boundary\n"
         "-----END PRIVATE KEY-----"
+    )
+    http = FakeHttp(
+        {
+            f"{FILES_URL}/f1": {
+                "id": "f1",
+                "name": "Setup",
+                "mimeType": "application/vnd.google-apps.document",
+            },
+            f"{FILES_URL}/f1/export": private_key,
+        }
+    )
+
+    out = DriveApi(secrets, http=http, client_id="cid", client_secret="sec").read("f1")
+
+    assert private_key not in out["content"]
+    assert out["content"] == "[REDACTED PRIVATE KEY]"
+    assert out["redaction_count"] == 1
+
+
+def test_drive_read_redacts_encrypted_private_key_blocks(tmp_path):
+    secrets = SecretStore(tmp_path / "secrets.json")
+    save_google(secrets, {"refresh_token": "rt", "access_token": "at", "scopes": [DRIVE_SCOPE]})
+    private_key = (
+        "-----BEGIN ENCRYPTED PRIVATE KEY-----\n"
+        "encrypted-private-key-material-that-must-never-leave-the-boundary\n"
+        "-----END ENCRYPTED PRIVATE KEY-----"
     )
     http = FakeHttp(
         {
@@ -229,6 +283,47 @@ def test_ws_drive_read_redacts_before_provider_events_and_persistence(tmp_path):
     finished = next(event for event in events if event["type"] == "tool_finished")
     assert finished["result"]["content"] == "APOLLO_API_KEY=[REDACTED]"
     assert finished["result"]["sensitive_content_redacted"] is True
+
+
+def test_ws_drive_read_redacts_filename_before_provider_events_and_persistence(tmp_path):
+    raw_secret = "apollo_filename_secret_1234567890"
+    http = FakeHttp(
+        {
+            f"{FILES_URL}/f1": {
+                "id": "f1",
+                "name": f"APOLLO_API_KEY={raw_secret}",
+                "mimeType": "application/vnd.google-apps.document",
+            },
+            f"{FILES_URL}/f1/export": "ordinary body",
+        }
+    )
+    fake = FakeProvider(
+        steps=[
+            {"tool_calls": [ToolCall(id="c1", name="drive_read", arguments={"file_id": "f1"})]},
+            {"deltas": ("The credential was redacted.",)},
+        ]
+    )
+    app = create_app(token=TOKEN, provider=fake, state=tmp_path, http=http)
+    save_google(app.state.secrets, {"refresh_token": "rt", "access_token": "at", "scopes": [DRIVE_SCOPE]})
+    app.state.drive = DriveApi(app.state.secrets, http=http, client_id="cid", client_secret="sec")
+    sid = app.state.store.open_session_id()
+
+    with TestClient(app).websocket_connect("/ws/chat", subprotocols=["club", TOKEN]) as ws:
+        ws.send_json({"type": "chat", "text": "check the source", "session_id": sid})
+        events = []
+        while True:
+            event = ws.receive_json()
+            events.append(event)
+            if event["type"] in ("turn_end", "error"):
+                break
+
+    assert raw_secret not in json.dumps(events)
+    assert raw_secret not in json.dumps(fake.calls)
+    assert raw_secret not in json.dumps(app.state.store.load_events(sid))
+    finished = next(event for event in events if event["type"] == "tool_finished")
+    assert finished["result"]["name"] == "APOLLO_API_KEY=[REDACTED]"
+    assert finished["result"]["sensitive_content_redacted"] is True
+    assert finished["result"]["redaction_count"] == 1
 
 
 def test_drive_connect_url_requests_readonly(tmp_path, monkeypatch):

--- a/desktop/tests/test_drive.py
+++ b/desktop/tests/test_drive.py
@@ -1,5 +1,7 @@
+import json
 from urllib.parse import unquote
 
+import pytest
 from fastapi.testclient import TestClient
 
 from coworker.apollo import FakeHttp
@@ -60,6 +62,173 @@ def test_drive_read_exports_google_doc(tmp_path):
     out = DriveApi(secrets, http=http, client_id="cid", client_secret="sec").read("f1")
     assert out["content"] == "plain text body"
     assert out["truncated"] is False
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "APOLLO_API_KEY=apollo_live_1234567890",
+        "access token: ya29.example_access_token_123456",
+        "secret = internal_secret_value_123456",
+        "password: example_password_value_123456",
+        "password: abc",
+        '\"private_key\": \"private_key_material_1234567890\"',
+        '\"password\": \"P@ssw0rd!with:punctuation#123\"',
+    ],
+)
+def test_drive_read_redacts_credential_assignments(tmp_path, source):
+    secrets = SecretStore(tmp_path / "secrets.json")
+    save_google(secrets, {"refresh_token": "rt", "access_token": "at", "scopes": [DRIVE_SCOPE]})
+    http = FakeHttp(
+        {
+            f"{FILES_URL}/f1": {
+                "id": "f1",
+                "name": "Sourcing SOP",
+                "mimeType": "application/vnd.google-apps.document",
+            },
+            f"{FILES_URL}/f1/export": f"Setup\n{source}\nDone",
+        }
+    )
+
+    out = DriveApi(secrets, http=http, client_id="cid", client_secret="sec").read("f1")
+
+    assert source not in out["content"]
+    assert "[REDACTED]" in out["content"]
+    assert out["sensitive_content_redacted"] is True
+    assert out["redaction_count"] == 1
+
+
+def test_drive_read_redacts_private_key_blocks(tmp_path):
+    secrets = SecretStore(tmp_path / "secrets.json")
+    save_google(secrets, {"refresh_token": "rt", "access_token": "at", "scopes": [DRIVE_SCOPE]})
+    private_key = (
+        "-----BEGIN PRIVATE KEY-----\n"
+        "private-key-material-that-must-never-leave-the-boundary\n"
+        "-----END PRIVATE KEY-----"
+    )
+    http = FakeHttp(
+        {
+            f"{FILES_URL}/f1": {
+                "id": "f1",
+                "name": "Setup",
+                "mimeType": "application/vnd.google-apps.document",
+            },
+            f"{FILES_URL}/f1/export": private_key,
+        }
+    )
+
+    out = DriveApi(secrets, http=http, client_id="cid", client_secret="sec").read("f1")
+
+    assert private_key not in out["content"]
+    assert out["content"] == "[REDACTED PRIVATE KEY]"
+    assert out["redaction_count"] == 1
+
+
+def test_drive_read_does_not_redact_ordinary_security_prose(tmp_path):
+    secrets = SecretStore(tmp_path / "secrets.json")
+    save_google(secrets, {"refresh_token": "rt", "access_token": "at", "scopes": [DRIVE_SCOPE]})
+    prose = "Keep the API key in the local secret store. Password rotation is required."
+    http = FakeHttp(
+        {
+            f"{FILES_URL}/f1": {
+                "id": "f1",
+                "name": "Security guide",
+                "mimeType": "application/vnd.google-apps.document",
+            },
+            f"{FILES_URL}/f1/export": prose,
+        }
+    )
+
+    out = DriveApi(secrets, http=http, client_id="cid", client_secret="sec").read("f1")
+
+    assert out["content"] == prose
+    assert out["sensitive_content_redacted"] is False
+    assert out["redaction_count"] == 0
+
+
+def test_drive_read_flags_mismatched_legal_template_as_not_ready(tmp_path):
+    secrets = SecretStore(tmp_path / "secrets.json")
+    save_google(secrets, {"refresh_token": "rt", "access_token": "at", "scopes": [DRIVE_SCOPE]})
+    http = FakeHttp(
+        {
+            f"{FILES_URL}/f1": {
+                "id": "f1",
+                "name": "Codeology NDA Template",
+                "mimeType": "application/vnd.google-apps.document",
+            },
+            f"{FILES_URL}/f1/export": (
+                "NONDISCLOSURE AGREEMENT between De Beers and Berkeley Consulting."
+            ),
+        }
+    )
+
+    out = DriveApi(secrets, http=http, client_id="cid", client_secret="sec").read("f1")
+
+    assert out["source_safety"] == {
+        "legal_document": True,
+        "ready_to_use": False,
+        "status": "party_mismatch",
+        "reasons": ["unexpected_recipient_berkeley_consulting"],
+    }
+
+
+def test_drive_read_does_not_classify_ordinary_agreement_prose_as_legal(tmp_path):
+    secrets = SecretStore(tmp_path / "secrets.json")
+    save_google(secrets, {"refresh_token": "rt", "access_token": "at", "scopes": [DRIVE_SCOPE]})
+    http = FakeHttp(
+        {
+            f"{FILES_URL}/f1": {
+                "id": "f1",
+                "name": "Meeting notes",
+                "mimeType": "application/vnd.google-apps.document",
+            },
+            f"{FILES_URL}/f1/export": "We reached agreement on the project dates.",
+        }
+    )
+
+    out = DriveApi(secrets, http=http, client_id="cid", client_secret="sec").read("f1")
+
+    assert "source_safety" not in out
+
+
+def test_ws_drive_read_redacts_before_provider_events_and_persistence(tmp_path):
+    raw_secret = "apollo_live_secret_1234567890"
+    http = FakeHttp(
+        {
+            f"{FILES_URL}/f1": {
+                "id": "f1",
+                "name": "Sourcing SOP",
+                "mimeType": "application/vnd.google-apps.document",
+            },
+            f"{FILES_URL}/f1/export": f"APOLLO_API_KEY={raw_secret}",
+        }
+    )
+    fake = FakeProvider(
+        steps=[
+            {"tool_calls": [ToolCall(id="c1", name="drive_read", arguments={"file_id": "f1"})]},
+            {"deltas": ("The credential was redacted.",)},
+        ]
+    )
+    app = create_app(token=TOKEN, provider=fake, state=tmp_path, http=http)
+    save_google(app.state.secrets, {"refresh_token": "rt", "access_token": "at", "scopes": [DRIVE_SCOPE]})
+    app.state.drive = DriveApi(app.state.secrets, http=http, client_id="cid", client_secret="sec")
+    sid = app.state.store.open_session_id()
+
+    with TestClient(app).websocket_connect("/ws/chat", subprotocols=["club", TOKEN]) as ws:
+        ws.send_json({"type": "chat", "text": "check the sourcing SOP", "session_id": sid})
+        events = []
+        while True:
+            event = ws.receive_json()
+            events.append(event)
+            if event["type"] in ("turn_end", "error"):
+                break
+
+    assert raw_secret not in json.dumps(events)
+    assert raw_secret not in json.dumps(fake.calls)
+    assert raw_secret not in json.dumps(app.state.store.load_events(sid))
+    finished = next(event for event in events if event["type"] == "tool_finished")
+    assert finished["result"]["content"] == "APOLLO_API_KEY=[REDACTED]"
+    assert finished["result"]["sensitive_content_redacted"] is True
 
 
 def test_drive_connect_url_requests_readonly(tmp_path, monkeypatch):

--- a/desktop/tests/test_persona.py
+++ b/desktop/tests/test_persona.py
@@ -32,6 +32,15 @@ def test_system_prompt_uses_on_duty_body(tmp_path):
     assert buddy.body not in sourcing_prompt
 
 
+def test_system_prompt_blocks_unverified_legal_templates(tmp_path):
+    prompt = system_prompt(ConversationStore(tmp_path), load_persona("sourcing"))
+
+    assert "Legal templates are source evidence, not ready-to-use agreements" in prompt
+    assert "verify every named party" in prompt
+    assert "source_safety.ready_to_use is false" in prompt
+    assert "record a knowledge gap" in prompt
+
+
 def test_parse_rejects_missing_frontmatter():
     try:
         parse_persona("just a body")

--- a/docs/runbooks/p0-source-safety-remediation.md
+++ b/docs/runbooks/p0-source-safety-remediation.md
@@ -1,0 +1,64 @@
+# P0 source-safety remediation
+
+Issues: #38 and #39
+
+This runbook contains no credential values. Do not paste old or replacement credentials into GitHub, chat, logs, screenshots, or Google Docs.
+
+## 1. Contain model and event exposure
+
+Deploy the source-boundary hotfix before running another broad Drive ingestion:
+
+- credential assignments and private-key blocks are replaced before tool results leave the Drive client;
+- the result records only whether redaction occurred and how many values were removed;
+- legal-looking sources are marked `ready_to_use: false` until an authorized review;
+- known Codeology/Berkeley Consulting recipient mismatch is marked `party_mismatch`.
+
+## 2. Rotate the Apollo credential
+
+Authorized Apollo operator:
+
+1. Create a replacement credential in Apollo without exposing it in this runbook or an issue comment.
+2. Store it only in the approved local secret configuration (`~/.config/club/.env` for the current local app).
+3. Restart the sidecar and verify Apollo reports Connected without printing the value.
+4. Run one bounded, read-only Apollo search smoke.
+5. Revoke the exposed credential.
+6. Verify the revoked credential no longer authenticates using Apollo's own key-management status; do not replay it through logs or shell output.
+
+If Apollo cannot overlap credentials, reverse steps 1 and 5 while keeping the interruption explicit.
+
+## 3. Remove the credential from Drive sources
+
+Authorized Google Drive editor:
+
+1. Replace the credential value in `Codeology Sourcing SOP` with a non-secret instruction such as `[REDACTED — use local secret configuration]`.
+2. Search the active sourcing folder for copied values without displaying matches in screenshots or comments.
+3. Inspect Google Docs version-history behavior. If the sensitive revision cannot be removed individually, create a clean replacement document, preserve only safe content, quarantine the original, and permanently remove the original only after the authorized owner confirms retention requirements.
+4. Update links/bookmarks so operators use the clean canonical SOP.
+5. Record the clean document id and remediation timestamp in issue #38 without including credential material.
+
+## 4. Quarantine the stale NDA
+
+Authorized Drive owner:
+
+1. Rename or move the existing file so it is visibly quarantined and cannot be mistaken for an approved template.
+2. Do not perform search-and-replace on party names and call the result approved.
+3. Obtain a Berkeley Codeology template reviewed by an authorized officer or counsel.
+4. Record template version, approval date, and canonical Drive id.
+5. Verify the body and signature blocks use the intended recipient plus explicit counterparty placeholders consistently.
+6. Keep executed agreements distinct from drafts and templates.
+
+## 5. Verify local residue safely
+
+Search local conversations, events, and logs using a non-printing check derived from the revoked credential. The check should return only matched file counts or paths approved for remediation, never matching lines or values.
+
+Expected post-remediation state:
+
+- no active credential in Drive documents or local event payloads;
+- replacement credential present only in secret configuration;
+- Drive reads report redaction metadata without raw values;
+- stale NDA is quarantined;
+- no legal template is marked ready until its review metadata exists.
+
+## 6. Backout
+
+If the containment hotfix over-redacts ordinary prose, disable broad ingestion and revert the code change; do not restore the exposed source value. Keep the Apollo credential revoked and the stale NDA quarantined while refining detection tests.

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   esbuild: { jsx: "automatic" },
   test: {
     environment: "node",
+    include: ["tests/**/*.test.{ts,tsx}"],
     fileParallelism: false,
     // fileParallelism alone does not serialize the DB suites (verified:
     // parallel workers race on Postgres catalog resets, 80-118 flaky


### PR DESCRIPTION
## Summary

- redact credential assignments and PEM private keys before Drive content can reach provider messages, WebSocket events, durable event storage, or Inspector
- attach explicit redaction receipts without exposing matched values
- mark legal-looking Drive sources as unverified/not ready to use and detect the known Codeology/Berkeley Consulting recipient mismatch
- require the sourcing prompt to record a knowledge gap instead of adapting an unverified legal template
- add the operator runbook for Apollo rotation, Drive source cleanup, NDA quarantine, residue checks, and backout
- restore the root Vitest boundary so desktop GUI tests stay in their jsdom-configured CI job instead of running twice under root Node

## Issues

Addresses #38 and #39.

This PR is immediate application-side containment. It intentionally does not close either issue: Apollo credential rotation, Google Drive revision cleanup, and approval of a replacement NDA remain authorized human actions documented in the runbook.

## Verification

- `pytest -q` — 336 passed, 1 skipped
- GUI `npm test` — 335 passed
- GUI `npm run build` — passed
- root Vitest collection — only `tests/**`; reproduces 18/18 transport failures before the boundary and excludes them after
- adversarial review against `main` — low merge risk, no code blockers

The full local root suite was attempted but the isolated Docker Postgres service reset connections; GitHub's root CI job is the authoritative rerun for the CI-only boundary change.

## Security invariants

- raw matched values never enter downstream tool results
- redaction metadata contains counts/status only
- ordinary security prose is preserved
- legal sources default to `ready_to_use: false`
- no real credential value appears in the patch or runbook
