### PR TITLE
fix(desktop): isolate OAuth browser launches in tests

### DIFF
--- a/desktop/coworker/mcp_oauth.py
+++ b/desktop/coworker/mcp_oauth.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import secrets as pysecrets
-from typing import Any
+from typing import Any, Callable
 from urllib.parse import urlencode
 
 from coworker.secrets import SecretStore
@@ -20,16 +20,33 @@ RESOURCE = "https://mcp.granola.ai/mcp"
 PRM_URL = "https://mcp.granola.ai/.well-known/oauth-protected-resource"
 
 
+def _open_browser(url: str) -> bool:
+    try:
+        import subprocess
+
+        subprocess.Popen(["open", url], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return True
+    except Exception:
+        return False
+
+
 def _pkce(verifier: str) -> str:
     digest = hashlib.sha256(verifier.encode("ascii")).digest()
     return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
 
 
 class McpOAuth:
-    def __init__(self, secrets: SecretStore, public_url: str, http: Any | None = None) -> None:
+    def __init__(
+        self,
+        secrets: SecretStore,
+        public_url: str,
+        http: Any | None = None,
+        browser_opener: Callable[[str], bool] | None = None,
+    ) -> None:
         self.secrets = secrets
         self.public_url = public_url.rstrip("/")
         self.http = http
+        self.browser_opener = browser_opener or _open_browser
         self._pending: dict[str, str] | None = None
 
     def _client(self) -> Any:
@@ -93,14 +110,7 @@ class McpOAuth:
             }
         )
         url = f"{auth_endpoint}?{query}"
-        opened = False
-        try:
-            import subprocess
-
-            subprocess.Popen(["open", url], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-            opened = True
-        except Exception:
-            opened = False
+        opened = bool(self.browser_opener(url))
         return {"url": url, "started": True, "opened": opened, "redirect_uri": redirect}
 
     def finish(self, *, code: str, state: str) -> None:

--- a/desktop/coworker/server.py
+++ b/desktop/coworker/server.py
@@ -17,7 +17,7 @@ import threading
 import coworker.turn as turn_runtime
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
@@ -166,6 +166,16 @@ def state_dir() -> Path:
     return Path.home() / ".config" / "club"
 
 
+def _open_browser(url: str) -> bool:
+    try:
+        import subprocess
+
+        subprocess.Popen(["open", url], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        return True
+    except Exception:
+        return False
+
+
 _SECRET_EVENT_KEYS = frozenset(
     {"access_token", "refresh_token", "authorization", "api_key", "token"}
 )
@@ -237,6 +247,7 @@ def create_app(
     apollo_key: str | None = None,
     public_url: str | None = None,
     mcp: Any = None,
+    browser_opener: Callable[[str], bool] | None = None,
 ) -> FastAPI:
     if not token:
         raise ValueError("sidecar token must be non-empty")
@@ -272,10 +283,16 @@ def create_app(
     app.state.apollo_key = apollo_key if apollo_key is not None else os.environ.get("APOLLO_API_KEY")
     app.state.tavily_key = os.environ.get("TAVILY_API_KEY")
     app.state.public_url = public_url or "http://127.0.0.1:8765"
+    app.state.browser_opener = browser_opener or _open_browser
     app.state.oauth_state = ""
     app.state.skills = SkillLoader([BUILTIN_SKILLS, Path(root) / "skills"])
     write_default_mcp_json(Path(root) / "mcp.json")
-    app.state.mcp_oauth = McpOAuth(app.state.secrets, app.state.public_url, http=http)
+    app.state.mcp_oauth = McpOAuth(
+        app.state.secrets,
+        app.state.public_url,
+        http=http,
+        browser_opener=app.state.browser_opener,
+    )
     app.state.mcp = (
         mcp
         if mcp is not None
@@ -1070,14 +1087,7 @@ def create_app(
         url = authorization_url(
             client_id=client_id, redirect_uri=redirect, state=state, extra_scopes=(extra,)
         )
-        opened = False
-        try:
-            import subprocess
-
-            subprocess.Popen(["open", url], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-            opened = True
-        except Exception:
-            opened = False
+        opened = bool(app.state.browser_opener(url))
         return {"url": url, "opened": opened, "redirect_uri": redirect}
 
     @app.post("/v1/connectors/drive/connect")
@@ -1140,14 +1150,7 @@ def create_app(
         app.state.oauth_state = state
         redirect = f"{app.state.public_url.rstrip('/')}/v1/gmail/callback"
         url = authorization_url(client_id=client_id, redirect_uri=redirect, state=state)
-        opened = False
-        try:
-            import subprocess
-
-            subprocess.Popen(["open", url], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-            opened = True
-        except Exception:
-            opened = False
+        opened = bool(app.state.browser_opener(url))
         return {"url": url, "opened": opened, "redirect_uri": redirect}
 
     @app.post("/v1/gmail/disconnect")

--- a/desktop/tests/conftest.py
+++ b/desktop/tests/conftest.py
@@ -1,0 +1,17 @@
+import subprocess
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def forbid_host_browser_launches(monkeypatch):
+    real_popen = subprocess.Popen
+
+    def guarded_popen(command, *args, **kwargs):
+        if isinstance(command, (list, tuple)) and command and command[0] == "open":
+            pytest.fail(
+                "desktop tests must inject a browser_opener instead of opening the host browser"
+            )
+        return real_popen(command, *args, **kwargs)
+
+    monkeypatch.setattr(subprocess, "Popen", guarded_popen)

--- a/desktop/tests/test_calendar.py
+++ b/desktop/tests/test_calendar.py
@@ -25,11 +25,19 @@ EVENTS_URL = "https://www.googleapis.com/calendar/v3/calendars/primary/events"
 def test_calendar_connect_url_requests_full_google_grant(tmp_path, monkeypatch):
     monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "cid")
     monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_SECRET", "sec")
-    res = TestClient(create_app(token=TOKEN, state=tmp_path)).post(
+    opened_urls = []
+    res = TestClient(
+        create_app(
+            token=TOKEN,
+            state=tmp_path,
+            browser_opener=lambda url: opened_urls.append(url) or True,
+        )
+    ).post(
         "/v1/connectors/calendar/connect", headers={TOKEN_HEADER: TOKEN}
     )
     assert res.status_code == 200
     decoded = unquote(res.json()["url"])
+    assert opened_urls == [res.json()["url"]]
     assert CALENDAR_SCOPE in decoded
     assert COMPOSE_SCOPE in decoded
     assert READ_SCOPE in decoded

--- a/desktop/tests/test_drive.py
+++ b/desktop/tests/test_drive.py
@@ -329,11 +329,19 @@ def test_ws_drive_read_redacts_filename_before_provider_events_and_persistence(t
 def test_drive_connect_url_requests_readonly(tmp_path, monkeypatch):
     monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "cid")
     monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_SECRET", "sec")
-    res = TestClient(create_app(token=TOKEN, state=tmp_path)).post(
+    opened_urls = []
+    res = TestClient(
+        create_app(
+            token=TOKEN,
+            state=tmp_path,
+            browser_opener=lambda url: opened_urls.append(url) or True,
+        )
+    ).post(
         "/v1/connectors/drive/connect", headers={TOKEN_HEADER: TOKEN}
     )
     assert res.status_code == 200
     decoded = unquote(res.json()["url"])
+    assert opened_urls == [res.json()["url"]]
     assert DRIVE_SCOPE in decoded
     assert COMPOSE_SCOPE in decoded
     assert READ_SCOPE in decoded

--- a/desktop/tests/test_gmail.py
+++ b/desktop/tests/test_gmail.py
@@ -312,6 +312,22 @@ def test_gmail_connect_requires_oauth_client(tmp_path, monkeypatch):
     assert "GOOGLE_OAUTH_CLIENT_ID" in res.json()["error"]
 
 
+def test_gmail_connect_uses_injected_browser_opener(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("GOOGLE_OAUTH_CLIENT_SECRET", "sec")
+    opened_urls = []
+    app = create_app(
+        token=TOKEN,
+        state=tmp_path,
+        browser_opener=lambda url: opened_urls.append(url) or True,
+    )
+
+    res = TestClient(app).post("/v1/gmail/connect", headers={TOKEN_HEADER: TOKEN})
+
+    assert res.status_code == 200
+    assert opened_urls == [res.json()["url"]]
+
+
 def test_auth_url_includes_readonly_and_compose():
     url = authorization_url(
         client_id="cid",

--- a/desktop/tests/test_granola.py
+++ b/desktop/tests/test_granola.py
@@ -58,13 +58,19 @@ def test_granola_status_needs_auth(tmp_path):
     assert gran["status"] == "available"
 
 
-def test_connect_does_not_persist_forged_token(tmp_path, monkeypatch):
-    monkeypatch.setattr("subprocess.Popen", lambda *a, **k: None)
+def test_connect_does_not_persist_forged_token(tmp_path):
+    opened_urls = []
     http = granola_http()
-    app = create_app(token=TOKEN, state=tmp_path, http=http)
+    app = create_app(
+        token=TOKEN,
+        state=tmp_path,
+        http=http,
+        browser_opener=lambda url: opened_urls.append(url) or True,
+    )
     res = TestClient(app).post("/v1/connectors/granola/connect", headers={TOKEN_HEADER: TOKEN})
     body = res.json()
     assert body["started"] is True
+    assert opened_urls == [body["url"]]
     parsed = urlparse(body["url"])
     assert parsed.netloc == "mcp-auth.granola.ai"
     assert parsed.path.rstrip("/") == "/oauth2/authorize"
@@ -181,9 +187,16 @@ def test_oauth_finish_without_waiter_rejected(tmp_path):
 
 
 def test_oauth_mismatched_state_does_not_consume(tmp_path):
-    oauth = McpOAuth(SecretStore(tmp_path / "secrets.json"), "http://127.0.0.1:8765", http=granola_http())
+    opened_urls = []
+    oauth = McpOAuth(
+        SecretStore(tmp_path / "secrets.json"),
+        "http://127.0.0.1:8765",
+        http=granola_http(),
+        browser_opener=lambda url: opened_urls.append(url) or True,
+    )
     started = oauth.start("granola")
     assert started["started"] is True
+    assert opened_urls == [started["url"]]
     try:
         oauth.finish(code="abc", state="wrong")
     except Exception:
@@ -191,10 +204,14 @@ def test_oauth_mismatched_state_does_not_consume(tmp_path):
     assert getattr(oauth, "_pending", None) is not None
 
 
-def test_oauth_finish_exchanges_code_at_auth_server(tmp_path, monkeypatch):
-    monkeypatch.setattr("subprocess.Popen", lambda *a, **k: None)
+def test_oauth_finish_exchanges_code_at_auth_server(tmp_path):
     http = granola_http()
-    oauth = McpOAuth(SecretStore(tmp_path / "secrets.json"), "http://127.0.0.1:8765", http=http)
+    oauth = McpOAuth(
+        SecretStore(tmp_path / "secrets.json"),
+        "http://127.0.0.1:8765",
+        http=http,
+        browser_opener=lambda _url: True,
+    )
     started = oauth.start("granola")
     state = parse_qs(urlparse(started["url"]).query)["state"][0]
     oauth.finish(code="real-code", state=state)


### PR DESCRIPTION
## Summary

- inject the external-browser launcher through create_app and McpOAuth
- make Google and Granola connector tests capture authorization URLs instead of opening Chrome
- add a suite-wide guard that fails any future desktop test attempting the macOS open command

## Root cause

Three connector tests exercised production OAuth launch code with synthetic client IDs. Full pytest runs therefore opened two invalid Google authorization tabs and one invalid Granola authorization tab in the operator browser. App startup itself does not auto-connect.

## Verification

- focused connector authorization tests: 7 passed
- full desktop suite: 337 passed, 1 skipped
- full suite completed with the host-browser guard active and opened no external tabs