### PR TITLE
feat(desktop): add Board tools and truthful Drive reads

### DIFF
--- a/desktop/coworker/apollo.py
+++ b/desktop/coworker/apollo.py
@@ -32,7 +32,13 @@ def _decode_response(res: Any) -> Any:
     text = getattr(res, "text", "") or ""
     if "json" in ctype.lower() or text[:1] in "{[":
         return res.json()
-    return text
+    textual = ctype.lower().startswith("text/") or any(
+        marker in ctype.lower() for marker in ("csv", "xml", "yaml")
+    )
+    if textual:
+        return text
+    content = getattr(res, "content", None)
+    return content if isinstance(content, bytes) else text
 
 
 class LiveHttp:

--- a/desktop/coworker/board_tools.py
+++ b/desktop/coworker/board_tools.py
@@ -1,0 +1,249 @@
+"""Agent-facing tools for the durable Board and sourcing index."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from coworker.sourcing_index import RECORD_TYPES, SourcingIndex
+
+_RECORD_TYPE_SCHEMA = {"type": "string", "enum": sorted(RECORD_TYPES)}
+
+BOARD_GET_SCHEMA: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "board_get",
+        "description": "Read one exact Board or sourcing-index record by id.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "record_id": {"type": "string"},
+                "expand_sources": {"type": "boolean"},
+            },
+            "required": ["record_id"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+BOARD_QUERY_SCHEMA: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "board_query",
+        "description": "Filter Board and sourcing-index records by type and exact field values.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "record_type": _RECORD_TYPE_SCHEMA,
+                "filters": {"type": "object"},
+                "expand_sources": {"type": "boolean"},
+            },
+            "additionalProperties": False,
+        },
+    },
+}
+
+BOARD_UPSERT_SCHEMA: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "board_upsert",
+        "description": "Idempotently create a typed Board or sourcing-index record with provenance.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "record_type": _RECORD_TYPE_SCHEMA,
+                "fields": {"type": "object"},
+                "idempotency_key": {"type": "string"},
+                "rationale_summary": {"type": "string"},
+                "source_refs": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["record_type", "fields", "idempotency_key", "rationale_summary"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+BOARD_MUTATE_SCHEMA: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "board_mutate",
+        "description": (
+            "Apply one reversible, version-checked Board operation: patch, link, unlink, "
+            "transition, capture_outcome, complete_action, or revert."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": [
+                        "patch",
+                        "link",
+                        "unlink",
+                        "transition",
+                        "capture_outcome",
+                        "complete_action",
+                        "revert",
+                    ],
+                },
+                "record_id": {"type": "string"},
+                "target_id": {"type": "string"},
+                "relationship": {"type": "string"},
+                "fields": {"type": "object"},
+                "expected_version": {"type": "integer"},
+                "to_stage": {"type": "string"},
+                "evidence_record_ids": {"type": "array", "items": {"type": "string"}},
+                "outcome": {"type": "string"},
+                "to_version": {"type": "integer"},
+                "rationale_summary": {"type": "string"},
+                "source_refs": {"type": "array", "items": {"type": "string"}},
+            },
+            "required": ["action", "record_id", "rationale_summary"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+BOARD_DELETE_SCHEMA: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "board_delete",
+        "description": "Permanently delete one Board record after explicit human approval.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "record_id": {"type": "string"},
+                "expected_version": {"type": "integer"},
+                "rationale_summary": {"type": "string"},
+            },
+            "required": ["record_id", "expected_version", "rationale_summary"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+BOARD_TOOL_SCHEMAS = [
+    BOARD_GET_SCHEMA,
+    BOARD_QUERY_SCHEMA,
+    BOARD_UPSERT_SCHEMA,
+    BOARD_MUTATE_SCHEMA,
+    BOARD_DELETE_SCHEMA,
+]
+BOARD_TOOL_NAMES = frozenset(schema["function"]["name"] for schema in BOARD_TOOL_SCHEMAS)
+
+
+def _text_list(value: Any) -> list[str]:
+    return [str(item) for item in value] if isinstance(value, list) else []
+
+
+def execute_board_tool(
+    name: str,
+    arguments: dict[str, Any],
+    *,
+    index: SourcingIndex,
+    actor: str,
+    session_id: str | None,
+    run_id: str | None,
+    allowed_source_ids: set[str] | None,
+) -> tuple[bool, dict[str, Any]]:
+    args = arguments or {}
+    try:
+        if name == "board_get":
+            record = index.get(
+                str(args.get("record_id") or ""),
+                expand_sources=bool(args.get("expand_sources")),
+                allowed_source_ids=allowed_source_ids,
+            )
+            return (True, {"record": record}) if record is not None else (
+                False,
+                {"status": "failed", "error": "record not found or not granted"},
+            )
+        if name == "board_query":
+            records = index.query(
+                record_type=str(args.get("record_type") or "") or None,
+                filters=args.get("filters") if isinstance(args.get("filters"), dict) else {},
+                expand_sources=bool(args.get("expand_sources")),
+                allowed_source_ids=allowed_source_ids,
+            )
+            return True, {"records": records, "count": len(records)}
+        identity = {
+            "actor": actor,
+            "session_id": session_id,
+            "run_id": run_id,
+            "rationale_summary": str(args.get("rationale_summary") or ""),
+        }
+        source_refs = _text_list(args.get("source_refs"))
+        if name == "board_upsert":
+            record = index.upsert(
+                record_type=str(args.get("record_type") or ""),
+                fields=args.get("fields") if isinstance(args.get("fields"), dict) else {},
+                idempotency_key=str(args.get("idempotency_key") or ""),
+                source_refs=source_refs,
+                **identity,
+            )
+            return True, {"record": record, "board_changed": True}
+        if name == "board_delete":
+            result = index.delete(
+                str(args.get("record_id") or ""),
+                expected_version=int(args.get("expected_version") or 0),
+                **identity,
+            )
+            return True, {**result, "board_changed": bool(result.get("deleted"))}
+        if name != "board_mutate":
+            return False, {"status": "failed", "error": f"unknown board tool {name}"}
+        action = str(args.get("action") or "")
+        record_id = str(args.get("record_id") or "")
+        if action == "patch":
+            result = index.patch(
+                record_id,
+                fields=args.get("fields") if isinstance(args.get("fields"), dict) else {},
+                expected_version=int(args.get("expected_version") or 0),
+                source_refs=source_refs,
+                **identity,
+            )
+            return True, {"record": result, "board_changed": True}
+        if action in {"link", "unlink"}:
+            method = index.link if action == "link" else index.unlink
+            result = method(
+                record_id,
+                str(args.get("target_id") or ""),
+                relationship=str(args.get("relationship") or ""),
+                source_refs=source_refs,
+                **identity,
+            )
+            return True, {action: result, "board_changed": True}
+        if action == "transition":
+            result = index.transition(
+                record_id,
+                to_stage=str(args.get("to_stage") or ""),
+                evidence_record_ids=_text_list(args.get("evidence_record_ids")),
+                expected_version=int(args.get("expected_version") or 0),
+                source_refs=source_refs,
+                **identity,
+            )
+        elif action == "capture_outcome":
+            result = index.capture_outcome(
+                record_id,
+                outcome=str(args.get("outcome") or ""),
+                expected_version=int(args.get("expected_version") or 0),
+                source_refs=source_refs,
+                **identity,
+            )
+        elif action == "complete_action":
+            result = index.complete_action(
+                record_id,
+                expected_version=int(args.get("expected_version") or 0),
+                source_refs=source_refs,
+                **identity,
+            )
+        elif action == "revert":
+            result = index.revert(
+                record_id,
+                to_version=int(args.get("to_version") or 0),
+                expected_version=int(args.get("expected_version") or 0),
+                **identity,
+            )
+        else:
+            raise ValueError(f"unknown board mutation {action}")
+        return True, {"record": result, "board_changed": True}
+    except (TypeError, ValueError) as exc:
+        return False, {"status": "failed", "error": str(exc)}

--- a/desktop/coworker/drive.py
+++ b/desktop/coworker/drive.py
@@ -16,13 +16,26 @@ from coworker.connectors.google_oauth import (
 )
 from coworker.gmail import GmailError
 from coworker.secrets import SecretStore
+from coworker.drive_extract import DriveExtractionError, EXTRACTABLE_MIMES, extract_drive_text
 
 FILES_URL = "https://www.googleapis.com/drive/v3/files"
+FORMS_URL = "https://forms.googleapis.com/v1/forms"
+FOLDER_MIME = "application/vnd.google-apps.folder"
+FORM_MIME = "application/vnd.google-apps.form"
 EXPORT = {
     "application/vnd.google-apps.document": "text/plain",
     "application/vnd.google-apps.spreadsheet": "text/csv",
     "application/vnd.google-apps.presentation": "text/plain",
 }
+TEXT_MIMES = frozenset(
+    {
+        "application/csv",
+        "application/json",
+        "application/xml",
+        "application/yaml",
+        "text/csv",
+    }
+)
 _CREDENTIAL_PREFIX = (
     r"(?P<prefix>[\"']?(?:[A-Za-z][A-Za-z0-9]*[_-])*"
     r"(?:api[\s_-]*key|access[\s_-]*token|auth[\s_-]*token|token|secret|password|"
@@ -86,6 +99,18 @@ def _legal_source_safety(name: str, text: str) -> dict[str, Any] | None:
     }
 
 
+def _source_reference(
+    file_id: str, name: str | None, url: Any, *, truncated: bool = False
+) -> dict[str, Any]:
+    return {
+        "id": file_id,
+        "title": name or "Drive file",
+        "url": url,
+        "provider": "Google Drive",
+        "truncated": truncated,
+    }
+
+
 class DriveApi:
     def __init__(self, secrets: SecretStore, *, http: Any, client_id: str, client_secret: str) -> None:
         self.secrets = secrets
@@ -102,7 +127,7 @@ class DriveApi:
             params={
                 "q": f"(name contains '{q}' or fullText contains '{q}') and trashed=false",
                 "pageSize": max(1, min(int(max_results), 10)),
-                "fields": "files(id,name,mimeType,modifiedTime,size,webViewLink)",
+                "fields": "files(id,name,mimeType,modifiedTime,size,parents,webViewLink)",
             },
         ) or {}
         files = []
@@ -117,24 +142,150 @@ class DriveApi:
                     "name": safe_name if raw_name is not None else None,
                     "mimeType": row.get("mimeType"),
                     "modifiedTime": row.get("modifiedTime"),
+                    "parents": list(row.get("parents") or []),
+                    "webViewLink": row.get("webViewLink"),
+                    "status": "metadata_only",
                 }
             )
         return {
             "files": files,
+            "sources": [
+                {
+                    "id": str(row.get("id") or ""),
+                    "title": str(row.get("name") or "Drive file"),
+                    "url": row.get("webViewLink"),
+                    "provider": "Google Drive",
+                    "truncated": False,
+                }
+                for row in files
+                if row.get("id")
+            ],
             "sensitive_content_redacted": redaction_count > 0,
             "redaction_count": redaction_count,
         }
 
     def read(self, file_id: str, max_chars: int = 20000) -> dict[str, Any]:
         self._require()
-        meta = self._request("get", f"{FILES_URL}/{file_id}") or {}
+        meta = self._request(
+            "get",
+            f"{FILES_URL}/{file_id}",
+            params={"fields": "id,name,mimeType,modifiedTime,size,parents,webViewLink"},
+        ) or {}
         mime = str(meta.get("mimeType") or "")
+        if mime == FOLDER_MIME:
+            return self.list_folder(file_id, folder_meta=meta)
+        if mime == FORM_MIME:
+            form_reason = None
+            try:
+                form = self._request("get", f"{FORMS_URL}/{file_id}") or {}
+            except GmailError:
+                form = {}
+                form_reason = "form_metadata_unavailable"
+            raw_name = meta.get("name")
+            safe_name, redaction_count = _redact_credentials(str(raw_name or ""))
+            result = {
+                "id": str(meta.get("id") or file_id),
+                "name": safe_name if raw_name is not None else None,
+                "mimeType": mime,
+                "modifiedTime": meta.get("modifiedTime"),
+                "parents": list(meta.get("parents") or []),
+                "webViewLink": meta.get("webViewLink"),
+                "status": "metadata_only",
+                "linkedSheetId": form.get("linkedSheetId"),
+                "responderUri": form.get("responderUri"),
+                "sources": [
+                    _source_reference(
+                        str(meta.get("id") or file_id), safe_name, meta.get("webViewLink")
+                    )
+                ],
+                "truncated": False,
+                "sensitive_content_redacted": redaction_count > 0,
+                "redaction_count": redaction_count,
+            }
+            if form_reason:
+                result["reason"] = form_reason
+            return result
         export = EXPORT.get(mime)
+        if (
+            export is None
+            and mime not in EXTRACTABLE_MIMES
+            and not (mime.startswith("text/") or mime in TEXT_MIMES)
+        ):
+            raw_name = meta.get("name")
+            safe_name, redaction_count = _redact_credentials(str(raw_name or ""))
+            return {
+                "id": str(meta.get("id") or file_id),
+                "name": safe_name if raw_name is not None else None,
+                "mimeType": mime,
+                "modifiedTime": meta.get("modifiedTime"),
+                "parents": list(meta.get("parents") or []),
+                "webViewLink": meta.get("webViewLink"),
+                "status": "unsupported",
+                "reason": "unsupported_mime_type",
+                "sources": [
+                    _source_reference(
+                        str(meta.get("id") or file_id), safe_name, meta.get("webViewLink")
+                    )
+                ],
+                "truncated": False,
+                "sensitive_content_redacted": redaction_count > 0,
+                "redaction_count": redaction_count,
+            }
         if export:
             content = self._request("get", f"{FILES_URL}/{file_id}/export", params={"mimeType": export})
         else:
             content = self._request("get", f"{FILES_URL}/{file_id}", params={"alt": "media"})
-        text = content if isinstance(content, str) else str(content or "")
+        if mime in EXTRACTABLE_MIMES:
+            try:
+                text = extract_drive_text(
+                    mime,
+                    content if isinstance(content, bytes) else bytes(content or b""),
+                )
+            except (DriveExtractionError, TypeError, ValueError) as exc:
+                reason = exc.reason if isinstance(exc, DriveExtractionError) else "invalid_binary_payload"
+                raw_name = meta.get("name")
+                safe_name, redaction_count = _redact_credentials(str(raw_name or ""))
+                return {
+                    "id": str(meta.get("id") or file_id),
+                    "name": safe_name if raw_name is not None else None,
+                    "mimeType": mime,
+                    "modifiedTime": meta.get("modifiedTime"),
+                    "parents": list(meta.get("parents") or []),
+                    "webViewLink": meta.get("webViewLink"),
+                    "status": "failed",
+                    "reason": reason,
+                    "sources": [
+                        _source_reference(
+                            str(meta.get("id") or file_id), safe_name, meta.get("webViewLink")
+                        )
+                    ],
+                    "truncated": False,
+                    "sensitive_content_redacted": redaction_count > 0,
+                    "redaction_count": redaction_count,
+                }
+            if not text.strip():
+                raw_name = meta.get("name")
+                safe_name, redaction_count = _redact_credentials(str(raw_name or ""))
+                return {
+                    "id": str(meta.get("id") or file_id),
+                    "name": safe_name if raw_name is not None else None,
+                    "mimeType": mime,
+                    "modifiedTime": meta.get("modifiedTime"),
+                    "parents": list(meta.get("parents") or []),
+                    "webViewLink": meta.get("webViewLink"),
+                    "status": "metadata_only",
+                    "reason": "no_extractable_text",
+                    "sources": [
+                        _source_reference(
+                            str(meta.get("id") or file_id), safe_name, meta.get("webViewLink")
+                        )
+                    ],
+                    "truncated": False,
+                    "sensitive_content_redacted": redaction_count > 0,
+                    "redaction_count": redaction_count,
+                }
+        else:
+            text = content if isinstance(content, str) else str(content or "")
         truncated = len(text) > max_chars
         safe_text, redaction_count = _redact_credentials(text)
         raw_name = meta.get("name")
@@ -145,8 +296,20 @@ class DriveApi:
             "id": str(meta.get("id") or file_id),
             "name": safe_name if raw_name is not None else None,
             "mimeType": mime,
+            "modifiedTime": meta.get("modifiedTime"),
+            "parents": list(meta.get("parents") or []),
+            "webViewLink": meta.get("webViewLink"),
             "content": safe_text[:max_chars],
             "truncated": truncated,
+            "status": "truncated" if truncated else "read",
+            "sources": [
+                _source_reference(
+                    str(meta.get("id") or file_id),
+                    safe_name,
+                    meta.get("webViewLink"),
+                    truncated=truncated,
+                )
+            ],
             "sensitive_content_redacted": redaction_count > 0,
             "redaction_count": redaction_count,
         }
@@ -154,6 +317,75 @@ class DriveApi:
         if source_safety is not None:
             result["source_safety"] = source_safety
         return result
+
+    def list_folder(
+        self,
+        folder_id: str,
+        max_results: int = 100,
+        page_token: str | None = None,
+        *,
+        folder_meta: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        self._require()
+        params: dict[str, Any] = {
+            "q": f"'{folder_id}' in parents and trashed=false",
+            "pageSize": max(1, min(int(max_results), 100)),
+            "fields": (
+                "nextPageToken,files("
+                "id,name,mimeType,modifiedTime,size,parents,webViewLink)"
+            ),
+        }
+        if page_token:
+            params["pageToken"] = page_token
+        data = self._request("get", FILES_URL, params=params) or {}
+        redaction_count = 0
+        files: list[dict[str, Any]] = []
+        for row in data.get("files") or []:
+            safe_name, count = _redact_credentials(str(row.get("name") or ""))
+            redaction_count += count
+            files.append(
+                {
+                    "id": row.get("id"),
+                    "name": safe_name if row.get("name") is not None else None,
+                    "mimeType": row.get("mimeType"),
+                    "modifiedTime": row.get("modifiedTime"),
+                    "parents": list(row.get("parents") or []),
+                    "webViewLink": row.get("webViewLink"),
+                }
+            )
+        meta = folder_meta or {}
+        safe_folder_name, folder_count = _redact_credentials(str(meta.get("name") or ""))
+        redaction_count += folder_count
+        return {
+            "id": str(meta.get("id") or folder_id),
+            "name": safe_folder_name if meta.get("name") is not None else None,
+            "mimeType": FOLDER_MIME,
+            "modifiedTime": meta.get("modifiedTime"),
+            "parents": list(meta.get("parents") or []),
+            "webViewLink": meta.get("webViewLink"),
+            "status": "metadata_only",
+            "files": files,
+            "sources": [
+                _source_reference(
+                    str(meta.get("id") or folder_id),
+                    safe_folder_name,
+                    meta.get("webViewLink"),
+                ),
+                *[
+                    _source_reference(
+                        str(file.get("id") or ""),
+                        str(file.get("name") or "") or None,
+                        file.get("webViewLink"),
+                    )
+                    for file in files
+                    if file.get("id")
+                ],
+            ],
+            "nextPageToken": data.get("nextPageToken"),
+            "truncated": False,
+            "sensitive_content_redacted": redaction_count > 0,
+            "redaction_count": redaction_count,
+        }
 
     def _require(self) -> None:
         if not has_scope(load_google(self.secrets), DRIVE_SCOPE):

--- a/desktop/coworker/drive_extract.py
+++ b/desktop/coworker/drive_extract.py
@@ -1,0 +1,63 @@
+"""Bounded text extraction for Drive blob documents."""
+
+from __future__ import annotations
+
+from io import BytesIO
+from xml.etree import ElementTree
+from zipfile import BadZipFile, ZipFile
+
+DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+PDF_MIME = "application/pdf"
+EXTRACTABLE_MIMES = frozenset({DOCX_MIME, PPTX_MIME, PDF_MIME})
+
+
+class DriveExtractionError(ValueError):
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+def _xml_text(payload: bytes) -> str:
+    root = ElementTree.fromstring(payload)
+    return "\n".join(
+        text.strip()
+        for node in root.iter()
+        if (node.tag == "t" or node.tag.endswith("}t"))
+        if (text := (node.text or "").strip())
+    )
+
+
+def _office_text(mime_type: str, payload: bytes) -> str:
+    try:
+        with ZipFile(BytesIO(payload)) as archive:
+            if mime_type == DOCX_MIME:
+                return _xml_text(archive.read("word/document.xml"))
+            slide_names = sorted(
+                name
+                for name in archive.namelist()
+                if name.startswith("ppt/slides/slide") and name.endswith(".xml")
+            )
+            if not slide_names:
+                raise KeyError("no slides")
+            return "\n".join(_xml_text(archive.read(name)) for name in slide_names)
+    except (BadZipFile, KeyError, ElementTree.ParseError) as exc:
+        raise DriveExtractionError("malformed_office_archive") from exc
+
+
+def _pdf_text(payload: bytes) -> str:
+    try:
+        from pypdf import PdfReader
+
+        reader = PdfReader(BytesIO(payload))
+        return "\n".join((page.extract_text() or "").strip() for page in reader.pages).strip()
+    except Exception as exc:
+        raise DriveExtractionError("malformed_pdf") from exc
+
+
+def extract_drive_text(mime_type: str, payload: bytes) -> str:
+    if mime_type in {DOCX_MIME, PPTX_MIME}:
+        return _office_text(mime_type, payload)
+    if mime_type == PDF_MIME:
+        return _pdf_text(payload)
+    raise DriveExtractionError("unsupported_mime_type")

--- a/desktop/coworker/ledger.py
+++ b/desktop/coworker/ledger.py
@@ -158,12 +158,37 @@ def event_from_tool(
             payload={"query": query, "files": files},
             tool=name,
         )
+    if name == "drive_list_folder":
+        files = [
+            {"id": row.get("id"), "name": row.get("name")}
+            for row in (result.get("files") or [])
+            if isinstance(row, dict)
+        ]
+        folder_id = str(result.get("id") or arguments.get("folder_id") or "")
+        return _event(
+            source="drive",
+            kind="file",
+            summary=f"Listed Drive folder {result.get('name') or folder_id}".strip(),
+            payload={
+                "folder_id": folder_id,
+                "status": result.get("status"),
+                "files": files,
+            },
+            tool=name,
+        )
     if name == "drive_read":
         return _event(
             source="drive",
             kind="file",
             summary=f"Read Drive file {result.get('name') or result.get('id') or ''}".strip(),
-            payload={"id": result.get("id"), "name": result.get("name")},
+            payload={
+                "id": result.get("id"),
+                "name": result.get("name"),
+                "mimeType": result.get("mimeType"),
+                "status": result.get("status"),
+                "truncated": bool(result.get("truncated", False)),
+                "reason": result.get("reason"),
+            },
             tool=name,
         )
     if name == "calendar_list":

--- a/desktop/coworker/permissions.py
+++ b/desktop/coworker/permissions.py
@@ -21,9 +21,14 @@ AUTO = frozenset(
         "gmail_search",
         "gmail_read",
         "drive_search",
+        "drive_list_folder",
         "drive_read",
         "calendar_list",
         "web_search",
+        "board_get",
+        "board_query",
+        "board_upsert",
+        "board_mutate",
     }
 )
 ASK = frozenset(
@@ -33,6 +38,7 @@ ASK = frozenset(
         "apollo_enrich_contact",
         "calendar_create",
         "calendar_update",
+        "board_delete",
     }
 )
 # Read-only members of AUTO that can re-run without a second external effect.
@@ -45,9 +51,12 @@ RETRY_SAFE = frozenset(
         "gmail_search",
         "gmail_read",
         "drive_search",
+        "drive_list_folder",
         "drive_read",
         "calendar_list",
         "apollo_search_people",
+        "board_get",
+        "board_query",
     }
 )
 _MCP_WRITE = re.compile(r"write|create|delete|update", re.I)

--- a/desktop/coworker/server.py
+++ b/desktop/coworker/server.py
@@ -61,6 +61,7 @@ from coworker.permissions import decide
 from coworker.provider import ToolCall, provider_from_env
 from coworker.secrets import SecretStore
 from coworker.store import ConversationStore, valid_session_id
+from coworker.sourcing_index import SourcingIndex
 from coworker.tools import OPENAI_TOOLS, execute
 from coworker.turn import (
     close_open_tool_calls,
@@ -87,9 +88,11 @@ KERNEL = (
     "Tools: now (America/Los_Angeles clock, auto), remember / memory_update / "
     "memory_forget (auto), load_skill (auto), gmail_search / gmail_read (auto), "
     "gmail_draft (ask), gmail_send (ask; sends a reviewed draft after Allow), "
-    "drive_search / drive_read (auto, readonly), "
+    "drive_search / drive_list_folder / drive_read (auto, readonly), "
     "calendar_list (auto; upcoming from now unless a time range is given), "
     "calendar_create / calendar_update (ask, no delete), "
+    "board_get / board_query (auto), board_upsert / board_mutate (auto, audited), "
+    "board_delete (ask; destructive), "
     "apollo_search_people (no emails), people_keep (auto; file curated search "
     "rows after the director chooses, do not invent the target), "
     "apollo_enrich_contact "
@@ -258,6 +261,7 @@ def create_app(
     root = state if state is not None else state_dir()
     app.state.store = ConversationStore(root)
     app.state.people = PersonStore(root)
+    app.state.sourcing_index = SourcingIndex(root)
     app.state.secrets = SecretStore(Path(root) / "secrets.json")
     store = app.state.store
     if store.open_session_id() is None:
@@ -332,6 +336,7 @@ def create_app(
                     "skills": app.state.skills,
                     "mcp": app.state.mcp,
                     "people": app.state.people,
+                    "sourcing_index": app.state.sourcing_index,
                 },
                 emit=None,
                 wait_permission=None,
@@ -429,7 +434,10 @@ def create_app(
                 skills=app.state.skills,
                 mcp=app.state.mcp,
                 people=app.state.people,
+                sourcing_index=app.state.sourcing_index,
+                actor=str(item.get("actor") or "assistant"),
                 session_id=str(item.get("session_id") or ""),
+                run_id=str(item.get("run_id") or "") or None,
             )
         except Exception as exc:
             ok, result = False, {"error": str(exc)}
@@ -637,7 +645,10 @@ def create_app(
                     skills=app.state.skills,
                     mcp=app.state.mcp,
                     people=app.state.people,
+                    sourcing_index=app.state.sourcing_index,
+                    actor=str(item.get("actor") or "assistant"),
                     session_id=str(item.get("session_id") or ""),
+                    run_id=str(item.get("run_id") or "") or None,
                 )
                 result = dict(result)
             except Exception as exc:
@@ -806,7 +817,7 @@ def create_app(
             if claim.decision_recorded:
                 _persist_approval_receipt(receipt)
         elif claim.claimed and claim.owned:
-            receipt = await _execute_claimed_approval(item, claimant=claimant)
+            receipt = await _execute_claimed_approval(claim.item, claimant=claimant)
         else:
             receipt = await app.state.inbox.wait_for_execution(item_id)
         if receipt is None:
@@ -1012,7 +1023,7 @@ def create_app(
                     connector_email=email if refresh else None,
                     required_scopes=["Read Drive files"],
                     missing_scopes=drive_missing if refresh else ["Read Drive files"],
-                    supported_actions=["Search files", "Read files"],
+                    supported_actions=["Search files", "List folders", "Read files"],
                     available_actions=(
                         ["connect"]
                         if not refresh
@@ -1224,6 +1235,61 @@ def create_app(
     @app.get("/v1/board")
     def board_get():
         return app.state.people.list_board()
+
+    @app.get("/v1/board/records")
+    def board_records_list(
+        record_type: str | None = None,
+        stage: str | None = None,
+        owner: str | None = None,
+        due_date: str | None = None,
+        name: str | None = None,
+        expand_sources: bool = False,
+    ):
+        filters = {
+            key: value
+            for key, value in {
+                "stage": stage,
+                "owner": owner,
+                "due_date": due_date,
+                "name": name,
+            }.items()
+            if value is not None
+        }
+        try:
+            records = app.state.sourcing_index.query(
+                record_type=record_type,
+                filters=filters,
+                expand_sources=expand_sources,
+            )
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        return {"records": records, "count": len(records)}
+
+    @app.get("/v1/board/records/{record_id}")
+    def board_record_get(record_id: str):
+        record = app.state.sourcing_index.get(record_id, expand_sources=True)
+        if record is None:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        return {
+            "record": record,
+            "links": app.state.sourcing_index.links(record_id),
+            "receipts": app.state.sourcing_index.receipts(record_id),
+        }
+
+    @app.post("/v1/board/records/{record_id}/revert")
+    async def board_record_revert(record_id: str, request: Request):
+        payload = await request.json()
+        try:
+            record = app.state.sourcing_index.revert(
+                record_id,
+                to_version=int(payload.get("to_version") or 0),
+                expected_version=int(payload.get("expected_version") or 0),
+                actor="director",
+                rationale_summary=str(payload.get("rationale_summary") or ""),
+            )
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=409)
+        return {"record": record}
 
     @app.post("/v1/people/{person_id}/sequence")
     async def people_sequence(person_id: str, request: Request):
@@ -1513,7 +1579,9 @@ def create_app(
                     skills=app.state.skills,
                     mcp=app.state.mcp,
                     people=app.state.people,
+                    sourcing_index=app.state.sourcing_index,
                     session_id=session_id,
+                    run_id=run_id,
                 )
             except Exception as exc:
                 # The claim is held: this command must still record an outcome.
@@ -1647,6 +1715,7 @@ def create_app(
                         "skills": app.state.skills,
                         "mcp": app.state.mcp,
                         "people": app.state.people,
+                        "sourcing_index": app.state.sourcing_index,
                     },
                     emit=_broadcast,
                     wait_permission=_wait,

--- a/desktop/coworker/sourcing_index.py
+++ b/desktop/coworker/sourcing_index.py
@@ -1,0 +1,742 @@
+"""Durable Board and sourcing-index domain records."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+RECORD_TYPES = frozenset(
+    {
+        "semester",
+        "company",
+        "contact",
+        "opportunity",
+        "touchpoint",
+        "action",
+        "knowledge_gap",
+        "artifact",
+        "source_ref",
+    }
+)
+OPPORTUNITY_TRANSITIONS = {
+    "research": frozenset({"ready", "closed"}),
+    "ready": frozenset({"contacted", "closed"}),
+    "contacted": frozenset({"replied", "closed"}),
+    "replied": frozenset({"qualified", "closed"}),
+    "qualified": frozenset({"closed"}),
+    "closed": frozenset(),
+}
+
+
+class SourcingIndex:
+    def __init__(self, base_dir: str | Path) -> None:
+        self.base = Path(base_dir).expanduser()
+        self.base.mkdir(parents=True, exist_ok=True)
+        self.db_path = self.base / "sourcing-index.db"
+        self._lock = threading.RLock()
+        self._conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS sourcing_records (
+                id TEXT PRIMARY KEY,
+                record_type TEXT NOT NULL,
+                fields_json TEXT NOT NULL,
+                source_refs_json TEXT NOT NULL DEFAULT '[]',
+                idempotency_key TEXT,
+                version INTEGER NOT NULL DEFAULT 1,
+                restricted INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                UNIQUE(record_type, idempotency_key)
+            );
+            CREATE TABLE IF NOT EXISTS sourcing_receipts (
+                id TEXT PRIMARY KEY,
+                record_id TEXT NOT NULL,
+                operation TEXT NOT NULL,
+                before_json TEXT,
+                after_json TEXT,
+                actor TEXT NOT NULL,
+                session_id TEXT,
+                run_id TEXT,
+                rationale_summary TEXT NOT NULL,
+                source_refs_json TEXT NOT NULL DEFAULT '[]',
+                created_at TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS sourcing_links (
+                from_id TEXT NOT NULL,
+                to_id TEXT NOT NULL,
+                relationship TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                PRIMARY KEY (from_id, to_id, relationship)
+            );
+            """
+        )
+        self._conn.commit()
+
+    @staticmethod
+    def _record(row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "id": str(row["id"]),
+            "type": str(row["record_type"]),
+            "fields": json.loads(str(row["fields_json"])),
+            "source_refs": json.loads(str(row["source_refs_json"])),
+            "version": int(row["version"]),
+            "restricted": bool(row["restricted"]),
+            "created_at": str(row["created_at"]),
+            "updated_at": str(row["updated_at"]),
+        }
+
+    @staticmethod
+    def _require_audit(actor: str, rationale_summary: str) -> None:
+        if not actor.strip() or not rationale_summary.strip():
+            raise ValueError("actor and rationale_summary are required")
+
+    def get(
+        self,
+        record_id: str,
+        *,
+        expand_sources: bool = False,
+        allowed_source_ids: set[str] | None = None,
+    ) -> dict[str, Any] | None:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM sourcing_records WHERE id = ?", (record_id,)
+            ).fetchone()
+            if row is None:
+                return None
+            record = self._record(row)
+            allowed = allowed_source_ids or set()
+            if record["restricted"] and record["id"] not in allowed:
+                return None
+            if not expand_sources:
+                return record
+            sources: list[dict[str, Any]] = []
+            restricted_count = 0
+            for source_id in record["source_refs"]:
+                source_row = self._conn.execute(
+                    "SELECT * FROM sourcing_records WHERE id = ? AND record_type = 'source_ref'",
+                    (source_id,),
+                ).fetchone()
+                if source_row is None:
+                    continue
+                source = self._record(source_row)
+                if source["restricted"] and source["id"] not in allowed:
+                    restricted_count += 1
+                    continue
+                sources.append(source)
+        return {
+            **record,
+            "sources": sources,
+            "restricted_source_count": restricted_count,
+        }
+
+    def query(
+        self,
+        *,
+        record_type: str | None = None,
+        filters: dict[str, Any] | None = None,
+        expand_sources: bool = False,
+        allowed_source_ids: set[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        if record_type is not None and record_type not in RECORD_TYPES:
+            raise ValueError(f"unknown record type {record_type}")
+        with self._lock:
+            if record_type is None:
+                rows = self._conn.execute(
+                    "SELECT * FROM sourcing_records ORDER BY updated_at DESC, id"
+                ).fetchall()
+            else:
+                rows = self._conn.execute(
+                    """
+                    SELECT * FROM sourcing_records
+                    WHERE record_type = ? ORDER BY updated_at DESC, id
+                    """,
+                    (record_type,),
+                ).fetchall()
+        expected = filters or {}
+        allowed = allowed_source_ids or set()
+        records = [
+            self._record(row)
+            for row in rows
+            if not bool(row["restricted"]) or str(row["id"]) in allowed
+        ]
+        matched = [
+            record
+            for record in records
+            if all(record["fields"].get(key) == value for key, value in expected.items())
+        ]
+        if not expand_sources:
+            return matched
+        return [
+            expanded
+            for record in matched
+            if (
+                expanded := self.get(
+                    record["id"],
+                    expand_sources=True,
+                    allowed_source_ids=allowed,
+                )
+            )
+            is not None
+        ]
+
+    def _append_receipt(
+        self,
+        *,
+        record_id: str,
+        operation: str,
+        before: dict[str, Any] | None,
+        after: dict[str, Any] | None,
+        actor: str,
+        session_id: str | None,
+        run_id: str | None,
+        rationale_summary: str,
+        source_refs: list[str],
+        created_at: str,
+    ) -> None:
+        self._conn.execute(
+            """
+            INSERT INTO sourcing_receipts (
+                id, record_id, operation, before_json, after_json, actor,
+                session_id, run_id, rationale_summary, source_refs_json, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                f"receipt_{uuid.uuid4().hex}",
+                record_id,
+                operation,
+                json.dumps(before, sort_keys=True) if before is not None else None,
+                json.dumps(after, sort_keys=True) if after is not None else None,
+                actor,
+                session_id,
+                run_id,
+                rationale_summary,
+                json.dumps(source_refs),
+                created_at,
+            ),
+        )
+
+    def upsert(
+        self,
+        *,
+        record_type: str,
+        fields: dict[str, Any],
+        idempotency_key: str,
+        actor: str,
+        rationale_summary: str,
+        session_id: str | None = None,
+        run_id: str | None = None,
+        source_refs: list[str] | None = None,
+    ) -> dict[str, Any]:
+        if record_type not in RECORD_TYPES:
+            raise ValueError(f"unknown record type {record_type}")
+        if not isinstance(fields, dict):
+            raise ValueError("fields must be an object")
+        if not idempotency_key.strip():
+            raise ValueError("idempotency_key is required")
+        self._require_audit(actor, rationale_summary)
+        refs = [str(value) for value in source_refs or [] if str(value)]
+        with self._lock:
+            existing = self._conn.execute(
+                "SELECT * FROM sourcing_records WHERE record_type = ? AND idempotency_key = ?",
+                (record_type, idempotency_key),
+            ).fetchone()
+            if existing is not None:
+                current = self._record(existing)
+                if current["fields"] != fields or current["source_refs"] != refs:
+                    raise ValueError(
+                        "idempotency conflict: key already belongs to different record facts"
+                    )
+                return current
+            now = datetime.now(UTC).isoformat()
+            record_id = f"{record_type}_{uuid.uuid4().hex}"
+            restricted = int(
+                record_type == "source_ref"
+                and str(fields.get("sensitivity") or "").lower() == "restricted"
+            )
+            self._conn.execute(
+                """
+                INSERT INTO sourcing_records (
+                    id, record_type, fields_json, source_refs_json,
+                    idempotency_key, version, restricted, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?)
+                """,
+                (
+                    record_id,
+                    record_type,
+                    json.dumps(fields, sort_keys=True),
+                    json.dumps(refs),
+                    idempotency_key,
+                    restricted,
+                    now,
+                    now,
+                ),
+            )
+            row = self._conn.execute(
+                "SELECT * FROM sourcing_records WHERE id = ?", (record_id,)
+            ).fetchone()
+            assert row is not None
+            record = self._record(row)
+            self._append_receipt(
+                record_id=record_id,
+                operation="create",
+                before=None,
+                after=record,
+                actor=actor,
+                session_id=session_id,
+                run_id=run_id,
+                rationale_summary=rationale_summary,
+                source_refs=refs,
+                created_at=now,
+            )
+            self._conn.commit()
+        return record
+
+    def patch(
+        self,
+        record_id: str,
+        *,
+        fields: dict[str, Any],
+        expected_version: int,
+        actor: str,
+        rationale_summary: str,
+        session_id: str | None = None,
+        run_id: str | None = None,
+        source_refs: list[str] | None = None,
+        _operation: str = "patch",
+    ) -> dict[str, Any]:
+        if not isinstance(fields, dict):
+            raise ValueError("fields must be an object")
+        self._require_audit(actor, rationale_summary)
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM sourcing_records WHERE id = ?", (record_id,)
+            ).fetchone()
+            if row is None:
+                raise ValueError(f"unknown record {record_id}")
+            before = self._record(row)
+            if before["version"] != expected_version:
+                raise ValueError(
+                    f"stale record version: expected {expected_version}, current {before['version']}"
+                )
+            next_fields = dict(before["fields"])
+            next_fields.update(fields)
+            refs = list(dict.fromkeys([*before["source_refs"], *(source_refs or [])]))
+            now = datetime.now(UTC).isoformat()
+            restricted = int(
+                before["type"] == "source_ref"
+                and str(next_fields.get("sensitivity") or "").lower() == "restricted"
+            )
+            cursor = self._conn.execute(
+                """
+                UPDATE sourcing_records
+                SET fields_json = ?, source_refs_json = ?, version = version + 1,
+                    restricted = ?, updated_at = ?
+                WHERE id = ? AND version = ?
+                """,
+                (
+                    json.dumps(next_fields, sort_keys=True),
+                    json.dumps(refs),
+                    restricted,
+                    now,
+                    record_id,
+                    expected_version,
+                ),
+            )
+            if cursor.rowcount != 1:
+                self._conn.rollback()
+                raise ValueError("stale record version")
+            updated_row = self._conn.execute(
+                "SELECT * FROM sourcing_records WHERE id = ?", (record_id,)
+            ).fetchone()
+            assert updated_row is not None
+            after = self._record(updated_row)
+            self._append_receipt(
+                record_id=record_id,
+                operation=_operation,
+                before=before,
+                after=after,
+                actor=actor,
+                session_id=session_id,
+                run_id=run_id,
+                rationale_summary=rationale_summary,
+                source_refs=[str(value) for value in source_refs or []],
+                created_at=now,
+            )
+            self._conn.commit()
+        return after
+
+    def transition(
+        self,
+        record_id: str,
+        *,
+        to_stage: str,
+        evidence_record_ids: list[str],
+        expected_version: int,
+        actor: str,
+        rationale_summary: str,
+        session_id: str | None = None,
+        run_id: str | None = None,
+        source_refs: list[str] | None = None,
+    ) -> dict[str, Any]:
+        record = self.get(record_id)
+        if record is None or record["type"] != "opportunity":
+            raise ValueError("stage transitions require an opportunity")
+        current = str(record["fields"].get("stage") or "research")
+        if to_stage not in OPPORTUNITY_TRANSITIONS.get(current, frozenset()):
+            raise ValueError(f"invalid opportunity transition {current} -> {to_stage}")
+        evidence = [self.get(evidence_id) for evidence_id in evidence_record_ids]
+        evidence = [item for item in evidence if item is not None]
+        if to_stage == "contacted" and not any(
+            item["type"] == "touchpoint"
+            and item["fields"].get("direction") == "outbound"
+            and item["fields"].get("status") in {"sent", "completed"}
+            for item in evidence
+        ):
+            raise ValueError("contacted requires an outbound sent touchpoint")
+        if to_stage == "replied" and not any(
+            item["type"] == "touchpoint"
+            and item["fields"].get("direction") == "inbound"
+            and item["fields"].get("status") in {"received", "replied", "completed"}
+            for item in evidence
+        ):
+            raise ValueError("replied requires an inbound reply touchpoint")
+        if to_stage == "qualified" and not any(
+            item["type"] == "touchpoint"
+            and (
+                item["fields"].get("qualified") is True
+                or item["fields"].get("status") == "qualified"
+            )
+            for item in evidence
+        ):
+            raise ValueError("qualified requires a qualified touchpoint")
+        return self.patch(
+            record_id,
+            fields={"stage": to_stage, "stage_evidence_ids": evidence_record_ids},
+            expected_version=expected_version,
+            actor=actor,
+            session_id=session_id,
+            run_id=run_id,
+            rationale_summary=rationale_summary,
+            source_refs=source_refs,
+            _operation="transition",
+        )
+
+    def complete_action(
+        self,
+        record_id: str,
+        *,
+        expected_version: int,
+        actor: str,
+        rationale_summary: str,
+        session_id: str | None = None,
+        run_id: str | None = None,
+        source_refs: list[str] | None = None,
+    ) -> dict[str, Any]:
+        record = self.get(record_id)
+        if record is None or record["type"] != "action":
+            raise ValueError("action completion requires an action")
+        return self.patch(
+            record_id,
+            fields={"status": "completed", "completed_at": datetime.now(UTC).isoformat()},
+            expected_version=expected_version,
+            actor=actor,
+            session_id=session_id,
+            run_id=run_id,
+            rationale_summary=rationale_summary,
+            source_refs=source_refs,
+            _operation="complete_action",
+        )
+
+    def capture_outcome(
+        self,
+        record_id: str,
+        *,
+        outcome: str,
+        expected_version: int,
+        actor: str,
+        rationale_summary: str,
+        session_id: str | None = None,
+        run_id: str | None = None,
+        source_refs: list[str] | None = None,
+    ) -> dict[str, Any]:
+        record = self.get(record_id)
+        if record is None or record["type"] != "opportunity":
+            raise ValueError("outcome capture requires an opportunity")
+        if not outcome.strip():
+            raise ValueError("outcome is required")
+        return self.patch(
+            record_id,
+            fields={"outcome": outcome.strip(), "outcome_at": datetime.now(UTC).isoformat()},
+            expected_version=expected_version,
+            actor=actor,
+            session_id=session_id,
+            run_id=run_id,
+            rationale_summary=rationale_summary,
+            source_refs=source_refs,
+            _operation="capture_outcome",
+        )
+
+    def revert(
+        self,
+        record_id: str,
+        *,
+        to_version: int,
+        expected_version: int,
+        actor: str,
+        rationale_summary: str,
+        session_id: str | None = None,
+        run_id: str | None = None,
+    ) -> dict[str, Any]:
+        self._require_audit(actor, rationale_summary)
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM sourcing_records WHERE id = ?", (record_id,)
+            ).fetchone()
+            if row is None:
+                raise ValueError(f"unknown record {record_id}")
+            before = self._record(row)
+            if before["version"] != expected_version:
+                raise ValueError(
+                    f"stale record version: expected {expected_version}, current {before['version']}"
+                )
+            target = next(
+                (
+                    receipt["after"]
+                    for receipt in self.receipts(record_id)
+                    if receipt["after"] is not None
+                    and receipt["after"].get("version") == to_version
+                ),
+                None,
+            )
+            if target is None:
+                raise ValueError(f"unknown record version {to_version}")
+            now = datetime.now(UTC).isoformat()
+            next_version = expected_version + 1
+            self._conn.execute(
+                """
+                UPDATE sourcing_records
+                SET fields_json = ?, source_refs_json = ?, version = ?, restricted = ?, updated_at = ?
+                WHERE id = ? AND version = ?
+                """,
+                (
+                    json.dumps(target["fields"], sort_keys=True),
+                    json.dumps(target["source_refs"]),
+                    next_version,
+                    int(bool(target["restricted"])),
+                    now,
+                    record_id,
+                    expected_version,
+                ),
+            )
+            after_row = self._conn.execute(
+                "SELECT * FROM sourcing_records WHERE id = ?", (record_id,)
+            ).fetchone()
+            assert after_row is not None
+            after = self._record(after_row)
+            self._append_receipt(
+                record_id=record_id,
+                operation="revert",
+                before=before,
+                after=after,
+                actor=actor,
+                session_id=session_id,
+                run_id=run_id,
+                rationale_summary=rationale_summary,
+                source_refs=[],
+                created_at=now,
+            )
+            self._conn.commit()
+        return after
+
+    def delete(
+        self,
+        record_id: str,
+        *,
+        expected_version: int,
+        actor: str,
+        rationale_summary: str,
+        session_id: str | None = None,
+        run_id: str | None = None,
+    ) -> dict[str, Any]:
+        self._require_audit(actor, rationale_summary)
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM sourcing_records WHERE id = ?", (record_id,)
+            ).fetchone()
+            if row is None:
+                return {"deleted": False, "id": record_id}
+            before = self._record(row)
+            if before["version"] != expected_version:
+                raise ValueError(
+                    f"stale record version: expected {expected_version}, current {before['version']}"
+                )
+            self._conn.execute(
+                "DELETE FROM sourcing_links WHERE from_id = ? OR to_id = ?",
+                (record_id, record_id),
+            )
+            self._conn.execute("DELETE FROM sourcing_records WHERE id = ?", (record_id,))
+            now = datetime.now(UTC).isoformat()
+            self._append_receipt(
+                record_id=record_id,
+                operation="delete",
+                before=before,
+                after=None,
+                actor=actor,
+                session_id=session_id,
+                run_id=run_id,
+                rationale_summary=rationale_summary,
+                source_refs=[],
+                created_at=now,
+            )
+            self._conn.commit()
+        return {"deleted": True, "id": record_id}
+
+    def links(self, record_id: str) -> list[dict[str, Any]]:
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT from_id, to_id, relationship, created_at
+                FROM sourcing_links
+                WHERE from_id = ? OR to_id = ?
+                ORDER BY created_at, from_id, to_id, relationship
+                """,
+                (record_id, record_id),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def link(
+        self,
+        from_id: str,
+        to_id: str,
+        *,
+        relationship: str,
+        actor: str,
+        rationale_summary: str,
+        session_id: str | None = None,
+        run_id: str | None = None,
+        source_refs: list[str] | None = None,
+    ) -> dict[str, Any]:
+        if not relationship.strip():
+            raise ValueError("relationship is required")
+        self._require_audit(actor, rationale_summary)
+        with self._lock:
+            count = self._conn.execute(
+                "SELECT COUNT(*) FROM sourcing_records WHERE id IN (?, ?)",
+                (from_id, to_id),
+            ).fetchone()[0]
+            if int(count) != 2:
+                raise ValueError("link records must exist")
+            existing = self._conn.execute(
+                """
+                SELECT from_id, to_id, relationship, created_at FROM sourcing_links
+                WHERE from_id = ? AND to_id = ? AND relationship = ?
+                """,
+                (from_id, to_id, relationship),
+            ).fetchone()
+            if existing is not None:
+                return dict(existing)
+            now = datetime.now(UTC).isoformat()
+            self._conn.execute(
+                """
+                INSERT INTO sourcing_links (from_id, to_id, relationship, created_at)
+                VALUES (?, ?, ?, ?)
+                """,
+                (from_id, to_id, relationship, now),
+            )
+            link = {
+                "from_id": from_id,
+                "to_id": to_id,
+                "relationship": relationship,
+                "created_at": now,
+            }
+            self._append_receipt(
+                record_id=from_id,
+                operation="link",
+                before=None,
+                after=link,
+                actor=actor,
+                session_id=session_id,
+                run_id=run_id,
+                rationale_summary=rationale_summary,
+                source_refs=[str(value) for value in source_refs or []],
+                created_at=now,
+            )
+            self._conn.commit()
+        return link
+
+    def unlink(
+        self,
+        from_id: str,
+        to_id: str,
+        *,
+        relationship: str,
+        actor: str,
+        rationale_summary: str,
+        session_id: str | None = None,
+        run_id: str | None = None,
+        source_refs: list[str] | None = None,
+    ) -> dict[str, Any]:
+        self._require_audit(actor, rationale_summary)
+        with self._lock:
+            existing = self._conn.execute(
+                """
+                SELECT from_id, to_id, relationship, created_at FROM sourcing_links
+                WHERE from_id = ? AND to_id = ? AND relationship = ?
+                """,
+                (from_id, to_id, relationship),
+            ).fetchone()
+            if existing is None:
+                return {"removed": False}
+            before = dict(existing)
+            self._conn.execute(
+                """
+                DELETE FROM sourcing_links
+                WHERE from_id = ? AND to_id = ? AND relationship = ?
+                """,
+                (from_id, to_id, relationship),
+            )
+            now = datetime.now(UTC).isoformat()
+            self._append_receipt(
+                record_id=from_id,
+                operation="unlink",
+                before=before,
+                after=None,
+                actor=actor,
+                session_id=session_id,
+                run_id=run_id,
+                rationale_summary=rationale_summary,
+                source_refs=[str(value) for value in source_refs or []],
+                created_at=now,
+            )
+            self._conn.commit()
+        return {"removed": True}
+
+    def receipts(self, record_id: str) -> list[dict[str, Any]]:
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT * FROM sourcing_receipts WHERE record_id = ? ORDER BY created_at, id",
+                (record_id,),
+            ).fetchall()
+        return [
+            {
+                "id": str(row["id"]),
+                "record_id": str(row["record_id"]),
+                "operation": str(row["operation"]),
+                "before": json.loads(str(row["before_json"])) if row["before_json"] else None,
+                "after": json.loads(str(row["after_json"])) if row["after_json"] else None,
+                "actor": str(row["actor"]),
+                "session_id": row["session_id"],
+                "run_id": row["run_id"],
+                "rationale_summary": str(row["rationale_summary"]),
+                "source_refs": json.loads(str(row["source_refs_json"])),
+                "created_at": str(row["created_at"]),
+            }
+            for row in rows
+        ]

--- a/desktop/coworker/tools.py
+++ b/desktop/coworker/tools.py
@@ -15,6 +15,8 @@ from coworker.apollo import MISSING_KEY, enrich_contact, search_people
 from coworker.web import MISSING_KEY as TAVILY_MISSING, search_web
 from coworker.gmail import GmailError, MissingGmail
 from coworker.people import PersonStore
+from coworker.board_tools import BOARD_TOOL_NAMES, BOARD_TOOL_SCHEMAS, execute_board_tool
+from coworker.sourcing_index import SourcingIndex
 from coworker.store import ConversationStore
 
 TZ = ZoneInfo("America/Los_Angeles")
@@ -237,6 +239,24 @@ DRIVE_READ_SCHEMA: dict[str, Any] = {
     },
 }
 
+DRIVE_LIST_FOLDER_SCHEMA: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "drive_list_folder",
+        "description": "List one Google Drive folder by its exact id. Readonly and parent-scoped.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "folder_id": {"type": "string"},
+                "max_results": {"type": "integer"},
+                "page_token": {"type": "string"},
+            },
+            "required": ["folder_id"],
+            "additionalProperties": False,
+        },
+    },
+}
+
 CALENDAR_LIST_SCHEMA: dict[str, Any] = {
     "type": "function",
     "function": {
@@ -385,6 +405,7 @@ OPENAI_TOOLS = [
     GMAIL_DRAFT_SCHEMA,
     GMAIL_SEND_SCHEMA,
     DRIVE_SEARCH_SCHEMA,
+    DRIVE_LIST_FOLDER_SCHEMA,
     DRIVE_READ_SCHEMA,
     CALENDAR_LIST_SCHEMA,
     CALENDAR_CREATE_SCHEMA,
@@ -394,6 +415,7 @@ OPENAI_TOOLS = [
     APOLLO_ENRICH_SCHEMA,
     LOAD_SKILL_SCHEMA,
     WEB_SEARCH_SCHEMA,
+    *BOARD_TOOL_SCHEMAS,
 ]
 
 
@@ -428,8 +450,24 @@ def execute(
     people: PersonStore | None = None,
     session_id: str | None = None,
     tavily_key: str | None = None,
+    sourcing_index: SourcingIndex | None = None,
+    actor: str = "assistant",
+    run_id: str | None = None,
+    allowed_source_ids: set[str] | None = None,
 ) -> tuple[bool, dict[str, Any]]:
     args = arguments or {}
+    if name in BOARD_TOOL_NAMES:
+        if sourcing_index is None:
+            return False, {"status": "failed", "error": "sourcing index missing"}
+        return execute_board_tool(
+            name,
+            args,
+            index=sourcing_index,
+            actor=actor,
+            session_id=session_id,
+            run_id=run_id,
+            allowed_source_ids=allowed_source_ids,
+        )
     if name == "now":
         return True, now()
     if name == "load_skill":
@@ -476,18 +514,28 @@ def execute(
             return False, {"error": str(exc)}
         except Exception as exc:
             return False, {"error": str(exc)}
-    if name in {"drive_search", "drive_read"}:
+    if name in {"drive_search", "drive_list_folder", "drive_read"}:
         if drive is None:
             return False, {"error": "Drive is not connected."}
         try:
             if name == "drive_search":
                 return True, drive.search(str(args.get("query") or ""), int(args.get("max_results") or 10))
+            if name == "drive_list_folder":
+                folder_id = str(args.get("folder_id") or "").strip()
+                if not folder_id:
+                    return False, {"status": "failed", "error": "folder_id is required"}
+                return True, drive.list_folder(
+                    folder_id,
+                    int(args.get("max_results") or 100),
+                    str(args.get("page_token") or "") or None,
+                )
             fid = str(args.get("file_id") or "").strip()
             if not fid:
                 return False, {"error": "file_id is required"}
-            return True, drive.read(fid, int(args.get("max_chars") or 20000))
+            result = drive.read(fid, int(args.get("max_chars") or 20000))
+            return result.get("status") != "failed", result
         except Exception as exc:
-            return False, {"error": str(exc)}
+            return False, {"status": "failed", "error": str(exc)}
     if name in {"calendar_list", "calendar_create", "calendar_update"}:
         if calendar is None:
             return False, {"error": "Calendar is not connected."}

--- a/desktop/coworker/turn.py
+++ b/desktop/coworker/turn.py
@@ -29,6 +29,7 @@ _TOOL_SOURCES: dict[str, tuple[str | None, str]] = {
     "gmail_read": ("gmail", "Gmail"),
     "gmail_draft": ("gmail", "Gmail"),
     "drive_search": ("drive", "Google Drive"),
+    "drive_list_folder": ("drive", "Google Drive"),
     "drive_read": ("drive", "Google Drive"),
     "calendar_list": ("calendar", "Google Calendar"),
     "calendar_create": ("calendar", "Google Calendar"),
@@ -739,6 +740,7 @@ async def run_turn(
                 try:
                     kw = {k: v for k, v in execute_kwargs.items() if not k.startswith("_")}
                     kw["session_id"] = sid
+                    kw["run_id"] = events.identity.run_id
                     ok, result = await asyncio.to_thread(
                         execute, call.name, call.arguments, **kw
                     )

--- a/desktop/requirements.txt
+++ b/desktop/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]>=0.27
 httpx>=0.27
 pytest>=8
 mcp>=1.28.1,<2
+pypdf>=5,<7

--- a/desktop/surfaces/gui/src/Board.tsx
+++ b/desktop/surfaces/gui/src/Board.tsx
@@ -1,6 +1,15 @@
 import { useEffect, useState } from "react";
 
-import { getBoard, type Board, type BoardPerson } from "./api";
+import {
+  getBoard,
+  getBoardRecord,
+  getBoardRecords,
+  revertBoardRecord,
+  type Board,
+  type BoardPerson,
+  type SourcingRecord,
+  type SourcingRecordDetail,
+} from "./api";
 
 function label(person: BoardPerson): { name: string; detail: string | null } {
   const name = [person.first_name, person.last_name].filter(Boolean).join(" ") || "Unknown person";
@@ -47,17 +56,29 @@ function Bucket({
   );
 }
 
+function recordTitle(record: SourcingRecord): string {
+  for (const key of ["name", "title", "question", "summary"]) {
+    const value = record.fields[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return `${record.type} ${record.id}`;
+}
+
 export function BoardView() {
   const [board, setBoard] = useState<Board | null>(null);
+  const [records, setRecords] = useState<SourcingRecord[] | null>(null);
+  const [detail, setDetail] = useState<SourcingRecordDetail | null>(null);
   const [failed, setFailed] = useState(false);
   const [attempt, setAttempt] = useState(0);
 
   useEffect(() => {
     let active = true;
     setFailed(false);
-    getBoard().then(
-      (next) => {
-        if (active) setBoard(next);
+    Promise.all([getBoard(), getBoardRecords()]).then(
+      ([nextBoard, nextRecords]) => {
+        if (!active) return;
+        setBoard(nextBoard);
+        setRecords(nextRecords.records);
       },
       () => {
         if (active) setFailed(true);
@@ -67,6 +88,27 @@ export function BoardView() {
       active = false;
     };
   }, [attempt]);
+
+  useEffect(() => {
+    const refresh = () => setAttempt((value) => value + 1);
+    window.addEventListener("sourcecado:board-changed", refresh);
+    return () => window.removeEventListener("sourcecado:board-changed", refresh);
+  }, []);
+
+  async function inspectRecord(record: SourcingRecord) {
+    setDetail(await getBoardRecord(record.id));
+  }
+
+  async function revertRecord(toVersion: number) {
+    if (!detail) return;
+    await revertBoardRecord(detail.record.id, {
+      toVersion,
+      expectedVersion: detail.record.version,
+      rationaleSummary: `Restore version ${toVersion} from Board history.`,
+    });
+    setDetail(await getBoardRecord(detail.record.id));
+    setAttempt((value) => value + 1);
+  }
 
   const empty =
     board !== null &&
@@ -107,6 +149,51 @@ export function BoardView() {
           <Bucket id="done" title="Done" people={board.done} />
         </div>
       ) : null}
+      <section className="board-index" aria-labelledby="board-index-heading">
+        <header>
+          <h2 id="board-index-heading">Sourcing index</h2>
+          <p>{records?.length ?? 0} structured records</p>
+        </header>
+        {records === null ? <p role="status">Loading sourcing index…</p> : null}
+        {records?.length === 0 ? <p>No structured records yet.</p> : null}
+        {records && records.length > 0 ? (
+          <ul>
+            {records.map((record) => (
+              <li key={record.id}>
+                <button
+                  type="button"
+                  aria-label={`Inspect ${recordTitle(record)}`}
+                  onClick={() => void inspectRecord(record)}
+                >
+                  <strong>{recordTitle(record)}</strong>
+                  <span>{record.type} · v{record.version}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+        {detail ? (
+          <section className="board-record-history" aria-labelledby="board-history-heading">
+            <h3 id="board-history-heading">Version history</h3>
+            <p>{recordTitle(detail.record)} · current version {detail.record.version}</p>
+            <ol>
+              {detail.receipts.map((receipt) => {
+                const version = receipt.after?.version;
+                return (
+                  <li key={receipt.id}>
+                    <span>{receipt.operation}</span>
+                    {typeof version === "number" && version < detail.record.version ? (
+                      <button type="button" onClick={() => void revertRecord(version)}>
+                        Revert to version {version}
+                      </button>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ol>
+          </section>
+        ) : null}
+      </section>
     </main>
   );
 }

--- a/desktop/surfaces/gui/src/api.ts
+++ b/desktop/surfaces/gui/src/api.ts
@@ -238,6 +238,33 @@ export type Board = {
   done: BoardPerson[];
 };
 
+export type SourcingRecord = {
+  id: string;
+  type: string;
+  fields: Record<string, unknown>;
+  source_refs: string[];
+  version: number;
+  restricted: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+export type SourcingReceipt = {
+  id: string;
+  operation: string;
+  before?: { version?: number } | null;
+  after?: { version?: number } | null;
+  actor?: string;
+  rationale_summary?: string;
+  created_at: string;
+};
+
+export type SourcingRecordDetail = {
+  record: SourcingRecord;
+  links: Array<Record<string, unknown>>;
+  receipts: SourcingReceipt[];
+};
+
 export type PersonFile = {
   person: BoardPerson & Record<string, unknown>;
   brief: {
@@ -259,6 +286,38 @@ export type PersonFile = {
 export async function getBoard(): Promise<Board> {
   const res = await get("/v1/board");
   if (!res.ok) throw new Error(`board ${res.status}`);
+  return res.json();
+}
+
+export async function getBoardRecords(): Promise<{ records: SourcingRecord[]; count: number }> {
+  const res = await get("/v1/board/records");
+  if (!res.ok) throw new Error(`board records ${res.status}`);
+  return res.json();
+}
+
+export async function getBoardRecord(id: string): Promise<SourcingRecordDetail> {
+  const res = await get(`/v1/board/records/${encodeURIComponent(id)}`);
+  if (!res.ok) throw new Error(`board record ${res.status}`);
+  return res.json();
+}
+
+export async function revertBoardRecord(
+  id: string,
+  input: { toVersion: number; expectedVersion: number; rationaleSummary: string },
+): Promise<{ record: SourcingRecord }> {
+  const res = await fetch(
+    `${httpBase()}/v1/board/records/${encodeURIComponent(id)}/revert`,
+    {
+      method: "POST",
+      headers: { "X-Club-Token": apiToken(), "Content-Type": "application/json" },
+      body: JSON.stringify({
+        to_version: input.toVersion,
+        expected_version: input.expectedVersion,
+        rationale_summary: input.rationaleSummary,
+      }),
+    },
+  );
+  if (!res.ok) throw new Error(`board revert ${res.status}`);
   return res.json();
 }
 

--- a/desktop/surfaces/gui/src/app/AppShell.tsx
+++ b/desktop/surfaces/gui/src/app/AppShell.tsx
@@ -38,6 +38,8 @@ export function AppShell() {
   const railFocusTimerRef = useRef<number | null>(null);
   const railWasOpenedRef = useRef(false);
   const searchReturnFocusRef = useRef<HTMLElement | null>(null);
+  const deferDestinationPersistenceRef = useRef(isRootHash(window.location.hash));
+  const cachedRestoreHashRef = useRef<string | null>(null);
   function openSearch() {
     searchReturnFocusRef.current =
       document.activeElement instanceof HTMLElement ? document.activeElement : null;
@@ -81,7 +83,10 @@ export function AppShell() {
     }
   }, [railOpen]);
   useEffect(() => {
+    if (deferDestinationPersistenceRef.current) return;
     if (isRootHash(window.location.hash)) return;
+    if (cachedRestoreHashRef.current === window.location.hash) return;
+    cachedRestoreHashRef.current = null;
     if (route.kind === "chat" && route.sessionId?.startsWith("sched-")) return;
     setLastDestination(window.location.hash).catch(() => {});
   }, [route]);
@@ -168,8 +173,10 @@ export function AppShell() {
       const restored = cachedListing.last_destination ||
         (cachedListing.open_id ? `#/chat/${encodeURIComponent(cachedListing.open_id)}` : "");
       if (restored) {
+        cachedRestoreHashRef.current = restored;
         window.location.hash = restored;
       } else if (cachedListing.sessions.length > 0) {
+        cachedRestoreHashRef.current = "#/chat";
         window.location.hash = "#/chat";
       }
     }
@@ -180,19 +187,26 @@ export function AppShell() {
         setOpenSessionId(listing.open_id);
         setStale(false);
         writeShellCache(listing);
-        if (!isRootHash(window.location.hash)) return;
-        const restored = listing.last_destination ||
-          (listing.open_id ? `#/chat/${encodeURIComponent(listing.open_id)}` : "");
-        if (restored) {
-          window.location.hash = restored;
-        } else if (listing.sessions.length > 0) {
-          // Sessions exist but neither open_id nor last_destination named one:
-          // escape the root "Restoring workspace" skeleton instead of hanging on it.
-          window.location.hash = "#/chat";
+        const currentHash = window.location.hash;
+        const cacheStillOwnsHash = cachedRestoreHashRef.current === currentHash;
+        if (isRootHash(currentHash) || cacheStillOwnsHash) {
+          const restored = listing.last_destination ||
+            (listing.open_id ? `#/chat/${encodeURIComponent(listing.open_id)}` : "");
+          if (restored) {
+            window.location.hash = restored;
+          } else if (listing.sessions.length > 0) {
+            // Sessions exist but neither open_id nor last_destination named one:
+            // escape the root "Restoring workspace" skeleton instead of hanging on it.
+            window.location.hash = "#/chat";
+          }
         }
+        cachedRestoreHashRef.current = null;
+        deferDestinationPersistenceRef.current = false;
       })
       .catch((error: unknown) => {
-        if (active) setBootError(error instanceof Error ? error.message : String(error));
+        if (!active) return;
+        deferDestinationPersistenceRef.current = false;
+        setBootError(error instanceof Error ? error.message : String(error));
       });
     return () => {
       active = false;

--- a/desktop/surfaces/gui/src/chat/toolRegistry.tsx
+++ b/desktop/surfaces/gui/src/chat/toolRegistry.tsx
@@ -44,6 +44,11 @@ const KNOWN_TOOLS: Readonly<Record<string, ToolPresentation>> = {
     category: "source",
     slot: "evidence",
   },
+  drive_list_folder: {
+    label: "Listed Drive folder",
+    category: "source",
+    slot: "evidence",
+  },
   drive_read: {
     label: "Read Drive evidence",
     category: "source",
@@ -89,6 +94,11 @@ const KNOWN_TOOLS: Readonly<Record<string, ToolPresentation>> = {
     category: "action",
     slot: "calendar",
   },
+  board_get: { label: "Read Board record", category: "source" },
+  board_query: { label: "Queried Board", category: "source" },
+  board_upsert: { label: "Created Board record", category: "action" },
+  board_mutate: { label: "Updated Board record", category: "action" },
+  board_delete: { label: "Deleted Board record", category: "action" },
   now: { label: "Checked current time", category: "source" },
 };
 

--- a/desktop/surfaces/gui/src/generative/EvidenceSetResult.tsx
+++ b/desktop/surfaces/gui/src/generative/EvidenceSetResult.tsx
@@ -15,6 +15,7 @@ type EvidenceItem = {
   readonly externalUrl: string | null;
   readonly stale: boolean;
   readonly truncated: boolean;
+  readonly extractionStatus: string | null;
   readonly callIds: readonly string[];
 };
 
@@ -70,7 +71,7 @@ function providerForTool(tool: ToolCallMessagePart): "Google Drive" | "Granola" 
 
 function malformedEvidenceTool(tool: ToolCallMessagePart): boolean {
   if (tool.result === undefined || failedProvider(tool)) return false;
-  if (tool.toolName === "drive_search") {
+  if (tool.toolName === "drive_search" || tool.toolName === "drive_list_folder") {
     const result = record(tool.result);
     return !result || !Array.isArray(result.files);
   }
@@ -96,7 +97,7 @@ function malformedEvidenceTool(tool: ToolCallMessagePart): boolean {
 
 function driveItems(tool: ToolCallMessagePart): EvidenceItem[] {
   const result = record(tool.result);
-  if (tool.toolName === "drive_search") {
+  if (tool.toolName === "drive_search" || tool.toolName === "drive_list_folder") {
     const files = Array.isArray(result?.files) ? result.files : [];
     return files.flatMap((value, index) => {
       const file = record(value);
@@ -109,11 +110,15 @@ function driveItems(tool: ToolCallMessagePart): EvidenceItem[] {
         provider: "Google Drive" as const,
         title: text(file.name) ?? "Untitled Drive file",
         excerpt: text(file.excerpt) ?? text(file.snippet),
-        context: ["Search match", mime].filter(Boolean).join(" · "),
+        context: [
+          tool.toolName === "drive_list_folder" ? "Folder item" : "Search match",
+          mime,
+        ].filter(Boolean).join(" · "),
         externalUrl:
           text(file.webViewLink) ?? text(file.url) ?? text(file.external_url),
         stale: file.stale === true,
         truncated: file.truncated === true,
+        extractionStatus: null,
         callIds: [tool.toolCallId],
       }];
     });
@@ -121,17 +126,26 @@ function driveItems(tool: ToolCallMessagePart): EvidenceItem[] {
   if (tool.toolName === "drive_read" && result) {
     const sourceId = text(result.id) ?? text(record(tool.args)?.file_id) ?? tool.toolCallId;
     const mime = text(result.mimeType);
+    const extractionStatus = text(result.status);
+    const action = extractionStatus === "metadata_only"
+      ? "Metadata only"
+      : extractionStatus === "unsupported"
+        ? "Unsupported format"
+        : extractionStatus === "failed"
+          ? "Read failed"
+          : "Read document";
     return [{
       key: `drive:${sourceId}`,
       sourceId,
       provider: "Google Drive",
       title: text(result.name) ?? "Drive document",
       excerpt: text(result.content),
-      context: ["Read document", mime].filter(Boolean).join(" · "),
+      context: [action, mime].filter(Boolean).join(" · "),
       externalUrl:
         text(result.webViewLink) ?? text(result.url) ?? text(result.external_url),
       stale: result.stale === true,
       truncated: result.truncated === true,
+      extractionStatus,
       callIds: [tool.toolCallId],
     }];
   }
@@ -169,6 +183,7 @@ function granolaItems(tool: ToolCallMessagePart): EvidenceItem[] {
           text(item.url) ?? text(item.htmlLink) ?? text(item.external_url),
         stale: item.stale === true,
         truncated: item.truncated === true,
+        extractionStatus: null,
         callIds: [tool.toolCallId],
       }];
     });
@@ -185,6 +200,7 @@ function granolaItems(tool: ToolCallMessagePart): EvidenceItem[] {
         externalUrl: null,
         stale: false,
         truncated: false,
+        extractionStatus: null,
         callIds: [tool.toolCallId],
       }]
     : [];
@@ -215,6 +231,7 @@ function evidenceItems(tools: readonly ToolCallMessagePart[]): EvidenceItem[] {
               externalUrl: item.externalUrl ?? current.externalUrl,
               stale: current.stale || item.stale,
               truncated: current.truncated || item.truncated,
+              extractionStatus: item.extractionStatus ?? current.extractionStatus,
               callIds: [...current.callIds, ...item.callIds],
             }
           : item,
@@ -340,6 +357,7 @@ export function EvidenceSetResult({
                       sourceId: item.sourceId,
                       callIds: item.callIds,
                       context: item.context,
+                      extractionStatus: item.extractionStatus,
                     },
                   },
                   event.currentTarget,
@@ -352,6 +370,12 @@ export function EvidenceSetResult({
             <p>{item.context}</p>
             {item.stale ? <span className="sourcecado-evidence-badge">Cached stale</span> : null}
             {item.truncated ? <span className="sourcecado-evidence-badge">Truncated</span> : null}
+            {item.extractionStatus === "metadata_only" ? (
+              <span className="sourcecado-evidence-badge">Metadata only</span>
+            ) : null}
+            {item.extractionStatus === "unsupported" ? (
+              <span className="sourcecado-evidence-badge">Unsupported format</span>
+            ) : null}
             {item.excerpt ? <EvidenceExcerpt excerpt={item.excerpt} /> : null}
           </li>
         ))}

--- a/desktop/surfaces/gui/src/routes/ChatPage.tsx
+++ b/desktop/surfaces/gui/src/routes/ChatPage.tsx
@@ -178,6 +178,15 @@ export function ChatPage({ sessionId: requestedSessionId }: { sessionId?: string
         if (event.session_id === activeThreadRef.current) refresh();
         return;
       }
+      if (
+        event.type === "tool_finished" &&
+        event.result !== null &&
+        typeof event.result === "object" &&
+        !Array.isArray(event.result) &&
+        (event.result as Record<string, unknown>).board_changed === true
+      ) {
+        window.dispatchEvent(new CustomEvent("sourcecado:board-changed"));
+      }
       const applied = storeRef.current.applyChatEvent(event);
       if (applied.type === "connection_change") {
         connectionStatusRef.current = applied.status;

--- a/desktop/surfaces/gui/tests/activityGroup.test.tsx
+++ b/desktop/surfaces/gui/tests/activityGroup.test.tsx
@@ -78,6 +78,23 @@ describe("ActivityGroup", () => {
   });
 
   it.each([
+    ["board_get", "Read Board record"],
+    ["board_query", "Queried Board"],
+    ["board_upsert", "Created Board record"],
+    ["board_mutate", "Updated Board record"],
+    ["board_delete", "Deleted Board record"],
+  ])("labels %s receipts with a reviewable Board action", (toolName, label) => {
+    render(
+      <ActivityGroup
+        tools={[tool({ toolName, result: { board_changed: true } })]}
+        messageState="complete"
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: `${label} · Completed` })).toBeInTheDocument();
+  });
+
+  it.each([
     ["Running", [tool({ toolName: "private_internal_tool", result: undefined })], "running"],
     ["Failed", [tool({ toolName: "private_internal_tool", result: undefined, isError: true })], "complete"],
     [

--- a/desktop/surfaces/gui/tests/boardPerson.test.tsx
+++ b/desktop/surfaces/gui/tests/boardPerson.test.tsx
@@ -6,13 +6,19 @@ import { PersonFileView } from "../src/PersonFile";
 
 const api = vi.hoisted(() => ({
   getBoard: vi.fn(),
+  getBoardRecord: vi.fn(),
+  getBoardRecords: vi.fn(),
   getPerson: vi.fn(),
+  revertBoardRecord: vi.fn(),
   setPersonSequence: vi.fn(),
 }));
 
 vi.mock("../src/api", () => ({
   getBoard: api.getBoard,
+  getBoardRecord: api.getBoardRecord,
+  getBoardRecords: api.getBoardRecords,
   getPerson: api.getPerson,
+  revertBoardRecord: api.revertBoardRecord,
   setPersonSequence: api.setPersonSequence,
 }));
 
@@ -54,6 +60,41 @@ describe("Board and person-file routes", () => {
     api.setPersonSequence.mockResolvedValue({
       person: { person_id: "person one", sequence_state: "in_conversation" },
     });
+    api.getBoardRecords.mockResolvedValue({
+      records: [
+        {
+          id: "contact_ada",
+          type: "contact",
+          fields: { name: "Ada Lovelace", title: "Founder" },
+          source_refs: ["source_web"],
+          version: 2,
+          restricted: false,
+          created_at: "2026-08-26T10:00:00Z",
+          updated_at: "2026-08-26T11:00:00Z",
+        },
+      ],
+      count: 1,
+    });
+    api.getBoardRecord.mockResolvedValue({
+      record: {
+        id: "contact_ada",
+        type: "contact",
+        fields: { name: "Ada Lovelace", title: "Founder" },
+        source_refs: ["source_web"],
+        version: 2,
+        restricted: false,
+        created_at: "2026-08-26T10:00:00Z",
+        updated_at: "2026-08-26T11:00:00Z",
+      },
+      links: [],
+      receipts: [
+        { id: "r1", operation: "create", after: { version: 1 }, created_at: "1" },
+        { id: "r2", operation: "patch", after: { version: 2 }, created_at: "2" },
+      ],
+    });
+    api.revertBoardRecord.mockResolvedValue({
+      record: { id: "contact_ada", version: 3, fields: { name: "Ada Lovelace" } },
+    });
   });
 
   it("renders labeled Board buckets and safe person links", async () => {
@@ -83,5 +124,32 @@ describe("Board and person-file routes", () => {
     );
     expect(screen.getByText("Found in a sourcing search.")).toBeInTheDocument();
     expect(container.querySelector(".tool-card")).not.toBeInTheDocument();
+  });
+
+  it("shows sourcing-index records with inspectable and revertible version history", async () => {
+    render(<BoardView />);
+
+    expect(await screen.findByRole("heading", { name: "Sourcing index" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Inspect Ada Lovelace" }));
+
+    expect(await screen.findByRole("heading", { name: "Version history" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Revert to version 1" }));
+    await waitFor(() =>
+      expect(api.revertBoardRecord).toHaveBeenCalledWith("contact_ada", {
+        toVersion: 1,
+        expectedVersion: 2,
+        rationaleSummary: "Restore version 1 from Board history.",
+      }),
+    );
+  });
+
+  it("refreshes both Board stores after an agent Board write", async () => {
+    render(<BoardView />);
+    await screen.findByText("Ada Lovelace");
+
+    window.dispatchEvent(new CustomEvent("sourcecado:board-changed"));
+
+    await waitFor(() => expect(api.getBoard).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(api.getBoardRecords).toHaveBeenCalledTimes(2));
   });
 });

--- a/desktop/surfaces/gui/tests/chatPage.test.tsx
+++ b/desktop/surfaces/gui/tests/chatPage.test.tsx
@@ -110,6 +110,38 @@ describe("ChatPage Warm Operator thread", () => {
     });
   });
 
+  it("notifies the Board when a live agent tool changes indexed records", async () => {
+    api.getSession.mockResolvedValue({
+      id: "thread-alpha",
+      title: "Board write",
+      messages: [],
+      events: [],
+    });
+    const changed = vi.fn();
+    window.addEventListener("sourcecado:board-changed", changed);
+    render(<ChatPage sessionId="thread-alpha" />);
+    await waitFor(() => expect(onChatEvent).toBeDefined());
+
+    act(() => {
+      onChatEvent?.({
+        version: 2,
+        session_id: "thread-alpha",
+        run_id: "run-board",
+        message_id: "assistant-board",
+        part_id: "assistant-board-part",
+        type: "tool_finished",
+        event_id: "board-live-1",
+        id: "board-call-1",
+        name: "board_upsert",
+        ok: true,
+        result: { board_changed: true, record: { id: "contact_ada" } },
+      });
+    });
+
+    expect(changed).toHaveBeenCalledTimes(1);
+    window.removeEventListener("sourcecado:board-changed", changed);
+  });
+
   it("renders restored assistant GFM as semantic content", async () => {
     api.getSession.mockResolvedValue({
       id: "thread-alpha",

--- a/desktop/surfaces/gui/tests/evidenceSetResult.test.tsx
+++ b/desktop/surfaces/gui/tests/evidenceSetResult.test.tsx
@@ -190,6 +190,72 @@ describe("Evidence set result", () => {
     expect(within(inspector).queryByRole("link")).not.toBeInTheDocument();
   });
 
+  it("renders Drive extraction classifications instead of pretending every source was read", () => {
+    renderEvidence([
+      tool(
+        "call-drive-form",
+        "drive_read",
+        { file_id: "form-1" },
+        {
+          id: "form-1",
+          name: "Interest form",
+          mimeType: "application/vnd.google-apps.form",
+          status: "metadata_only",
+          linkedSheetId: "sheet-1",
+        },
+      ),
+      tool(
+        "call-drive-image",
+        "drive_read",
+        { file_id: "image-1" },
+        {
+          id: "image-1",
+          name: "Headshot",
+          mimeType: "image/jpeg",
+          status: "unsupported",
+          reason: "unsupported_mime_type",
+        },
+      ),
+    ]);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Checked 2 sources · Completed" }),
+    );
+
+    expect(screen.getByText("Metadata only")).toBeInTheDocument();
+    expect(screen.getByText("Unsupported format")).toBeInTheDocument();
+    expect(screen.getByText("Interest form")).toBeInTheDocument();
+    expect(screen.getByText("Headshot")).toBeInTheDocument();
+  });
+
+  it("renders exact Drive folder listings as scoped evidence", () => {
+    renderEvidence([
+      tool(
+        "call-drive-folder",
+        "drive_list_folder",
+        { folder_id: "folder-1" },
+        {
+          id: "folder-1",
+          name: "Fall 2026",
+          status: "metadata_only",
+          files: [
+            {
+              id: "child-1",
+              name: "Target list",
+              mimeType: "application/vnd.google-apps.document",
+            },
+          ],
+        },
+      ),
+    ]);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Listed Drive folder · Completed" }),
+    );
+
+    expect(screen.getByText("Target list")).toBeInTheDocument();
+    expect(screen.getByText(/Folder item/)).toBeInTheDocument();
+  });
+
   it("bounds large evidence sets behind a keyboard-operable show-more control", () => {
     renderEvidence([
       tool(

--- a/desktop/surfaces/gui/tests/shell.test.tsx
+++ b/desktop/surfaces/gui/tests/shell.test.tsx
@@ -3,10 +3,22 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { App } from "../src/App";
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 const api = vi.hoisted(() => ({
   createScheduleJob: vi.fn(),
   createSession: vi.fn(),
   getBoard: vi.fn(),
+  getBoardRecord: vi.fn(),
+  getBoardRecords: vi.fn(),
   getConnectors: vi.fn(),
   getGmail: vi.fn(),
   getHealth: vi.fn(),
@@ -22,6 +34,7 @@ const api = vi.hoisted(() => ({
   openChat: vi.fn(),
   pinSession: vi.fn(),
   renameSession: vi.fn(),
+  revertBoardRecord: vi.fn(),
   setLastDestination: vi.fn(),
   setPersonSequence: vi.fn(),
 }));
@@ -35,6 +48,8 @@ vi.mock("../src/api", () => ({
   createSession: api.createSession,
   disconnectGmail: vi.fn(),
   getBoard: api.getBoard,
+  getBoardRecord: api.getBoardRecord,
+  getBoardRecords: api.getBoardRecords,
   getConnectors: api.getConnectors,
   getGmail: api.getGmail,
   getHealth: api.getHealth,
@@ -50,6 +65,7 @@ vi.mock("../src/api", () => ({
   openChat: api.openChat,
   pinSession: api.pinSession,
   renameSession: api.renameSession,
+  revertBoardRecord: api.revertBoardRecord,
   resolveInbox: vi.fn(),
   runScheduleJob: vi.fn(),
   setPersona: vi.fn(),
@@ -64,6 +80,8 @@ describe("App shell routing", () => {
     window.location.hash = "#/skills";
     api.getConnectors.mockResolvedValue({ connectors: [] });
     api.getBoard.mockResolvedValue({ open: [], in_conversation: [], done: [] });
+    api.getBoardRecords.mockResolvedValue({ records: [], count: 0 });
+    api.getBoardRecord.mockResolvedValue({ record: {}, links: [], receipts: [] });
     api.getGmail.mockResolvedValue({ connected: false, email: null });
     api.getHealth.mockResolvedValue({ status: "ok", piece: "test", slice: 1, model: "test" });
     api.getInbox.mockResolvedValue({ items: [] });
@@ -87,6 +105,7 @@ describe("App shell routing", () => {
     api.openChat.mockReturnValue({ send: vi.fn(), approve: vi.fn(), close: vi.fn() });
     api.pinSession.mockResolvedValue({ id: "alpha", title: "Alpha", pinned: true });
     api.renameSession.mockResolvedValue({ id: "alpha", title: "Renamed Alpha" });
+    api.revertBoardRecord.mockResolvedValue({ record: {} });
     api.setLastDestination.mockResolvedValue({ destination: "#/skills" });
     api.setPersonSequence.mockResolvedValue({
       person: { person_id: "person-1", sequence_state: "open" },
@@ -259,6 +278,47 @@ describe("App shell routing", () => {
 
     expect(await screen.findByRole("heading", { level: 1, name: "Settings" })).toBeInTheDocument();
     expect(window.location.hash).toBe("#/settings");
+  });
+
+  it("does not persist a cached destination before fresh session state resolves", async () => {
+    window.location.hash = "";
+    window.localStorage.setItem("sourcecado.shell.sessions.v1", JSON.stringify({
+      sessions: [],
+      open_id: null,
+      last_destination: "#/scheduled",
+    }));
+    const listing = deferred<{
+      sessions: never[];
+      open_id: null;
+      last_destination: string;
+    }>();
+    api.getSessions.mockReturnValue(listing.promise);
+
+    render(<App />);
+
+    await waitFor(() => expect(window.location.hash).toBe("#/scheduled"));
+    expect(api.setLastDestination).not.toHaveBeenCalled();
+
+    listing.resolve({ sessions: [], open_id: null, last_destination: "#/skills" });
+    await waitFor(() => expect(window.location.hash).toBe("#/skills"));
+  });
+
+  it("keeps a stale destination read-only after refresh failure but persists later navigation", async () => {
+    window.location.hash = "";
+    window.localStorage.setItem("sourcecado.shell.sessions.v1", JSON.stringify({
+      sessions: [],
+      open_id: null,
+      last_destination: "#/scheduled",
+    }));
+    api.getSessions.mockRejectedValue(new Error("sidecar offline"));
+
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { level: 1, name: "Scheduled" })).toBeInTheDocument();
+    expect(api.setLastDestination).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("link", { name: "Skills" }));
+    await waitFor(() => expect(api.setLastDestination).toHaveBeenCalledWith("#/skills"));
   });
 
   it("escapes the boot skeleton when sessions exist but no restore target is known", async () => {

--- a/desktop/tests/test_board_index_api.py
+++ b/desktop/tests/test_board_index_api.py
@@ -1,0 +1,78 @@
+from fastapi.testclient import TestClient
+
+from coworker.server import TOKEN_HEADER, create_app
+
+TOKEN = "test-token-board-index-api"
+
+
+def test_board_index_api_lists_inspects_and_reverts_versioned_records(tmp_path):
+    app = create_app(token=TOKEN, state=tmp_path)
+    created = app.state.sourcing_index.upsert(
+        record_type="contact",
+        fields={"name": "Ada", "title": "Founder"},
+        idempotency_key="contact:api-ada",
+        actor="assistant",
+        session_id="session-api",
+        run_id="run-api",
+        rationale_summary="Create Ada.",
+    )
+    updated = app.state.sourcing_index.patch(
+        created["id"],
+        fields={"title": "Incorrect"},
+        expected_version=1,
+        actor="assistant",
+        rationale_summary="Apply an incorrect value for the revert fixture.",
+    )
+    client = TestClient(app)
+
+    listing = client.get(
+        "/v1/board/records?record_type=contact&name=Ada",
+        headers={TOKEN_HEADER: TOKEN},
+    )
+    assert listing.status_code == 200
+    assert [record["id"] for record in listing.json()["records"]] == [created["id"]]
+
+    detail = client.get(
+        f"/v1/board/records/{created['id']}", headers={TOKEN_HEADER: TOKEN}
+    )
+    assert detail.status_code == 200
+    assert detail.json()["record"]["version"] == 2
+    assert [receipt["operation"] for receipt in detail.json()["receipts"]] == [
+        "create",
+        "patch",
+    ]
+
+    reverted = client.post(
+        f"/v1/board/records/{created['id']}/revert",
+        headers={TOKEN_HEADER: TOKEN},
+        json={
+            "to_version": 1,
+            "expected_version": updated["version"],
+            "rationale_summary": "Restore the verified value.",
+        },
+    )
+    assert reverted.status_code == 200
+    assert reverted.json()["record"]["fields"]["title"] == "Founder"
+    assert reverted.json()["record"]["version"] == 3
+
+
+def test_board_index_api_does_not_expose_restricted_sources_without_a_grant(tmp_path):
+    app = create_app(token=TOKEN, state=tmp_path)
+    restricted = app.state.sourcing_index.upsert(
+        record_type="source_ref",
+        fields={"title": "Resume", "sensitivity": "restricted"},
+        idempotency_key="source:api-resume",
+        actor="director",
+        rationale_summary="Register the restricted source.",
+    )
+    client = TestClient(app)
+
+    listing = client.get(
+        "/v1/board/records?record_type=source_ref", headers={TOKEN_HEADER: TOKEN}
+    )
+    detail = client.get(
+        f"/v1/board/records/{restricted['id']}", headers={TOKEN_HEADER: TOKEN}
+    )
+
+    assert listing.json()["records"] == []
+    assert detail.status_code == 404

--- a/desktop/tests/test_board_tools.py
+++ b/desktop/tests/test_board_tools.py
@@ -1,0 +1,183 @@
+from fastapi.testclient import TestClient
+
+from coworker.permissions import decide
+from coworker.provider import FakeProvider, ToolCall
+from coworker.server import TOKEN_HEADER, create_app
+from coworker.sourcing_index import SourcingIndex
+from coworker.tools import OPENAI_TOOLS, execute
+
+TOKEN = "test-token-board-tools"
+
+
+def test_board_tool_contract_exposes_reads_reversible_writes_and_approved_delete():
+    names = {schema["function"]["name"] for schema in OPENAI_TOOLS}
+
+    assert {"board_get", "board_query", "board_upsert", "board_mutate", "board_delete"} <= names
+    for name in ("board_get", "board_query", "board_upsert", "board_mutate"):
+        decision = decide(name)
+        assert decision.allowed is True
+        assert decision.needs_user is False
+    delete = decide("board_delete")
+    assert delete.allowed is False
+    assert delete.needs_user is True
+
+    for schema in OPENAI_TOOLS:
+        if not schema["function"]["name"].startswith("board_"):
+            continue
+        properties = schema["function"]["parameters"].get("properties", {})
+        assert not {"actor", "session_id", "run_id", "allowed_source_ids"} & set(properties)
+
+
+def test_board_upsert_injects_execution_identity_and_query_reads_it_back(tmp_path):
+    index = SourcingIndex(tmp_path)
+
+    ok, created = execute(
+        "board_upsert",
+        {
+            "record_type": "company",
+            "fields": {"name": "Analytic Engines"},
+            "idempotency_key": "company:analytic-engines",
+            "rationale_summary": "Create the target company from sourced evidence.",
+            "source_refs": ["source:web-1"],
+        },
+        sourcing_index=index,
+        actor="assistant",
+        session_id="session-tools",
+        run_id="run-tools",
+    )
+
+    assert ok is True
+    assert created["record"]["type"] == "company"
+    receipt = index.receipts(created["record"]["id"])[0]
+    assert receipt["actor"] == "assistant"
+    assert receipt["session_id"] == "session-tools"
+    assert receipt["run_id"] == "run-tools"
+
+    ok, queried = execute(
+        "board_query",
+        {"record_type": "company", "filters": {"name": "Analytic Engines"}},
+        sourcing_index=index,
+    )
+    assert ok is True
+    assert [record["id"] for record in queried["records"]] == [created["record"]["id"]]
+
+
+def test_board_mutate_routes_patch_and_delete_preserves_audit(tmp_path):
+    index = SourcingIndex(tmp_path)
+    created = index.upsert(
+        record_type="action",
+        fields={"title": "Review target", "status": "open"},
+        idempotency_key="action:tool-mutate",
+        actor="assistant",
+        rationale_summary="Create the review action.",
+    )
+
+    ok, patched = execute(
+        "board_mutate",
+        {
+            "action": "patch",
+            "record_id": created["id"],
+            "expected_version": 1,
+            "fields": {"owner": "fisher"},
+            "rationale_summary": "Assign the review action.",
+        },
+        sourcing_index=index,
+        actor="assistant",
+        session_id="session-mutate",
+        run_id="run-mutate",
+    )
+    assert ok is True
+    assert patched["record"]["fields"]["owner"] == "fisher"
+
+    ok, deleted = execute(
+        "board_delete",
+        {
+            "record_id": created["id"],
+            "expected_version": 2,
+            "rationale_summary": "Delete after the approval layer allowed it.",
+        },
+        sourcing_index=index,
+        actor="director",
+        session_id="session-delete",
+        run_id="run-delete",
+    )
+    assert ok is True
+    assert deleted["deleted"] is True
+    assert index.receipts(created["id"])[-1]["operation"] == "delete"
+
+
+def test_chat_board_write_injects_durable_session_and_run_identity(tmp_path):
+    provider = FakeProvider(
+        steps=[
+            {
+                "tool_calls": [
+                    ToolCall(
+                        id="board-create-1",
+                        name="board_upsert",
+                        arguments={
+                            "record_type": "contact",
+                            "fields": {"name": "Ada"},
+                            "idempotency_key": "contact:chat-ada",
+                            "rationale_summary": "Create the sourced contact.",
+                            "source_refs": ["source:web-ada"],
+                        },
+                    )
+                ]
+            },
+            {"deltas": ("Ada is now on the Board.",)},
+        ]
+    )
+    app = create_app(token=TOKEN, provider=provider, state=tmp_path)
+    session_id = app.state.store.open_session_id()
+
+    with TestClient(app).websocket_connect("/ws/chat", subprotocols=["club", TOKEN]) as ws:
+        ws.send_json({"type": "chat", "text": "Add Ada", "session_id": session_id})
+        events = []
+        while True:
+            event = ws.receive_json()
+            events.append(event)
+            if event["type"] in {"turn_end", "error"}:
+                break
+
+    finished = next(event for event in events if event["type"] == "tool_finished")
+    assert finished["ok"] is True
+    record_id = finished["result"]["record"]["id"]
+    receipt = app.state.sourcing_index.receipts(record_id)[0]
+    assert receipt["actor"] == "assistant"
+    assert receipt["session_id"] == session_id
+    assert receipt["run_id"] == finished["run_id"]
+
+
+def test_approved_board_delete_receipt_uses_the_human_actor(tmp_path):
+    app = create_app(token=TOKEN, state=tmp_path)
+    created = app.state.sourcing_index.upsert(
+        record_type="action",
+        fields={"title": "Duplicate"},
+        idempotency_key="action:approved-delete",
+        actor="assistant",
+        rationale_summary="Create the duplicate fixture.",
+    )
+    item = app.state.inbox.park(
+        "board_delete",
+        {
+            "record_id": created["id"],
+            "expected_version": 1,
+            "rationale_summary": "Delete the duplicate after review.",
+        },
+        item_id="board-delete-approved",
+        session_id="session-delete-approved",
+        run_id="run-delete-approved",
+    )
+
+    response = TestClient(app).post(
+        f"/v1/inbox/{item['id']}",
+        headers={TOKEN_HEADER: TOKEN},
+        json={"decision": "allow", "actor": "Fisher", "scope": "once"},
+    )
+
+    assert response.status_code == 200
+    receipt = app.state.sourcing_index.receipts(created["id"])[-1]
+    assert receipt["operation"] == "delete"
+    assert receipt["actor"] == "Fisher"
+    assert receipt["session_id"] == "session-delete-approved"
+    assert receipt["run_id"] == "run-delete-approved"

--- a/desktop/tests/test_bound_turn.py
+++ b/desktop/tests/test_bound_turn.py
@@ -530,5 +530,8 @@ def test_kernel_says_send_requires_allow():
     from coworker.server import KERNEL
 
     assert "gmail_send" in KERNEL
+    assert "board_query" in KERNEL
+    assert "board_upsert" in KERNEL
+    assert "board_delete" in KERNEL
     assert "Allow" in KERNEL
     assert "never sends" not in KERNEL

--- a/desktop/tests/test_connectors.py
+++ b/desktop/tests/test_connectors.py
@@ -94,6 +94,7 @@ def test_connectors_normalize_safe_health_scope_and_recovery_metadata(tmp_path):
     assert drive["status"] == "connected"
     assert drive["missing_scopes"] == []
     assert drive["email"] == "fisher@example.com"
+    assert drive["supported_actions"] == ["Search files", "List folders", "Read files"]
 
     calendar = by_id["calendar"]
     assert calendar["status"] == "missing_scopes"

--- a/desktop/tests/test_drive.py
+++ b/desktop/tests/test_drive.py
@@ -1,10 +1,12 @@
 import json
+from io import BytesIO
 from urllib.parse import unquote
+from zipfile import ZIP_DEFLATED, ZipFile
 
 import pytest
 from fastapi.testclient import TestClient
 
-from coworker.apollo import FakeHttp
+from coworker.apollo import FakeHttp, HttpError, _decode_response
 from coworker.connectors.google_oauth import (
     CALENDAR_SCOPE,
     COMPOSE_SCOPE,
@@ -18,14 +20,122 @@ from coworker.permissions import decide
 from coworker.provider import FakeProvider, ToolCall
 from coworker.secrets import SecretStore
 from coworker.server import TOKEN_HEADER, create_app
+from coworker.tools import OPENAI_TOOLS, execute
 
 TOKEN = "test-token-drive"
 FILES_URL = "https://www.googleapis.com/drive/v3/files"
+FORMS_URL = "https://forms.googleapis.com/v1/forms"
+FOLDER_MIME = "application/vnd.google-apps.folder"
+DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+
+
+class DriveMediaHttp(FakeHttp):
+    def __init__(self, *, file_id: str, metadata: dict, media: bytes) -> None:
+        super().__init__({f"{FILES_URL}/{file_id}": metadata})
+        self.file_id = file_id
+        self.media = media
+
+    def get(self, url, *, headers=None, params=None):
+        if url == f"{FILES_URL}/{self.file_id}" and (params or {}).get("alt") == "media":
+            self.calls.append(
+                {
+                    "method": "GET",
+                    "url": url,
+                    "headers": dict(headers or {}),
+                    "json": {},
+                    "data": {},
+                    "params": dict(params or {}),
+                }
+            )
+            return self.media
+        return super().get(url, headers=headers, params=params)
+
+
+def office_archive(path: str, xml: str) -> bytes:
+    output = BytesIO()
+    with ZipFile(output, "w", ZIP_DEFLATED) as archive:
+        archive.writestr(path, xml)
+    return output.getvalue()
+
+
+def text_pdf(text: str) -> bytes:
+    stream = f"BT /F1 12 Tf 72 72 Td ({text}) Tj ET".encode()
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        (
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] "
+            b"/Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>"
+        ),
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+        b"<< /Length " + str(len(stream)).encode() + b" >>\nstream\n" + stream + b"\nendstream",
+    ]
+    payload = bytearray(b"%PDF-1.4\n")
+    offsets = [0]
+    for index, body in enumerate(objects, start=1):
+        offsets.append(len(payload))
+        payload.extend(f"{index} 0 obj\n".encode())
+        payload.extend(body)
+        payload.extend(b"\nendobj\n")
+    xref = len(payload)
+    payload.extend(f"xref\n0 {len(objects) + 1}\n".encode())
+    payload.extend(b"0000000000 65535 f \n")
+    for offset in offsets[1:]:
+        payload.extend(f"{offset:010d} 00000 n \n".encode())
+    payload.extend(
+        f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n".encode()
+    )
+    return bytes(payload)
+
+
+def test_live_http_decode_preserves_binary_response_bytes():
+    raw = b"%PDF binary API_KEY=must-not-be-decoded"
+    response = type(
+        "BinaryResponse",
+        (),
+        {
+            "headers": {"content-type": "application/pdf"},
+            "text": raw.decode(),
+            "content": raw,
+        },
+    )()
+
+    assert _decode_response(response) == raw
 
 
 def test_drive_tools_are_auto():
-    assert decide("drive_search").needs_user is False
-    assert decide("drive_read").needs_user is False
+    assert decide("drive_search").allowed is True
+    assert decide("drive_list_folder").allowed is True
+    assert decide("drive_read").allowed is True
+    names = {schema["function"]["name"] for schema in OPENAI_TOOLS}
+    assert {"drive_search", "drive_list_folder", "drive_read"} <= names
+
+
+def test_drive_list_folder_tool_passes_scope_and_page_token(tmp_path):
+    secrets = SecretStore(tmp_path / "secrets.json")
+    save_google(secrets, {"refresh_token": "rt", "access_token": "at", "scopes": [DRIVE_SCOPE]})
+    http = FakeHttp(
+        {
+            FILES_URL: {
+                "files": [{"id": "child-1", "name": "Child", "mimeType": "text/plain"}],
+                "nextPageToken": "page-3",
+            }
+        }
+    )
+    drive = DriveApi(secrets, http=http, client_id="cid", client_secret="sec")
+
+    ok, result = execute(
+        "drive_list_folder",
+        {"folder_id": "folder-1", "max_results": 20, "page_token": "page-2"},
+        drive=drive,
+    )
+
+    assert ok is True
+    assert result["files"][0]["id"] == "child-1"
+    assert result["nextPageToken"] == "page-3"
+    assert http.calls[-1]["params"]["pageToken"] == "page-2"
+    assert "'folder-1' in parents" in http.calls[-1]["params"]["q"]
 
 
 def test_drive_search_fake_http(tmp_path):
@@ -40,6 +150,8 @@ def test_drive_search_fake_http(tmp_path):
                         "name": "Q3 plan",
                         "mimeType": "text/plain",
                         "modifiedTime": "2026-08-01T00:00:00Z",
+                        "parents": ["folder-1"],
+                        "webViewLink": "https://drive.google.com/open?id=f1",
                     }
                 ]
             }
@@ -47,6 +159,10 @@ def test_drive_search_fake_http(tmp_path):
     )
     out = DriveApi(secrets, http=http, client_id="cid", client_secret="sec").search("Q3 plan")
     assert out["files"][0]["id"] == "f1"
+    assert out["files"][0]["status"] == "metadata_only"
+    assert out["files"][0]["parents"] == ["folder-1"]
+    assert out["files"][0]["webViewLink"].endswith("id=f1")
+    assert out["sources"][0]["id"] == "f1"
     assert "/upload" not in str(http.calls)
 
 
@@ -81,13 +197,289 @@ def test_drive_read_exports_google_doc(tmp_path):
     save_google(secrets, {"refresh_token": "rt", "access_token": "at", "scopes": [DRIVE_SCOPE]})
     http = FakeHttp(
         {
-            f"{FILES_URL}/f1": {"id": "f1", "name": "doc", "mimeType": "application/vnd.google-apps.document"},
+            f"{FILES_URL}/f1": {
+                "id": "f1",
+                "name": "doc",
+                "mimeType": "application/vnd.google-apps.document",
+                "modifiedTime": "2026-08-26T10:00:00Z",
+                "parents": ["folder-1"],
+                "webViewLink": "https://drive.google.com/open?id=f1",
+            },
             f"{FILES_URL}/f1/export": "plain text body",
         }
     )
     out = DriveApi(secrets, http=http, client_id="cid", client_secret="sec").read("f1")
     assert out["content"] == "plain text body"
     assert out["truncated"] is False
+    assert out["status"] == "read"
+    assert out["modifiedTime"] == "2026-08-26T10:00:00Z"
+    assert out["parents"] == ["folder-1"]
+    assert out["sources"] == [
+        {
+            "id": "f1",
+            "title": "doc",
+            "url": "https://drive.google.com/open?id=f1",
+            "provider": "Google Drive",
+            "truncated": False,
+        }
+    ]
+
+
+def test_drive_read_classifies_truncated_google_export(tmp_path):
+    secrets = SecretStore(tmp_path / "secrets.json")
+    save_google(secrets, {"refresh_token": "rt", "access_token": "at", "scopes": [DRIVE_SCOPE]})
+    http = FakeHttp(
+        {
+            f"{FILES_URL}/f1": {
+                "id": "f1",
+                "name": "long doc",
+                "mimeType": "application/vnd.google-apps.document",
+            },
+            f"{FILES_URL}/f1/export": "abcdefghij",
+        }
+    )
+
+    out = DriveApi(secrets, http=http, client_id="cid", client_secret="sec").read(
+        "f1", max_chars=5
+    )
+
+    assert out["content"] == "abcde"
+    assert out["truncated"] is True
+    assert out["status"] == "truncated"
+
+
+def test_drive_read_routes_folder_ids_to_scoped_listing_without_media_download(tmp_path):
+    secrets = SecretStore(tmp_path / "secrets.json")
+    save_google(secrets, {"refresh_token": "rt", "access_token": "at", "scopes": [DRIVE_SCOPE]})
+    http = FakeHttp(
+        {
+            f"{FILES_URL}/folder-1": {
+                "id": "folder-1",
+                "name": "Fall 2026",
+                "mimeType": FOLDER_MIME,
+                "parents": ["sourcing"],
+            },
+            FILES_URL: {
+                "files": [
+                    {
+                        "id": "doc-1",
+                        "name": "Target list",
+                        "mimeType": "application/vnd.google-apps.document",
+                        "parents": ["folder-1"],
+                    }
+                ]
+            },
+        }
+    )
+
+    out = DriveApi(secrets, http=http, client_id="cid", client_secret="sec").read("folder-1")
+
+    assert out["status"] == "metadata_only"
+    assert out["files"][0]["id"] == "doc-1"
+    assert {source["id"] for source in out["sources"]} == {"folder-1", "doc-1"}
+    assert http.calls[-1]["url"] == FILES_URL
+    assert "'folder-1' in parents" in http.calls[-1]["params"]["q"]
+    assert not any(call["params"].get("alt") == "media" for call in http.calls)
+
+
+def test_drive_read_classifies_unsupported_binary_without_downloading_or_leaking_it(tmp_path):
+    secrets = SecretStore(tmp_path / "secrets.json")
+    save_google(secrets, {"refresh_token": "rt", "access_token": "at", "scopes": [DRIVE_SCOPE]})
+    http = FakeHttp(
+        {
+            f"{FILES_URL}/image-1": {
+                "id": "image-1",
+                "name": "headshot.jpg",
+                "mimeType": "image/jpeg",
+            }
+        }
+    )
+
+    out = DriveApi(secrets, http=http, client_id="cid", client_secret="sec").read("image-1")
+
+    assert out["status"] == "unsupported"
+    assert out["reason"] == "unsupported_mime_type"
+    assert "content" not in out
+    assert out["sources"][0]["id"] == "image-1"
+    assert not any(call["params"].get("alt") == "media" for call in http.calls)
+
+
+def test_drive_read_returns_form_metadata_and_linked_response_sheet(tmp_path):
+    secrets = SecretStore(tmp_path / "secrets.json")
+    save_google(secrets, {"refresh_token": "rt", "access_token": "at", "scopes": [DRIVE_SCOPE]})
+    http = FakeHttp(
+        {
+            f"{FILES_URL}/form-1": {
+                "id": "form-1",
+                "name": "Fall interest form",
+                "mimeType": "application/vnd.google-apps.form",
+            },
+            f"{FORMS_URL}/form-1": {
+                "formId": "form-1",
+                "linkedSheetId": "sheet-1",
+                "responderUri": "https://docs.google.com/forms/d/form-1/viewform",
+                "info": {"title": "Fall interest form"},
+            },
+        }
+    )
+
+    out = DriveApi(secrets, http=http, client_id="cid", client_secret="sec").read("form-1")
+
+    assert out["status"] == "metadata_only"
+    assert out["linkedSheetId"] == "sheet-1"
+    assert out["responderUri"].endswith("/viewform")
+    assert "content" not in out
+    assert out["sources"][0]["id"] == "form-1"
+    assert not any(call["params"].get("alt") == "media" for call in http.calls)
+
+
+def test_drive_read_keeps_form_metadata_truthful_when_forms_detail_is_unavailable(tmp_path):
+    secrets = SecretStore(tmp_path / "secrets.json")
+    save_google(secrets, {"refresh_token": "rt", "access_token": "at", "scopes": [DRIVE_SCOPE]})
+    http = FakeHttp(
+        {
+            f"{FILES_URL}/form-1": {
+                "id": "form-1",
+                "name": "Fall interest form",
+                "mimeType": "application/vnd.google-apps.form",
+            },
+            f"{FORMS_URL}/form-1": HttpError(
+                403, f"{FORMS_URL}/form-1", "PRIVATE_FORMS_ERROR_BODY"
+            ),
+        }
+    )
+
+    out = DriveApi(secrets, http=http, client_id="cid", client_secret="sec").read("form-1")
+
+    assert out["status"] == "metadata_only"
+    assert out["reason"] == "form_metadata_unavailable"
+    assert out["linkedSheetId"] is None
+    assert "PRIVATE_FORMS_ERROR_BODY" not in json.dumps(out)
+
+
+@pytest.mark.parametrize(
+    ("file_id", "mime_type", "media", "expected"),
+    [
+        (
+            "docx-1",
+            DOCX_MIME,
+            office_archive(
+                "word/document.xml",
+                '<w:document xmlns:w="urn:w"><w:body><w:p><w:r><w:t>Board notes</w:t></w:r></w:p></w:body></w:document>',
+            ),
+            "Board notes",
+        ),
+        (
+            "pptx-1",
+            PPTX_MIME,
+            office_archive(
+                "ppt/slides/slide1.xml",
+                '<p:sld xmlns:p="urn:p" xmlns:a="urn:a"><p:cSld><a:t>Partner pitch</a:t></p:cSld></p:sld>',
+            ),
+            "Partner pitch",
+        ),
+        ("pdf-1", "application/pdf", text_pdf("Source evidence"), "Source evidence"),
+    ],
+)
+def test_drive_read_extracts_supported_binary_documents(
+    tmp_path, file_id, mime_type, media, expected
+):
+    secrets = SecretStore(tmp_path / "secrets.json")
+    save_google(secrets, {"refresh_token": "rt", "access_token": "at", "scopes": [DRIVE_SCOPE]})
+    http = DriveMediaHttp(
+        file_id=file_id,
+        metadata={"id": file_id, "name": file_id, "mimeType": mime_type},
+        media=media,
+    )
+
+    out = DriveApi(secrets, http=http, client_id="cid", client_secret="sec").read(file_id)
+
+    assert out["status"] == "read"
+    assert expected in out["content"]
+
+
+def test_drive_read_classifies_empty_pdf_as_metadata_only(tmp_path):
+    secrets = SecretStore(tmp_path / "secrets.json")
+    save_google(secrets, {"refresh_token": "rt", "access_token": "at", "scopes": [DRIVE_SCOPE]})
+    http = DriveMediaHttp(
+        file_id="empty-pdf",
+        metadata={"id": "empty-pdf", "name": "scan.pdf", "mimeType": "application/pdf"},
+        media=text_pdf(""),
+    )
+
+    out = DriveApi(secrets, http=http, client_id="cid", client_secret="sec").read("empty-pdf")
+
+    assert out["status"] == "metadata_only"
+    assert out["reason"] == "no_extractable_text"
+    assert "content" not in out
+
+
+@pytest.mark.parametrize("mime_type", [DOCX_MIME, PPTX_MIME])
+def test_drive_read_classifies_malformed_office_archive_without_leaking_bytes(
+    tmp_path, mime_type
+):
+    raw = b"not-a-zip API_KEY=must-not-leak"
+    secrets = SecretStore(tmp_path / "secrets.json")
+    save_google(secrets, {"refresh_token": "rt", "access_token": "at", "scopes": [DRIVE_SCOPE]})
+    http = DriveMediaHttp(
+        file_id="broken-office",
+        metadata={"id": "broken-office", "name": "broken", "mimeType": mime_type},
+        media=raw,
+    )
+
+    out = DriveApi(secrets, http=http, client_id="cid", client_secret="sec").read(
+        "broken-office"
+    )
+
+    assert out["status"] == "failed"
+    assert out["reason"] == "malformed_office_archive"
+    assert raw.decode() not in json.dumps(out)
+
+
+def test_drive_tool_marks_extraction_failure_as_a_failed_tool_result(tmp_path):
+    secrets = SecretStore(tmp_path / "secrets.json")
+    save_google(secrets, {"refresh_token": "rt", "access_token": "at", "scopes": [DRIVE_SCOPE]})
+    drive = DriveApi(
+        secrets,
+        http=DriveMediaHttp(
+            file_id="broken-docx",
+            metadata={"id": "broken-docx", "name": "broken.docx", "mimeType": DOCX_MIME},
+            media=b"not a zip",
+        ),
+        client_id="cid",
+        client_secret="sec",
+    )
+
+    ok, result = execute("drive_read", {"file_id": "broken-docx"}, drive=drive)
+
+    assert ok is False
+    assert result["status"] == "failed"
+    assert result["reason"] == "malformed_office_archive"
+
+
+def test_drive_tool_returns_sanitized_failed_status_for_genuine_auth_failure(tmp_path):
+    raw_provider_body = "PRIVATE_PROVIDER_ERROR_BODY"
+    secrets = SecretStore(tmp_path / "secrets.json")
+    save_google(secrets, {"refresh_token": "rt", "access_token": "at", "scopes": [DRIVE_SCOPE]})
+    drive = DriveApi(
+        secrets,
+        http=FakeHttp(
+            {
+                f"{FILES_URL}/forbidden": HttpError(
+                    403, f"{FILES_URL}/forbidden", raw_provider_body
+                )
+            }
+        ),
+        client_id="cid",
+        client_secret="sec",
+    )
+
+    ok, result = execute("drive_read", {"file_id": "forbidden"}, drive=drive)
+
+    assert ok is False
+    assert result["status"] == "failed"
+    assert result["error"] == "Drive API returned HTTP 403."
+    assert raw_provider_body not in json.dumps(result)
 
 
 @pytest.mark.parametrize(

--- a/desktop/tests/test_ledger.py
+++ b/desktop/tests/test_ledger.py
@@ -147,15 +147,47 @@ def test_drive_search_and_read_file_as_file():
             "name": "Dinner notes",
             "mimeType": "application/pdf",
             "content": "secret file body",
-            "truncated": False,
+            "status": "truncated",
+            "truncated": True,
         },
         ok=True,
     )
     assert read is not None
     assert read["source"] == "drive"
     assert read["kind"] == "file"
-    assert read["payload"] == {"id": "d1", "name": "Dinner notes"}
+    assert read["payload"] == {
+        "id": "d1",
+        "name": "Dinner notes",
+        "mimeType": "application/pdf",
+        "status": "truncated",
+        "truncated": True,
+        "reason": None,
+    }
     assert "content" not in read["payload"]
+
+
+def test_drive_folder_listing_files_scoped_children_without_bodies():
+    event = event_from_tool(
+        "drive_list_folder",
+        {"folder_id": "folder-1"},
+        {
+            "id": "folder-1",
+            "name": "Fall 2026",
+            "status": "metadata_only",
+            "files": [
+                {"id": "child-1", "name": "Targets", "content": "must not be filed"}
+            ],
+        },
+        ok=True,
+    )
+
+    assert event is not None
+    assert event["source"] == "drive"
+    assert event["payload"] == {
+        "folder_id": "folder-1",
+        "status": "metadata_only",
+        "files": [{"id": "child-1", "name": "Targets"}],
+    }
 
 
 def test_calendar_list_create_update_file_as_event():

--- a/desktop/tests/test_sourcing_index.py
+++ b/desktop/tests/test_sourcing_index.py
@@ -1,0 +1,404 @@
+import pytest
+
+from coworker.sourcing_index import RECORD_TYPES, SourcingIndex
+
+
+def test_upsert_supports_every_board_record_type_with_idempotent_audit_receipts(tmp_path):
+    index = SourcingIndex(tmp_path)
+
+    for record_type in sorted(RECORD_TYPES):
+        created = index.upsert(
+            record_type=record_type,
+            fields={"name": f"Example {record_type}"},
+            idempotency_key=f"fixture:{record_type}",
+            actor="assistant",
+            session_id="session-1",
+            run_id="run-1",
+            rationale_summary=f"Create the {record_type} fixture.",
+            source_refs=["source:fixture"],
+        )
+        replayed = index.upsert(
+            record_type=record_type,
+            fields={"name": f"Example {record_type}"},
+            idempotency_key=f"fixture:{record_type}",
+            actor="assistant",
+            session_id="session-1",
+            run_id="run-1",
+            rationale_summary=f"Create the {record_type} fixture.",
+            source_refs=["source:fixture"],
+        )
+
+        assert created["type"] == record_type
+        assert created["version"] == 1
+        assert replayed == created
+        receipts = index.receipts(created["id"])
+        assert len(receipts) == 1
+        assert receipts[0]["operation"] == "create"
+        assert receipts[0]["actor"] == "assistant"
+        assert receipts[0]["session_id"] == "session-1"
+        assert receipts[0]["run_id"] == "run-1"
+        assert receipts[0]["rationale_summary"] == f"Create the {record_type} fixture."
+        assert receipts[0]["source_refs"] == ["source:fixture"]
+
+
+def test_upsert_rejects_unknown_record_type(tmp_path):
+    index = SourcingIndex(tmp_path)
+
+    with pytest.raises(ValueError, match="unknown record type"):
+        index.upsert(
+            record_type="lead",
+            fields={"name": "Not a domain record"},
+            idempotency_key="fixture:lead",
+            actor="assistant",
+            rationale_summary="Do not create an ad-hoc type.",
+        )
+
+
+def test_idempotency_key_deduplicates_identity_but_rejects_conflicting_facts(tmp_path):
+    index = SourcingIndex(tmp_path)
+    created = index.upsert(
+        record_type="contact",
+        fields={"name": "Ada", "primary_email": "ada@example.com"},
+        idempotency_key="contact:ada@example.com",
+        actor="assistant",
+        rationale_summary="Create the email identity.",
+    )
+    replayed = index.upsert(
+        record_type="contact",
+        fields={"name": "Ada", "primary_email": "ada@example.com"},
+        idempotency_key="contact:ada@example.com",
+        actor="assistant",
+        rationale_summary="Create the email identity.",
+    )
+
+    assert replayed["id"] == created["id"]
+    assert len(index.query(record_type="contact")) == 1
+    with pytest.raises(ValueError, match="idempotency conflict"):
+        index.upsert(
+            record_type="contact",
+            fields={"name": "Grace", "primary_email": "ada@example.com"},
+            idempotency_key="contact:ada@example.com",
+            actor="assistant",
+            rationale_summary="Do not overwrite the conflicting identity.",
+        )
+
+
+def test_patch_uses_optimistic_versions_and_survives_restart(tmp_path):
+    index = SourcingIndex(tmp_path)
+    created = index.upsert(
+        record_type="contact",
+        fields={"name": "Ada", "owner": "fisher"},
+        idempotency_key="contact:ada",
+        actor="assistant",
+        rationale_summary="Create Ada.",
+    )
+
+    updated = index.patch(
+        created["id"],
+        fields={"title": "Founder"},
+        expected_version=1,
+        actor="director",
+        session_id="session-2",
+        run_id="run-2",
+        rationale_summary="Add the verified role.",
+        source_refs=["source:apollo"],
+    )
+
+    assert updated["version"] == 2
+    assert updated["fields"] == {"name": "Ada", "owner": "fisher", "title": "Founder"}
+    with pytest.raises(ValueError, match="stale record version"):
+        index.patch(
+            created["id"],
+            fields={"title": "Stale overwrite"},
+            expected_version=1,
+            actor="assistant",
+            rationale_summary="This should not overwrite a human edit.",
+        )
+    receipts = index.receipts(created["id"])
+    assert [receipt["operation"] for receipt in receipts] == ["create", "patch"]
+    assert receipts[-1]["before"]["version"] == 1
+    assert receipts[-1]["after"]["version"] == 2
+    assert SourcingIndex(tmp_path).get(created["id"]) == updated
+
+
+def test_query_filters_board_records_by_type_stage_owner_and_due_date(tmp_path):
+    index = SourcingIndex(tmp_path)
+    for key, fields in (
+        (
+            "opportunity:ada",
+            {"name": "Ada dinner", "stage": "research", "owner": "fisher", "due_date": "2026-09-01"},
+        ),
+        (
+            "opportunity:grace",
+            {"name": "Grace panel", "stage": "ready", "owner": "lavanya", "due_date": "2026-09-02"},
+        ),
+    ):
+        index.upsert(
+            record_type="opportunity",
+            fields=fields,
+            idempotency_key=key,
+            actor="assistant",
+            rationale_summary="Create a query fixture.",
+        )
+
+    rows = index.query(
+        record_type="opportunity",
+        filters={"stage": "research", "owner": "fisher", "due_date": "2026-09-01"},
+    )
+
+    assert [row["fields"]["name"] for row in rows] == ["Ada dinner"]
+
+
+def test_restricted_source_refs_require_server_supplied_grants_for_reads_and_expansion(tmp_path):
+    index = SourcingIndex(tmp_path)
+    restricted = index.upsert(
+        record_type="source_ref",
+        fields={
+            "title": "Resume",
+            "provider": "drive",
+            "external_id": "drive-resume-1",
+            "sensitivity": "restricted",
+        },
+        idempotency_key="source:resume-1",
+        actor="director",
+        rationale_summary="Register a restricted resume source.",
+    )
+    contact = index.upsert(
+        record_type="contact",
+        fields={"name": "Ada"},
+        idempotency_key="contact:ada-restricted",
+        actor="assistant",
+        rationale_summary="Create the contact without copying resume content.",
+        source_refs=[restricted["id"]],
+    )
+
+    assert index.get(restricted["id"]) is None
+    assert index.get(restricted["id"], allowed_source_ids={restricted["id"]}) == restricted
+    without_grant = index.get(contact["id"], expand_sources=True)
+    assert without_grant is not None
+    assert without_grant["sources"] == []
+    assert without_grant["restricted_source_count"] == 1
+    with_grant = index.get(
+        contact["id"],
+        expand_sources=True,
+        allowed_source_ids={restricted["id"]},
+    )
+    assert with_grant is not None
+    assert [source["id"] for source in with_grant["sources"]] == [restricted["id"]]
+
+
+def test_relationship_link_and_unlink_are_idempotent_audited_and_durable(tmp_path):
+    index = SourcingIndex(tmp_path)
+    contact = index.upsert(
+        record_type="contact",
+        fields={"name": "Ada"},
+        idempotency_key="contact:ada-link",
+        actor="assistant",
+        rationale_summary="Create Ada.",
+    )
+    opportunity = index.upsert(
+        record_type="opportunity",
+        fields={"name": "Fall dinner", "stage": "research"},
+        idempotency_key="opportunity:fall-dinner",
+        actor="assistant",
+        rationale_summary="Create the opportunity.",
+    )
+
+    linked = index.link(
+        contact["id"],
+        opportunity["id"],
+        relationship="candidate_for",
+        actor="assistant",
+        session_id="session-3",
+        run_id="run-3",
+        rationale_summary="Associate the contact with the opportunity.",
+        source_refs=["source:director-note"],
+    )
+    replayed = index.link(
+        contact["id"],
+        opportunity["id"],
+        relationship="candidate_for",
+        actor="assistant",
+        session_id="session-3",
+        run_id="run-3",
+        rationale_summary="Associate the contact with the opportunity.",
+        source_refs=["source:director-note"],
+    )
+
+    assert replayed == linked
+    assert SourcingIndex(tmp_path).links(contact["id"]) == [linked]
+    removed = index.unlink(
+        contact["id"],
+        opportunity["id"],
+        relationship="candidate_for",
+        actor="director",
+        rationale_summary="Remove the mistaken relationship.",
+    )
+    assert removed["removed"] is True
+    assert index.links(contact["id"]) == []
+    operations = [receipt["operation"] for receipt in index.receipts(contact["id"])]
+    assert operations == ["create", "link", "unlink"]
+
+
+def test_opportunity_transition_requires_real_touchpoint_evidence_not_collateral(tmp_path):
+    index = SourcingIndex(tmp_path)
+    opportunity = index.upsert(
+        record_type="opportunity",
+        fields={"name": "Fall dinner", "stage": "ready"},
+        idempotency_key="opportunity:transition",
+        actor="assistant",
+        rationale_summary="Create the ready opportunity.",
+    )
+    artifact = index.upsert(
+        record_type="artifact",
+        fields={"title": "Draft email", "artifact_type": "gmail_draft"},
+        idempotency_key="artifact:draft",
+        actor="assistant",
+        rationale_summary="Record a draft, not a sent message.",
+    )
+
+    with pytest.raises(ValueError, match="outbound sent touchpoint"):
+        index.transition(
+            opportunity["id"],
+            to_stage="contacted",
+            evidence_record_ids=[artifact["id"]],
+            expected_version=1,
+            actor="assistant",
+            rationale_summary="A draft alone must not count as contact.",
+        )
+
+    touchpoint = index.upsert(
+        record_type="touchpoint",
+        fields={"channel": "email", "direction": "outbound", "status": "sent"},
+        idempotency_key="touchpoint:sent-email",
+        actor="director",
+        rationale_summary="Record the actual sent email.",
+        source_refs=["source:gmail-message"],
+    )
+    transitioned = index.transition(
+        opportunity["id"],
+        to_stage="contacted",
+        evidence_record_ids=[touchpoint["id"]],
+        expected_version=1,
+        actor="director",
+        rationale_summary="The sent touchpoint proves contact occurred.",
+        source_refs=["source:gmail-message"],
+    )
+
+    assert transitioned["fields"]["stage"] == "contacted"
+    assert transitioned["version"] == 2
+    assert index.receipts(opportunity["id"])[-1]["operation"] == "transition"
+
+
+def test_action_completion_and_outcome_capture_are_versioned_domain_operations(tmp_path):
+    index = SourcingIndex(tmp_path)
+    action = index.upsert(
+        record_type="action",
+        fields={"title": "Review draft", "status": "open"},
+        idempotency_key="action:review-draft",
+        actor="assistant",
+        rationale_summary="Create the review action.",
+    )
+    opportunity = index.upsert(
+        record_type="opportunity",
+        fields={"name": "Fall dinner", "stage": "contacted"},
+        idempotency_key="opportunity:outcome",
+        actor="assistant",
+        rationale_summary="Create the contacted opportunity.",
+    )
+
+    completed = index.complete_action(
+        action["id"],
+        expected_version=1,
+        actor="director",
+        rationale_summary="The director reviewed the draft.",
+    )
+    captured = index.capture_outcome(
+        opportunity["id"],
+        outcome="declined",
+        expected_version=1,
+        actor="director",
+        rationale_summary="Record the explicit response outcome.",
+        source_refs=["source:gmail-reply"],
+    )
+
+    assert completed["fields"]["status"] == "completed"
+    assert completed["fields"]["completed_at"]
+    assert captured["fields"]["outcome"] == "declined"
+    assert captured["fields"]["outcome_at"]
+    assert index.receipts(action["id"])[-1]["operation"] == "complete_action"
+    assert index.receipts(opportunity["id"])[-1]["operation"] == "capture_outcome"
+
+
+def test_revert_restores_a_prior_snapshot_as_a_new_audited_version(tmp_path):
+    index = SourcingIndex(tmp_path)
+    created = index.upsert(
+        record_type="contact",
+        fields={"name": "Ada", "title": "Founder"},
+        idempotency_key="contact:revert",
+        actor="assistant",
+        rationale_summary="Create Ada.",
+    )
+    updated = index.patch(
+        created["id"],
+        fields={"title": "Incorrect title"},
+        expected_version=1,
+        actor="assistant",
+        rationale_summary="Apply a mistaken source value.",
+    )
+
+    reverted = index.revert(
+        created["id"],
+        to_version=1,
+        expected_version=updated["version"],
+        actor="director",
+        rationale_summary="Restore the verified title.",
+    )
+
+    assert reverted["fields"] == created["fields"]
+    assert reverted["version"] == 3
+    assert index.receipts(created["id"])[-1]["operation"] == "revert"
+
+
+def test_delete_removes_record_but_preserves_immutable_delete_receipt(tmp_path):
+    index = SourcingIndex(tmp_path)
+    created = index.upsert(
+        record_type="knowledge_gap",
+        fields={"question": "Who approved this?"},
+        idempotency_key="gap:delete",
+        actor="assistant",
+        rationale_summary="Create the gap.",
+    )
+
+    deleted = index.delete(
+        created["id"],
+        expected_version=1,
+        actor="director",
+        rationale_summary="Delete the duplicate after explicit approval.",
+    )
+
+    assert deleted == {"deleted": True, "id": created["id"]}
+    assert index.get(created["id"]) is None
+    receipts = index.receipts(created["id"])
+    assert [receipt["operation"] for receipt in receipts] == ["create", "delete"]
+    assert receipts[-1]["before"]["id"] == created["id"]
+    assert receipts[-1]["after"] is None
+
+
+def test_every_low_level_write_requires_actor_and_rationale(tmp_path):
+    index = SourcingIndex(tmp_path)
+    created = index.upsert(
+        record_type="contact",
+        fields={"name": "Ada"},
+        idempotency_key="contact:write-metadata",
+        actor="assistant",
+        rationale_summary="Create Ada.",
+    )
+
+    with pytest.raises(ValueError, match="actor and rationale_summary are required"):
+        index.delete(
+            created["id"],
+            expected_version=1,
+            actor="",
+            rationale_summary="",
+        )


### PR DESCRIPTION
## Summary

- add a durable, versioned sourcing index and agent Board tools for Semester, Company, Contact, Opportunity, Touchpoint, Action, KnowledgeGap, Artifact, and SourceRef records
- add optimistic concurrency, provenance expansion, restricted-source default denial, immutable audit receipts, validated transitions, explicit-delete approval, API inspection/revert, and live Board refresh
- make Drive reads MIME-aware across folders, Forms, Google Workspace exports, PDF, DOCX, PPTX, unsupported formats, durable events, citations, and evidence UI
- prevent cached shell navigation from mutating fresher durable destination state during boot
- retain the browser-launch isolation landed in #46 by building directly on its merge commit

## Verification

- desktop Python: 372 passed, 1 skipped
- desktop GUI: 347 passed
- desktop GUI production build: passed
- git diff --check: passed
- root npm checks could not start locally because the existing root dependency installation lacks vitest and tsc; GitHub CI is the authoritative root rerun

## Scope

Workspace filesystem and Bash tooling remain out of this PR and will be designed under #41. Restricted sources default to denied; the server-injected grant seam is present for #41 to connect to the eventual workspace permission model.

Closes #36
Closes #37
Closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a sourcing index for viewing, querying, updating, linking, and reverting records with version history.
  - Added Board tools and API support for record inspection and management.
  - Added Google Drive folder browsing and text extraction for supported documents.
  - Added richer source metadata, status details, and evidence classifications.
- **Bug Fixes**
  - Improved response handling for text, structured, binary, and unsupported content.
  - Improved startup navigation restoration and Board refresh behavior.
- **Permissions**
  - Added appropriate approval and retry handling for new Board and Drive actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->