### PR TITLE
feat(desktop): add person-file Board tools

### DIFF
--- a/desktop/coworker/board_tools.py
+++ b/desktop/coworker/board_tools.py
@@ -1,0 +1,220 @@
+"""Agent-facing tools for the person-file Board."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from coworker.people import ATTACHMENT_TYPES, PersonStore
+
+_ATTACHMENT_SCHEMA = {"type": "string", "enum": sorted(ATTACHMENT_TYPES)}
+
+BOARD_GET_SCHEMA: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "board_get",
+        "description": "Read one person file by id. Optional source expansion.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "person_id": {"type": "string"},
+                "expand_sources": {"type": "boolean"},
+            },
+            "required": ["person_id"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+BOARD_QUERY_SCHEMA: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "board_query",
+        "description": "List person files on the Board by sequence, company tag, or target.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "sequence": {"type": "string", "enum": ["open", "in_conversation", "done"]},
+                "company": {"type": "string"},
+                "target": {"type": "string"},
+            },
+            "additionalProperties": False,
+        },
+    },
+}
+
+BOARD_UPSERT_SCHEMA: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "board_upsert",
+        "description": (
+            "Attach an artifact, knowledge gap, or source ref to an existing person file. "
+            "Does not create people. Use people_keep for Apollo rows."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "person_id": {"type": "string"},
+                "record_type": _ATTACHMENT_SCHEMA,
+                "fields": {"type": "object"},
+                "idempotency_key": {"type": "string"},
+                "rationale_summary": {"type": "string"},
+            },
+            "required": [
+                "person_id",
+                "record_type",
+                "fields",
+                "idempotency_key",
+                "rationale_summary",
+            ],
+            "additionalProperties": False,
+        },
+    },
+}
+
+BOARD_MUTATE_SCHEMA: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "board_mutate",
+        "description": (
+            "Version-checked person-file write: patch, transition, capture_outcome, or revert."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["patch", "transition", "capture_outcome", "revert"],
+                },
+                "person_id": {"type": "string"},
+                "expected_version": {"type": "integer"},
+                "rationale_summary": {"type": "string"},
+                "fields": {"type": "object"},
+                "to_state": {"type": "string", "enum": ["open", "in_conversation", "done"]},
+                "outcome": {"type": "string"},
+                "to_version": {"type": "integer"},
+            },
+            "required": ["action", "person_id", "expected_version", "rationale_summary"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+BOARD_DELETE_SCHEMA: dict[str, Any] = {
+    "type": "function",
+    "function": {
+        "name": "board_delete",
+        "description": "Delete a person file after explicit human approval.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "person_id": {"type": "string"},
+                "expected_version": {"type": "integer"},
+                "rationale_summary": {"type": "string"},
+            },
+            "required": ["person_id", "expected_version", "rationale_summary"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+BOARD_TOOL_SCHEMAS = [
+    BOARD_GET_SCHEMA,
+    BOARD_QUERY_SCHEMA,
+    BOARD_UPSERT_SCHEMA,
+    BOARD_MUTATE_SCHEMA,
+    BOARD_DELETE_SCHEMA,
+]
+BOARD_TOOL_NAMES = frozenset(schema["function"]["name"] for schema in BOARD_TOOL_SCHEMAS)
+
+
+def execute_board_tool(
+    name: str,
+    arguments: dict[str, Any],
+    *,
+    people: PersonStore,
+    actor: str,
+    session_id: str | None,
+    run_id: str | None,
+    allowed_source_ids: set[str] | None,
+) -> tuple[bool, dict[str, Any]]:
+    args = arguments or {}
+    actor = "assistant" if actor == "assistant" else "director"
+    try:
+        if name == "board_get":
+            person = people.get(
+                str(args.get("person_id") or ""),
+                expand_sources=bool(args.get("expand_sources")),
+                allowed_source_ids=allowed_source_ids,
+            )
+            return (True, {"person": person}) if person is not None else (
+                False,
+                {"status": "failed", "error": "record not found or not granted"},
+            )
+        if name == "board_query":
+            records = people.query(
+                sequence=str(args.get("sequence") or "") or None,
+                company=str(args.get("company") or "") or None,
+                target=str(args.get("target") or "") or None,
+            )
+            return True, {"people": records, "count": len(records)}
+        identity = {
+            "actor": actor,
+            "session_id": session_id,
+            "run_id": run_id,
+            "rationale_summary": str(args.get("rationale_summary") or ""),
+        }
+        person_id = str(args.get("person_id") or "")
+        if name == "board_upsert":
+            record = people.upsert_attachment(
+                person_id,
+                record_type=str(args.get("record_type") or ""),
+                fields=args.get("fields") if isinstance(args.get("fields"), dict) else {},
+                idempotency_key=str(args.get("idempotency_key") or ""),
+                allowed_source_ids=allowed_source_ids,
+                **identity,
+            )
+            return True, {"record": record, "board_changed": True}
+        if name == "board_delete":
+            result = people.delete(
+                person_id,
+                expected_version=int(args.get("expected_version") or 0),
+                **identity,
+            )
+            return True, {**result, "board_changed": True}
+        if name != "board_mutate":
+            return False, {"status": "failed", "error": f"unknown board tool {name}"}
+        action = str(args.get("action") or "")
+        expected_version = int(args.get("expected_version") or 0)
+        if action == "patch":
+            person = people.patch(
+                person_id,
+                fields=args.get("fields") if isinstance(args.get("fields"), dict) else {},
+                expected_version=expected_version,
+                **identity,
+            )
+        elif action == "transition":
+            person = people.set_sequence(
+                person_id,
+                str(args.get("to_state") or ""),
+                expected_version=expected_version,
+                **identity,
+            )
+        elif action == "capture_outcome":
+            person = people.capture_outcome(
+                person_id,
+                outcome=str(args.get("outcome") or ""),
+                expected_version=expected_version,
+                **identity,
+            )
+        elif action == "revert":
+            person = people.revert(
+                person_id,
+                to_version=int(args.get("to_version") or 0),
+                expected_version=expected_version,
+                **identity,
+            )
+        else:
+            raise ValueError(f"unknown board mutation {action}")
+        return True, {"person": person, "board_changed": True}
+    except (TypeError, ValueError) as exc:
+        return False, {"status": "failed", "error": str(exc)}

--- a/desktop/coworker/ledger.py
+++ b/desktop/coworker/ledger.py
@@ -15,6 +15,11 @@ _NOT_FILED = frozenset(
         "memory_forget",
         "load_skill",
         "apollo_search_people",
+        "board_get",
+        "board_query",
+        "board_upsert",
+        "board_mutate",
+        "board_delete",
     }
 )
 _MCP_WRITE = re.compile(r"write|create|delete|update", re.I)

--- a/desktop/coworker/people.py
+++ b/desktop/coworker/people.py
@@ -7,6 +7,7 @@ import re
 import sqlite3
 import threading
 import uuid
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -14,6 +15,20 @@ _SID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 
 SEQUENCE_STATES = ("open", "in_conversation", "done")
 ACTORS = ("director", "assistant")
+ATTACHMENT_TYPES = frozenset({"artifact", "knowledge_gap", "source_ref"})
+PERSON_PATCH_FIELDS = frozenset(
+    {
+        "first_name",
+        "last_name",
+        "title",
+        "company",
+        "target",
+        "handoff_who",
+        "handoff_wanted",
+        "handoff_happened",
+        "handoff_they_want",
+    }
+)
 SOURCES = (
     "apollo",
     "gmail",
@@ -63,6 +78,9 @@ class PersonStore:
                 handoff_wanted TEXT,
                 handoff_happened TEXT,
                 handoff_they_want TEXT,
+                version INTEGER NOT NULL DEFAULT 1,
+                outcome TEXT,
+                deleted_at TEXT,
                 created_at TEXT DEFAULT CURRENT_TIMESTAMP,
                 updated_at TEXT DEFAULT CURRENT_TIMESTAMP
             );
@@ -83,14 +101,181 @@ class PersonStore:
                 session_id TEXT PRIMARY KEY,
                 person_id TEXT NOT NULL
             );
+            CREATE TABLE IF NOT EXISTS person_attachments (
+                id TEXT PRIMARY KEY,
+                person_id TEXT NOT NULL,
+                record_type TEXT NOT NULL,
+                idempotency_key TEXT NOT NULL,
+                fields_json TEXT NOT NULL,
+                restricted INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                UNIQUE(person_id, record_type, idempotency_key)
+            );
+            CREATE TABLE IF NOT EXISTS person_versions (
+                person_id TEXT NOT NULL,
+                version INTEGER NOT NULL,
+                person_json TEXT NOT NULL,
+                attachments_json TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                PRIMARY KEY (person_id, version)
+            );
             """
         )
+        self._ensure_schema()
         self._conn.commit()
+
+    def _ensure_schema(self) -> None:
+        columns = {
+            str(row["name"])
+            for row in self._conn.execute("PRAGMA table_info(people)").fetchall()
+        }
+        if "version" not in columns:
+            self._conn.execute(
+                "ALTER TABLE people ADD COLUMN version INTEGER NOT NULL DEFAULT 1"
+            )
+        if "outcome" not in columns:
+            self._conn.execute("ALTER TABLE people ADD COLUMN outcome TEXT")
+        if "deleted_at" not in columns:
+            self._conn.execute("ALTER TABLE people ADD COLUMN deleted_at TEXT")
+
+    def _now(self) -> str:
+        return datetime.now(UTC).isoformat()
+
+    def _new_attachment_id(self, record_type: str) -> str:
+        return f"{record_type}_{uuid.uuid4().hex}"
 
     def _person_dict(self, row: sqlite3.Row | None) -> dict[str, Any] | None:
         if row is None:
             return None
-        return dict(row)
+        person = dict(row)
+        person["version"] = int(person.get("version") or 1)
+        person["restricted"] = False
+        return person
+
+    def _attachment_dict(self, row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "id": str(row["id"]),
+            "person_id": str(row["person_id"]),
+            "type": str(row["record_type"]),
+            "fields": json.loads(str(row["fields_json"])),
+            "restricted": bool(row["restricted"]),
+            "created_at": str(row["created_at"]),
+            "updated_at": str(row["updated_at"]),
+        }
+
+    def _require_audit(self, actor: str, rationale_summary: str) -> None:
+        if actor not in ACTORS:
+            raise ValueError(f"invalid actor {actor}")
+        if not rationale_summary.strip():
+            raise ValueError("actor and rationale_summary are required")
+
+    def _load_person_row(self, person_id: str, *, include_deleted: bool = False) -> sqlite3.Row:
+        row = self._conn.execute(
+            "SELECT * FROM people WHERE person_id = ?",
+            (person_id,),
+        ).fetchone()
+        if row is None:
+            raise ValueError("unknown person")
+        if not include_deleted and row["deleted_at"]:
+            raise ValueError("unknown person")
+        return row
+
+    def _attachments_for(
+        self,
+        person_id: str,
+        *,
+        allowed_source_ids: set[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        allowed = allowed_source_ids or set()
+        rows = self._conn.execute(
+            """
+            SELECT * FROM person_attachments
+            WHERE person_id = ?
+            ORDER BY created_at, id
+            """,
+            (person_id,),
+        ).fetchall()
+        records: list[dict[str, Any]] = []
+        for row in rows:
+            record = self._attachment_dict(row)
+            if record["restricted"] and record["id"] not in allowed:
+                continue
+            records.append(record)
+        return records
+
+    def _snapshot(self, person_id: str, version: int, created_at: str) -> None:
+        person = self._person_dict(
+            self._conn.execute(
+                "SELECT * FROM people WHERE person_id = ?", (person_id,)
+            ).fetchone()
+        )
+        attachments = [
+            self._attachment_dict(row)
+            for row in self._conn.execute(
+                "SELECT * FROM person_attachments WHERE person_id = ? ORDER BY id",
+                (person_id,),
+            ).fetchall()
+        ]
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO person_versions (
+                person_id, version, person_json, attachments_json, created_at
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                person_id,
+                version,
+                json.dumps(person, sort_keys=True),
+                json.dumps(attachments, sort_keys=True),
+                created_at,
+            ),
+        )
+
+    def _receipt(
+        self,
+        person_id: str,
+        *,
+        kind: str,
+        summary: str,
+        payload: dict[str, Any],
+        actor: str,
+        session_id: str | None,
+        run_id: str | None,
+        tool: str | None = None,
+    ) -> None:
+        self._conn.execute(
+            """
+            INSERT INTO events (
+                event_id, person_id, source, kind, summary, payload,
+                actor, session_id, run_id, tool
+            ) VALUES (?, ?, 'sourcecado', ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                _new_event_id(),
+                person_id,
+                kind,
+                summary,
+                json.dumps(payload),
+                actor,
+                session_id,
+                run_id,
+                tool,
+            ),
+        )
+
+    def _has_conversation_evidence(self, person_id: str) -> bool:
+        for event in self.timeline(person_id):
+            payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
+            if event.get("kind") == "send" or event.get("tool") == "gmail_send":
+                return True
+            if payload.get("sent") is True:
+                return True
+            if payload.get("direction") == "inbound":
+                return True
+            if event.get("kind") == "mail" and "reply" in str(event.get("summary") or "").lower():
+                return True
+        return False
 
     def keep_from_apollo(
         self,
@@ -164,6 +349,10 @@ class PersonStore:
                     "SELECT * FROM people WHERE person_id = ?",
                     (pid,),
                 ).fetchone()
+            person = self._person_dict(row)
+            assert person is not None
+            self._snapshot(person["person_id"], int(person["version"]), self._now())
+            self._conn.commit()
         person = self._person_dict(row)
         assert person is not None
         return person
@@ -171,7 +360,7 @@ class PersonStore:
     def get_by_apollo_id(self, apollo_id: str) -> dict[str, Any] | None:
         with self._lock:
             row = self._conn.execute(
-                "SELECT * FROM people WHERE apollo_id = ?",
+                "SELECT * FROM people WHERE apollo_id = ? AND deleted_at IS NULL",
                 (apollo_id,),
             ).fetchone()
         return self._person_dict(row)
@@ -227,47 +416,96 @@ class PersonStore:
             self._conn.commit()
         return self.get(person_id)
 
-    def get(self, person_id: str) -> dict[str, Any] | None:
+    def get(
+        self,
+        person_id: str,
+        *,
+        expand_sources: bool = False,
+        allowed_source_ids: set[str] | None = None,
+    ) -> dict[str, Any] | None:
         with self._lock:
             row = self._conn.execute(
-                "SELECT * FROM people WHERE person_id = ?",
+                "SELECT * FROM people WHERE person_id = ? AND deleted_at IS NULL",
                 (person_id,),
             ).fetchone()
-        return self._person_dict(row)
+            person = self._person_dict(row)
+            if person is None or not expand_sources:
+                return person
+            attachments = self._attachments_for(
+                person_id, allowed_source_ids=allowed_source_ids
+            )
+            restricted_hidden = self._conn.execute(
+                """
+                SELECT COUNT(*) FROM person_attachments
+                WHERE person_id = ? AND restricted = 1
+                """,
+                (person_id,),
+            ).fetchone()[0]
+        person["attachments"] = attachments
+        person["sources"] = [item for item in attachments if item["type"] == "source_ref"]
+        person["artifacts"] = [item for item in attachments if item["type"] == "artifact"]
+        person["knowledge_gaps"] = [
+            item for item in attachments if item["type"] == "knowledge_gap"
+        ]
+        visible_restricted = sum(1 for item in attachments if item["restricted"])
+        person["restricted_source_count"] = int(restricted_hidden) - visible_restricted
+        return person
 
-    def set_sequence(self, person_id: str, state: str, *, actor: str) -> dict[str, Any]:
+    def set_sequence(
+        self,
+        person_id: str,
+        state: str,
+        *,
+        actor: str,
+        expected_version: int | None = None,
+        session_id: str | None = None,
+        run_id: str | None = None,
+        rationale_summary: str = "",
+    ) -> dict[str, Any]:
         if state not in SEQUENCE_STATES:
             raise ValueError(f"invalid sequence state {state}")
         if actor not in ACTORS:
             raise ValueError(f"invalid actor {actor}")
         with self._lock:
-            row = self._conn.execute(
-                "SELECT * FROM people WHERE person_id = ?",
-                (person_id,),
-            ).fetchone()
-            if row is None:
-                raise ValueError("unknown person")
+            row = self._load_person_row(person_id)
+            if expected_version is not None and int(row["version"]) != expected_version:
+                raise ValueError(
+                    f"stale record version: expected {expected_version}, current {row['version']}"
+                )
+            if state == "in_conversation" and actor == "assistant":
+                if not self._has_conversation_evidence(person_id):
+                    raise ValueError(
+                        "in_conversation requires sent outreach, an inbound reply, or director Allow"
+                    )
+            next_outcome = row["outcome"]
+            if state == "done" and not str(row["outcome"] or "").strip():
+                if actor != "director":
+                    raise ValueError("done requires a recorded outcome")
+                next_outcome = "closed"
+            now = self._now()
+            next_version = int(row["version"] or 1) + 1
             self._conn.execute(
                 """
-                UPDATE people SET sequence_state = ?, updated_at = CURRENT_TIMESTAMP
+                UPDATE people
+                SET sequence_state = ?, outcome = ?, version = ?, updated_at = ?
                 WHERE person_id = ?
                 """,
-                (state, person_id),
+                (state, next_outcome, next_version, now, person_id),
             )
-            self._conn.execute(
-                """
-                INSERT INTO events (
-                    event_id, person_id, source, kind, summary, payload, actor
-                ) VALUES (?, ?, 'sourcecado', 'state', ?, ?, ?)
-                """,
-                (
-                    _new_event_id(),
-                    person_id,
-                    f"Moved to {state.replace('_', ' ')}",
-                    json.dumps({"state": state}),
-                    actor,
-                ),
+            self._receipt(
+                person_id,
+                kind="state",
+                summary=f"Moved to {state.replace('_', ' ')}",
+                payload={
+                    "state": state,
+                    "rationale_summary": rationale_summary,
+                    "version": next_version,
+                },
+                actor=actor,
+                session_id=session_id,
+                run_id=run_id,
             )
+            self._snapshot(person_id, next_version, now)
             self._conn.commit()
             row = self._conn.execute(
                 "SELECT * FROM people WHERE person_id = ?",
@@ -283,7 +521,7 @@ class PersonStore:
             rows = self._conn.execute(
                 """
                 SELECT * FROM people
-                WHERE sequence_state IS NOT NULL
+                WHERE sequence_state IS NOT NULL AND deleted_at IS NULL
                 ORDER BY updated_at DESC, person_id
                 """
             ).fetchall()
@@ -320,7 +558,7 @@ class PersonStore:
             raise ValueError("summary is required")
         with self._lock:
             exists = self._conn.execute(
-                "SELECT 1 FROM people WHERE person_id = ?",
+                "SELECT 1 FROM people WHERE person_id = ? AND deleted_at IS NULL",
                 (person_id,),
             ).fetchone()
             if exists is None:
@@ -435,3 +673,371 @@ class PersonStore:
         person = self._person_dict(row)
         assert person is not None
         return person
+
+    def query(
+        self,
+        *,
+        sequence: str | None = None,
+        company: str | None = None,
+        target: str | None = None,
+    ) -> list[dict[str, Any]]:
+        if sequence is not None and sequence not in SEQUENCE_STATES:
+            raise ValueError(f"invalid sequence state {sequence}")
+        board = self.list_board()
+        people = (
+            board[sequence]
+            if sequence is not None
+            else [person for state in SEQUENCE_STATES for person in board[state]]
+        )
+        matched = []
+        for person in people:
+            if company is not None and person.get("company") != company:
+                continue
+            if target is not None and person.get("target") != target:
+                continue
+            matched.append(person)
+        return matched
+
+    def patch(
+        self,
+        person_id: str,
+        *,
+        fields: dict[str, Any],
+        expected_version: int,
+        actor: str,
+        rationale_summary: str,
+        session_id: str | None = None,
+        run_id: str | None = None,
+    ) -> dict[str, Any]:
+        if not isinstance(fields, dict) or not fields:
+            raise ValueError("fields must be an object")
+        unknown = set(fields) - PERSON_PATCH_FIELDS
+        if unknown:
+            raise ValueError(f"unsupported person fields {sorted(unknown)}")
+        self._require_audit(actor, rationale_summary)
+        with self._lock:
+            row = self._load_person_row(person_id)
+            if int(row["version"]) != expected_version:
+                raise ValueError(
+                    f"stale record version: expected {expected_version}, current {row['version']}"
+                )
+            now = self._now()
+            next_version = expected_version + 1
+            assignments = [f"{key} = ?" for key in fields]
+            values: list[Any] = [fields[key] for key in fields]
+            values.extend([next_version, now, person_id, expected_version])
+            cursor = self._conn.execute(
+                f"""
+                UPDATE people
+                SET {", ".join([*assignments, "version = ?", "updated_at = ?"])}
+                WHERE person_id = ? AND version = ?
+                """,
+                values,
+            )
+            if cursor.rowcount != 1:
+                self._conn.rollback()
+                raise ValueError("stale record version")
+            self._receipt(
+                person_id,
+                kind="patch",
+                summary=rationale_summary.strip(),
+                payload={"fields": fields, "version": next_version},
+                actor=actor,
+                session_id=session_id,
+                run_id=run_id,
+            )
+            self._snapshot(person_id, next_version, now)
+            self._conn.commit()
+        person = self.get(person_id)
+        assert person is not None
+        return person
+
+    def upsert_attachment(
+        self,
+        person_id: str,
+        *,
+        record_type: str,
+        fields: dict[str, Any],
+        idempotency_key: str,
+        actor: str,
+        rationale_summary: str,
+        session_id: str | None = None,
+        run_id: str | None = None,
+        allowed_source_ids: set[str] | None = None,
+    ) -> dict[str, Any]:
+        if record_type not in ATTACHMENT_TYPES:
+            raise ValueError(f"unknown record type {record_type}")
+        if not isinstance(fields, dict):
+            raise ValueError("fields must be an object")
+        if not idempotency_key.strip():
+            raise ValueError("idempotency_key is required")
+        self._require_audit(actor, rationale_summary)
+        restricted = int(
+            record_type == "source_ref"
+            and str(fields.get("sensitivity") or "").lower() == "restricted"
+        )
+        allowed = allowed_source_ids or set()
+
+        def _public(record: dict[str, Any]) -> dict[str, Any]:
+            if record["restricted"] and record["id"] not in allowed:
+                return {
+                    "id": record["id"],
+                    "person_id": record["person_id"],
+                    "type": record["type"],
+                    "restricted": True,
+                }
+            return record
+
+        with self._lock:
+            row = self._load_person_row(person_id)
+            existing = self._conn.execute(
+                """
+                SELECT * FROM person_attachments
+                WHERE person_id = ? AND record_type = ? AND idempotency_key = ?
+                """,
+                (person_id, record_type, idempotency_key),
+            ).fetchone()
+            if existing is not None:
+                current = self._attachment_dict(existing)
+                if current["fields"] != fields or current["restricted"] != bool(restricted):
+                    raise ValueError(
+                        "idempotency conflict: key already belongs to different record facts"
+                    )
+                return _public(current)
+            now = self._now()
+            record_id = self._new_attachment_id(record_type)
+            self._conn.execute(
+                """
+                INSERT INTO person_attachments (
+                    id, person_id, record_type, idempotency_key, fields_json,
+                    restricted, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record_id,
+                    person_id,
+                    record_type,
+                    idempotency_key,
+                    json.dumps(fields, sort_keys=True),
+                    restricted,
+                    now,
+                    now,
+                ),
+            )
+            next_version = int(row["version"] or 1) + 1
+            self._conn.execute(
+                "UPDATE people SET version = ?, updated_at = ? WHERE person_id = ?",
+                (next_version, now, person_id),
+            )
+            self._receipt(
+                person_id,
+                kind=record_type,
+                summary=rationale_summary.strip(),
+                payload={"id": record_id, "type": record_type, "version": next_version},
+                actor=actor,
+                session_id=session_id,
+                run_id=run_id,
+            )
+            self._snapshot(person_id, next_version, now)
+            self._conn.commit()
+            stored = self._conn.execute(
+                "SELECT * FROM person_attachments WHERE id = ?", (record_id,)
+            ).fetchone()
+        return _public(self._attachment_dict(stored))
+
+    def capture_outcome(
+        self,
+        person_id: str,
+        *,
+        outcome: str,
+        expected_version: int,
+        actor: str,
+        rationale_summary: str,
+        session_id: str | None = None,
+        run_id: str | None = None,
+    ) -> dict[str, Any]:
+        if not outcome.strip():
+            raise ValueError("outcome is required")
+        self._require_audit(actor, rationale_summary)
+        with self._lock:
+            row = self._load_person_row(person_id)
+            if int(row["version"]) != expected_version:
+                raise ValueError(
+                    f"stale record version: expected {expected_version}, current {row['version']}"
+                )
+            now = self._now()
+            next_version = expected_version + 1
+            cursor = self._conn.execute(
+                """
+                UPDATE people SET outcome = ?, version = ?, updated_at = ?
+                WHERE person_id = ? AND version = ?
+                """,
+                (outcome.strip(), next_version, now, person_id, expected_version),
+            )
+            if cursor.rowcount != 1:
+                self._conn.rollback()
+                raise ValueError("stale record version")
+            self._receipt(
+                person_id,
+                kind="outcome",
+                summary=rationale_summary.strip(),
+                payload={"outcome": outcome.strip(), "version": next_version},
+                actor=actor,
+                session_id=session_id,
+                run_id=run_id,
+            )
+            self._snapshot(person_id, next_version, now)
+            self._conn.commit()
+        person = self.get(person_id)
+        assert person is not None
+        return person
+
+    def revert(
+        self,
+        person_id: str,
+        *,
+        to_version: int,
+        expected_version: int,
+        actor: str,
+        rationale_summary: str,
+        session_id: str | None = None,
+        run_id: str | None = None,
+    ) -> dict[str, Any]:
+        self._require_audit(actor, rationale_summary)
+        with self._lock:
+            row = self._load_person_row(person_id)
+            if int(row["version"]) != expected_version:
+                raise ValueError(
+                    f"stale record version: expected {expected_version}, current {row['version']}"
+                )
+            snapshot = self._conn.execute(
+                """
+                SELECT * FROM person_versions
+                WHERE person_id = ? AND version = ?
+                """,
+                (person_id, to_version),
+            ).fetchone()
+            if snapshot is None:
+                raise ValueError(f"unknown record version {to_version}")
+            target = json.loads(str(snapshot["person_json"]))
+            attachments = json.loads(str(snapshot["attachments_json"]))
+            now = self._now()
+            next_version = expected_version + 1
+            cursor = self._conn.execute(
+                """
+                UPDATE people SET
+                    first_name = ?, last_name = ?, title = ?, company = ?, target = ?,
+                    sequence_state = ?, outcome = ?,
+                    handoff_who = ?, handoff_wanted = ?, handoff_happened = ?,
+                    handoff_they_want = ?, version = ?, updated_at = ?
+                WHERE person_id = ? AND version = ?
+                """,
+                (
+                    target.get("first_name"),
+                    target.get("last_name"),
+                    target.get("title"),
+                    target.get("company"),
+                    target.get("target"),
+                    target.get("sequence_state"),
+                    target.get("outcome"),
+                    target.get("handoff_who"),
+                    target.get("handoff_wanted"),
+                    target.get("handoff_happened"),
+                    target.get("handoff_they_want"),
+                    next_version,
+                    now,
+                    person_id,
+                    expected_version,
+                ),
+            )
+            if cursor.rowcount != 1:
+                self._conn.rollback()
+                raise ValueError("stale record version")
+            self._conn.execute(
+                "DELETE FROM person_attachments WHERE person_id = ?", (person_id,)
+            )
+            for item in attachments:
+                self._conn.execute(
+                    """
+                    INSERT INTO person_attachments (
+                        id, person_id, record_type, idempotency_key, fields_json,
+                        restricted, created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        item["id"],
+                        person_id,
+                        item["type"],
+                        f"restored:{item['id']}",
+                        json.dumps(item.get("fields") or {}, sort_keys=True),
+                        int(bool(item.get("restricted"))),
+                        item.get("created_at") or now,
+                        now,
+                    ),
+                )
+            self._receipt(
+                person_id,
+                kind="revert",
+                summary=rationale_summary.strip(),
+                payload={"to_version": to_version, "version": next_version},
+                actor=actor,
+                session_id=session_id,
+                run_id=run_id,
+            )
+            self._snapshot(person_id, next_version, now)
+            self._conn.commit()
+        person = self.get(person_id)
+        assert person is not None
+        return person
+
+    def delete(
+        self,
+        person_id: str,
+        *,
+        expected_version: int,
+        actor: str,
+        rationale_summary: str,
+        session_id: str | None = None,
+        run_id: str | None = None,
+    ) -> dict[str, Any]:
+        self._require_audit(actor, rationale_summary)
+        with self._lock:
+            row = self._load_person_row(person_id)
+            if int(row["version"]) != expected_version:
+                raise ValueError(
+                    f"stale record version: expected {expected_version}, current {row['version']}"
+                )
+            now = self._now()
+            next_version = expected_version + 1
+            self._conn.execute(
+                """
+                UPDATE people SET deleted_at = ?, version = ?, updated_at = ?
+                WHERE person_id = ? AND version = ?
+                """,
+                (now, next_version, now, person_id, expected_version),
+            )
+            self._receipt(
+                person_id,
+                kind="delete",
+                summary=rationale_summary.strip(),
+                payload={"deleted": True, "version": next_version},
+                actor=actor,
+                session_id=session_id,
+                run_id=run_id,
+            )
+            self._conn.commit()
+        return {"deleted": True, "id": person_id}
+
+    def versions(self, person_id: str) -> list[dict[str, Any]]:
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT version, created_at FROM person_versions
+                WHERE person_id = ? ORDER BY version
+                """,
+                (person_id,),
+            ).fetchall()
+        return [
+            {"version": int(row["version"]), "created_at": str(row["created_at"])}
+            for row in rows
+        ]

--- a/desktop/coworker/people.py
+++ b/desktop/coworker/people.py
@@ -266,14 +266,16 @@ class PersonStore:
 
     def _has_conversation_evidence(self, person_id: str) -> bool:
         for event in self.timeline(person_id):
+            if event.get("kind") == "error":
+                continue
             payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
-            if event.get("kind") == "send" or event.get("tool") == "gmail_send":
+            if event.get("kind") == "send":
                 return True
             if payload.get("sent") is True:
                 return True
             if payload.get("direction") == "inbound":
                 return True
-            if event.get("kind") == "mail" and "reply" in str(event.get("summary") or "").lower():
+            if event.get("kind") == "mail" and event.get("tool") == "gmail_read":
                 return True
         return False
 
@@ -301,6 +303,9 @@ class PersonStore:
                     (apollo,),
                 ).fetchone()
             if existing is not None:
+                restoring = bool(existing["deleted_at"])
+                now = self._now()
+                next_version = int(existing["version"] or 1) + (1 if restoring else 0)
                 self._conn.execute(
                     """
                     UPDATE people SET
@@ -309,7 +314,9 @@ class PersonStore:
                         title = COALESCE(?, title),
                         company = COALESCE(?, company),
                         target = COALESCE(?, target),
-                        updated_at = CURRENT_TIMESTAMP
+                        deleted_at = NULL,
+                        version = ?,
+                        updated_at = ?
                     WHERE person_id = ?
                     """,
                     (
@@ -318,9 +325,22 @@ class PersonStore:
                         title,
                         company,
                         cleaned_target,
+                        next_version,
+                        now,
                         existing["person_id"],
                     ),
                 )
+                if restoring:
+                    self._receipt(
+                        existing["person_id"],
+                        kind="keep",
+                        summary="Restored person file from Apollo keep",
+                        payload={"version": next_version, "apollo_id": apollo},
+                        actor="assistant",
+                        session_id=None,
+                        run_id=None,
+                        tool="people_keep",
+                    )
                 self._conn.commit()
                 row = self._conn.execute(
                     "SELECT * FROM people WHERE person_id = ?",

--- a/desktop/coworker/permissions.py
+++ b/desktop/coworker/permissions.py
@@ -25,6 +25,10 @@ AUTO = frozenset(
         "drive_read",
         "calendar_list",
         "web_search",
+        "board_get",
+        "board_query",
+        "board_upsert",
+        "board_mutate",
     }
 )
 ASK = frozenset(
@@ -34,6 +38,7 @@ ASK = frozenset(
         "apollo_enrich_contact",
         "calendar_create",
         "calendar_update",
+        "board_delete",
     }
 )
 # Read-only members of AUTO that can re-run without a second external effect.
@@ -50,6 +55,8 @@ RETRY_SAFE = frozenset(
         "drive_read",
         "calendar_list",
         "apollo_search_people",
+        "board_get",
+        "board_query",
     }
 )
 _MCP_WRITE = re.compile(r"write|create|delete|update", re.I)

--- a/desktop/coworker/server.py
+++ b/desktop/coworker/server.py
@@ -92,6 +92,9 @@ KERNEL = (
     "calendar_create / calendar_update (ask, no delete), "
     "apollo_search_people (no emails), people_keep (auto; file curated search "
     "rows after the director chooses, do not invent the target), "
+    "board_get / board_query (auto; person files on Open / In conversation / Done), "
+    "board_upsert / board_mutate (auto; artifacts, gaps, source refs, sequence, outcomes), "
+    "board_delete (ask; deletes a person file), "
     "apollo_enrich_contact "
     "(ask), web_search (auto). MCP tools are named mcp__server__tool. Do not invent the time, tool "
     "results, emails, or memories. Do not claim you sent or drafted unless the "
@@ -430,6 +433,8 @@ def create_app(
                 mcp=app.state.mcp,
                 people=app.state.people,
                 session_id=str(item.get("session_id") or ""),
+                actor=str(item.get("actor") or "assistant"),
+                run_id=str(item.get("run_id") or "") or None,
             )
         except Exception as exc:
             ok, result = False, {"error": str(exc)}
@@ -638,6 +643,8 @@ def create_app(
                     mcp=app.state.mcp,
                     people=app.state.people,
                     session_id=str(item.get("session_id") or ""),
+                    actor=str(item.get("actor") or "assistant"),
+                    run_id=str(item.get("run_id") or "") or None,
                 )
                 result = dict(result)
             except Exception as exc:
@@ -806,7 +813,7 @@ def create_app(
             if claim.decision_recorded:
                 _persist_approval_receipt(receipt)
         elif claim.claimed and claim.owned:
-            receipt = await _execute_claimed_approval(item, claimant=claimant)
+            receipt = await _execute_claimed_approval(claim.item, claimant=claimant)
         else:
             receipt = await app.state.inbox.wait_for_execution(item_id)
         if receipt is None:
@@ -1240,7 +1247,7 @@ def create_app(
 
     @app.get("/v1/people/{person_id}")
     def people_get(person_id: str):
-        person = app.state.people.get(person_id)
+        person = app.state.people.get(person_id, expand_sources=True)
         if person is None:
             return JSONResponse({"error": "not found"}, status_code=404)
         timeline = [_public_event(event) for event in app.state.people.timeline(person_id)]
@@ -1248,7 +1255,25 @@ def create_app(
             "person": person,
             "brief": build_brief(person, timeline),
             "timeline": timeline,
+            "versions": app.state.people.versions(person_id),
         }
+
+    @app.post("/v1/people/{person_id}/revert")
+    async def people_revert(person_id: str, request: Request):
+        payload = await request.json()
+        if app.state.people.get(person_id) is None:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        try:
+            person = app.state.people.revert(
+                person_id,
+                to_version=int(payload.get("to_version") or 0),
+                expected_version=int(payload.get("expected_version") or 0),
+                actor="director",
+                rationale_summary=str(payload.get("rationale_summary") or ""),
+            )
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=409)
+        return {"person": person}
 
     @app.get("/v1/sessions")
     def sessions_list():

--- a/desktop/coworker/tools.py
+++ b/desktop/coworker/tools.py
@@ -14,6 +14,7 @@ from zoneinfo import ZoneInfo
 from coworker.apollo import MISSING_KEY, enrich_contact, search_people
 from coworker.web import MISSING_KEY as TAVILY_MISSING, search_web
 from coworker.gmail import GmailError, MissingGmail
+from coworker.board_tools import BOARD_TOOL_NAMES, BOARD_TOOL_SCHEMAS, execute_board_tool
 from coworker.people import PersonStore
 from coworker.store import ConversationStore
 
@@ -413,6 +414,7 @@ OPENAI_TOOLS = [
     APOLLO_ENRICH_SCHEMA,
     LOAD_SKILL_SCHEMA,
     WEB_SEARCH_SCHEMA,
+    *BOARD_TOOL_SCHEMAS,
 ]
 
 
@@ -447,8 +449,23 @@ def execute(
     people: PersonStore | None = None,
     session_id: str | None = None,
     tavily_key: str | None = None,
+    actor: str = "assistant",
+    run_id: str | None = None,
+    allowed_source_ids: set[str] | None = None,
 ) -> tuple[bool, dict[str, Any]]:
     args = arguments or {}
+    if name in BOARD_TOOL_NAMES:
+        if people is None:
+            return False, {"status": "failed", "error": "people store missing"}
+        return execute_board_tool(
+            name,
+            args,
+            people=people,
+            actor=actor,
+            session_id=session_id,
+            run_id=run_id,
+            allowed_source_ids=allowed_source_ids,
+        )
     if name == "now":
         return True, now()
     if name == "load_skill":

--- a/desktop/coworker/turn.py
+++ b/desktop/coworker/turn.py
@@ -31,6 +31,11 @@ _TOOL_SOURCES: dict[str, tuple[str | None, str]] = {
     "drive_search": ("drive", "Google Drive"),
     "drive_list_folder": ("drive", "Google Drive"),
     "drive_read": ("drive", "Google Drive"),
+    "board_get": (None, "Board"),
+    "board_query": (None, "Board"),
+    "board_upsert": (None, "Board"),
+    "board_mutate": (None, "Board"),
+    "board_delete": (None, "Board"),
     "calendar_list": ("calendar", "Google Calendar"),
     "calendar_create": ("calendar", "Google Calendar"),
     "calendar_update": ("calendar", "Google Calendar"),
@@ -747,6 +752,7 @@ async def run_turn(
                 try:
                     kw = {k: v for k, v in execute_kwargs.items() if not k.startswith("_")}
                     kw["session_id"] = sid
+                    kw["run_id"] = events.identity.run_id
                     ok, result = await asyncio.to_thread(
                         execute, call.name, call.arguments, **kw
                     )

--- a/desktop/surfaces/gui/src/Board.tsx
+++ b/desktop/surfaces/gui/src/Board.tsx
@@ -68,6 +68,12 @@ export function BoardView() {
     };
   }, [attempt]);
 
+  useEffect(() => {
+    const refresh = () => setAttempt((value) => value + 1);
+    window.addEventListener("sourcecado:board-changed", refresh);
+    return () => window.removeEventListener("sourcecado:board-changed", refresh);
+  }, []);
+
   const empty =
     board !== null &&
     board.open.length === 0 &&

--- a/desktop/surfaces/gui/src/PersonFile.tsx
+++ b/desktop/surfaces/gui/src/PersonFile.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { getPerson, setPersonSequence, type PersonFile } from "./api";
+import { getPerson, revertPerson, setPersonSequence, type PersonFile } from "./api";
 
 const STATES = [
   { id: "open", label: "Open" },
@@ -31,6 +31,12 @@ export function PersonFileView({ personId }: { personId: string }) {
       active = false;
     };
   }, [attempt, personId]);
+
+  useEffect(() => {
+    const refresh = () => setAttempt((value) => value + 1);
+    window.addEventListener("sourcecado:board-changed", refresh);
+    return () => window.removeEventListener("sourcecado:board-changed", refresh);
+  }, []);
 
   async function move(state: string) {
     if (moving) return;
@@ -126,6 +132,43 @@ export function PersonFileView({ personId }: { personId: string }) {
           </ul>
         )}
       </section>
+
+      {file.versions && file.versions.length > 0 ? (
+        <section className="person-section" aria-labelledby="person-history-heading">
+          <h2 id="person-history-heading">Version history</h2>
+          <p>
+            {typeof file.person.version === "number"
+              ? `Current version ${file.person.version}`
+              : "Prior versions"}
+          </p>
+          <ol>
+            {file.versions.map((entry) => {
+              const current = file.person.version;
+              const canRevert =
+                typeof current === "number" && entry.version < current;
+              return (
+                <li key={entry.version}>
+                  <span>Version {entry.version}</span>
+                  {canRevert ? (
+                    <button
+                      type="button"
+                      onClick={() =>
+                        void revertPerson(personId, {
+                          toVersion: entry.version,
+                          expectedVersion: current,
+                          rationaleSummary: `Restore version ${entry.version} from person history.`,
+                        }).then(() => setAttempt((value) => value + 1))
+                      }
+                    >
+                      Revert to version {entry.version}
+                    </button>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ol>
+        </section>
+      ) : null}
 
       <section className="person-section" aria-labelledby="person-timeline-heading">
         <h2 id="person-timeline-heading">Timeline</h2>

--- a/desktop/surfaces/gui/src/api.ts
+++ b/desktop/surfaces/gui/src/api.ts
@@ -254,6 +254,7 @@ export type PersonFile = {
     summary: string;
     payload: Record<string, unknown>;
   }>;
+  versions?: Array<{ version: number; created_at: string }>;
 };
 
 export async function getBoard(): Promise<Board> {
@@ -281,6 +282,24 @@ export async function setPersonSequence(
   const body = await res.json();
   if (!res.ok) throw new Error(body.error || `sequence ${res.status}`);
   return body;
+}
+
+export async function revertPerson(
+  id: string,
+  body: { toVersion: number; expectedVersion: number; rationaleSummary: string },
+): Promise<{ person: BoardPerson }> {
+  const res = await fetch(`${httpBase()}/v1/people/${encodeURIComponent(id)}/revert`, {
+    method: "POST",
+    headers: { "X-Club-Token": apiToken(), "Content-Type": "application/json" },
+    body: JSON.stringify({
+      to_version: body.toVersion,
+      expected_version: body.expectedVersion,
+      rationale_summary: body.rationaleSummary,
+    }),
+  });
+  const payload = await res.json();
+  if (!res.ok) throw new Error(payload.error || `revert ${res.status}`);
+  return payload;
 }
 
 export async function pinSession(

--- a/desktop/surfaces/gui/src/chat/toolRegistry.tsx
+++ b/desktop/surfaces/gui/src/chat/toolRegistry.tsx
@@ -94,6 +94,11 @@ const KNOWN_TOOLS: Readonly<Record<string, ToolPresentation>> = {
     category: "action",
     slot: "calendar",
   },
+  board_get: { label: "Read person file", category: "source" },
+  board_query: { label: "Queried Board", category: "source" },
+  board_upsert: { label: "Updated person file", category: "action" },
+  board_mutate: { label: "Updated person file", category: "action" },
+  board_delete: { label: "Deleted person file", category: "action" },
   now: { label: "Checked current time", category: "source" },
 };
 

--- a/desktop/surfaces/gui/src/routes/ChatPage.tsx
+++ b/desktop/surfaces/gui/src/routes/ChatPage.tsx
@@ -178,6 +178,15 @@ export function ChatPage({ sessionId: requestedSessionId }: { sessionId?: string
         if (event.session_id === activeThreadRef.current) refresh();
         return;
       }
+      if (
+        event.type === "tool_finished" &&
+        event.result !== null &&
+        typeof event.result === "object" &&
+        !Array.isArray(event.result) &&
+        (event.result as Record<string, unknown>).board_changed === true
+      ) {
+        window.dispatchEvent(new CustomEvent("sourcecado:board-changed"));
+      }
       const applied = storeRef.current.applyChatEvent(event);
       if (applied.type === "connection_change") {
         connectionStatusRef.current = applied.status;

--- a/desktop/surfaces/gui/src/styles.css
+++ b/desktop/surfaces/gui/src/styles.css
@@ -188,6 +188,19 @@
   line-height: 1.55;
 }
 
+.person-section ol {
+  margin: 0;
+  padding: 0 16px 12px 32px;
+}
+
+.person-section ol li {
+  display: flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
 .person-section ul {
   display: grid;
   gap: 8px;

--- a/desktop/surfaces/gui/tests/boardPerson.test.tsx
+++ b/desktop/surfaces/gui/tests/boardPerson.test.tsx
@@ -7,12 +7,14 @@ import { PersonFileView } from "../src/PersonFile";
 const api = vi.hoisted(() => ({
   getBoard: vi.fn(),
   getPerson: vi.fn(),
+  revertPerson: vi.fn(),
   setPersonSequence: vi.fn(),
 }));
 
 vi.mock("../src/api", () => ({
   getBoard: api.getBoard,
   getPerson: api.getPerson,
+  revertPerson: api.revertPerson,
   setPersonSequence: api.setPersonSequence,
 }));
 
@@ -32,8 +34,11 @@ describe("Board and person-file routes", () => {
       in_conversation: [],
       done: [],
     });
+    api.revertPerson.mockResolvedValue({
+      person: { person_id: "person one", sequence_state: "open", version: 3, title: "Founder" },
+    });
     api.getPerson.mockResolvedValue({
-      person: { person_id: "person one", sequence_state: "open" },
+      person: { person_id: "person one", sequence_state: "open", version: 2 },
       brief: {
         who: "Alyssa Lee",
         why: "Strong sourcing fit.",
@@ -49,6 +54,10 @@ describe("Board and person-file routes", () => {
           summary: "Found in a sourcing search.",
           payload: {},
         },
+      ],
+      versions: [
+        { version: 1, created_at: "2026-08-26T10:00:00Z" },
+        { version: 2, created_at: "2026-08-26T11:00:00Z" },
       ],
     });
     api.setPersonSequence.mockResolvedValue({
@@ -83,5 +92,25 @@ describe("Board and person-file routes", () => {
     );
     expect(screen.getByText("Found in a sourcing search.")).toBeInTheDocument();
     expect(container.querySelector(".tool-card")).not.toBeInTheDocument();
+  });
+
+  it("refreshes Board buckets after a person-file write", async () => {
+    render(<BoardView />);
+    await screen.findByRole("link", { name: /Alyssa Lee/ });
+    window.dispatchEvent(new CustomEvent("sourcecado:board-changed"));
+    await waitFor(() => expect(api.getBoard).toHaveBeenCalledTimes(2));
+  });
+
+  it("can inspect and revert a prior person-file version", async () => {
+    render(<PersonFileView personId="person one" />);
+    expect(await screen.findByRole("heading", { name: "Version history" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Revert to version 1" }));
+    await waitFor(() =>
+      expect(api.revertPerson).toHaveBeenCalledWith("person one", {
+        toVersion: 1,
+        expectedVersion: 2,
+        rationaleSummary: "Restore version 1 from person history.",
+      }),
+    );
   });
 });

--- a/desktop/surfaces/gui/tests/chatPage.test.tsx
+++ b/desktop/surfaces/gui/tests/chatPage.test.tsx
@@ -110,6 +110,38 @@ describe("ChatPage Warm Operator thread", () => {
     });
   });
 
+  it("notifies the Board when a live person-file tool changes it", async () => {
+    api.getSession.mockResolvedValue({
+      id: "thread-alpha",
+      title: "Board write",
+      messages: [],
+      events: [],
+    });
+    const changed = vi.fn();
+    window.addEventListener("sourcecado:board-changed", changed);
+    render(<ChatPage sessionId="thread-alpha" />);
+    await waitFor(() => expect(onChatEvent).toBeDefined());
+
+    act(() => {
+      onChatEvent?.({
+        version: 2,
+        session_id: "thread-alpha",
+        run_id: "run-board",
+        message_id: "assistant-board",
+        part_id: "assistant-board-part",
+        type: "tool_finished",
+        event_id: "board-live-1",
+        id: "board-call-1",
+        name: "board_mutate",
+        ok: true,
+        result: { board_changed: true, person: { person_id: "per_ada" } },
+      });
+    });
+
+    expect(changed).toHaveBeenCalledTimes(1);
+    window.removeEventListener("sourcecado:board-changed", changed);
+  });
+
   it("renders restored assistant GFM as semantic content", async () => {
     api.getSession.mockResolvedValue({
       id: "thread-alpha",

--- a/desktop/tests/test_board_tools.py
+++ b/desktop/tests/test_board_tools.py
@@ -1,0 +1,455 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from coworker.permissions import decide
+from coworker.people import PersonStore
+from coworker.server import TOKEN_HEADER, create_app
+from coworker.tools import OPENAI_TOOLS, execute
+
+TOKEN = "test-token-person-board"
+
+
+def _ada(store: PersonStore) -> dict:
+    return store.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L***e",
+        title="Founder",
+        company="Analytic",
+        target="research dinner",
+    )
+
+
+def test_board_tools_are_person_file_operations_not_a_second_crm():
+    names = {schema["function"]["name"] for schema in OPENAI_TOOLS}
+    assert {"board_get", "board_query", "board_upsert", "board_mutate", "board_delete"} <= names
+    for name in ("board_get", "board_query", "board_upsert", "board_mutate"):
+        decision = decide(name)
+        assert decision.allowed is True
+        assert decision.needs_user is False
+    delete = decide("board_delete")
+    assert delete.allowed is False
+    assert delete.needs_user is True
+    upsert = next(schema for schema in OPENAI_TOOLS if schema["function"]["name"] == "board_upsert")
+    assert set(upsert["function"]["parameters"]["properties"]["record_type"]["enum"]) == {
+        "artifact",
+        "knowledge_gap",
+        "source_ref",
+    }
+
+
+def test_board_upsert_does_not_create_a_person_or_fill_open(tmp_path):
+    store = PersonStore(tmp_path)
+    ok, result = execute(
+        "board_upsert",
+        {
+            "person_id": "per_" + "0" * 32,
+            "record_type": "artifact",
+            "fields": {"title": "Draft"},
+            "idempotency_key": "artifact:draft",
+            "rationale_summary": "File a draft.",
+        },
+        people=store,
+    )
+    assert ok is False
+    assert store.list_board() == {"open": [], "in_conversation": [], "done": []}
+
+
+def test_keeping_then_patching_puts_ada_on_the_person_board(tmp_path):
+    store = PersonStore(tmp_path)
+    ada = _ada(store)
+    store.set_sequence(ada["person_id"], "open", actor="director")
+
+    ok, patched = execute(
+        "board_mutate",
+        {
+            "action": "patch",
+            "person_id": ada["person_id"],
+            "expected_version": store.get(ada["person_id"])["version"],
+            "fields": {"title": "Founding partner"},
+            "rationale_summary": "Correct the title from a cited source.",
+        },
+        people=store,
+        actor="assistant",
+        session_id="session-1",
+        run_id="run-1",
+    )
+
+    assert ok is True
+    assert patched["board_changed"] is True
+    assert patched["person"]["title"] == "Founding partner"
+    assert [row["person_id"] for row in store.list_board()["open"]] == [ada["person_id"]]
+    receipt = store.timeline(ada["person_id"])[-1]
+    assert receipt["actor"] == "assistant"
+    assert receipt["session_id"] == "session-1"
+    assert receipt["run_id"] == "run-1"
+
+
+def test_stale_patch_cannot_overwrite_a_newer_human_edit(tmp_path):
+    store = PersonStore(tmp_path)
+    ada = _ada(store)
+    store.patch(
+        ada["person_id"],
+        fields={"title": "Director edit"},
+        expected_version=1,
+        actor="director",
+        rationale_summary="Human corrected the title.",
+    )
+    ok, result = execute(
+        "board_mutate",
+        {
+            "action": "patch",
+            "person_id": ada["person_id"],
+            "expected_version": 1,
+            "fields": {"title": "Stale agent overwrite"},
+            "rationale_summary": "This should not land.",
+        },
+        people=store,
+    )
+    assert ok is False
+    assert "stale" in result["error"]
+    assert store.get(ada["person_id"])["title"] == "Director edit"
+
+
+def test_draft_artifact_cannot_move_a_person_to_in_conversation(tmp_path):
+    store = PersonStore(tmp_path)
+    ada = _ada(store)
+    store.set_sequence(ada["person_id"], "open", actor="director")
+    execute(
+        "board_upsert",
+        {
+            "person_id": ada["person_id"],
+            "record_type": "artifact",
+            "fields": {"title": "Outreach draft", "artifact_type": "gmail_draft"},
+            "idempotency_key": "artifact:draft",
+            "rationale_summary": "File the unsent draft.",
+        },
+        people=store,
+    )
+    version = store.get(ada["person_id"])["version"]
+    ok, result = execute(
+        "board_mutate",
+        {
+            "action": "transition",
+            "person_id": ada["person_id"],
+            "expected_version": version,
+            "to_state": "in_conversation",
+            "rationale_summary": "A draft is not a sent email.",
+        },
+        people=store,
+        actor="assistant",
+    )
+    assert ok is False
+    assert "in_conversation" in result["error"]
+    assert store.get(ada["person_id"])["sequence_state"] == "open"
+
+
+def test_sent_mail_lets_the_assistant_move_to_in_conversation(tmp_path):
+    store = PersonStore(tmp_path)
+    ada = _ada(store)
+    store.set_sequence(ada["person_id"], "open", actor="director")
+    store.append_event(
+        ada["person_id"],
+        source="gmail",
+        kind="send",
+        summary="Sent draft d1",
+        payload={"sent": True, "draft_id": "d1"},
+        actor="assistant",
+        tool="gmail_send",
+    )
+    version = store.get(ada["person_id"])["version"]
+    ok, result = execute(
+        "board_mutate",
+        {
+            "action": "transition",
+            "person_id": ada["person_id"],
+            "expected_version": version,
+            "to_state": "in_conversation",
+            "rationale_summary": "The sent mail opened the conversation.",
+        },
+        people=store,
+        actor="assistant",
+    )
+    assert ok is True
+    assert result["person"]["sequence_state"] == "in_conversation"
+
+
+def test_director_allow_can_move_without_sent_mail(tmp_path):
+    store = PersonStore(tmp_path)
+    ada = _ada(store)
+    updated = store.set_sequence(ada["person_id"], "in_conversation", actor="director")
+    assert updated["sequence_state"] == "in_conversation"
+
+
+def test_done_requires_an_outcome_for_the_assistant(tmp_path):
+    store = PersonStore(tmp_path)
+    ada = _ada(store)
+    store.set_sequence(ada["person_id"], "open", actor="director")
+    version = store.get(ada["person_id"])["version"]
+    ok, result = execute(
+        "board_mutate",
+        {
+            "action": "transition",
+            "person_id": ada["person_id"],
+            "expected_version": version,
+            "to_state": "done",
+            "rationale_summary": "Close without an outcome.",
+        },
+        people=store,
+        actor="assistant",
+    )
+    assert ok is False
+    store.capture_outcome(
+        ada["person_id"],
+        outcome="not a fit",
+        expected_version=store.get(ada["person_id"])["version"],
+        actor="assistant",
+        rationale_summary="Record the outcome first.",
+    )
+    ok, result = execute(
+        "board_mutate",
+        {
+            "action": "transition",
+            "person_id": ada["person_id"],
+            "expected_version": store.get(ada["person_id"])["version"],
+            "to_state": "done",
+            "rationale_summary": "Close after the outcome.",
+        },
+        people=store,
+        actor="assistant",
+    )
+    assert ok is True
+    assert result["person"]["sequence_state"] == "done"
+    assert result["person"]["outcome"] == "not a fit"
+
+
+def test_restricted_source_is_hidden_on_get_query_and_patch_results(tmp_path):
+    store = PersonStore(tmp_path)
+    ada = _ada(store)
+    created = store.upsert_attachment(
+        ada["person_id"],
+        record_type="source_ref",
+        fields={"title": "Resume", "excerpt": "SSN 123-45-6789", "sensitivity": "restricted"},
+        idempotency_key="source:resume",
+        actor="assistant",
+        rationale_summary="File a restricted resume.",
+    )
+    assert created["restricted"] is True
+    assert "excerpt" not in created
+    expanded = store.get(ada["person_id"], expand_sources=True)
+    assert expanded is not None
+    assert expanded["sources"] == []
+    assert expanded["restricted_source_count"] == 1
+    granted = store.get(
+        ada["person_id"],
+        expand_sources=True,
+        allowed_source_ids={created["id"]},
+    )
+    assert granted is not None
+    assert granted["sources"][0]["fields"]["excerpt"] == "SSN 123-45-6789"
+
+
+def test_conflicting_source_facts_do_not_silently_overwrite(tmp_path):
+    store = PersonStore(tmp_path)
+    ada = _ada(store)
+    store.upsert_attachment(
+        ada["person_id"],
+        record_type="source_ref",
+        fields={"title": "Apollo", "claimed_title": "Founder"},
+        idempotency_key="source:apollo-title",
+        actor="assistant",
+        rationale_summary="Apollo title.",
+    )
+    with pytest.raises(ValueError, match="idempotency conflict"):
+        store.upsert_attachment(
+            ada["person_id"],
+            record_type="source_ref",
+            fields={"title": "Apollo", "claimed_title": "Partner"},
+            idempotency_key="source:apollo-title",
+            actor="assistant",
+            rationale_summary="Conflicting title.",
+        )
+    second = store.upsert_attachment(
+        ada["person_id"],
+        record_type="knowledge_gap",
+        fields={"question": "Is the title Founder or Partner?"},
+        idempotency_key="gap:title",
+        actor="assistant",
+        rationale_summary="Name the conflict.",
+    )
+    expanded = store.get(ada["person_id"], expand_sources=True)
+    assert expanded is not None
+    assert len(expanded["sources"]) == 1
+    assert expanded["knowledge_gaps"][0]["id"] == second["id"]
+
+
+def test_duplicate_apollo_keep_stays_one_person_on_the_board(tmp_path):
+    store = PersonStore(tmp_path)
+    first = store.keep_from_apollo(
+        apollo_id="abc123",
+        first_name="Alyssa",
+        last_name_obfuscated="W***n",
+        title="Partner",
+        company="Codeology",
+    )
+    store.set_sequence(first["person_id"], "open", actor="director")
+    second = store.keep_from_apollo(
+        apollo_id="abc123",
+        first_name="Alyssa",
+        last_name_obfuscated="Wilson",
+        title="Partner",
+        company="Codeology",
+    )
+    assert second["person_id"] == first["person_id"]
+    assert [row["person_id"] for row in store.list_board()["open"]] == [first["person_id"]]
+
+
+def test_revert_restores_a_prior_person_version(tmp_path):
+    store = PersonStore(tmp_path)
+    ada = _ada(store)
+    patched = store.patch(
+        ada["person_id"],
+        fields={"title": "Wrong title"},
+        expected_version=1,
+        actor="assistant",
+        rationale_summary="Bad source.",
+    )
+    reverted = store.revert(
+        ada["person_id"],
+        to_version=1,
+        expected_version=patched["version"],
+        actor="director",
+        rationale_summary="Restore the verified title.",
+    )
+    assert reverted["title"] == "Founder"
+    assert reverted["version"] == patched["version"] + 1
+    assert PersonStore(tmp_path).get(ada["person_id"])["title"] == "Founder"
+
+
+def test_delete_hides_the_person_from_the_board_and_keeps_a_receipt(tmp_path):
+    store = PersonStore(tmp_path)
+    ada = _ada(store)
+    store.set_sequence(ada["person_id"], "open", actor="director")
+    deleted = store.delete(
+        ada["person_id"],
+        expected_version=store.get(ada["person_id"])["version"],
+        actor="director",
+        rationale_summary="Remove the duplicate after Allow.",
+    )
+    assert deleted["deleted"] is True
+    assert store.get(ada["person_id"]) is None
+    assert store.list_board() == {"open": [], "in_conversation": [], "done": []}
+    assert store.timeline(ada["person_id"])[-1]["kind"] == "delete"
+
+
+def test_query_filters_board_people_by_sequence_and_company(tmp_path):
+    store = PersonStore(tmp_path)
+    ada = _ada(store)
+    store.set_sequence(ada["person_id"], "open", actor="director")
+    rows = store.query(sequence="open", company="Analytic", target="research dinner")
+    assert [row["person_id"] for row in rows] == [ada["person_id"]]
+    assert store.query(sequence="done") == []
+
+
+def test_keep_then_open_lands_on_the_person_board(tmp_path):
+    store = PersonStore(tmp_path)
+    ok, kept = execute(
+        "people_keep",
+        {
+            "people": [
+                {
+                    "apolloId": "ada",
+                    "firstName": "Ada",
+                    "lastNameObfuscated": "L***e",
+                    "title": "Founder",
+                    "organizationName": "Analytic",
+                }
+            ],
+            "target": "research dinner",
+        },
+        people=store,
+    )
+    assert ok is True
+    person_id = kept["kept"][0]["person_id"]
+    assert store.list_board()["open"] == []
+    ok, opened = execute(
+        "board_mutate",
+        {
+            "action": "transition",
+            "person_id": person_id,
+            "expected_version": store.get(person_id)["version"],
+            "to_state": "open",
+            "rationale_summary": "Start the sequence.",
+        },
+        people=store,
+    )
+    assert ok is True
+    assert [row["person_id"] for row in store.list_board()["open"]] == [person_id]
+
+
+def test_approved_board_delete_uses_the_human_actor(tmp_path):
+    app = create_app(token=TOKEN, state=tmp_path)
+    person = app.state.people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+    )
+    app.state.people.set_sequence(person["person_id"], "open", actor="director")
+    item = app.state.inbox.park(
+        "board_delete",
+        {
+            "person_id": person["person_id"],
+            "expected_version": app.state.people.get(person["person_id"])["version"],
+            "rationale_summary": "Delete the duplicate after review.",
+        },
+        item_id="board-delete-approved",
+        session_id="session-delete",
+        run_id="run-delete",
+    )
+    response = TestClient(app).post(
+        f"/v1/inbox/{item['id']}",
+        headers={TOKEN_HEADER: TOKEN},
+        json={"decision": "allow", "actor": "director", "scope": "once"},
+    )
+    assert response.status_code == 200
+    assert app.state.people.get(person["person_id"]) is None
+    assert app.state.people.list_board()["open"] == []
+    assert app.state.people.timeline(person["person_id"])[-1]["actor"] == "director"
+
+
+def test_person_api_lists_versions_and_reverts(tmp_path):
+    app = create_app(token=TOKEN, state=tmp_path)
+    person = app.state.people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+    )
+    updated = app.state.people.patch(
+        person["person_id"],
+        fields={"title": "Wrong"},
+        expected_version=1,
+        actor="assistant",
+        rationale_summary="Bad title.",
+    )
+    client = TestClient(app)
+    detail = client.get(
+        f"/v1/people/{person['person_id']}", headers={TOKEN_HEADER: TOKEN}
+    )
+    assert detail.status_code == 200
+    assert detail.json()["person"]["title"] == "Wrong"
+    assert [row["version"] for row in detail.json()["versions"]]
+    reverted = client.post(
+        f"/v1/people/{person['person_id']}/revert",
+        headers={TOKEN_HEADER: TOKEN},
+        json={
+            "to_version": 1,
+            "expected_version": updated["version"],
+            "rationale_summary": "Restore Founder.",
+        },
+    )
+    assert reverted.status_code == 200
+    assert reverted.json()["person"]["title"] == "Founder"

--- a/desktop/tests/test_board_tools.py
+++ b/desktop/tests/test_board_tools.py
@@ -174,6 +174,98 @@ def test_sent_mail_lets_the_assistant_move_to_in_conversation(tmp_path):
     assert result["person"]["sequence_state"] == "in_conversation"
 
 
+def test_reading_inbound_mail_lets_the_assistant_move_to_in_conversation(tmp_path):
+    store = PersonStore(tmp_path)
+    ada = _ada(store)
+    store.set_sequence(ada["person_id"], "open", actor="director")
+    store.append_event(
+        ada["person_id"],
+        source="gmail",
+        kind="mail",
+        summary="Read mail Re: research dinner",
+        payload={
+            "id": "m1",
+            "from": "ada@analytic.example",
+            "subject": "Re: research dinner",
+        },
+        actor="assistant",
+        tool="gmail_read",
+    )
+    ok, result = execute(
+        "board_mutate",
+        {
+            "action": "transition",
+            "person_id": ada["person_id"],
+            "expected_version": store.get(ada["person_id"])["version"],
+            "to_state": "in_conversation",
+            "rationale_summary": "Ada replied.",
+        },
+        people=store,
+        actor="assistant",
+    )
+    assert ok is True
+    assert result["person"]["sequence_state"] == "in_conversation"
+
+
+def test_gmail_search_mentioning_reply_cannot_move_to_in_conversation(tmp_path):
+    store = PersonStore(tmp_path)
+    ada = _ada(store)
+    store.set_sequence(ada["person_id"], "open", actor="director")
+    store.append_event(
+        ada["person_id"],
+        source="gmail",
+        kind="mail",
+        summary="Searched Gmail for 'Ada reply' (0)",
+        payload={"query": "Ada reply", "ids": []},
+        actor="assistant",
+        tool="gmail_search",
+    )
+    ok, result = execute(
+        "board_mutate",
+        {
+            "action": "transition",
+            "person_id": ada["person_id"],
+            "expected_version": store.get(ada["person_id"])["version"],
+            "to_state": "in_conversation",
+            "rationale_summary": "A search is not a reply.",
+        },
+        people=store,
+        actor="assistant",
+    )
+    assert ok is False
+    assert "in_conversation" in result["error"]
+    assert store.get(ada["person_id"])["sequence_state"] == "open"
+
+
+def test_failed_gmail_send_cannot_move_to_in_conversation(tmp_path):
+    store = PersonStore(tmp_path)
+    ada = _ada(store)
+    store.set_sequence(ada["person_id"], "open", actor="director")
+    store.append_event(
+        ada["person_id"],
+        source="gmail",
+        kind="error",
+        summary="Gmail send failed",
+        payload={"detail": "gmail 500"},
+        actor="assistant",
+        tool="gmail_send",
+    )
+    ok, result = execute(
+        "board_mutate",
+        {
+            "action": "transition",
+            "person_id": ada["person_id"],
+            "expected_version": store.get(ada["person_id"])["version"],
+            "to_state": "in_conversation",
+            "rationale_summary": "A failed send is not outreach.",
+        },
+        people=store,
+        actor="assistant",
+    )
+    assert ok is False
+    assert store.get(ada["person_id"])["sequence_state"] == "open"
+
+
 def test_director_allow_can_move_without_sent_mail(tmp_path):
     store = PersonStore(tmp_path)
     ada = _ada(store)
@@ -340,6 +432,54 @@ def test_delete_hides_the_person_from_the_board_and_keeps_a_receipt(tmp_path):
     assert store.get(ada["person_id"]) is None
     assert store.list_board() == {"open": [], "in_conversation": [], "done": []}
     assert store.timeline(ada["person_id"])[-1]["kind"] == "delete"
+
+
+def test_keep_after_delete_restores_the_same_apollo_person(tmp_path):
+    store = PersonStore(tmp_path)
+    ada = _ada(store)
+    store.set_sequence(ada["person_id"], "open", actor="director")
+    store.delete(
+        ada["person_id"],
+        expected_version=store.get(ada["person_id"])["version"],
+        actor="director",
+        rationale_summary="Remove the duplicate after Allow.",
+    )
+    ok, kept = execute(
+        "people_keep",
+        {
+            "people": [
+                {
+                    "apolloId": "ada",
+                    "firstName": "Ada",
+                    "lastNameObfuscated": "L***e",
+                    "title": "Founder",
+                    "organizationName": "Analytic",
+                }
+            ],
+            "target": "research dinner",
+        },
+        people=store,
+    )
+    assert ok is True
+    person_id = kept["kept"][0]["person_id"]
+    assert person_id == ada["person_id"]
+    restored = store.get(person_id)
+    assert restored is not None
+    assert restored["deleted_at"] in (None, "")
+    assert [row["person_id"] for row in store.list_board()["open"]] == [person_id]
+    ok, opened = execute(
+        "board_mutate",
+        {
+            "action": "transition",
+            "person_id": person_id,
+            "expected_version": restored["version"],
+            "to_state": "open",
+            "rationale_summary": "File Ada again.",
+        },
+        people=store,
+    )
+    assert ok is True
+    assert opened["person"]["sequence_state"] == "open"
 
 
 def test_query_filters_board_people_by_sequence_and_company(tmp_path):

--- a/desktop/tests/test_bound_turn.py
+++ b/desktop/tests/test_bound_turn.py
@@ -530,5 +530,7 @@ def test_kernel_says_send_requires_allow():
     from coworker.server import KERNEL
 
     assert "gmail_send" in KERNEL
+    assert "board_query" in KERNEL
+    assert "board_delete" in KERNEL
     assert "Allow" in KERNEL
     assert "never sends" not in KERNEL


### PR DESCRIPTION
## Summary

The agent can now read and write the existing person-file Board. One operating picture: people in Open, In conversation, and Done.

`people_keep` still creates files from Apollo. New tools attach artifacts, knowledge gaps, and source refs to a person, patch identity fields with a version check, move sequence state, record outcomes, revert, and delete after Allow.

This is the #42 rewrite after the #47 CRM review. No `sourcing-index.db`. No company, contact, or opportunity records.

## Before / after

| Case | Before | After |
|---|---|---|
| Agent files Ada | No Board write path except keep | Keep, then `board_mutate` transition to `open`. Ada is in Open. |
| Draft only | n/a | Cannot move to In conversation |
| Sent mail | n/a | Assistant can move to In conversation |
| Director clicks In conversation | Always allowed | Still allowed (director Allow) |
| Restricted resume | n/a | Hidden on get/expand unless granted. Patch results do not return the body. |
| Delete person file | n/a | `board_delete` waits for Allow |

## Not in this PR

- Semester, company, contact, or opportunity records.
- Workspace filesystem tools (#41).
- Resumable Drive folder ingestion.

## Verification

- desktop pytest: 374 passed, 1 skipped
- desktop GUI vitest: 343 passed
- git diff --check: passed

Closes #42