### PR TITLE
feat(agent-runs): add durable checkpoint spine

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,6 +37,32 @@ The director's explicit instruction to send a reviewed Gmail message from Source
 **Outreach Outcome**
 What happened after outreach: no response, replied, interested, not a fit, needs follow-up, met, booked, or another recorded result. Outcomes update the person file and may move its sequence.
 
+## Agent work
+
+**Agent Job**
+A concrete outcome the director asks Sourcecado to produce. A job begins as instructions and does not require a skill.
+_Avoid_: Prompt, task, skill run
+
+**Agent Run**
+The durable execution of one Agent Job through clarification, approvals, tools, interruption, resume, and terminal delivery. A later revision to a completed result is a new linked Agent Run.
+_Avoid_: Skill run, message, model call
+
+**Skill**
+Optional instructions that teach the agent how to approach a kind of Agent Job. A Skill does not own persistence, permissions, scheduling, or execution.
+_Avoid_: Feature, workflow engine, agent runtime
+
+**Knowledge Workspace**
+The Drive folder selected as Sourcecado's bounded sourcing knowledge. Drive remains authoritative; Sourcecado may keep a local read-only searchable projection.
+_Avoid_: Entire Drive, memory dump, global search scope
+
+**Artifact Workspace**
+The private writable workspace belonging to one Agent Run where Sourcecado creates file deliverables. Files in this workspace can become Artifacts.
+_Avoid_: Repository, unrestricted filesystem, chat attachment folder
+
+**Semantic Agent Trace**
+The durable observable record of an Agent Run: instructions, model turns, tools, evidence, approvals, timing, usage, artifacts, outcomes, errors, and feedback. It excludes transport-level token chunks and hidden chain-of-thought.
+_Avoid_: Raw stream log, chain-of-thought, transcript dump
+
 ## Evidence and memory
 
 **Source Material**
@@ -49,10 +75,10 @@ A stable pointer from a claim or artifact to its underlying source record. It sh
 Important missing, stale, conflicting, or uncertain context. Sourcecado names gaps instead of hiding them behind confident prose.
 
 **Artifact**
-A durable, reviewable output from a run, such as an outreach draft, evidence set, living brief update, calendar result, or handoff summary. A transient chat message is not automatically an artifact.
+A durable, reviewable output from an Agent Run, such as a PPTX, DOCX, XLSX, PDF, Google document, campaign package, outreach draft, or handoff. A transient chat message is not automatically an Artifact.
 
 **Run Ledger**
-The local record of what Sourcecado did: run steps, tool calls, artifacts, sources, permission decisions, usage, failures, and rationale summaries. It is operational evidence, not hidden chain-of-thought.
+The local collection of Semantic Agent Traces. It is operational and evaluation evidence, not hidden chain-of-thought.
 
 **Sourcing Memory**
 The accumulated person files, outcomes, source-backed notes, and handoffs that prevent future officers from reconstructing relationships from scratch. The current runtime is local to one operator, but its records should remain intelligible to a successor.
@@ -69,7 +95,7 @@ The assistant's operating picture of sequences in Open, In conversation, and Don
 The full person file and handoff record. A compact version of the living brief may appear beside work in other surfaces.
 
 **Scheduled Job**
-A saved local task that can run on a schedule. Scheduling supports the assistant but is not the product's defining weekly-ranking loop.
+A saved prompt and schedule that starts an ordinary Agent Run through the same engine as Chat. Scheduling supports the assistant but is not the product's defining weekly-ranking loop.
 
 ## Safety and scope invariants
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -4,11 +4,15 @@ This file tracks product-level gaps only. Implementation checklists belong in da
 
 ## Current spring
 
-- Finish the target → Apollo candidates → keep person flow in the active desktop UI.
-- Complete the review → enrich → approve → Gmail send path with ledger coverage for every costly or external action.
-- Make Open, In conversation, and Done reliable as the sourcing director's operating picture.
-- Keep the living brief and handoff summary synchronized with a person's Gmail, Drive, Calendar, web, and meeting-note evidence.
-- Close the remaining desktop accessibility, crash recovery, and responsive QA findings recorded in current plans and QA reports.
+- Build the Durable Agent Run around the existing loop using OpenWorker's prompt-driven lifecycle, question/approval suspension, partial preservation, durable resume, checkpoints, and compaction.
+- Let the director select one Drive Knowledge Workspace and maintain a local read-only FTS index using the approved narrow OpenClaw memory-host design.
+- Port OpenWorker's per-run scratch workspace, files/search/persistent shell/todo tools, and file-backed Artifact surface; teach common formats through Skills and add Google-native connector tools.
+- Replace hard-coded connection status/tool copy with OpenWorker-style Connector Descriptors and real provider validators.
+- Preserve an eval-ready Semantic Agent Trace while keeping token-stream deltas ephemeral.
+- Re-run the outreach campaign and company pitch package until both finish in one Agent Run and produce accepted editable Artifacts.
+
+The approved architecture and implementation order are recorded in
+`docs/superpowers/plans/2026-08-26-evidence-reconciled-agent-os-roadmap.md`.
 
 ## Deliberately later
 

--- a/desktop/coworker/agent_runs.py
+++ b/desktop/coworker/agent_runs.py
@@ -1,0 +1,338 @@
+"""Durable Agent Run vocabulary and JSON merge helpers.
+
+Agent Run checkpoints describe semantic progress only. Presentation stream
+deltas stay in the event log and never enter this durable authority.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+AGENT_RUN_STATES = frozenset(
+    {
+        "running",
+        "waiting_approval",
+        "waiting_question",
+        "complete",
+        "partial",
+        "stopped",
+        "failed",
+        "interrupted",
+    }
+)
+TERMINAL_AGENT_RUN_STATES = frozenset({"complete", "partial", "stopped", "failed"})
+AGENT_RUN_CHECKPOINT_KINDS = frozenset(
+    {
+        "run_started",
+        "user_input",
+        "model_completed",
+        "tool_completed",
+        "waiting_approval",
+        "approval_resolved",
+        "terminal",
+        "process_interrupted",
+    }
+)
+
+_SENSITIVE_KEY_MARKERS = (
+    "password",
+    "apikey",
+    "cookie",
+    "authorization",
+    "header",
+    "token",
+    "secret",
+    "credential",
+    "body",
+    "rawsource",
+    "rawpayload",
+    "awsaccesskeyid",
+)
+_MAX_CHECKPOINT_STRING = 512
+_MAX_CHECKPOINT_ITEMS = 50
+_MAX_CHECKPOINT_DEPTH = 4
+_CREDENTIAL_ASSIGNMENT_RE = re.compile(
+    r"(?<![A-Za-z0-9])((?:[A-Za-z][A-Za-z0-9_.-]*?)?"
+    r"(?:token|secret|password|credential|cookie)|api[-_ ]?key|authorization"
+    r"|awsaccesskeyid)"
+    r"[ \t]*([=:])[ \t]*(?:(?:Bearer|Basic)[ \t]+)?"
+    r"(?:\"(?:\\.|[^\"])*\"|'(?:\\.|[^'])*'|[^\s,;]+)",
+    re.IGNORECASE,
+)
+_JSON_AUTH_RE = re.compile(
+    r"(?P<prefix>[\"']?authorization[\"']?[ \t]*[:=][ \t]*)"
+    r"(?P<quote>[\"']?)(?:Bearer|Basic)[ \t]+[^\"'\s,;}]+(?P=quote)",
+    re.IGNORECASE,
+)
+_HIGH_ENTROPY_ASSIGNMENT_RE = re.compile(
+    r"(?<![A-Za-z0-9])(signature|code|key)[ \t]*([=:])[ \t]*"
+    r"(?=[A-Za-z0-9_./+=-]*[0-9_./+=-])"
+    r"[A-Za-z0-9_./+=-]{20,}(?![A-Za-z0-9_./+=-])",
+    re.IGNORECASE,
+)
+_PROVIDER_TOKEN_RE = re.compile(
+    r"(?:sk-(?:proj-)?[A-Za-z0-9_-]{20,}"
+    r"|AIza[A-Za-z0-9_-]{20,}"
+    r"|AKIA[A-Z0-9]{16}"
+    r"|ghp_[A-Za-z0-9]{20,}"
+    r"|xoxb-[A-Za-z0-9-]{20,}"
+    r"|eyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,})"
+)
+_PRIVATE_KEY_RE = re.compile(
+    r"-----BEGIN (?:(?:RSA|EC|DSA|OPENSSH|ENCRYPTED) )?PRIVATE KEY-----.*?"
+    r"-----END (?:(?:RSA|EC|DSA|OPENSSH|ENCRYPTED) )?PRIVATE KEY-----",
+    re.IGNORECASE | re.DOTALL,
+)
+_SAFE_REF_STRING = 512
+_SAFE_ID_STRING = 256
+
+
+def json_list(raw: Any) -> list[Any]:
+    parsed = _json_value(raw, [])
+    return parsed if isinstance(parsed, list) else []
+
+
+def json_object(raw: Any) -> dict[str, Any]:
+    parsed = _json_value(raw, {})
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def nullable_json_object(raw: Any) -> dict[str, Any] | None:
+    if raw is None:
+        return None
+    parsed = _json_value(raw, None)
+    return parsed if isinstance(parsed, dict) else None
+
+
+def merge_unique_json(
+    existing: list[dict[str, Any]], incoming: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Keep first-seen values, preferring a record id as its stable key."""
+    merged: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in [*existing, *incoming]:
+        if not isinstance(item, dict):
+            continue
+        item_id = item.get("id")
+        key = (
+            f"id:{item_id}"
+            if item_id not in (None, "")
+            else "json:" + json.dumps(item, sort_keys=True, separators=(",", ":"))
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        merged.append(item)
+    return merged
+
+
+def merge_unique_strings(existing: list[Any], incoming: list[str]) -> list[str]:
+    merged: list[str] = []
+    seen: set[str] = set()
+    for raw in [*existing, *incoming]:
+        value = str(raw).strip()
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        merged.append(value)
+    return merged
+
+
+def add_usage(
+    existing: dict[str, Any], deltas: dict[str, int | float]
+) -> dict[str, int | float]:
+    usage: dict[str, int | float] = {
+        str(key): value
+        for key, value in existing.items()
+        if isinstance(value, (int, float)) and not isinstance(value, bool)
+    }
+    for key, value in deltas.items():
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            continue
+        name = str(key)
+        usage[name] = usage.get(name, 0) + value
+    return usage
+
+
+def bounded_checkpoint_payload(payload: dict[str, Any] | None) -> dict[str, Any]:
+    """Bound semantic summaries and discard obvious credential-shaped fields."""
+    bounded = sanitize_agent_run_value(
+        payload or {},
+        max_string=_MAX_CHECKPOINT_STRING,
+        max_items=_MAX_CHECKPOINT_ITEMS,
+        max_depth=_MAX_CHECKPOINT_DEPTH,
+    )
+    return bounded if isinstance(bounded, dict) else {}
+
+
+def safe_error_summary(message: str) -> str:
+    """Keep a useful bounded failure summary without credential-shaped values."""
+    return redact_sensitive_assignments(str(message))[:_MAX_CHECKPOINT_STRING]
+
+
+def original_goal_fingerprint(original_goal: str) -> str:
+    return hashlib.sha256(str(original_goal).encode("utf-8")).hexdigest()
+
+
+def project_source_refs(values: Any) -> list[dict[str, Any]]:
+    projected: list[dict[str, Any]] = []
+    for raw in values if isinstance(values, list) else []:
+        if not isinstance(raw, dict):
+            continue
+        projected.append(
+            {
+                "id": _safe_string(raw.get("id"), _SAFE_ID_STRING),
+                "title": _safe_string(raw.get("title"), _SAFE_REF_STRING),
+                "url": sanitize_http_url(raw.get("url")),
+                "provider": _safe_string(raw.get("provider"), _SAFE_REF_STRING),
+                "stale": bool(raw.get("stale", False)),
+                "truncated": bool(raw.get("truncated", False)),
+            }
+        )
+    return projected
+
+
+def project_artifact_refs(values: Any) -> list[dict[str, Any]]:
+    projected: list[dict[str, Any]] = []
+    for raw in values if isinstance(values, list) else []:
+        if not isinstance(raw, dict):
+            continue
+        projected.append(
+            {
+                "id": _safe_string(raw.get("id"), _SAFE_ID_STRING),
+                "artifact_type": _safe_string(
+                    raw.get("artifact_type"), _SAFE_REF_STRING
+                ),
+                "title": _safe_string(raw.get("title"), _SAFE_REF_STRING),
+                "external_url": sanitize_http_url(raw.get("external_url")),
+                "stale": bool(raw.get("stale", False)),
+                "truncated": bool(raw.get("truncated", False)),
+            }
+        )
+    return projected
+
+
+def project_terminal_result(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    projected: dict[str, Any] = {}
+    if value.get("status") is not None:
+        projected["status"] = _safe_string(value.get("status"), 64)
+    if value.get("message_id") is not None:
+        projected["message_id"] = _safe_string(value.get("message_id"), 256)
+    raw_length = value.get("text_length")
+    if isinstance(raw_length, (int, float)) and not isinstance(raw_length, bool):
+        projected["text_length"] = max(0, int(raw_length))
+    elif isinstance(value.get("text"), str):
+        projected["text_length"] = len(value["text"])
+    if value.get("error") is not None:
+        projected["error"] = safe_error_summary(str(value.get("error")))
+    if value.get("class") is not None:
+        projected["class"] = _safe_string(value.get("class"), 128)
+    return projected
+
+
+def sanitize_http_url(value: Any) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = urlsplit(value.strip())
+        if parsed.scheme.lower() not in {"http", "https"} or not parsed.hostname:
+            return None
+        host = parsed.hostname
+        if ":" in host and not host.startswith("["):
+            host = f"[{host}]"
+        port = parsed.port
+        netloc = f"{host}:{port}" if port is not None else host
+        return urlunsplit((parsed.scheme.lower(), netloc, parsed.path, "", ""))
+    except (TypeError, ValueError):
+        return None
+
+
+def sanitize_agent_run_value(
+    value: Any,
+    *,
+    max_string: int | None = None,
+    max_items: int | None = None,
+    max_depth: int = 12,
+    _depth: int = 0,
+) -> Any:
+    """Recursively remove secret-shaped keys and redact values in safe fields."""
+    if _depth >= max_depth:
+        return None
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        redacted = redact_sensitive_assignments(value)
+        return redacted if max_string is None else redacted[:max_string]
+    if isinstance(value, list):
+        items = value if max_items is None else value[:max_items]
+        return [
+            sanitize_agent_run_value(
+                item,
+                max_string=max_string,
+                max_items=max_items,
+                max_depth=max_depth,
+                _depth=_depth + 1,
+            )
+            for item in items
+        ]
+    if isinstance(value, dict):
+        items = list(value.items())
+        if max_items is not None:
+            items = items[:max_items]
+        result: dict[str, Any] = {}
+        for raw_key, item in items:
+            key = str(raw_key)[:128]
+            if _sensitive_key(key):
+                continue
+            result[key] = sanitize_agent_run_value(
+                item,
+                max_string=max_string,
+                max_items=max_items,
+                max_depth=max_depth,
+                _depth=_depth + 1,
+            )
+        return result
+    rendered = redact_sensitive_assignments(str(value))
+    return rendered if max_string is None else rendered[:max_string]
+
+
+def redact_sensitive_assignments(value: str) -> str:
+    redacted = _PRIVATE_KEY_RE.sub("[REDACTED PRIVATE KEY]", value)
+    redacted = _JSON_AUTH_RE.sub(
+        lambda match: (
+            f"{match.group('prefix')}{match.group('quote')}"
+            f"[REDACTED]{match.group('quote')}"
+        ),
+        redacted,
+    )
+    redacted = _CREDENTIAL_ASSIGNMENT_RE.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}[REDACTED]", redacted
+    )
+    redacted = _HIGH_ENTROPY_ASSIGNMENT_RE.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}[REDACTED]", redacted
+    )
+    return _PROVIDER_TOKEN_RE.sub("[REDACTED]", redacted)
+
+
+def _safe_string(value: Any, limit: int) -> str:
+    return redact_sensitive_assignments(str(value or ""))[:limit]
+
+
+def _sensitive_key(key: str) -> bool:
+    normalized = re.sub(r"[^a-z0-9]", "", key.lower())
+    return any(marker in normalized for marker in _SENSITIVE_KEY_MARKERS)
+
+
+def _json_value(raw: Any, fallback: Any) -> Any:
+    if not isinstance(raw, str):
+        return raw
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return fallback

--- a/desktop/coworker/automation/scheduler.py
+++ b/desktop/coworker/automation/scheduler.py
@@ -194,6 +194,9 @@ class Scheduler:
                 duration_ms=int((time.perf_counter() - started) * 1000),
                 finished_at=datetime.now(UTC).isoformat(),
                 waiting_approval_count=waiting_approval_count,
+                agent_run_id=(
+                    str(result["run_id"]) if result.get("run_id") else None
+                ),
             )
             if advance:
                 self.store.set_job_next_run(job_id, next_monday_0900(now))

--- a/desktop/coworker/builtin_skills/company-pitch-package/SKILL.md
+++ b/desktop/coworker/builtin_skills/company-pitch-package/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: company-pitch-package
+description: Prepare a source-grounded company brief, editable pitch deck, talking points, and follow-up draft for a Codeology approach.
+allowed-tools: search_memory, gmail_search, gmail_read, drive_search, drive_list_folder, drive_read, web_search, calendar_list, add_memory_note
+---
+
+Use this skill when the Sourcing Director wants to approach or meet one company
+for a concrete Codeology partnership, sponsorship, speaker, or project goal.
+
+## Completion contract
+
+The work is complete only when the director has an accurate brief, a verified
+ask, an editable company-specific deck based on the approved template, talking
+points, knowledge gaps, and a follow-up draft. Research notes without the
+usable package are incomplete.
+
+## Workflow
+
+1. Confirm the company, objective, audience, desired ask, deadline or meeting,
+   required slide format, and intended output location.
+2. Locate the canonical pitch SOP and approved slide template in Drive. Verify
+   title, named parties, approval state, and freshness. Never adapt a legal or
+   external-facing template that is stale or unverified.
+3. Search memory, Gmail, Drive, meeting notes, and the web for prior contact,
+   current company context, relevant Codeology work, and credible reasons for
+   the approach. Keep sources and conflicting facts visible.
+4. Produce the evidence brief first: who the company is, relationship history,
+   why-now, proposed value exchange, desired ask, risks, and knowledge gaps.
+5. Build the company-specific deck from the approved template. Preserve its
+   structure and brand unless the director asks otherwise. Every company claim
+   must trace to a source.
+6. If no active tool can create or edit the requested slide artifact, say so
+   explicitly and return a slide-by-slide content package as partial work.
+   Never claim the deck was edited without a write or artifact receipt.
+7. Produce talking points and a follow-up email draft consistent with the deck
+   and ask.
+8. Present the full package for review and preserve the accepted artifact,
+   sources, decisions, relationship context, corrections, and gaps for later
+   conversations.
+
+## Failure behavior
+
+Do not discard a verified brief because slide creation fails. Return the
+completed evidence, the exact artifact limitation, and the safe next step.

--- a/desktop/coworker/builtin_skills/outreach-campaign/SKILL.md
+++ b/desktop/coworker/builtin_skills/outreach-campaign/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: outreach-campaign
+description: Run a source-grounded Codeology outreach campaign from target definition through reviewed sends and follow-up state.
+allowed-tools: search_memory, gmail_search, gmail_read, drive_search, drive_list_folder, drive_read, web_search, apollo_search_people, people_keep, apollo_enrich_contact, gmail_draft, gmail_send, add_memory_note
+---
+
+Use this skill when the Sourcing Director wants to find and contact a bounded
+set of people for one concrete Codeology objective.
+
+## Completion contract
+
+The work is complete only when the director has a qualified shortlist, a clear
+status for every chosen person, reviewable personalized messages, durable
+receipts for authorized actions, and explicit next actions. A list or a set of
+drafts alone is not a completed campaign.
+
+## Workflow
+
+1. Confirm the campaign objective, target roles or organizations, contact
+   count, deadline, exclusions, and whether the run may enrich, draft, or send.
+2. Locate and read the canonical Drive SOP and outreach template. If multiple
+   plausible sources exist, ask the director to choose. Never treat an
+   unverified or stale template as approved.
+3. Search memory and Gmail for prior relationships, prior outreach, refusals,
+   do-not-contact constraints, and warm paths.
+4. Search Apollo for candidates. Return a bounded shortlist with role,
+   organization, why-now, evidence, missing fields, and any relationship risk.
+5. Let the director curate the shortlist. File only the chosen people. Do not
+   enrich or send to everyone returned by search.
+6. Enrich one chosen person at a time when an address is required. Treat every
+   enrichment as credit-sensitive and wait for its approval.
+7. Draft a message for each chosen person using the approved template and only
+   professionally relevant verified facts. Preserve the campaign objective and
+   the reason this person was chosen.
+8. Present the review set with recipient, subject, body, sources, and status.
+   Create or send only through the corresponding approval-gated tool. Never
+   claim a draft was sent without a send receipt.
+9. Finish with a campaign ledger: chosen, enriched, drafted, sent, blocked,
+   failed, and awaiting follow-up. Record durable relationship facts, outcomes,
+   corrections, and knowledge gaps in memory/person state.
+
+## Failure behavior
+
+Preserve completed people and messages when one person or connector fails.
+Report the exact partial state and a safe resume point. Never replace a scoped
+source failure with unrelated global evidence without telling the director.

--- a/desktop/coworker/server.py
+++ b/desktop/coworker/server.py
@@ -336,6 +336,7 @@ def create_app(
                 emit=None,
                 wait_permission=None,
                 system_prompt_fn=system_prompt,
+                trigger="schedule",
             )
         )
 
@@ -1653,6 +1654,7 @@ def create_app(
                     system_prompt_fn=system_prompt,
                     identity=control.identity,
                     control=control,
+                    trigger="chat_queue" if queue_item_id is not None else "chat",
                 )
                 status = str(result.get("status") or "error")
                 if queue_item_id is not None:

--- a/desktop/coworker/store.py
+++ b/desktop/coworker/store.py
@@ -17,6 +17,24 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from coworker.agent_runs import (
+    AGENT_RUN_CHECKPOINT_KINDS,
+    AGENT_RUN_STATES,
+    TERMINAL_AGENT_RUN_STATES,
+    add_usage,
+    bounded_checkpoint_payload,
+    json_list,
+    json_object,
+    merge_unique_json,
+    merge_unique_strings,
+    nullable_json_object,
+    original_goal_fingerprint,
+    project_artifact_refs,
+    project_source_refs,
+    project_terminal_result,
+    sanitize_agent_run_value,
+)
+
 _SID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 _INTERRUPTED_APPROVAL_ERROR = (
     "Outcome is unknown after Sourcecado restarted. "
@@ -35,6 +53,7 @@ _INTERRUPTED_RUN_SUMMARY = (
     "Review the thread before retrying."
 )
 _DEFAULT_APPROVAL_TTL_SECONDS = 24 * 60 * 60.0
+_AGENT_RUN_PRIVACY_MIGRATION = "agent_run_privacy_v3"
 
 
 def _approval_ttl_seconds() -> float:
@@ -126,6 +145,42 @@ class ConversationStore:
                 result TEXT,
                 created_at TEXT DEFAULT CURRENT_TIMESTAMP
             );
+            CREATE TABLE IF NOT EXISTS agent_runs (
+                run_id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                parent_run_id TEXT,
+                trigger TEXT NOT NULL,
+                original_goal TEXT NOT NULL,
+                original_goal_fingerprint TEXT,
+                original_goal_fingerprint_source TEXT,
+                current_state TEXT NOT NULL,
+                provider_model_id TEXT,
+                checkpoint_sequence INTEGER NOT NULL DEFAULT 0,
+                skills_loaded TEXT NOT NULL DEFAULT '[]',
+                source_refs TEXT NOT NULL DEFAULT '[]',
+                artifact_refs TEXT NOT NULL DEFAULT '[]',
+                usage TEXT NOT NULL DEFAULT '{}',
+                terminal_result TEXT,
+                created_at TEXT NOT NULL,
+                started_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                finished_at TEXT
+            );
+            CREATE TABLE IF NOT EXISTS agent_run_checkpoints (
+                run_id TEXT NOT NULL,
+                sequence INTEGER NOT NULL,
+                kind TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                PRIMARY KEY (run_id, sequence),
+                FOREIGN KEY (run_id) REFERENCES agent_runs(run_id)
+            );
+            CREATE INDEX IF NOT EXISTS agent_runs_session_created
+                ON agent_runs(session_id, created_at);
+            CREATE TABLE IF NOT EXISTS schema_migrations (
+                name TEXT PRIMARY KEY,
+                applied_at TEXT NOT NULL
+            );
             CREATE TABLE IF NOT EXISTS settings (
                 key TEXT PRIMARY KEY,
                 value TEXT NOT NULL
@@ -192,6 +247,23 @@ class ConversationStore:
             """
         )
         try:
+            self._conn.execute(
+                "ALTER TABLE agent_runs ADD COLUMN original_goal_fingerprint TEXT"
+            )
+        except sqlite3.OperationalError:
+            pass
+        try:
+            self._conn.execute(
+                """
+                ALTER TABLE agent_runs
+                ADD COLUMN original_goal_fingerprint_source TEXT
+                """
+            )
+        except sqlite3.OperationalError:
+            pass
+        self._conn.commit()
+        self._migrate_agent_run_privacy()
+        try:
             self._conn.execute("ALTER TABLE jobs ADD COLUMN next_run_at TEXT")
         except sqlite3.OperationalError:
             pass
@@ -216,6 +288,7 @@ class ConversationStore:
             "artifacts": "TEXT",
             "session_id": "TEXT",
             "waiting_approval_count": "INTEGER DEFAULT 0",
+            "agent_run_id": "TEXT",
         }
         for column, definition in run_migrations.items():
             try:
@@ -290,7 +363,125 @@ class ConversationStore:
         self._reconcile_orphaned_inbox_executions()
         self._reconcile_orphaned_queue_items()
         self._reconcile_orphaned_runs()
+        self._reconcile_orphaned_agent_runs()
         self._reconcile_orphaned_recovery_commands()
+
+    def _migrate_agent_run_privacy(self) -> None:
+        """Scrub pre-invariant Agent Run rows without changing their history."""
+        self._conn.execute("BEGIN IMMEDIATE")
+        try:
+            applied = self._conn.execute(
+                "SELECT 1 FROM schema_migrations WHERE name = ?",
+                (_AGENT_RUN_PRIVACY_MIGRATION,),
+            ).fetchone()
+            if applied is not None:
+                self._conn.commit()
+                return
+            runs = self._conn.execute(
+                """
+                SELECT run_id, original_goal, original_goal_fingerprint,
+                       original_goal_fingerprint_source,
+                       skills_loaded, source_refs, artifact_refs,
+                       terminal_result
+                FROM agent_runs
+                """
+            ).fetchall()
+
+            # Identity must be derived from the pre-scrub goal. Backfill every
+            # missing fingerprint before any original_goal value is redacted.
+            for row in runs:
+                stored_goal = str(row["original_goal"])
+                fingerprint = row["original_goal_fingerprint"]
+                if fingerprint is None:
+                    fingerprint = original_goal_fingerprint(stored_goal)
+                source = row["original_goal_fingerprint_source"]
+                if source not in {"raw", "legacy_sanitized"}:
+                    source = (
+                        "legacy_sanitized"
+                        if "[REDACTED" in stored_goal
+                        and fingerprint == original_goal_fingerprint(stored_goal)
+                        else "raw"
+                    )
+                self._conn.execute(
+                    """
+                    UPDATE agent_runs SET
+                        original_goal_fingerprint = ?,
+                        original_goal_fingerprint_source = ?
+                    WHERE run_id = ?
+                    """,
+                    (
+                        fingerprint,
+                        source,
+                        str(row["run_id"]),
+                    ),
+                )
+
+            for row in runs:
+                safe_goal = str(sanitize_agent_run_value(row["original_goal"]))
+                safe_skills = sanitize_agent_run_value(
+                    json_list(row["skills_loaded"])
+                )
+                safe_sources = project_source_refs(json_list(row["source_refs"]))
+                safe_artifacts = project_artifact_refs(
+                    json_list(row["artifact_refs"])
+                )
+                terminal = nullable_json_object(row["terminal_result"])
+                safe_terminal = (
+                    None
+                    if terminal is None
+                    else json.dumps(
+                        project_terminal_result(terminal), ensure_ascii=False
+                    )
+                )
+                self._conn.execute(
+                    """
+                    UPDATE agent_runs SET
+                        original_goal = ?, skills_loaded = ?, source_refs = ?,
+                        artifact_refs = ?, terminal_result = ?
+                    WHERE run_id = ?
+                    """,
+                    (
+                        safe_goal,
+                        json.dumps(safe_skills, ensure_ascii=False),
+                        json.dumps(safe_sources, ensure_ascii=False),
+                        json.dumps(safe_artifacts, ensure_ascii=False),
+                        safe_terminal,
+                        str(row["run_id"]),
+                    ),
+                )
+
+            checkpoints = self._conn.execute(
+                """
+                SELECT run_id, sequence, payload
+                FROM agent_run_checkpoints
+                """
+            ).fetchall()
+            for row in checkpoints:
+                safe_payload = bounded_checkpoint_payload(
+                    json_object(row["payload"])
+                )
+                self._conn.execute(
+                    """
+                    UPDATE agent_run_checkpoints SET payload = ?
+                    WHERE run_id = ? AND sequence = ?
+                    """,
+                    (
+                        json.dumps(safe_payload, ensure_ascii=False),
+                        str(row["run_id"]),
+                        int(row["sequence"]),
+                    ),
+                )
+            self._conn.execute(
+                """
+                INSERT INTO schema_migrations (name, applied_at)
+                VALUES (?, ?)
+                """,
+                (_AGENT_RUN_PRIVACY_MIGRATION, datetime.now(UTC).isoformat()),
+            )
+            self._conn.commit()
+        except Exception:
+            self._conn.rollback()
+            raise
 
     def _reconcile_orphaned_recovery_commands(self) -> None:
         """Drop in-flight recovery claims from the prior process.
@@ -392,6 +583,328 @@ class ConversationStore:
             except Exception:
                 self._conn.rollback()
                 raise
+
+    def _reconcile_orphaned_agent_runs(self) -> None:
+        """Make process-owned work resumable without disturbing parked waits."""
+        now = datetime.now(UTC).isoformat()
+        with self._lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                rows = self._conn.execute(
+                    """
+                    SELECT run_id, checkpoint_sequence
+                    FROM agent_runs
+                    WHERE current_state = 'running'
+                    """
+                ).fetchall()
+                for row in rows:
+                    sequence = int(row["checkpoint_sequence"]) + 1
+                    run_id = str(row["run_id"])
+                    self._conn.execute(
+                        """
+                        UPDATE agent_runs SET
+                            current_state = 'interrupted',
+                            checkpoint_sequence = ?,
+                            updated_at = ?
+                        WHERE run_id = ? AND current_state = 'running'
+                        """,
+                        (sequence, now, run_id),
+                    )
+                    self._conn.execute(
+                        """
+                        INSERT INTO agent_run_checkpoints
+                            (run_id, sequence, kind, payload, created_at)
+                        VALUES (?, ?, 'process_interrupted', ?, ?)
+                        """,
+                        (
+                            run_id,
+                            sequence,
+                            json.dumps(
+                                {"status": "interrupted", "reason": "process_restart"}
+                            ),
+                            now,
+                        ),
+                    )
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
+
+    def start_agent_run(
+        self,
+        *,
+        run_id: str,
+        session_id: str,
+        trigger: str,
+        original_goal: str,
+        provider_model_id: str | None = None,
+        parent_run_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Create one durable Agent Run and its single start checkpoint."""
+        if not run_id or not valid_session_id(session_id):
+            raise ValueError("invalid Agent Run identity")
+        if not trigger.strip():
+            raise ValueError("Agent Run trigger is required")
+        safe_original_goal = str(sanitize_agent_run_value(original_goal))
+        goal_fingerprint = original_goal_fingerprint(original_goal)
+        now = datetime.now(UTC).isoformat()
+        with self._lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                existing = self._conn.execute(
+                    "SELECT * FROM agent_runs WHERE run_id = ?", (run_id,)
+                ).fetchone()
+                if existing is not None:
+                    if str(existing["session_id"]) != session_id:
+                        raise ValueError(
+                            "Agent Run identity belongs to another session"
+                        )
+                    immutable_metadata = {
+                        "parent_run_id": parent_run_id,
+                        "trigger": trigger,
+                        "provider_model_id": provider_model_id,
+                    }
+                    conflicts = [
+                        field
+                        for field, value in immutable_metadata.items()
+                        if existing[field] != value
+                    ]
+                    if existing["original_goal_fingerprint"] != goal_fingerprint:
+                        if (
+                            existing["original_goal_fingerprint_source"]
+                            == "legacy_sanitized"
+                        ):
+                            raise ValueError(
+                                "legacy Agent Run goal identity is irrecoverable; "
+                                "start a new run"
+                            )
+                        conflicts.append("original_goal")
+                    if conflicts:
+                        raise ValueError(
+                            "conflicting Agent Run metadata: "
+                            + ", ".join(conflicts)
+                        )
+                    self._conn.commit()
+                    return _agent_run_row(existing)
+                self._conn.execute(
+                    """
+                    INSERT INTO agent_runs (
+                        run_id, session_id, parent_run_id, trigger,
+                        original_goal, original_goal_fingerprint,
+                        original_goal_fingerprint_source, current_state,
+                        provider_model_id,
+                        checkpoint_sequence, skills_loaded, source_refs,
+                        artifact_refs, usage, terminal_result, created_at,
+                        started_at, updated_at, finished_at
+                    ) VALUES (
+                        ?, ?, ?, ?, ?, ?, 'raw', 'running', ?, 1, '[]', '[]', '[]',
+                        '{}', NULL, ?, ?, ?, NULL
+                    )
+                    """,
+                    (
+                        run_id,
+                        session_id,
+                        parent_run_id,
+                        trigger,
+                        safe_original_goal,
+                        goal_fingerprint,
+                        provider_model_id,
+                        now,
+                        now,
+                        now,
+                    ),
+                )
+                start_payload = bounded_checkpoint_payload(
+                    {
+                        "trigger": trigger,
+                        "provider_model_id": provider_model_id,
+                        "has_parent": parent_run_id is not None,
+                    }
+                )
+                self._conn.execute(
+                    """
+                    INSERT INTO agent_run_checkpoints
+                        (run_id, sequence, kind, payload, created_at)
+                    VALUES (?, 1, 'run_started', ?, ?)
+                    """,
+                    (run_id, json.dumps(start_payload), now),
+                )
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
+        created = self.get_agent_run(run_id)
+        if created is None:
+            raise RuntimeError("Agent Run insert did not persist")
+        return created
+
+    def checkpoint_agent_run(
+        self,
+        run_id: str,
+        *,
+        kind: str,
+        payload: dict[str, Any] | None = None,
+        state: str | None = None,
+        skills_loaded: list[str] | None = None,
+        source_refs: list[dict[str, Any]] | None = None,
+        artifact_refs: list[dict[str, Any]] | None = None,
+        usage_delta: dict[str, int | float] | None = None,
+        terminal_result: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Atomically append semantic progress and update the run projection."""
+        if kind not in AGENT_RUN_CHECKPOINT_KINDS:
+            raise ValueError(f"invalid Agent Run checkpoint kind: {kind}")
+        if state is not None and state not in AGENT_RUN_STATES:
+            raise ValueError(f"invalid Agent Run state: {state}")
+        if kind == "terminal" and state not in TERMINAL_AGENT_RUN_STATES:
+            raise ValueError("terminal checkpoint requires a terminal state")
+        if state in TERMINAL_AGENT_RUN_STATES and kind != "terminal":
+            raise ValueError("terminal Agent Run state requires a terminal checkpoint")
+        now = datetime.now(UTC).isoformat()
+        with self._lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                row = self._conn.execute(
+                    "SELECT * FROM agent_runs WHERE run_id = ?", (run_id,)
+                ).fetchone()
+                if row is None:
+                    raise KeyError(run_id)
+                current_state = str(row["current_state"])
+                if kind == "terminal" and current_state in TERMINAL_AGENT_RUN_STATES:
+                    existing_terminal = self._conn.execute(
+                        """
+                        SELECT * FROM agent_run_checkpoints
+                        WHERE run_id = ? AND kind = 'terminal'
+                        ORDER BY sequence DESC LIMIT 1
+                        """,
+                        (run_id,),
+                    ).fetchone()
+                    self._conn.commit()
+                    if existing_terminal is None:
+                        raise RuntimeError(
+                            "terminal Agent Run is missing its checkpoint"
+                        )
+                    return _agent_run_checkpoint_row(existing_terminal)
+                if current_state in TERMINAL_AGENT_RUN_STATES:
+                    raise ValueError("cannot append to a terminal Agent Run")
+
+                sequence = int(row["checkpoint_sequence"]) + 1
+                next_state = state or current_state
+                existing_skills = sanitize_agent_run_value(
+                    json_list(row["skills_loaded"])
+                )
+                incoming_skills = sanitize_agent_run_value(skills_loaded or [])
+                merged_skills = merge_unique_strings(
+                    existing_skills, incoming_skills
+                )
+                existing_sources = project_source_refs(
+                    json_list(row["source_refs"])
+                )
+                incoming_sources = project_source_refs(source_refs or [])
+                existing_artifacts = project_artifact_refs(
+                    json_list(row["artifact_refs"])
+                )
+                incoming_artifacts = project_artifact_refs(artifact_refs or [])
+                merged_sources = merge_unique_json(
+                    existing_sources, incoming_sources
+                )
+                merged_artifacts = merge_unique_json(
+                    existing_artifacts, incoming_artifacts
+                )
+                usage = add_usage(json_object(row["usage"]), usage_delta or {})
+                next_terminal_result = (
+                    json.dumps(project_terminal_result(terminal_result))
+                    if kind == "terminal" and terminal_result is not None
+                    else row["terminal_result"]
+                )
+                finished_at = (
+                    now
+                    if next_state in TERMINAL_AGENT_RUN_STATES
+                    else row["finished_at"]
+                )
+                self._conn.execute(
+                    """
+                    UPDATE agent_runs SET
+                        current_state = ?, checkpoint_sequence = ?,
+                        skills_loaded = ?, source_refs = ?, artifact_refs = ?,
+                        usage = ?, terminal_result = ?, updated_at = ?,
+                        finished_at = ?
+                    WHERE run_id = ?
+                    """,
+                    (
+                        next_state,
+                        sequence,
+                        json.dumps(merged_skills),
+                        json.dumps(merged_sources),
+                        json.dumps(merged_artifacts),
+                        json.dumps(usage),
+                        next_terminal_result,
+                        now,
+                        finished_at,
+                        run_id,
+                    ),
+                )
+                bounded = bounded_checkpoint_payload(payload)
+                self._conn.execute(
+                    """
+                    INSERT INTO agent_run_checkpoints
+                        (run_id, sequence, kind, payload, created_at)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (run_id, sequence, kind, json.dumps(bounded), now),
+                )
+                checkpoint = self._conn.execute(
+                    """
+                    SELECT * FROM agent_run_checkpoints
+                    WHERE run_id = ? AND sequence = ?
+                    """,
+                    (run_id, sequence),
+                ).fetchone()
+                self._conn.commit()
+            except Exception:
+                self._conn.rollback()
+                raise
+        if checkpoint is None:
+            raise RuntimeError("Agent Run checkpoint insert did not persist")
+        return _agent_run_checkpoint_row(checkpoint)
+
+    def get_agent_run(self, run_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT * FROM agent_runs WHERE run_id = ?", (run_id,)
+            ).fetchone()
+        return None if row is None else _agent_run_row(row)
+
+    def list_agent_runs(
+        self, *, session_id: str | None = None
+    ) -> list[dict[str, Any]]:
+        with self._lock:
+            if session_id is None:
+                rows = self._conn.execute(
+                    "SELECT * FROM agent_runs ORDER BY created_at, rowid"
+                ).fetchall()
+            else:
+                rows = self._conn.execute(
+                    """
+                    SELECT * FROM agent_runs
+                    WHERE session_id = ?
+                    ORDER BY created_at, rowid
+                    """,
+                    (session_id,),
+                ).fetchall()
+        return [_agent_run_row(row) for row in rows]
+
+    def list_agent_run_checkpoints(self, run_id: str) -> list[dict[str, Any]]:
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT * FROM agent_run_checkpoints
+                WHERE run_id = ?
+                ORDER BY sequence
+                """,
+                (run_id,),
+            ).fetchall()
+        return [_agent_run_checkpoint_row(row) for row in rows]
 
     def _file(self, sid: str) -> Path:
         if not valid_session_id(sid):
@@ -655,6 +1168,7 @@ class ConversationStore:
         duration_ms: int,
         finished_at: str,
         waiting_approval_count: int = 0,
+        agent_run_id: str | None = None,
     ) -> dict[str, Any]:
         with self._lock:
             self._conn.execute(
@@ -662,7 +1176,7 @@ class ConversationStore:
                 UPDATE runs SET
                     status = ?, result = ?, summary = ?, artifacts = ?,
                     duration_ms = ?, finished_at = ?,
-                    waiting_approval_count = ?
+                    waiting_approval_count = ?, agent_run_id = ?
                 WHERE id = ?
                 """,
                 (
@@ -673,6 +1187,7 @@ class ConversationStore:
                     max(0, duration_ms),
                     finished_at,
                     max(0, waiting_approval_count),
+                    agent_run_id,
                     run_id,
                 ),
             )
@@ -1512,6 +2027,26 @@ def _run_row(row: sqlite3.Row) -> dict[str, Any]:
         parsed = []
     item["artifacts"] = parsed if isinstance(parsed, list) else []
     item["waiting_approval_count"] = int(item.get("waiting_approval_count") or 0)
+    return item
+
+
+def _agent_run_row(row: sqlite3.Row) -> dict[str, Any]:
+    item = dict(row)
+    item.pop("original_goal_fingerprint", None)
+    item.pop("original_goal_fingerprint_source", None)
+    item["checkpoint_sequence"] = int(item.get("checkpoint_sequence") or 0)
+    item["skills_loaded"] = json_list(item.get("skills_loaded"))
+    item["source_refs"] = json_list(item.get("source_refs"))
+    item["artifact_refs"] = json_list(item.get("artifact_refs"))
+    item["usage"] = json_object(item.get("usage"))
+    item["terminal_result"] = nullable_json_object(item.get("terminal_result"))
+    return item
+
+
+def _agent_run_checkpoint_row(row: sqlite3.Row) -> dict[str, Any]:
+    item = dict(row)
+    item["sequence"] = int(item["sequence"])
+    item["payload"] = json_object(item.get("payload"))
     return item
 
 

--- a/desktop/coworker/turn.py
+++ b/desktop/coworker/turn.py
@@ -8,6 +8,7 @@ import threading
 from datetime import UTC, datetime
 from typing import Any, Awaitable, Callable
 
+from coworker.agent_runs import safe_error_summary
 from coworker.events import TurnEventStream, TurnIdentity, new_turn_identity
 from coworker.inbox import Inbox
 from coworker.ledger import record_tool_on_person
@@ -448,17 +449,33 @@ async def run_turn(
     system_prompt_fn: Callable[..., str] | None = None,
     identity: TurnIdentity | None = None,
     control: RunControl | None = None,
+    trigger: str = "chat",
+    parent_run_id: str | None = None,
 ) -> dict[str, Any]:
     events = TurnEventStream(
         identity=identity or new_turn_identity(sid),
         store=store,
         emit=emit,
     )
+    # The Agent Run is the durable authority and intentionally exists before
+    # the presentation stream's turn_start event.
+    store.start_agent_run(
+        run_id=events.identity.run_id,
+        session_id=sid,
+        parent_run_id=parent_run_id,
+        trigger=trigger,
+        original_goal=text,
+        provider_model_id=(
+            str(provider.model_id)
+            if provider is not None and getattr(provider, "model_id", None)
+            else None
+        ),
+    )
     if control is not None:
         await control.attach(events)
 
-    async def _emit(event: dict[str, Any]) -> None:
-        await events.send(event)
+    async def _emit(event: dict[str, Any]) -> dict[str, Any]:
+        return await events.send(event)
 
     def _stamp(message: dict[str, Any]) -> dict[str, Any]:
         """Identity for restore merges; stripped before the model sees it."""
@@ -466,10 +483,66 @@ async def run_turn(
         return message
 
     async def _terminal(event: dict[str, Any]) -> None:
+        state = str(event.get("state") or "failed")
+        result_status = {
+            "complete": "ok",
+            "partial": "partial",
+            "stopped": "stopped",
+            "failed": "error",
+        }.get(state, "error")
+        final_text = str(event.get("text") or "")
+        terminal_result = {
+            "status": result_status,
+            "message_id": events.identity.message_id,
+            "text_length": len(final_text),
+        }
+        if state == "failed":
+            terminal_result["error"] = safe_error_summary(
+                str(event.get("message") or "Run failed.")
+            )
+            terminal_result["class"] = "run_error"
         if control is None:
-            await _emit(event)
+            persisted = await _emit(event)
         else:
-            await control.send_terminal(event)
+            persisted = await control.send_terminal(event)
+        if persisted is None:
+            return
+        store.checkpoint_agent_run(
+            events.identity.run_id,
+            kind="terminal",
+            payload={
+                "status": result_status,
+                "state": state,
+                "text_length": len(final_text),
+            },
+            state=state,
+            terminal_result=terminal_result,
+        )
+
+    def _checkpoint_tool(
+        call: ToolCall, *, ok: bool, result: dict[str, Any]
+    ) -> None:
+        sources, artifacts = _tool_provenance(call, result)
+        loaded_skills: list[str] = []
+        if call.name == "load_skill" and ok:
+            skill_name = str(result.get("name") or call.arguments.get("name") or "")
+            if skill_name:
+                loaded_skills.append(skill_name)
+        store.checkpoint_agent_run(
+            events.identity.run_id,
+            kind="tool_completed",
+            payload={
+                "id": call.id,
+                "name": call.name,
+                "ok": ok,
+                "source_count": len(sources),
+                "artifact_count": len(artifacts),
+            },
+            skills_loaded=loaded_skills,
+            source_refs=sources,
+            artifact_refs=artifacts,
+            usage_delta={"tool_calls": 1},
+        )
 
     async def _approval_receipt(
         item: dict[str, Any], *, resolution: str
@@ -487,43 +560,52 @@ async def run_turn(
         if existing is not None:
             if emit is not None:
                 await emit(existing)
-            return
-        await _emit(
-            {
-                "type": "approval_resolved",
-                "id": str(item["id"]),
-                "name": str(item["name"]),
-                "resolution": resolution,
-                "decision": item.get("decision"),
-                "actor": item.get("actor"),
-                "requested_at": str(
-                    item.get("requested_at") or item.get("created_at") or _now_iso()
-                ),
-                "resolved_at": str(item.get("resolved_at") or _now_iso()),
-                "scope": str(item.get("scope") or "once"),
-                "execution_status": str(
-                    item.get("execution_status") or "pending"
-                ),
-                "execution_error": item.get("execution_error"),
-            }
+        else:
+            await _emit(
+                {
+                    "type": "approval_resolved",
+                    "id": str(item["id"]),
+                    "name": str(item["name"]),
+                    "resolution": resolution,
+                    "decision": item.get("decision"),
+                    "actor": item.get("actor"),
+                    "requested_at": str(
+                        item.get("requested_at")
+                        or item.get("created_at")
+                        or _now_iso()
+                    ),
+                    "resolved_at": str(item.get("resolved_at") or _now_iso()),
+                    "scope": str(item.get("scope") or "once"),
+                    "execution_status": str(
+                        item.get("execution_status") or "pending"
+                    ),
+                    "execution_error": item.get("execution_error"),
+                }
+            )
+        store.checkpoint_agent_run(
+            events.identity.run_id,
+            kind="approval_resolved",
+            payload={"id": str(item["id"]), "resolution": resolution},
+            state="running",
         )
 
     async def _stopped(
         history: list[dict[str, Any]], text_so_far: str
     ) -> dict[str, Any]:
         _persist_closed(store, sid, history)
-        if control is not None:
-            await control.finish_stopped(text_so_far)
-        else:
-            await _emit(
-                {
-                    "type": "turn_end",
-                    "state": "stopped",
-                    "text": text_so_far,
-                    "message": "Run stopped.",
-                }
-            )
-        return {"status": "stopped", "text": text_so_far}
+        await _terminal(
+            {
+                "type": "turn_stopped" if control is not None else "turn_end",
+                "state": "stopped",
+                "text": text_so_far,
+                "message": "Run cancelled." if control is not None else "Run stopped.",
+            }
+        )
+        return {
+            "status": "stopped",
+            "text": text_so_far,
+            "run_id": events.identity.run_id,
+        }
 
     await _emit({"type": "turn_start", "state": "running"})
     if provider is None:
@@ -534,7 +616,7 @@ async def run_turn(
                 "message": "No model key. Set DEEPSEEK_API_KEY (deepseek-v4-pro) or MOONSHOT_API_KEY (kimi-k3) in ~/.config/club/.env.",
             }
         )
-        return {"status": "error", "text": ""}
+        return {"status": "error", "text": "", "run_id": events.identity.run_id}
 
     last_text = ""
     had_tool_failure = False
@@ -561,6 +643,11 @@ async def run_turn(
             user_msg = {"role": "user", "content": text}
             history.append(user_msg)
             store.append(sid, user_msg)
+        store.checkpoint_agent_run(
+            events.identity.run_id,
+            kind="user_input",
+            payload={"text_length": len(text)},
+        )
         for _ in range(MAX_STEPS):
             chunks: list[str] = []
             calls: list[ToolCall] = []
@@ -589,10 +676,25 @@ async def run_turn(
                     )
                     history.append(assistant_msg)
                     store.append(sid, assistant_msg)
+                store.checkpoint_agent_run(
+                    events.identity.run_id,
+                    kind="model_completed",
+                    payload={"text_length": len(last_text), "tool_call_count": 0},
+                    usage_delta={"model_calls": 1},
+                )
                 break
             tool_msg = _stamp(_assistant_tool_message(last_text, calls))
             history.append(tool_msg)
             store.append(sid, tool_msg)
+            store.checkpoint_agent_run(
+                events.identity.run_id,
+                kind="model_completed",
+                payload={
+                    "text_length": len(last_text),
+                    "tool_call_count": len(calls),
+                },
+                usage_delta={"model_calls": 1},
+            )
             for call in calls:
                 approval_claimant: str | None = None
                 gate = decide(call.name)
@@ -611,6 +713,7 @@ async def run_turn(
                     history.append(denied)
                     store.append(sid, denied)
                     _record_person_file(sid, call, False, result, execute_kwargs)
+                    _checkpoint_tool(call, ok=False, result=result)
                     continue
                 if gate.needs_user:
                     resource = approval_resource(
@@ -639,8 +742,18 @@ async def run_turn(
                             **({"resource": resource} if resource else {}),
                         }
                     )
+                    store.checkpoint_agent_run(
+                        events.identity.run_id,
+                        kind="waiting_approval",
+                        payload={"id": call.id, "name": call.name},
+                        state="waiting_approval",
+                    )
                     if wait_permission is None:
-                        return {"status": "waiting", "text": last_text}
+                        return {
+                            "status": "waiting",
+                            "text": last_text,
+                            "run_id": events.identity.run_id,
+                        }
                     choice = await wait_permission(call.id)
                     if choice == "cancel":
                         cancelled = inbox.cancel(call.id)
@@ -683,6 +796,7 @@ async def run_turn(
                         _record_person_file(
                             sid, call, False, result, execute_kwargs
                         )
+                        _checkpoint_tool(call, ok=False, result=result)
                         continue
                     if choice == "deny":
                         receipt = claim.item
@@ -700,6 +814,7 @@ async def run_turn(
                         history.append(denied)
                         store.append(sid, denied)
                         _record_person_file(sid, call, False, result, execute_kwargs)
+                        _checkpoint_tool(call, ok=False, result=result)
                         if receipt is not None:
                             await _approval_receipt(
                                 receipt, resolution="denied"
@@ -726,6 +841,7 @@ async def run_turn(
                         history.append(tool_result)
                         store.append(sid, tool_result)
                         _record_person_file(sid, call, ok, result, execute_kwargs)
+                        _checkpoint_tool(call, ok=ok, result=result)
                         if receipt is not None and receipt.get(
                             "execution_status"
                         ) not in ("executing", "pending"):
@@ -776,6 +892,7 @@ async def run_turn(
                 history.append(tool_result)
                 store.append(sid, tool_result)
                 _record_person_file(sid, call, ok, result, execute_kwargs)
+                _checkpoint_tool(call, ok=ok, result=result)
                 if approval_claimant is not None:
                     receipt = inbox.complete_execution(
                         call.id,
@@ -801,14 +918,29 @@ async def run_turn(
                     "message": f"Stopped after {MAX_STEPS} tool steps.",
                 }
             )
-            return {"status": "stopped", "text": last_text}
+            return {
+                "status": "stopped",
+                "text": last_text,
+                "run_id": events.identity.run_id,
+            }
     except Exception as exc:
         _persist_closed(store, sid, history)
-        await _terminal({"type": "error", "state": "failed", "message": str(exc)})
-        return {"status": "error", "text": last_text}
+        await _terminal(
+            {
+                "type": "error",
+                "state": "failed",
+                "message": safe_error_summary(str(exc)),
+            }
+        )
+        return {
+            "status": "error",
+            "text": last_text,
+            "run_id": events.identity.run_id,
+        }
     final_state = "partial" if had_tool_failure else "complete"
     await _terminal({"type": "turn_end", "text": last_text, "state": final_state})
     return {
         "status": "partial" if had_tool_failure else "ok",
         "text": last_text,
+        "run_id": events.identity.run_id,
     }

--- a/desktop/tests/test_agent_runs.py
+++ b/desktop/tests/test_agent_runs.py
@@ -1,0 +1,1737 @@
+import asyncio
+import hashlib
+import json
+import sqlite3
+
+import pytest
+from fastapi.testclient import TestClient
+
+from coworker.agent_runs import redact_sensitive_assignments
+from coworker.provider import FakeProvider, ToolCall
+from coworker.inbox import Inbox
+from coworker.server import TOKEN_HEADER, create_app
+from coworker.store import ConversationStore
+from coworker.turn import run_turn
+
+
+TOKEN = "test-token-agent-runs"
+
+
+def _drain(ws):
+    events = []
+    while True:
+        event = ws.receive_json()
+        events.append(event)
+        if event["type"] in {"turn_end", "turn_stopped", "error"}:
+            return events
+
+
+def _nested_keys(value):
+    if isinstance(value, dict):
+        return {
+            str(key).lower()
+            for key in value
+        } | {
+            nested
+            for item in value.values()
+            for nested in _nested_keys(item)
+        }
+    if isinstance(value, list):
+        return {nested for item in value for nested in _nested_keys(item)}
+    return set()
+
+
+def test_agent_run_round_trip_is_idempotent_and_merges_semantic_checkpoints(tmp_path):
+    store = ConversationStore(tmp_path)
+
+    first = store.start_agent_run(
+        run_id="run-alpha",
+        session_id="thread-alpha",
+        parent_run_id=None,
+        trigger="chat",
+        original_goal="Find three strong candidates.",
+        provider_model_id="fake",
+    )
+    duplicate = store.start_agent_run(
+        run_id="run-alpha",
+        session_id="thread-alpha",
+        parent_run_id=None,
+        trigger="chat",
+        original_goal="Find three strong candidates.",
+        provider_model_id="fake",
+    )
+
+    assert duplicate == first
+    assert [item["kind"] for item in store.list_agent_run_checkpoints("run-alpha")] == [
+        "run_started"
+    ]
+
+    store.checkpoint_agent_run(
+        "run-alpha",
+        kind="model_completed",
+        payload={"text_length": 42, "tool_call_count": 1},
+        skills_loaded=["candidate-search"],
+        source_refs=[{"id": "source-1", "title": "First source"}],
+        artifact_refs=[{"artifact_type": "shortlist", "title": "Top three"}],
+        usage_delta={"model_calls": 1},
+    )
+    store.checkpoint_agent_run(
+        "run-alpha",
+        kind="tool_completed",
+        payload={"id": "call-1", "name": "load_skill", "ok": True},
+        state="waiting_approval",
+        skills_loaded=["candidate-search", "outreach"],
+        source_refs=[
+            {"id": "source-1", "title": "Duplicate source"},
+            {"id": "source-2", "title": "Second source"},
+        ],
+        artifact_refs=[{"artifact_type": "shortlist", "title": "Top three"}],
+        usage_delta={"tool_calls": 1, "model_calls": 2},
+    )
+    store.checkpoint_agent_run(
+        "run-alpha",
+        kind="approval_resolved",
+        payload={"id": "call-1", "resolution": "allowed"},
+        state="running",
+    )
+    terminal = store.checkpoint_agent_run(
+        "run-alpha",
+        kind="terminal",
+        payload={"status": "ok", "text_length": 17},
+        state="complete",
+        terminal_result={"status": "ok", "text": "Three candidates."},
+    )
+    duplicate_terminal = store.checkpoint_agent_run(
+        "run-alpha",
+        kind="terminal",
+        payload={"status": "ok", "text_length": 17},
+        state="complete",
+        terminal_result={"status": "ok", "text": "Three candidates."},
+    )
+
+    assert terminal == duplicate_terminal
+    run = store.get_agent_run("run-alpha")
+    assert run is not None
+    assert run == store.list_agent_runs(session_id="thread-alpha")[0]
+    assert run["run_id"] == "run-alpha"
+    assert run["session_id"] == "thread-alpha"
+    assert run["trigger"] == "chat"
+    assert run["original_goal"] == "Find three strong candidates."
+    assert run["provider_model_id"] == "fake"
+    assert run["current_state"] == "complete"
+    assert run["checkpoint_sequence"] == 5
+    assert run["skills_loaded"] == ["candidate-search", "outreach"]
+    assert run["source_refs"] == [
+        {
+            "id": "source-1",
+            "title": "First source",
+            "url": None,
+            "provider": "",
+            "stale": False,
+            "truncated": False,
+        },
+        {
+            "id": "source-2",
+            "title": "Second source",
+            "url": None,
+            "provider": "",
+            "stale": False,
+            "truncated": False,
+        },
+    ]
+    assert run["artifact_refs"] == [
+        {
+            "id": "",
+            "artifact_type": "shortlist",
+            "title": "Top three",
+            "external_url": None,
+            "stale": False,
+            "truncated": False,
+        }
+    ]
+    assert run["usage"] == {"model_calls": 3, "tool_calls": 1}
+    assert run["terminal_result"] == {
+        "status": "ok",
+        "text_length": len("Three candidates."),
+    }
+    assert run["created_at"]
+    assert run["started_at"]
+    assert run["updated_at"]
+    assert run["finished_at"]
+    checkpoints = store.list_agent_run_checkpoints("run-alpha")
+    assert [item["sequence"] for item in checkpoints] == [1, 2, 3, 4, 5]
+    assert [item["kind"] for item in checkpoints] == [
+        "run_started",
+        "model_completed",
+        "tool_completed",
+        "approval_resolved",
+        "terminal",
+    ]
+
+
+def test_agent_run_persistence_sanitizes_every_json_boundary(tmp_path):
+    store = ConversationStore(tmp_path)
+    private_goal = (
+        "Prepare a safe summary.\n"
+        "token=goal-token-value\n"
+        "access_token=goal-access-token-value\n"
+        "Authorization: Bearer goal-authorization-value\n"
+        "Authorization: Basic goal-basic-value\n"
+        "Keep this goal line intact."
+    )
+    first = store.start_agent_run(
+        run_id="run-private",
+        session_id="thread-private",
+        trigger="chat",
+        original_goal=private_goal,
+        provider_model_id="fake",
+    )
+    duplicate = store.start_agent_run(
+        run_id="run-private",
+        session_id="thread-private",
+        trigger="chat",
+        original_goal=private_goal,
+        provider_model_id="fake",
+    )
+    assert duplicate == first
+    sensitive_fields = {
+        "password": "password-field-value",
+        "api_key": "api-underscore-value",
+        "api-key": "api-hyphen-value",
+        "cookie": "cookie-field-value",
+        "authorization": "Bearer authorization-field-value",
+        "header": "header-field-value",
+        "token": "token-field-value",
+        "secret": "secret-field-value",
+        "credential": "credential-field-value",
+        "body": "body-field-value",
+        "raw_body": "raw-body-field-value",
+        "raw_source": "raw-source-field-value",
+        "raw_payload": "raw-payload-field-value",
+    }
+    assignment_values = {
+        "token=embedded-token-value",
+        "refresh_token=embedded-refresh-token-value",
+        "client_secret=embedded-client-secret-value",
+        "api_key=embedded-api-key-value",
+        "Authorization: Bearer embedded-authorization-value",
+        "password=embedded-password-value",
+    }
+
+    store.checkpoint_agent_run(
+        "run-private",
+        kind="tool_completed",
+        payload={
+            **sensitive_fields,
+            "summary": (
+                "Useful checkpoint summary\n"
+                "token=embedded-token-value\n"
+                "refresh_token=embedded-refresh-token-value\n"
+                "client_secret=embedded-client-secret-value\n"
+                "api_key=embedded-api-key-value\n"
+                "Authorization: Bearer embedded-authorization-value\n"
+                "password=embedded-password-value"
+            ),
+        },
+        skills_loaded=[
+            "ordinary-sourcing-skill",
+            "skill access_token=skill-access-token-value",
+            "skill client_secret=skill-client-secret-value",
+            "skill Authorization: Bearer skill-bearer-value",
+        ],
+        source_refs=[
+            {
+                "id": "source-safe",
+                "title": (
+                    "Candidate notes\n"
+                    "access_token=source-access-token-value\n"
+                    "Authorization: Basic source-basic-value"
+                ),
+                "url": "https://example.test/file?api-key=source-api-key-value",
+                "body": "source-body-value",
+                "raw_source": "source-raw-value",
+                "authorization": "Bearer source-authorization-value",
+            }
+        ],
+        artifact_refs=[
+            {
+                "id": "artifact-safe",
+                "artifact_type": "shortlist",
+                "title": "Shortlist client_secret=artifact-client-secret-value",
+                "external_url": "https://example.test/artifact",
+                "raw_payload": "artifact-raw-value",
+                "cookie": "artifact-cookie-value",
+            }
+        ],
+    )
+    store.checkpoint_agent_run(
+        "run-private",
+        kind="terminal",
+        payload={"status": "ok", "text_length": 80},
+        state="complete",
+        terminal_result={
+            "status": "ok",
+            "text": (
+                "Ordinary user-facing text stays intact.\n"
+                "Authorization: Bearer terminal-authorization-value\n"
+                "Authorization: Basic terminal-basic-value\n"
+                "refresh_token=terminal-refresh-token-value\n"
+                "The final line also stays intact."
+            ),
+            "error": (
+                "password=terminal-password-value "
+                "API_KEY=terminal-api-assignment-value"
+            ),
+            "api_key": "terminal-api-key-value",
+            "body": "terminal-body-value",
+        },
+    )
+
+    run = store.get_agent_run("run-private")
+    checkpoints = store.list_agent_run_checkpoints("run-private")
+    durable = {"run": run, "checkpoints": checkpoints}
+    keys = _nested_keys(durable)
+    assert not keys.intersection(sensitive_fields)
+    assert run["source_refs"][0]["id"] == "source-safe"
+    assert run["source_refs"][0]["title"].startswith("Candidate notes\n")
+    assert run["artifact_refs"][0]["artifact_type"] == "shortlist"
+    assert run["skills_loaded"] == [
+        "ordinary-sourcing-skill",
+        "skill access_token=[REDACTED]",
+        "skill client_secret=[REDACTED]",
+        "skill Authorization:[REDACTED]",
+    ]
+    assert run["terminal_result"]["status"] == "ok"
+    assert run["terminal_result"]["text_length"] == len(
+        "Ordinary user-facing text stays intact.\n"
+        "Authorization: Bearer terminal-authorization-value\n"
+        "Authorization: Basic terminal-basic-value\n"
+        "refresh_token=terminal-refresh-token-value\n"
+        "The final line also stays intact."
+    )
+    assert run["terminal_result"]["error"] == (
+        "password=[REDACTED] API_KEY=[REDACTED]"
+    )
+    assert run["original_goal"].startswith("Prepare a safe summary.\n")
+    assert run["original_goal"].endswith("\nKeep this goal line intact.")
+    assert checkpoints[1]["payload"]["summary"].startswith(
+        "Useful checkpoint summary\n"
+    )
+    serialized = json.dumps(durable)
+    for value in sensitive_fields.values():
+        assert value not in serialized
+    for assignment in assignment_values:
+        assert assignment not in serialized
+    for secret_value in (
+        "source-access-token-value",
+        "source-basic-value",
+        "source-api-key-value",
+        "artifact-client-secret-value",
+        "terminal-authorization-value",
+        "terminal-basic-value",
+        "terminal-refresh-token-value",
+        "terminal-password-value",
+        "terminal-api-assignment-value",
+        "goal-token-value",
+        "goal-access-token-value",
+        "goal-authorization-value",
+        "goal-basic-value",
+        "skill-access-token-value",
+        "skill-client-secret-value",
+        "skill-bearer-value",
+    ):
+        assert secret_value not in serialized
+
+
+def test_agent_run_uses_field_specific_safe_projections_for_untrusted_metadata(
+    tmp_path,
+):
+    provider_secrets = {
+        # Assemble provider-shaped fixtures at runtime so repository push
+        # protection never mistakes the test source itself for a live secret.
+        "openai": "sk-" + "proj-abcdefghijklmnopqrstuvwxyz123456",
+        "google": "AI" + "zaSyA1234567890abcdefghijklmnopqrst",
+        "aws": "AK" + "IAIOSFODNN7EXAMPLE",
+        "github": "gh" + "p_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
+        "slack": "xo" + "xb-123456789012-123456789012-abcdefghijklmnopqrstuvwx",
+        "jwt": (
+            "eyJhbGciOiJIUzI1NiJ9."
+            "eyJzdWIiOiIxMjM0NTY3ODkwIn0.signatureABC"
+        ),
+    }
+    pem = (
+        "-----BEGIN PRIVATE KEY-----\n"
+        "cHJpdmF0ZS1rZXktbWF0ZXJpYWw=\n"
+        "-----END PRIVATE KEY-----"
+    )
+    unsafe_text = (
+        "Basic research and Bearer market analysis stay readable.\n"
+        f"Standalone {provider_secrets['openai']} {provider_secrets['google']} "
+        f"{provider_secrets['aws']} {provider_secrets['github']} "
+        f"{provider_secrets['slack']} {provider_secrets['jwt']}\n"
+        f"{pem}\n"
+        '{"Authorization":"Bearer json-header-secret"}\n'
+        "Authorization: Basic basic-header-secret\n"
+        "https://example.test/path?AWSAccessKeyId=aws-query-secret"
+        "&Signature=signature-secret&key=key-secret&code=code-secret"
+    )
+    terminal_error = (
+        "Basic research-methodology stays readable.\n"
+        f"Provider {provider_secrets['openai']}\n"
+        '{"Authorization":"Bearer terminal-json-secret"}'
+    )
+    store = ConversationStore(tmp_path)
+    store.start_agent_run(
+        run_id="run-field-safe",
+        session_id="thread-field-safe",
+        trigger="chat",
+        original_goal=unsafe_text,
+        provider_model_id="fake",
+    )
+    store.checkpoint_agent_run(
+        "run-field-safe",
+        kind="tool_completed",
+        payload={"summary": unsafe_text},
+        source_refs=[
+            {
+                "id": "source-safe",
+                "title": f"Source {provider_secrets['github']}",
+                "url": (
+                    "https://user:password@example.test/source/path"
+                    "?AWSAccessKeyId=source-key&Signature=source-signature#private"
+                ),
+                "provider": "Google Drive",
+                "stale": False,
+                "truncated": True,
+                "preview": "free-form source preview must not persist",
+                "body": "free-form source body must not persist",
+                "unexpected": "free-form source metadata must not persist",
+            },
+            {
+                "id": "source-unsafe-url",
+                "title": "Unsafe URL",
+                "url": "ftp://user:password@example.test/private?code=secret",
+                "provider": "Web",
+            },
+        ],
+        artifact_refs=[
+            {
+                "id": "artifact-safe",
+                "artifact_type": "shortlist",
+                "title": f"Artifact {provider_secrets['slack']}",
+                "external_url": (
+                    "http://user:password@files.test/artifacts/one"
+                    "?key=artifact-key&code=artifact-code#private"
+                ),
+                "stale": True,
+                "truncated": False,
+                "preview": "free-form artifact preview must not persist",
+                "raw_payload": "free-form artifact payload must not persist",
+                "unexpected": "free-form artifact metadata must not persist",
+            }
+        ],
+    )
+    store.checkpoint_agent_run(
+        "run-field-safe",
+        kind="terminal",
+        payload={"status": "failed"},
+        state="failed",
+        terminal_result={
+            "status": "error",
+            "message_id": "message-safe",
+            "text_length": 123,
+            "text": "free-form final model text must not persist",
+            "error": terminal_error,
+            "class": "provider_error",
+            "unexpected": "free-form terminal metadata must not persist",
+        },
+    )
+
+    run = store.get_agent_run("run-field-safe")
+    checkpoints = store.list_agent_run_checkpoints("run-field-safe")
+    assert run["source_refs"] == [
+        {
+            "id": "source-safe",
+            "title": "Source [REDACTED]",
+            "url": "https://example.test/source/path",
+            "provider": "Google Drive",
+            "stale": False,
+            "truncated": True,
+        },
+        {
+            "id": "source-unsafe-url",
+            "title": "Unsafe URL",
+            "url": None,
+            "provider": "Web",
+            "stale": False,
+            "truncated": False,
+        },
+    ]
+    assert run["artifact_refs"] == [
+        {
+            "id": "artifact-safe",
+            "artifact_type": "shortlist",
+            "title": "Artifact [REDACTED]",
+            "external_url": "http://files.test/artifacts/one",
+            "stale": True,
+            "truncated": False,
+        }
+    ]
+    assert run["terminal_result"] == {
+        "status": "error",
+        "message_id": "message-safe",
+        "text_length": 123,
+        "error": (
+            "Basic research-methodology stays readable.\n"
+            "Provider [REDACTED]\n"
+            '{"Authorization":"[REDACTED]"}'
+        ),
+        "class": "provider_error",
+    }
+    assert len(run["terminal_result"]["error"]) <= 512
+    assert "Basic research" in run["original_goal"]
+    assert "Bearer market" in run["original_goal"]
+    durable = json.dumps({"run": run, "checkpoints": checkpoints})
+    for secret in (
+        *provider_secrets.values(),
+        "cHJpdmF0ZS1rZXktbWF0ZXJpYWw=",
+        "json-header-secret",
+        "terminal-json-secret",
+        "basic-header-secret",
+        "aws-query-secret",
+        "signature-secret",
+        "key-secret",
+        "code-secret",
+        "user:password",
+        "source-key",
+        "source-signature",
+        "artifact-key",
+        "artifact-code",
+        "free-form source preview",
+        "free-form source body",
+        "free-form source metadata",
+        "free-form artifact preview",
+        "free-form artifact payload",
+        "free-form artifact metadata",
+        "free-form final model text",
+        "free-form terminal metadata",
+    ):
+        assert secret not in durable
+
+
+@pytest.mark.parametrize(
+    "ordinary_text",
+    [
+        "Basic research-methodology",
+        "Bearer market-analysis-report",
+        "code: Python",
+        "signature: Kind regards",
+        "key=value",
+        "First ordinary line\nSecond ordinary line\nThird ordinary line",
+    ],
+)
+def test_ordinary_long_prose_survives_sanitization_and_persistence_exactly(
+    tmp_path, ordinary_text
+):
+    assert redact_sensitive_assignments(ordinary_text) == ordinary_text
+    store = ConversationStore(tmp_path)
+    store.start_agent_run(
+        run_id="run-ordinary-prose",
+        session_id="thread-ordinary-prose",
+        trigger="chat",
+        original_goal=ordinary_text,
+        provider_model_id="fake",
+    )
+    store.checkpoint_agent_run(
+        "run-ordinary-prose",
+        kind="tool_completed",
+        payload={"summary": ordinary_text},
+        source_refs=[
+            {
+                "id": "source-ordinary",
+                "title": ordinary_text,
+                "provider": ordinary_text,
+            }
+        ],
+        artifact_refs=[
+            {
+                "id": "artifact-ordinary",
+                "artifact_type": "note",
+                "title": ordinary_text,
+            }
+        ],
+    )
+    store.checkpoint_agent_run(
+        "run-ordinary-prose",
+        kind="terminal",
+        payload={"status": "failed"},
+        state="failed",
+        terminal_result={"status": "error", "error": ordinary_text},
+    )
+
+    run = store.get_agent_run("run-ordinary-prose")
+    checkpoints = store.list_agent_run_checkpoints("run-ordinary-prose")
+    assert run["original_goal"] == ordinary_text
+    assert run["source_refs"][0]["title"] == ordinary_text
+    assert run["source_refs"][0]["provider"] == ordinary_text
+    assert run["artifact_refs"][0]["title"] == ordinary_text
+    assert run["terminal_result"]["error"] == ordinary_text
+    assert checkpoints[1]["payload"]["summary"] == ordinary_text
+
+
+@pytest.mark.parametrize(
+    ("secret_text", "expected"),
+    [
+        (
+            "signature=9f86d081884c7d659a2feaa0c55ad015",
+            "signature=[REDACTED]",
+        ),
+        (
+            "code=4/0AdQt8qgeWmYx9n24rNQ7sLcP6vB3k",
+            "code=[REDACTED]",
+        ),
+        (
+            "key=0123456789abcdef0123456789abcdef",
+            "key=[REDACTED]",
+        ),
+        (
+            "AWSAccessKeyId=" + "AK" + "IAIOSFODNN7EXAMPLE",
+            "AWSAccessKeyId=[REDACTED]",
+        ),
+    ],
+)
+def test_high_entropy_named_credentials_are_redacted_without_broad_word_rules(
+    secret_text, expected
+):
+    assert redact_sensitive_assignments(secret_text) == expected
+
+
+def test_structured_aws_key_is_sensitive_but_ordinary_signature_and_code_are_not(
+    tmp_path,
+):
+    store = ConversationStore(tmp_path)
+    store.start_agent_run(
+        run_id="run-structured-keys",
+        session_id="thread-structured-keys",
+        trigger="chat",
+        original_goal="Keep structured metadata safe.",
+        provider_model_id="fake",
+    )
+    store.checkpoint_agent_run(
+        "run-structured-keys",
+        kind="tool_completed",
+        payload={
+            "AWSAccessKeyId": "AK" + "IAIOSFODNN7EXAMPLE",
+            "signature": "Kind regards",
+            "code": "Python",
+            "key": "value",
+        },
+    )
+
+    payload = store.list_agent_run_checkpoints("run-structured-keys")[1]["payload"]
+    assert payload == {
+        "signature": "Kind regards",
+        "code": "Python",
+        "key": "value",
+    }
+
+
+def test_agent_run_raw_goal_fingerprint_preserves_secret_identity_without_storage(
+    tmp_path,
+):
+    store = ConversationStore(tmp_path)
+    identity = {
+        "run_id": "run-secret-goal",
+        "session_id": "thread-secret-goal",
+        "trigger": "chat",
+        "provider_model_id": "fake",
+        "parent_run_id": None,
+    }
+    raw_goal = "Use token=goal-secret-one to search."
+
+    first = store.start_agent_run(**identity, original_goal=raw_goal)
+    duplicate = store.start_agent_run(**identity, original_goal=raw_goal)
+
+    assert duplicate == first
+    with pytest.raises(ValueError, match="conflicting Agent Run metadata"):
+        store.start_agent_run(
+            **identity,
+            original_goal="Use token=goal-secret-two to search.",
+        )
+    persisted = store.get_agent_run("run-secret-goal")
+    assert persisted["original_goal"] == "Use token=[REDACTED] to search."
+    assert "original_goal_fingerprint" not in persisted
+    assert [
+        item["kind"]
+        for item in store.list_agent_run_checkpoints("run-secret-goal")
+    ] == ["run_started"]
+    durable = json.dumps(
+        {
+            "run": persisted,
+            "checkpoints": store.list_agent_run_checkpoints("run-secret-goal"),
+        }
+    )
+    assert "goal-secret-one" not in durable
+    assert "goal-secret-two" not in durable
+    with sqlite3.connect(tmp_path / "club.db") as db:
+        fingerprint = db.execute(
+            "SELECT original_goal_fingerprint FROM agent_runs WHERE run_id = ?",
+            ("run-secret-goal",),
+        ).fetchone()[0]
+    assert fingerprint == hashlib.sha256(raw_goal.encode("utf-8")).hexdigest()
+
+
+def test_existing_agent_runs_schema_migrates_and_backfills_goal_fingerprint(tmp_path):
+    stored_goal = "Review token=[REDACTED] safely."
+    with sqlite3.connect(tmp_path / "club.db") as db:
+        db.execute(
+            """
+            CREATE TABLE agent_runs (
+                run_id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                parent_run_id TEXT,
+                trigger TEXT NOT NULL,
+                original_goal TEXT NOT NULL,
+                current_state TEXT NOT NULL,
+                provider_model_id TEXT,
+                checkpoint_sequence INTEGER NOT NULL DEFAULT 0,
+                skills_loaded TEXT NOT NULL DEFAULT '[]',
+                source_refs TEXT NOT NULL DEFAULT '[]',
+                artifact_refs TEXT NOT NULL DEFAULT '[]',
+                usage TEXT NOT NULL DEFAULT '{}',
+                terminal_result TEXT,
+                created_at TEXT NOT NULL,
+                started_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                finished_at TEXT
+            )
+            """
+        )
+        db.execute(
+            """
+            INSERT INTO agent_runs (
+                run_id, session_id, parent_run_id, trigger, original_goal,
+                current_state, provider_model_id, checkpoint_sequence,
+                skills_loaded, source_refs, artifact_refs, usage,
+                terminal_result, created_at, started_at, updated_at, finished_at
+            ) VALUES (
+                'run-legacy-agent', 'thread-legacy-agent', NULL, 'chat', ?,
+                'complete', 'fake', 0, '[]', '[]', '[]', '{}',
+                '{"status":"ok","text":"done"}', ?, ?, ?, ?
+            )
+            """,
+            (
+                stored_goal,
+                "2026-08-26T12:00:00+00:00",
+                "2026-08-26T12:00:00+00:00",
+                "2026-08-26T12:01:00+00:00",
+                "2026-08-26T12:01:00+00:00",
+            ),
+        )
+
+    store = ConversationStore(tmp_path)
+    expected = hashlib.sha256(stored_goal.encode("utf-8")).hexdigest()
+    with sqlite3.connect(tmp_path / "club.db") as db:
+        columns = {
+            row[1] for row in db.execute("PRAGMA table_info(agent_runs)").fetchall()
+        }
+        assert "original_goal_fingerprint" in columns
+        fingerprint = db.execute(
+            """
+            SELECT original_goal_fingerprint
+            FROM agent_runs WHERE run_id = 'run-legacy-agent'
+            """
+        ).fetchone()[0]
+
+    assert fingerprint == expected
+    existing = store.start_agent_run(
+        run_id="run-legacy-agent",
+        session_id="thread-legacy-agent",
+        parent_run_id=None,
+        trigger="chat",
+        original_goal=stored_goal,
+        provider_model_id="fake",
+    )
+    assert existing["original_goal"] == stored_goal
+    assert "original_goal_fingerprint" not in existing
+    reopened = ConversationStore(tmp_path)
+    assert reopened.get_agent_run("run-legacy-agent") == existing
+
+
+def test_goal_fingerprint_provenance_distinguishes_raw_and_irrecoverable_rows(
+    tmp_path,
+):
+    raw_goal = "Use token=raw-goal-secret for sourcing."
+    raw_stored_goal = "Use token=[REDACTED] for sourcing."
+    legacy_stored_goal = "Use access_token=[REDACTED] for sourcing."
+    with sqlite3.connect(tmp_path / "club.db") as db:
+        db.execute(
+            """
+            CREATE TABLE agent_runs (
+                run_id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                parent_run_id TEXT,
+                trigger TEXT NOT NULL,
+                original_goal TEXT NOT NULL,
+                original_goal_fingerprint TEXT,
+                current_state TEXT NOT NULL,
+                provider_model_id TEXT,
+                checkpoint_sequence INTEGER NOT NULL DEFAULT 0,
+                skills_loaded TEXT NOT NULL DEFAULT '[]',
+                source_refs TEXT NOT NULL DEFAULT '[]',
+                artifact_refs TEXT NOT NULL DEFAULT '[]',
+                usage TEXT NOT NULL DEFAULT '{}',
+                terminal_result TEXT,
+                created_at TEXT NOT NULL,
+                started_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                finished_at TEXT
+            )
+            """
+        )
+        for values in (
+            (
+                "run-raw-provenance",
+                "thread-raw-provenance",
+                raw_stored_goal,
+                hashlib.sha256(raw_goal.encode("utf-8")).hexdigest(),
+            ),
+            (
+                "run-legacy-provenance",
+                "thread-legacy-provenance",
+                legacy_stored_goal,
+                hashlib.sha256(legacy_stored_goal.encode("utf-8")).hexdigest(),
+            ),
+        ):
+            db.execute(
+                """
+                INSERT INTO agent_runs (
+                    run_id, session_id, parent_run_id, trigger, original_goal,
+                    original_goal_fingerprint, current_state, provider_model_id,
+                    checkpoint_sequence, skills_loaded, source_refs,
+                    artifact_refs, usage, terminal_result, created_at,
+                    started_at, updated_at, finished_at
+                ) VALUES (?, ?, NULL, 'chat', ?, ?, 'complete', 'fake',
+                          0, '[]', '[]', '[]', '{}', NULL, ?, ?, ?, ?)
+                """,
+                (
+                    *values,
+                    "2026-08-26T12:00:00+00:00",
+                    "2026-08-26T12:00:00+00:00",
+                    "2026-08-26T12:01:00+00:00",
+                    "2026-08-26T12:01:00+00:00",
+                ),
+            )
+
+    store = ConversationStore(tmp_path)
+    with sqlite3.connect(tmp_path / "club.db") as db:
+        columns = {
+            row[1] for row in db.execute("PRAGMA table_info(agent_runs)").fetchall()
+        }
+        assert "original_goal_fingerprint_source" in columns
+        provenance = dict(
+            db.execute(
+                """
+                SELECT run_id, original_goal_fingerprint_source
+                FROM agent_runs ORDER BY run_id
+                """
+            ).fetchall()
+        )
+
+    assert provenance == {
+        "run-legacy-provenance": "legacy_sanitized",
+        "run-raw-provenance": "raw",
+    }
+    assert "original_goal_fingerprint_source" not in store.get_agent_run(
+        "run-raw-provenance"
+    )
+    assert store.start_agent_run(
+        run_id="run-raw-provenance",
+        session_id="thread-raw-provenance",
+        parent_run_id=None,
+        trigger="chat",
+        original_goal=raw_goal,
+        provider_model_id="fake",
+    )["run_id"] == "run-raw-provenance"
+    with pytest.raises(ValueError, match="conflicting Agent Run metadata"):
+        store.start_agent_run(
+            run_id="run-raw-provenance",
+            session_id="thread-raw-provenance",
+            parent_run_id=None,
+            trigger="chat",
+            original_goal=raw_goal.replace("raw-goal-secret", "different-secret"),
+            provider_model_id="fake",
+        )
+    assert store.start_agent_run(
+        run_id="run-legacy-provenance",
+        session_id="thread-legacy-provenance",
+        parent_run_id=None,
+        trigger="chat",
+        original_goal=legacy_stored_goal,
+        provider_model_id="fake",
+    )["run_id"] == "run-legacy-provenance"
+    with pytest.raises(ValueError, match="start a new run"):
+        store.start_agent_run(
+            run_id="run-legacy-provenance",
+            session_id="thread-legacy-provenance",
+            parent_run_id=None,
+            trigger="chat",
+            original_goal="Use access_token=unknown-original-secret for sourcing.",
+            provider_model_id="fake",
+        )
+
+
+def test_agent_run_privacy_migration_marker_skips_second_history_scan(tmp_path):
+    store = ConversationStore(tmp_path)
+    store.start_agent_run(
+        run_id="run-migration-marker",
+        session_id="thread-migration-marker",
+        trigger="chat",
+        original_goal="Ordinary goal",
+        provider_model_id="fake",
+    )
+    store.checkpoint_agent_run(
+        "run-migration-marker",
+        kind="terminal",
+        payload={"status": "ok"},
+        state="complete",
+        terminal_result={"status": "ok", "text_length": 0},
+    )
+    with sqlite3.connect(tmp_path / "club.db") as db:
+        tables = {
+            row[0]
+            for row in db.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+        assert "schema_migrations" in tables
+        markers = {
+            row[0]
+            for row in db.execute("SELECT name FROM schema_migrations").fetchall()
+        }
+        assert "agent_run_privacy_v3" in markers
+        db.execute(
+            """
+            CREATE TRIGGER reject_agent_run_rescan
+            BEFORE UPDATE ON agent_runs
+            BEGIN
+                SELECT RAISE(FAIL, 'agent run history rescan attempted');
+            END
+            """
+        )
+
+    reopened = ConversationStore(tmp_path)
+
+    assert reopened.get_agent_run("run-migration-marker")["current_state"] == "complete"
+
+
+def test_agent_run_privacy_migration_rolls_back_marker_and_retries(tmp_path):
+    with sqlite3.connect(tmp_path / "club.db") as db:
+        db.executescript(
+            """
+            CREATE TABLE agent_runs (
+                run_id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                parent_run_id TEXT,
+                trigger TEXT NOT NULL,
+                original_goal TEXT NOT NULL,
+                current_state TEXT NOT NULL,
+                provider_model_id TEXT,
+                checkpoint_sequence INTEGER NOT NULL DEFAULT 0,
+                skills_loaded TEXT NOT NULL DEFAULT '[]',
+                source_refs TEXT NOT NULL DEFAULT '[]',
+                artifact_refs TEXT NOT NULL DEFAULT '[]',
+                usage TEXT NOT NULL DEFAULT '{}',
+                terminal_result TEXT,
+                created_at TEXT NOT NULL,
+                started_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                finished_at TEXT
+            );
+            CREATE TABLE agent_run_checkpoints (
+                run_id TEXT NOT NULL,
+                sequence INTEGER NOT NULL,
+                kind TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                PRIMARY KEY (run_id, sequence)
+            );
+            INSERT INTO agent_runs (
+                run_id, session_id, trigger, original_goal, current_state,
+                provider_model_id, checkpoint_sequence, skills_loaded,
+                source_refs, artifact_refs, usage, created_at, started_at,
+                updated_at
+            ) VALUES (
+                'run-migration-retry', 'thread-migration-retry', 'chat',
+                'Use token=rollback-secret', 'complete', 'fake', 0, '[]',
+                '[]', '[]', '{}', '2026-08-26T12:00:00+00:00',
+                '2026-08-26T12:00:00+00:00', '2026-08-26T12:00:00+00:00'
+            );
+            CREATE TRIGGER block_agent_run_privacy_update
+            BEFORE UPDATE ON agent_runs
+            BEGIN
+                SELECT RAISE(FAIL, 'privacy migration blocked');
+            END;
+            """
+        )
+
+    with pytest.raises(sqlite3.IntegrityError, match="privacy migration blocked"):
+        ConversationStore(tmp_path)
+    with sqlite3.connect(tmp_path / "club.db") as db:
+        tables = {
+            row[0]
+            for row in db.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+        assert "schema_migrations" in tables
+        assert db.execute(
+            """
+            SELECT 1 FROM schema_migrations
+            WHERE name = 'agent_run_privacy_v3'
+            """
+        ).fetchone() is None
+        db.execute("DROP TRIGGER block_agent_run_privacy_update")
+
+    recovered = ConversationStore(tmp_path)
+
+    assert recovered.get_agent_run("run-migration-retry")["original_goal"] == (
+        "Use token=[REDACTED]"
+    )
+    with sqlite3.connect(tmp_path / "club.db") as db:
+        assert db.execute(
+            """
+            SELECT 1 FROM schema_migrations
+            WHERE name = 'agent_run_privacy_v3'
+            """
+        ).fetchone() == (1,)
+
+
+def test_agent_runs_schema_indexes_session_and_created_at(tmp_path):
+    ConversationStore(tmp_path)
+
+    with sqlite3.connect(tmp_path / "club.db") as db:
+        indexes = {
+            row[1] for row in db.execute("PRAGMA index_list(agent_runs)").fetchall()
+        }
+        assert "agent_runs_session_created" in indexes
+        columns = [
+            row[2]
+            for row in db.execute(
+                "PRAGMA index_info(agent_runs_session_created)"
+            ).fetchall()
+        ]
+    assert columns == ["session_id", "created_at"]
+
+
+def test_existing_agent_run_migration_scrubs_persisted_projection_and_checkpoints(
+    tmp_path,
+):
+    raw_goal = (
+        "Review the shortlist.\n"
+        "access_token=legacy-goal-secret\n"
+        "Keep this line."
+    )
+    usage_json = '{"model_calls":7,"tool_calls":3}'
+    with sqlite3.connect(tmp_path / "club.db") as db:
+        db.executescript(
+            """
+            CREATE TABLE agent_runs (
+                run_id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                parent_run_id TEXT,
+                trigger TEXT NOT NULL,
+                original_goal TEXT NOT NULL,
+                current_state TEXT NOT NULL,
+                provider_model_id TEXT,
+                checkpoint_sequence INTEGER NOT NULL DEFAULT 0,
+                skills_loaded TEXT NOT NULL DEFAULT '[]',
+                source_refs TEXT NOT NULL DEFAULT '[]',
+                artifact_refs TEXT NOT NULL DEFAULT '[]',
+                usage TEXT NOT NULL DEFAULT '{}',
+                terminal_result TEXT,
+                created_at TEXT NOT NULL,
+                started_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                finished_at TEXT
+            );
+            CREATE TABLE agent_run_checkpoints (
+                run_id TEXT NOT NULL,
+                sequence INTEGER NOT NULL,
+                kind TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                PRIMARY KEY (run_id, sequence)
+            );
+            """
+        )
+        db.execute(
+            """
+            INSERT INTO agent_runs (
+                run_id, session_id, parent_run_id, trigger, original_goal,
+                current_state, provider_model_id, checkpoint_sequence,
+                skills_loaded, source_refs, artifact_refs, usage,
+                terminal_result, created_at, started_at, updated_at, finished_at
+            ) VALUES (?, ?, NULL, 'chat', ?, 'complete', 'fake', 2,
+                      ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "run-legacy-private",
+                "thread-legacy-private",
+                raw_goal,
+                json.dumps(
+                    [
+                        "ordinary-legacy-skill",
+                        "load client_secret=legacy-skill-secret",
+                    ]
+                ),
+                json.dumps(
+                    [
+                        {
+                            "id": "legacy-source",
+                            "title": "Notes refresh_token=legacy-source-secret",
+                            "raw_body": "legacy-source-body",
+                        }
+                    ]
+                ),
+                json.dumps(
+                    [
+                        {
+                            "id": "legacy-artifact",
+                            "artifact_type": "draft",
+                            "title": (
+                                "Draft Authorization: Basic "
+                                "legacy-artifact-credential"
+                            ),
+                            "raw_payload": "legacy-artifact-payload",
+                        }
+                    ]
+                ),
+                usage_json,
+                json.dumps(
+                    {
+                        "status": "ok",
+                        "text": "Done api_key=legacy-terminal-secret",
+                        "password": "legacy-terminal-password",
+                    }
+                ),
+                "2026-08-26T12:00:00+00:00",
+                "2026-08-26T12:00:00+00:00",
+                "2026-08-26T12:01:00+00:00",
+                "2026-08-26T12:01:00+00:00",
+            ),
+        )
+        db.execute(
+            """
+            INSERT INTO agent_run_checkpoints
+                (run_id, sequence, kind, payload, created_at)
+            VALUES (?, 1, 'tool_completed', ?, ?)
+            """,
+            (
+                "run-legacy-private",
+                json.dumps(
+                    {
+                        "name": "drive_read",
+                        "summary": (
+                            "Authorization: Bearer legacy-checkpoint-secret"
+                        ),
+                        "body": "legacy-checkpoint-body",
+                    }
+                ),
+                "2026-08-26T12:00:30+00:00",
+            ),
+        )
+        db.execute(
+            """
+            INSERT INTO agent_run_checkpoints
+                (run_id, sequence, kind, payload, created_at)
+            VALUES (?, 2, 'terminal', 'not-json', ?)
+            """,
+            ("run-legacy-private", "2026-08-26T12:01:00+00:00"),
+        )
+
+    expected_fingerprint = hashlib.sha256(raw_goal.encode("utf-8")).hexdigest()
+    secret_values = (
+        "legacy-goal-secret",
+        "legacy-skill-secret",
+        "legacy-source-secret",
+        "legacy-source-body",
+        "legacy-artifact-credential",
+        "legacy-artifact-payload",
+        "legacy-terminal-secret",
+        "legacy-terminal-password",
+        "legacy-checkpoint-secret",
+        "legacy-checkpoint-body",
+    )
+    store = ConversationStore(tmp_path)
+    run = store.get_agent_run("run-legacy-private")
+    checkpoints = store.list_agent_run_checkpoints("run-legacy-private")
+
+    assert run["original_goal"] == (
+        "Review the shortlist.\naccess_token=[REDACTED]\nKeep this line."
+    )
+    assert run["skills_loaded"] == [
+        "ordinary-legacy-skill",
+        "load client_secret=[REDACTED]",
+    ]
+    assert run["source_refs"] == [
+        {
+            "id": "legacy-source",
+            "title": "Notes refresh_token=[REDACTED]",
+            "url": None,
+            "provider": "",
+            "stale": False,
+            "truncated": False,
+        }
+    ]
+    assert run["artifact_refs"] == [
+        {
+            "id": "legacy-artifact",
+            "artifact_type": "draft",
+            "title": "Draft Authorization:[REDACTED]",
+            "external_url": None,
+            "stale": False,
+            "truncated": False,
+        }
+    ]
+    assert run["terminal_result"] == {
+        "status": "ok",
+        "text_length": len("Done api_key=legacy-terminal-secret"),
+    }
+    assert run["usage"] == {"model_calls": 7, "tool_calls": 3}
+    assert run["current_state"] == "complete"
+    assert run["checkpoint_sequence"] == 2
+    assert checkpoints[0]["payload"] == {
+        "name": "drive_read",
+        "summary": "Authorization:[REDACTED]",
+    }
+    assert checkpoints[1]["payload"] == {}
+    returned = json.dumps({"run": run, "checkpoints": checkpoints})
+    assert all(secret not in returned for secret in secret_values)
+
+    with sqlite3.connect(tmp_path / "club.db") as db:
+        persisted_row = db.execute(
+            """
+            SELECT original_goal, original_goal_fingerprint, skills_loaded,
+                   source_refs, artifact_refs, usage, terminal_result,
+                   created_at, started_at, updated_at, finished_at,
+                   current_state, checkpoint_sequence
+            FROM agent_runs WHERE run_id = 'run-legacy-private'
+            """
+        ).fetchone()
+        persisted_checkpoints = db.execute(
+            """
+            SELECT sequence, kind, payload, created_at
+            FROM agent_run_checkpoints
+            WHERE run_id = 'run-legacy-private'
+            ORDER BY sequence
+            """
+        ).fetchall()
+    persisted = repr((persisted_row, persisted_checkpoints))
+    assert all(secret not in persisted for secret in secret_values)
+    assert persisted_row[1] == expected_fingerprint
+    assert persisted_row[5] == usage_json
+
+    assert store.start_agent_run(
+        run_id="run-legacy-private",
+        session_id="thread-legacy-private",
+        parent_run_id=None,
+        trigger="chat",
+        original_goal=raw_goal,
+        provider_model_id="fake",
+    ) == run
+    with pytest.raises(ValueError, match="conflicting Agent Run metadata"):
+        store.start_agent_run(
+            run_id="run-legacy-private",
+            session_id="thread-legacy-private",
+            parent_run_id=None,
+            trigger="chat",
+            original_goal=raw_goal.replace(
+                "legacy-goal-secret", "different-goal-secret"
+            ),
+            provider_model_id="fake",
+        )
+
+    reopened = ConversationStore(tmp_path)
+    assert reopened.get_agent_run("run-legacy-private") == run
+    assert reopened.list_agent_run_checkpoints("run-legacy-private") == checkpoints
+    with sqlite3.connect(tmp_path / "club.db") as db:
+        second_row = db.execute(
+            """
+            SELECT original_goal, original_goal_fingerprint, skills_loaded,
+                   source_refs, artifact_refs, usage, terminal_result,
+                   created_at, started_at, updated_at, finished_at,
+                   current_state, checkpoint_sequence
+            FROM agent_runs WHERE run_id = 'run-legacy-private'
+            """
+        ).fetchone()
+        second_checkpoints = db.execute(
+            """
+            SELECT sequence, kind, payload, created_at
+            FROM agent_run_checkpoints
+            WHERE run_id = 'run-legacy-private'
+            ORDER BY sequence
+            """
+        ).fetchall()
+    assert (second_row, second_checkpoints) == (
+        persisted_row,
+        persisted_checkpoints,
+    )
+
+
+def test_agent_run_start_rejects_conflicting_immutable_metadata(tmp_path):
+    store = ConversationStore(tmp_path)
+    identity = {
+        "run_id": "run-immutable",
+        "session_id": "thread-immutable",
+        "parent_run_id": "run-parent",
+        "trigger": "chat",
+        "original_goal": "Find candidates.",
+        "provider_model_id": "fake",
+    }
+    original = store.start_agent_run(**identity)
+
+    for field, conflicting in (
+        ("parent_run_id", "different-parent"),
+        ("trigger", "chat_queue"),
+        ("original_goal", "Send outreach."),
+        ("provider_model_id", "different-model"),
+    ):
+        with pytest.raises(ValueError, match="conflicting Agent Run metadata"):
+            store.start_agent_run(**{**identity, field: conflicting})
+
+    assert store.start_agent_run(**identity) == original
+    assert store.get_agent_run("run-immutable") == original
+    assert [
+        item["kind"]
+        for item in store.list_agent_run_checkpoints("run-immutable")
+    ] == ["run_started"]
+
+
+def test_store_reopen_interrupts_only_running_agent_runs(tmp_path):
+    store = ConversationStore(tmp_path)
+    for run_id in ("run-running", "run-waiting", "run-question", "run-complete"):
+        store.start_agent_run(
+            run_id=run_id,
+            session_id="thread-alpha",
+            trigger="chat",
+            original_goal=run_id,
+            provider_model_id="fake",
+        )
+    store.checkpoint_agent_run(
+        "run-waiting",
+        kind="waiting_approval",
+        payload={"id": "approval-1", "name": "gmail_send"},
+        state="waiting_approval",
+    )
+    store.checkpoint_agent_run(
+        "run-question",
+        kind="user_input",
+        payload={"text_length": 0},
+        state="waiting_question",
+    )
+    store.checkpoint_agent_run(
+        "run-complete",
+        kind="terminal",
+        payload={"status": "ok", "text_length": 4},
+        state="complete",
+        terminal_result={"status": "ok", "text": "done"},
+    )
+
+    reopened = ConversationStore(tmp_path)
+
+    assert reopened.get_agent_run("run-running")["current_state"] == "interrupted"
+    assert reopened.get_agent_run("run-running")["finished_at"] is None
+    assert [
+        item["kind"]
+        for item in reopened.list_agent_run_checkpoints("run-running")
+    ] == ["run_started", "process_interrupted"]
+    assert reopened.get_agent_run("run-waiting")["current_state"] == "waiting_approval"
+    assert reopened.get_agent_run("run-waiting")["finished_at"] is None
+    assert reopened.get_agent_run("run-question")["current_state"] == "waiting_question"
+    assert reopened.get_agent_run("run-question")["finished_at"] is None
+    assert reopened.get_agent_run("run-complete")["current_state"] == "complete"
+    assert [
+        item["kind"]
+        for item in reopened.list_agent_run_checkpoints("run-complete")
+    ] == ["run_started", "terminal"]
+
+
+def test_user_input_checkpoint_waits_for_durable_transcript_append(
+    tmp_path, monkeypatch
+):
+    store = ConversationStore(tmp_path)
+    inbox = Inbox(store)
+    original_append = store.append
+
+    def fail_user_append(session_id, message):
+        if message.get("role") == "user":
+            raise RuntimeError("user transcript append failed")
+        return original_append(session_id, message)
+
+    monkeypatch.setattr(store, "append", fail_user_append)
+    result = asyncio.run(
+        run_turn(
+            text="Find candidates",
+            sid="thread-user-order",
+            store=store,
+            provider=FakeProvider(deltas=("unused",)),
+            persona=None,
+            skills=None,
+            inbox=inbox,
+            openai_tools=[],
+            execute_kwargs={},
+        )
+    )
+
+    assert result["status"] == "error"
+    assert store.load("thread-user-order") == []
+    assert "user_input" not in {
+        item["kind"]
+        for item in store.list_agent_run_checkpoints(result["run_id"])
+    }
+
+
+def test_terminal_checkpoint_waits_for_durable_terminal_event(tmp_path, monkeypatch):
+    store = ConversationStore(tmp_path)
+    inbox = Inbox(store)
+    original_append_event = store.append_event
+
+    def fail_terminal_event(session_id, event):
+        if event.get("type") in {"turn_end", "turn_stopped", "error"}:
+            raise RuntimeError("terminal event append failed")
+        return original_append_event(session_id, event)
+
+    monkeypatch.setattr(store, "append_event", fail_terminal_event)
+    with pytest.raises(RuntimeError, match="terminal event append failed"):
+        asyncio.run(
+            run_turn(
+                text="Find candidates",
+                sid="thread-terminal-order",
+                store=store,
+                provider=FakeProvider(deltas=("Done",)),
+                persona=None,
+                skills=None,
+                inbox=inbox,
+                openai_tools=[],
+                execute_kwargs={},
+            )
+        )
+
+    run = store.list_agent_runs(session_id="thread-terminal-order")[0]
+    assert run["current_state"] == "running"
+    assert "terminal" not in {
+        item["kind"]
+        for item in store.list_agent_run_checkpoints(run["run_id"])
+    }
+
+
+def test_approval_checkpoint_waits_for_canonical_inbox_resolution(
+    tmp_path, monkeypatch
+):
+    store = ConversationStore(tmp_path)
+    inbox = Inbox(store)
+    provider = FakeProvider(
+        steps=[
+            {
+                "tool_calls": [
+                    ToolCall(
+                        id="approval-order-call",
+                        name="gmail_draft",
+                        arguments={
+                            "to": "person@example.test",
+                            "subject": "Hello",
+                            "body": "Draft body",
+                        },
+                    )
+                ]
+            }
+        ]
+    )
+
+    def fail_cancel(_item_id):
+        raise RuntimeError("inbox cancel failed")
+
+    async def choose_cancel(_item_id):
+        return "cancel"
+
+    monkeypatch.setattr(inbox, "cancel", fail_cancel)
+    result = asyncio.run(
+        run_turn(
+            text="Draft outreach",
+            sid="thread-approval-order",
+            store=store,
+            provider=provider,
+            persona=None,
+            skills=None,
+            inbox=inbox,
+            openai_tools=[],
+            execute_kwargs={},
+            wait_permission=choose_cancel,
+        )
+    )
+
+    assert result["status"] == "error"
+    checkpoints = store.list_agent_run_checkpoints(result["run_id"])
+    assert "waiting_approval" in {item["kind"] for item in checkpoints}
+    assert "approval_resolved" not in {item["kind"] for item in checkpoints}
+
+
+def test_websocket_chat_persists_canonical_agent_run_matching_event_identity(tmp_path):
+    application = create_app(
+        token=TOKEN,
+        provider=FakeProvider(deltas=("Three candidates are ready.",)),
+        state=tmp_path,
+    )
+    sid = application.state.store.open_session_id()
+
+    with TestClient(application).websocket_connect(
+        "/ws/chat", subprotocols=["club", TOKEN]
+    ) as ws:
+        ws.send_json(
+            {
+                "type": "chat",
+                "text": "Find three strong candidates.",
+                "session_id": sid,
+            }
+        )
+        events = _drain(ws)
+
+    run_id = events[0]["run_id"]
+    assert {event["run_id"] for event in events} == {run_id}
+    run = application.state.store.get_agent_run(run_id)
+    assert run is not None
+    assert run["session_id"] == sid
+    assert run["trigger"] == "chat"
+    assert run["original_goal"] == "Find three strong candidates."
+    assert run["provider_model_id"] == "fake"
+    assert run["current_state"] == "complete"
+    assert run["usage"] == {"model_calls": 1}
+    assert run["terminal_result"] == {
+        "status": "ok",
+        "message_id": events[-1]["message_id"],
+        "text_length": len("Three candidates are ready."),
+    }
+    checkpoints = application.state.store.list_agent_run_checkpoints(run_id)
+    assert [item["kind"] for item in checkpoints] == [
+        "run_started",
+        "user_input",
+        "model_completed",
+        "terminal",
+    ]
+    assert checkpoints[1]["payload"] == {
+        "text_length": len("Find three strong candidates.")
+    }
+    assert checkpoints[-1]["payload"] == {
+        "status": "ok",
+        "state": "complete",
+        "text_length": len("Three candidates are ready."),
+    }
+
+
+def test_tool_run_aggregates_skill_source_and_artifact_refs_without_delta_checkpoints(
+    tmp_path, monkeypatch
+):
+    provider = FakeProvider(
+        steps=[
+            {
+                "tool_calls": [
+                    ToolCall(
+                        id="call-skill",
+                        name="load_skill",
+                        arguments={"name": "candidate-search"},
+                    ),
+                    ToolCall(
+                        id="call-drive",
+                        name="drive_search",
+                        arguments={"query": "Codeology"},
+                    ),
+                ]
+            },
+            {"deltas": ("Shortlist ready.",)},
+        ]
+    )
+
+    def fake_execute(name, arguments, **_kwargs):
+        if name == "load_skill":
+            return True, {
+                "name": "candidate-search",
+                "description": "Search candidates",
+                "instructions": "raw skill instructions must not enter checkpoints",
+            }
+        return True, {
+            "sources": [
+                {
+                    "id": "source-drive-1",
+                    "title": "Candidate notes",
+                    "url": "https://example.test/source",
+                    "provider": "Google Drive",
+                    "raw_body": "private source body",
+                }
+            ],
+            "artifacts": [
+                {
+                    "id": "artifact-shortlist-1",
+                    "artifact_type": "shortlist",
+                    "title": "Candidate shortlist",
+                    "external_url": "https://example.test/shortlist",
+                    "raw_payload": "private artifact payload",
+                }
+            ],
+        }
+
+    monkeypatch.setattr("coworker.turn.execute", fake_execute)
+    application = create_app(token=TOKEN, provider=provider, state=tmp_path)
+    sid = application.state.store.open_session_id()
+    persistence_order = []
+    original_append = application.state.store.append
+    original_append_event = application.state.store.append_event
+    original_checkpoint = application.state.store.checkpoint_agent_run
+
+    def tracked_append(session_id, message):
+        original_append(session_id, message)
+        if message.get("role") in {"assistant", "tool"}:
+            persistence_order.append(f"message:{message['role']}")
+
+    def tracked_append_event(session_id, event):
+        original_append_event(session_id, event)
+        if event.get("type") == "tool_finished":
+            persistence_order.append("event:tool_finished")
+
+    def tracked_checkpoint(run_id, *, kind, **kwargs):
+        checkpoint = original_checkpoint(run_id, kind=kind, **kwargs)
+        if kind in {"model_completed", "tool_completed"}:
+            persistence_order.append(f"checkpoint:{kind}")
+        return checkpoint
+
+    monkeypatch.setattr(application.state.store, "append", tracked_append)
+    monkeypatch.setattr(
+        application.state.store, "append_event", tracked_append_event
+    )
+    monkeypatch.setattr(
+        application.state.store, "checkpoint_agent_run", tracked_checkpoint
+    )
+    with TestClient(application).websocket_connect(
+        "/ws/chat", subprotocols=["club", TOKEN]
+    ) as ws:
+        ws.send_json(
+            {"type": "chat", "text": "Build a shortlist", "session_id": sid}
+        )
+        events = _drain(ws)
+
+    run_id = events[0]["run_id"]
+    run = application.state.store.get_agent_run(run_id)
+    assert run["skills_loaded"] == ["candidate-search"]
+    assert run["source_refs"] == [
+        {
+            "id": "source-drive-1",
+            "title": "Candidate notes",
+            "url": "https://example.test/source",
+            "provider": "Google Drive",
+            "stale": False,
+            "truncated": False,
+        }
+    ]
+    assert run["artifact_refs"] == [
+        {
+            "id": "artifact-shortlist-1",
+            "artifact_type": "shortlist",
+            "title": "Candidate shortlist",
+            "external_url": "https://example.test/shortlist",
+            "stale": False,
+            "truncated": False,
+        }
+    ]
+    assert run["usage"] == {"model_calls": 2, "tool_calls": 2}
+    checkpoints = application.state.store.list_agent_run_checkpoints(run_id)
+    assert [item["kind"] for item in checkpoints] == [
+        "run_started",
+        "user_input",
+        "model_completed",
+        "tool_completed",
+        "tool_completed",
+        "model_completed",
+        "terminal",
+    ]
+    durable_agent_run = json.dumps({"run": run, "checkpoints": checkpoints})
+    assert "assistant_delta" not in durable_agent_run
+    assert "raw skill instructions" not in durable_agent_run
+    assert "private source body" not in durable_agent_run
+    assert "private artifact payload" not in durable_agent_run
+    assert persistence_order == [
+        "message:assistant",
+        "checkpoint:model_completed",
+        "event:tool_finished",
+        "message:tool",
+        "checkpoint:tool_completed",
+        "event:tool_finished",
+        "message:tool",
+        "checkpoint:tool_completed",
+        "message:assistant",
+        "checkpoint:model_completed",
+    ]
+
+
+def test_failed_run_preserves_only_a_safe_error_in_terminal_result(tmp_path):
+    class FailingProvider:
+        model_id = "failing"
+
+        async def astream(self, *, messages, tools):
+            if False:
+                yield
+            raise RuntimeError("provider unavailable token=provider-secret")
+
+    application = create_app(
+        token=TOKEN, provider=FailingProvider(), state=tmp_path
+    )
+    sid = application.state.store.open_session_id()
+
+    with TestClient(application).websocket_connect(
+        "/ws/chat", subprotocols=["club", TOKEN]
+    ) as ws:
+        ws.send_json({"type": "chat", "text": "Find candidates", "session_id": sid})
+        events = _drain(ws)
+
+    run = application.state.store.get_agent_run(events[0]["run_id"])
+    assert run["current_state"] == "failed"
+    assert run["terminal_result"] == {
+        "status": "error",
+        "message_id": events[-1]["message_id"],
+        "text_length": 0,
+        "error": "provider unavailable token=[REDACTED]",
+        "class": "run_error",
+    }
+    durable_agent_run = json.dumps(
+        {
+            "run": run,
+            "checkpoints": application.state.store.list_agent_run_checkpoints(
+                run["run_id"]
+            ),
+        }
+    )
+    assert "provider-secret" not in durable_agent_run
+
+
+def test_scheduled_receipt_links_to_schedule_triggered_agent_run(tmp_path):
+    application = create_app(
+        token=TOKEN,
+        provider=FakeProvider(deltas=("Weekly review complete.",)),
+        state=tmp_path,
+    )
+    job = application.state.store.add_job(
+        "0 9 * * 1", "Review priority sourcing work."
+    )
+
+    response = TestClient(application).post(
+        f"/v1/schedule/{job['id']}/run", headers={TOKEN_HEADER: TOKEN}
+    )
+
+    assert response.status_code == 200
+    receipt = response.json()["run"]
+    assert receipt["agent_run_id"]
+    run = application.state.store.get_agent_run(receipt["agent_run_id"])
+    assert run is not None
+    assert run["trigger"] == "schedule"
+    assert run["session_id"] == receipt["session_id"] == f"sched-{job['id']}"
+    assert run["original_goal"] == "Review priority sourcing work."
+    assert run["current_state"] == "complete"

--- a/desktop/tests/test_skills.py
+++ b/desktop/tests/test_skills.py
@@ -30,3 +30,33 @@ def test_catalog_text_lists_builtin():
     text = catalog_text(SkillLoader([BUILTIN_SKILLS]))
     assert "weekly-sourcing" in text
     assert "load_skill" in text
+
+
+def test_product_validation_skills_are_discoverable_and_outcome_bound():
+    loader = SkillLoader([BUILTIN_SKILLS])
+
+    outreach = loader.get("outreach-campaign")
+    pitch = loader.get("company-pitch-package")
+
+    assert outreach is not None
+    assert pitch is not None
+    assert "sent" in outreach.instructions.lower()
+    assert "send receipt" in outreach.instructions.lower()
+    assert "editable" in pitch.instructions.lower()
+    assert "never claim the deck was edited" in pitch.instructions.lower()
+
+
+def test_product_validation_skills_declare_real_tool_boundaries():
+    loader = SkillLoader([BUILTIN_SKILLS])
+    outreach = loader.get("outreach-campaign")
+    pitch = loader.get("company-pitch-package")
+
+    assert outreach is not None
+    assert pitch is not None
+    assert {"apollo_search_people", "gmail_draft", "gmail_send"} <= set(
+        outreach.allowed_tools
+    )
+    assert {"drive_search", "drive_read", "web_search"} <= set(
+        pitch.allowed_tools
+    )
+    assert "gmail_send" not in pitch.allowed_tools

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,8 @@ Sourcecado's dated documents record several product shapes. They are intentional
 ## Current source of truth
 
 - [Sourcing director spring specification](superpowers/specs/2026-08-25-sourcecado-sourcing-director-spring.md) — current product job, use cases, scope, and locked conditions
+- [Mature Agent System blueprint](superpowers/specs/2026-08-26-sourcecado-mature-agent-system-blueprint.md) — approved Agent OS architecture basis and primary reference donors
+- [Evidence-reconciled Agent OS roadmap](superpowers/plans/2026-08-26-evidence-reconciled-agent-os-roadmap.md) — approved Priority 0–4 implementation direction grounded in live workflow evidence
 - [Root README](../README.md) — setup, commands, repository map, and local-state policy
 - [Agent context](../AGENTS.md) — engineering guardrails and documentation precedence
 - [Domain context](../CONTEXT.md) — current sourcing language
@@ -14,6 +16,8 @@ Sourcecado's dated documents record several product shapes. They are intentional
 ## Current execution records
 
 - `superpowers/plans/2026-08-24-*` and `superpowers/plans/2026-08-25-*` — local runtime, sourcing spring, and desktop UI plans
+- `superpowers/plans/2026-08-26-product-validation-sprint-roadmap.md` — golden-workflow validation process and current execution status
+- `qa/2026-08-26-golden-workflow-baseline.md` — real outreach and pitch-package run evidence that drove the Agent OS roadmap
 - `qa/` — current end-to-end and visual QA evidence
 - `desktop/docs/adr/` — ADRs scoped to the active local runtime
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Sourcecado's dated documents record several product shapes. They are intentional
 
 - `superpowers/plans/2026-08-24-*` and `superpowers/plans/2026-08-25-*` — local runtime, sourcing spring, and desktop UI plans
 - `superpowers/plans/2026-08-26-product-validation-sprint-roadmap.md` — golden-workflow validation process and current execution status
+- `superpowers/plans/2026-08-26-priority-0-durable-agent-run-implementation.md` — dependency-ordered implementation plan for the approved Durable Agent Run
 - `qa/2026-08-26-golden-workflow-baseline.md` — real outreach and pitch-package run evidence that drove the Agent OS roadmap
 - `qa/` — current end-to-end and visual QA evidence
 - `desktop/docs/adr/` — ADRs scoped to the active local runtime

--- a/docs/qa/2026-08-26-golden-workflow-baseline.md
+++ b/docs/qa/2026-08-26-golden-workflow-baseline.md
@@ -1,0 +1,130 @@
+# Golden Workflow Baseline — 2026-08-26
+
+Branch: `codex/product-validation-sprint`  
+App: local FastAPI sidecar + React/Vite browser surface  
+Model: configured DeepSeek provider  
+Mode: real connectors and private sources; read-only product run; no enrichment,
+draft creation, sending, or Drive writes
+
+This report intentionally omits private contact details and source bodies. The
+full evidence remains in the local Sourcecado transcripts and event ledger.
+
+## Verdict
+
+Both v0 skills can eventually produce a useful review package, but neither can
+complete its job in one autonomous run. Both expanded research until manually
+stopped, then required a second user turn instructing the agent to stop using
+tools and synthesize the preserved evidence.
+
+This is a productive failure. The sourcing reasoning is promising; the mature
+agent operating-system behavior is not yet present.
+
+## Outreach campaign
+
+### Execution
+
+- The skill loaded successfully through the live skill catalog.
+- The first run gathered 33 visible Drive evidence items and completed eleven
+  displayed actions over roughly 74 seconds before manual cancellation.
+- Cancellation produced a durable interrupted receipt and preserved completed
+  tool work.
+- A second turn requested convergence from existing evidence. It made two more
+  source reads, then produced the director-review package.
+- Reloading the app preserved the transcript, evidence, interrupted receipt,
+  final response, and complete terminal state.
+
+### Product result
+
+The final package was useful. It:
+
+- selected the current-semester SOP and template over older duplicates;
+- found stale campaign-cycle language in the template;
+- distinguished warm relationship follow-ups from cold outreach;
+- produced a bounded five-contact review set with why-now, missing fields, and
+  relationship risks;
+- declined to spend Apollo credits, draft, or send without review;
+- surfaced incomplete source coverage and requested concrete director choices.
+
+### Failures
+
+- Research did not naturally converge to the requested shortlist.
+- The original prompt was appended to an existing QA thread after root restore
+  selected the prior destination rather than the newly created chat.
+- The final deliverable exists only as assistant prose, not as a campaign
+  artifact or durable campaign state.
+- No source-scoped campaign object bounded the Drive and Gmail searches.
+- The run needed a human-authored second turn to reserve time/context for the
+  deliverable.
+
+## Company pitch package
+
+### Execution
+
+- The skill loaded successfully in a clean new session.
+- The first run expanded to 155 visible Drive evidence items and nineteen
+  actions over roughly 58 seconds before manual cancellation.
+- Granola failed with an internal task-group error.
+- Both web-search attempts failed because the Tavily key was unavailable to the
+  sidecar, despite the other connector preflight being healthy.
+- Cancellation preserved all completed evidence and emitted an interrupted
+  receipt.
+- A second no-more-tools turn eventually produced the review package.
+- Reloading the app restored the complete package and terminal state.
+
+### Product result
+
+The final partial package was useful and honest. It:
+
+- stated immediately that no editable deck had been created because no
+  slide-write capability exists;
+- recovered a pitch script, historical company work, and prior relationship
+  clues;
+- produced a company brief, proposed value exchange, tiered ask,
+  slide-by-slide content package, talking points, knowledge gaps, and follow-up
+  email draft;
+- marked unverified company facts as training knowledge after web search failed;
+- surfaced conflicting project duration/pricing and an unconfirmed warm contact;
+- made no file, draft, or send claim without a receipt.
+
+### Failures
+
+- Global Drive discovery produced an evidence flood instead of a narrow Zoox
+  source set.
+- The existing company deck lived behind a Figma link the local toolset could
+  not read.
+- The candidate Google Slides template was located but not opened, copied, or
+  edited.
+- There is no first-class editable deck artifact.
+- The final answer required a second user turn and a long synthesis delay.
+- Web and Granola connector readiness was not truthful at preflight.
+
+## Durability and performance evidence
+
+- Interrupted and completed turns survive app reload.
+- Tool results and final answers survive the interruption/resume sequence.
+- The outreach transcript produced roughly 1,900 persisted assistant-delta
+  events; the pitch transcript produced roughly 3,300.
+- Local event logs reached approximately 710 KB and 1.2 MB respectively for
+  these two validation conversations.
+
+Persisting every streamed delta gives excellent replay fidelity but is too
+expensive as the long-term transcript representation for artifact-heavy work.
+
+## Acceptance status
+
+| Outcome | Baseline status |
+|---|---|
+| Outreach shortlist and review gate | Useful partial pass |
+| Reviewed/enriched/sent campaign | Not attempted; blocked on director choices and later write approvals |
+| Company brief and slide content package | Useful partial pass |
+| Editable company deck | Fail: capability absent |
+| Interrupt/reload recovery | Pass |
+| Scheduled execution of the same skill | Deferred until interactive convergence works |
+| First-class artifacts and durable workflow state | Fail |
+
+## Immediate product lesson
+
+Sourcecado does not primarily need more generic tools. It needs a skill-run
+contract that bounds sources, reserves a synthesis phase, checkpoints useful
+work, creates addressable artifacts, and can later be invoked unchanged from
+the scheduler.

--- a/docs/qa/2026-08-26-product-validation-readiness.md
+++ b/docs/qa/2026-08-26-product-validation-readiness.md
@@ -1,0 +1,66 @@
+# Product Validation Readiness — 2026-08-26
+
+Branch: `codex/product-validation-sprint`  
+Baseline: stacked on desktop-first repository cleanup PR #48  
+Mode: read-only connector and runtime preflight; no external writes performed
+
+## Ready
+
+- Sidecar starts and reports the `sourcing` persona on `deepseek-v4-pro`.
+- Gmail is connected for the Codeology account.
+- Google Drive is connected and reports healthy.
+- Google Calendar is connected and reports healthy.
+- Apollo is configured.
+- Granola is connected.
+- `outreach-campaign`, `company-pitch-package`, and `weekly-sourcing` are all
+  discoverable through the live `/v1/skills` catalog.
+- The scheduler has a weekly sourcing job and two historical receipts.
+
+No credential values were read or printed during this check.
+
+## Gaps already exposed by preflight
+
+1. The connector catalog advertises Drive search/read but not folder listing,
+   while the active tool catalog contains `drive_list_folder`. Model, runtime,
+   and UI do not yet share one capability contract.
+2. Historical scheduler rows still return raw status `ok` instead of canonical
+   `success`. This confirms the receipt-truthfulness gap in issue #40.
+3. Historical scheduled runs produced no first-class artifacts even when they
+   contained complete outreach drafts.
+4. The historical weekly run explicitly reported that team memory was not
+   writable, while the current person-file and memory tools suggest a newer
+   capability. The real workflow must prove which state is authoritative.
+5. The existing `weekly-sourcing` skill still says drafts never send. That is
+   stale relative to the current approval-gated `gmail_send` product behavior.
+6. The scheduler template runs a prompt, but does not explicitly identify a
+   skill. The baseline run must prove whether scheduled and interactive work
+   actually follow the same skill path.
+7. No current tool can create or edit a Google Slides/PowerPoint artifact. The
+   pitch-package baseline should return an honest partial result rather than
+   claiming a deck was edited.
+
+## Provisional live scenarios
+
+These selections are safe for a read-only baseline and are derived from the
+existing scheduled sourcing evidence. Fisher can replace either before any
+costly or external action.
+
+### Outreach
+
+Fall 2026 project-partner outreach, beginning with a bounded five-contact slice
+from the twelve researched companies already named in the sourcing masterdoc.
+Search and drafting may be tested; enrichment, draft creation, and sending
+remain approval-gated.
+
+### Pitch package
+
+Zoox partnership/project pitch package. The existing scheduled evidence says a
+deck exists and a warm contact path through Stella may exist, while no outreach
+trail was found. This makes it a strong test of source recovery, template
+selection, relationship context, and truthful artifact creation.
+
+## Next action
+
+Run both scenarios through the actual desktop/browser UI. Preserve the live
+transcript, tool receipts, approval states, final artifacts or honest partial
+artifacts, restart/resume behavior, and manual interventions.

--- a/docs/superpowers/plans/2026-08-26-evidence-reconciled-agent-os-roadmap.md
+++ b/docs/superpowers/plans/2026-08-26-evidence-reconciled-agent-os-roadmap.md
@@ -1,207 +1,336 @@
 # Evidence-Reconciled Agent OS Roadmap
 
-Date: 2026-08-26  
-Status: proposed at the product-validation decision gate  
+Date: 2026-08-26
+Status: approved architecture basis
 Evidence: `docs/qa/2026-08-26-golden-workflow-baseline.md`
+Product source: `docs/superpowers/specs/2026-08-25-sourcecado-sourcing-director-spring.md`
 
 ## Product conclusion
 
-Keep the sourcing skills. Do not solve their failures with increasingly long
-skill prose. The two runs exposed five shared operating-system capabilities
-that should form the next implementation sequence.
+Sourcecado is a generic local agent operating system for the club. Sourcing is
+the first department whose work must be proven end to end. Skills improve how
+the agent approaches a job, but durability, tools, artifacts, connectors,
+scheduling, and audit history exist independently of skills.
 
-## Priority 0: skill-run contract and convergence
+The two live sourcing workflows exposed five missing operating-system
+capabilities. Each priority below names one primary implementation donor and a
+minimal Sourcecado port. We do not combine frameworks merely because all three
+contain adjacent ideas.
 
-### Problem
+## Core execution model
 
-Both skills researched successfully but required manual cancellation and a
-second user turn before delivering the requested outcome.
+- A director gives Sourcecado a job as a prompt. The prompt may be freeform,
+  may load one or more skills, or may come from an automation.
+- One Agent Run owns that job through clarification questions, approval waits,
+  tools, interruption, resume, and terminal delivery.
+- Chat and scheduling invoke the same agent engine.
+- Files and cloud documents are deliverables. Assistant prose alone is not a
+  substitute when the job calls for an editable artifact.
+- The Run Ledger preserves the complete semantic agent trace for future evals,
+  without storing hidden chain-of-thought or transport-level token chunks.
 
-### Build
+## Priority 0: Durable Agent Run
 
-- Give each skill invocation one durable run record with skill name, validated
-  inputs, source scope, phases, checkpoints, artifact refs, and terminal state.
-- Reserve a synthesis/delivery phase before the tool or time budget is spent.
-- When the research budget ends, require a useful partial deliverable with
-  completed evidence and explicit gaps instead of another tool round.
-- Preserve partial assistant output and completed phase state on stop/error.
-- Expose current phase and progress in the existing run UI.
+### Observed failure
 
-### Copy
+Both golden workflows found useful evidence but kept researching until the
+operator interrupted them. Each required a second user message saying, in
+effect, "stop using tools and deliver now."
 
-- OpenWorker: mid-turn checkpoint events, persisted compaction state, partial
-  turn preservation, real-file artifact contract.
-- Grok Bot: turn checkpoint/settle boundary and transcript/index workers.
-- OpenClaw: incomplete-turn recovery, detached task status, attempt/terminal
-  records, and final-answer separation from reasoning/tool activity.
+### Primary donor
 
-### Done when
+**OpenWorker's prompt-driven `TurnEngine` lifecycle.**
 
-Each golden skill reaches its director-review deliverable in one run without a
-"stop using tools and answer now" follow-up.
+Copy these concrete behaviors:
 
-## Priority 1: explicit source scope and canonical source registry
+- a prompt enters one engine regardless of whether a skill is loaded;
+- the run can suspend for a human question or approval and continue in place;
+- interruption preserves the visible partial assistant output;
+- unanswered tool calls resume durably after restart;
+- completed model/tool iterations are persistence checkpoints;
+- context compaction preserves canonical history while bounding the outbound
+  model view;
+- automation sends ordinary instructions through the same engine.
 
-### Problem
+Use OpenClaw only as a contract check for the distinction between Session,
+Agent Run, model turn/attempt, approval ownership, and terminal state.
 
-The pitch run expanded to 155 evidence items and unrelated duplicate SOPs. Long
-documents truncated before relevant sections. Current search cannot distinguish
-canonical, stale, restricted, and merely matching sources.
+### Sourcecado port
 
-### Build
+- Preserve Sourcecado's provider adapters, tool execution, approval inbox,
+  semantic events, and replay UI.
+- Add a durable Agent Run around the existing loop rather than replacing the
+  loop wholesale.
+- A run stores stable identity, owning session, trigger, original goal, current
+  state, checkpoints, source and artifact refs, usage, and terminal result.
+- Clarification uses an `ask_user` suspension inside the same run. A later
+  request to revise a completed deliverable becomes a new linked run.
+- Skills are optional context recorded as `skills_loaded`; they are never the
+  execution boundary.
+- Reserve enough budget for terminal delivery. When the work budget ends, the
+  engine returns the best useful partial result with explicit gaps instead of
+  starting another tool round.
+- Scheduled jobs call this same Agent Run entry point with their saved prompt.
 
-- Resolve and persist an exact source scope before research: folder ids,
-  canonical document ids, company/people scope, and allowed connectors.
-- Add canonical-source metadata: purpose, semester, version, approval status,
-  sensitivity, supersedes/superseded-by, and owner.
-- Make Drive folder ingestion/indexing recursive, resumable, idempotent, and
-  outside the interactive step budget.
-- Query indexed chunks later instead of rereading full source bodies.
-- Exclude results outside the selected tree unless the director expands scope.
+### Do not copy
 
-### Copy
-
-- Grok Bot: worker-backed search index and corruption/rebuild behavior.
-- OpenClaw: workspace/source scope, bounded memory indexes, provenance, and
-  background-task progress.
-- OpenWorker: explicit roots and per-session workspace boundaries.
-
-### Related work
-
-Issue #43 is now directly product-proven. Drive MIME truth and cache fixes from
-PR #49 support this path. The broad generic record ontology in PR #47 should
-not be accepted wholesale without reconciling it with the person-file product
-model.
-
-### Done when
-
-The Zoox run reads only the approved pitch sources and company evidence, and the
-outreach run reads only the selected semester/campaign materials.
-
-## Priority 2: first-class deliverables and Google Slides
-
-### Problem
-
-The pitch skill produced strong prose but could not create the actual product:
-an editable company deck. Neither workflow emitted a first-class artifact.
-
-### Build
-
-- Add a Sourcecado artifact record with stable id, type, version, run, source
-  refs, review status, external/local location, and provenance.
-- Add Google Slides read/copy/update behind the existing Google connector:
-  inspect template structure, copy an approved template, apply bounded text and
-  image edits, and return an editable Slides URL.
-- Require approval before creating/copying/updating an external presentation.
-- Render deck, campaign-review set, and follow-up package as artifacts, not only
-  assistant Markdown.
-- Keep Figma out of the critical path initially; record its existing links as
-  source refs and migrate the approved template to Google Slides if necessary.
-
-### Copy
-
-- OpenWorker: workspace/scratch artifacts and addressable artifact panel.
-- OpenClaw: Workboard artifact/proof metadata and immutable attempt receipts.
-- Grok Bot: artifact-aware transcript/checkpoint settlement.
+- OpenWorker's full connector catalog or generic UI.
+- OpenClaw's Gateway/runtime breadth.
+- Skill-specific state machines or hard-coded sourcing phases.
 
 ### Done when
 
-The pitch skill produces an editable, source-linked deck from an approved
-template, and the outreach skill produces an addressable campaign-review
-artifact.
+The outreach and pitch jobs reach their director-review deliverables in one
+Agent Run, including any clarification/approval waits, without a follow-up
+"converge now" prompt.
 
-## Priority 3: connector and capability truth
+## Priority 1: Scoped Knowledge Workspace
 
-### Problem
+### Observed failure
 
-Granola appeared connected but failed at use. Web search was absent from the
-connector preflight and failed for missing Tavily configuration. Drive folder
-listing existed as a tool but was not advertised by the connection catalog.
+The outreach run surfaced 33 Drive matches and the pitch run 155. Duplicate,
+stale, and unrelated sources entered context. Large documents truncated before
+relevant sections.
 
-### Build
+### Product shape
 
-- Derive model tools, connection capabilities, and UI labels from one
-  server-owned capability registry.
-- Add safe live verification per connector and report `ready`, `degraded`, or
-  `unavailable` with a tested-at timestamp.
-- Repair Granola list/read error handling and make its failure class useful.
-- Configure a supported web-search provider or expose its missing configuration
-  before the run starts.
-- Fail the workflow preflight when a required capability is unavailable; allow
-  the director to approve a degraded run.
+The director selects the Codeology Sourcing Drive folder once. Google Drive
+remains authoritative. Sourcecado maintains a local read-only mirror/index of
+that folder with Drive id, folder path, MIME type, modified time, sensitivity,
+and extracted text.
 
-### Copy
+### Primary donor
 
-- OpenWorker: connector descriptors and readiness/recovery model.
-- OpenClaw: atomic runtime generations and capability publication.
+**OpenClaw's Markdown memory index in `packages/memory-host-sdk`.**
 
-### Done when
+Copy only this coherent path:
 
-A green connector in Sourcecado succeeds in the corresponding skill run, and a
-degraded connector is visible before work begins.
+- one explicit indexed path;
+- symlink-safe file discovery and real-path deduplication;
+- hash, modification-time, and size change detection;
+- Markdown chunks with line boundaries;
+- SQLite source/chunk tables and FTS search;
+- incremental resync when files change;
+- bounded snippets with file/line provenance.
 
-## Priority 4: durable transcript economy and scheduled skill parity
+### Sourcecado port
 
-### Problem
+- Mirror supported Drive documents into Sourcecado's local state; never treat
+  the mirror as the authoritative document store.
+- Preserve Drive metadata beside every mirrored file/chunk.
+- Normal agent retrieval uses `search_sources` and `read_source` against this
+  one Knowledge Workspace.
+- Global Drive search remains an explicit scope-expansion action, not the
+  default retrieval path.
+- A human may pin approved SOPs/templates later, but v1 does not ask the model
+  to infer canonical status from filenames or dates.
 
-Two validation conversations generated thousands of persisted deltas and
-multi-megabyte event logs. Scheduling currently stores a raw prompt rather than
-a skill plus validated inputs, and historical receipts still use legacy status
-`ok`.
+### Do not copy
 
-### Build
-
-- Coalesce persisted assistant deltas into bounded snapshots/final messages
-  while retaining live streaming over WebSocket.
-- Add event-log compaction or projection checkpoints without deleting audit
-  receipts, tool outcomes, or final artifacts.
-- Store `skill_name`, validated inputs, source scope, and grants on a scheduled
-  job. Invoke the same skill-run path as chat.
-- Normalize scheduler status and artifacts, including historical receipts.
-- Park unattended approvals in the existing inbox and resume the same run after
-  resolution.
-
-### Copy
-
-- OpenWorker: persisted compaction, automation models, approval inbox, and
-  run-once/skip-overlap scheduler.
-- Grok Bot: transcript window/index separation and automation spend state.
-- OpenClaw: database-first transcript projections and detached-task completion.
+- Vector embeddings, MMR, temporal decay, multimodal memory, session transcript
+  indexing, project annotations, or automatic canonical inference.
+- Grok Bot's separate transcript index worker.
+- OpenWorker's entire filesystem tool suite as part of retrieval.
 
 ### Done when
 
-The outreach skill can be scheduled without a second implementation path, its
-approval pauses/resumes durably, and a long artifact run does not grow the
-transcript by one durable row per streamed token.
+After selecting the Fall 2026 sourcing folder, a Zoox query returns fewer than
+ten relevant scoped results with Drive/source citations and no unrelated global
+Drive matches.
 
-## Proposed implementation sequence
+## Priority 2: Workspace, Shell, and Artifacts
 
-1. Land the narrow Drive/cache truth fixes; avoid merging overlapping PRs
-   blindly.
-2. Add the skill-run record, phases, checkpoint tool, and forced partial/final
-   delivery behavior.
-3. Add source-scope and canonical-source contracts.
-4. Implement the resumable Drive index for selected folders.
-5. Unify capability publication and repair web/Granola preflight.
-6. Add the artifact store and campaign-review artifact.
-7. Add Google Slides read/copy/update and deck artifact UI.
-8. Coalesce transcript persistence and bind scheduler jobs to skills.
-9. Re-run both golden workflows interactively.
-10. Run outreach through scheduling and continue to enrichment/draft/send only
-    after Fisher approves the exact contacts and messages.
+### Observed failure
+
+The pitch workflow produced strong prose but no editable deck. Neither workflow
+produced a durable file artifact. Treating PPTX, DOCX, XLSX, PDF, HTML, and CSV
+as separate platform features would create the wrong abstraction.
+
+### Primary donor
+
+**OpenWorker's Cowork workspace and artifact lifecycle.**
+
+Copy these concrete behaviors:
+
+- one per-run writable scratch workspace;
+- workspace-scoped file read/write and search;
+- a persistent, workspace-rooted, approval-gated shell;
+- `todo_write` as visible execution progress;
+- the instruction to finish with the actual file plus an `artifact:` link;
+- artifact discovery by scanning the run's scratch workspace;
+- preview/read/open/reveal behavior for common file types;
+- scheduled-run artifact collection from files modified during the run.
+
+### Sourcecado port
+
+- Use files in the run workspace as the initial artifact source of truth. The
+  Run Ledger records references and provenance; do not add an artifact database
+  before file-backed artifacts prove insufficient.
+- Add skills that teach the agent how to create and verify common formats using
+  the shell: PPTX, DOCX, XLSX, PDF, HTML, Markdown, CSV, images, and packages.
+- Skills specify the appropriate library/tool, render the output, inspect the
+  rendering, and repair layout/content defects before delivery.
+- Cloud-native Google Slides, Docs, and Sheets remain connector tools. They are
+  not special cases in the artifact runtime.
+- Google Slides is the first cloud artifact adapter required by the pitch
+  workflow; Google Docs and Sheets follow the same connector boundary.
+
+### Do not copy
+
+- OpenClaw's box/remote-computer infrastructure.
+- Grok Bot's canvas/attachment internals.
+- One bespoke runtime subsystem per office format.
+- A restricted artifact-only command language that would grow into a shell.
+
+### Done when
+
+The pitch job creates a real editable PowerPoint artifact in its workspace and,
+when requested, an editable Google Slides copy through the Google connector.
+The outreach job creates a reviewable campaign package as a file artifact.
+
+## Priority 3: Connector Truth
+
+### Observed failure
+
+Granola appeared connected but failed on its first real read. Web search failed
+for missing configuration despite no visible preflight warning. Drive folder
+listing existed as a tool but was absent from the connection catalog.
+
+### Primary donor
+
+**OpenWorker's `ConnectorDescriptor` and `ValidationResult` model.**
+
+Copy these concrete behaviors:
+
+- each connector owns its authentication shape, scopes, setup copy, safe
+  identity, pinned capabilities, and real validator;
+- validation makes a bounded provider call instead of checking only for a
+  stored credential;
+- the same descriptor drives setup, status, and tool publication;
+- connected account, persona default, and session override are separate
+  concerns.
+
+### Sourcecado port
+
+- Create descriptors only for Sourcecado's small connector set.
+- Generate `/v1/connectors`, model tools, and UI capability labels from the same
+  descriptor data.
+- "Connected" means the provider validator passed. Store safe identity,
+  `last_verified_at`, status, and a recovery message.
+- Validate on connect and before a run that requires the connector.
+- Granola validation performs the MCP handshake and a harmless bounded read.
+- Web search becomes a visible connector with configuration/validation state.
+- Failed validation permits a degraded run by default. Block only when the
+  missing capability makes the requested deliverable impossible.
+
+### Do not copy
+
+- OpenWorker's 25-connector catalog, cloud OAuth broker, messaging gateway, or
+  persona connector-management breadth.
+- OpenClaw runtime generations as a second connector system.
+
+### Done when
+
+A green connector succeeds in the corresponding golden workflow. A degraded
+connector is visible before work begins, and the director can choose whether to
+continue when the final deliverable remains possible.
+
+## Priority 4: Semantic Agent Trace
+
+### Observed failure
+
+The two validation conversations persisted roughly 1,900 and 3,300 assistant
+delta events, producing event logs up to 1.2 MB. Sourcecado needs a complete
+trace for later evals, but transport-level token chunks are not the trace.
+
+### Primary donor
+
+**OpenWorker's canonical `engine.messages` plus semantic checkpoint persistence.**
+
+Copy these concrete behaviors:
+
+- stream text/reasoning deltas live to connected clients;
+- keep canonical completed messages and tool results in session history;
+- persist at meaningful checkpoints: user input, waiting approval/question,
+  completed model/tool iteration, and terminal completion/interruption;
+- always perform a final save in cleanup;
+- compact only the outbound model view while preserving canonical history.
+
+### Sourcecado port
+
+- Keep live WebSocket streaming.
+- Coalesce assistant deltas into a completed model-message record for durable
+  storage.
+- Preserve the full semantic trace: original goal and user answers,
+  prompt/context version or hash, model/provider/configuration, completed model
+  turns, tool arguments/results, approvals, sources, checkpoints, timing,
+  usage/cost, artifacts, errors, terminal result, and later human feedback.
+- Keep visible reasoning and structured rationale summaries when present.
+- Never store hidden chain-of-thought.
+- Scheduling already calls the same Sourcecado engine; do not create a second
+  scheduling runtime or require a skill name on a job.
+- Treat legacy scheduler status normalization as a small bug, not an
+  architecture priority.
+
+### Do not copy
+
+- OpenClaw's full database-first transcript projection system.
+- Grok Bot's transcript mirror.
+- Durable per-token stream chunks or hidden model reasoning.
+- A separate skill-aware automation runtime.
+
+### Done when
+
+Reload shows final messages, meaningful progress/tool/approval receipts, and
+terminal state. The trace can be exported for evals without replaying thousands
+of token-delta rows.
+
+## Implementation sequence
+
+1. Reconcile and land the narrow Drive/cache truth fixes; do not merge
+   overlapping branches blindly.
+2. Port the OpenWorker Durable Agent Run lifecycle around Sourcecado's existing
+   loop.
+3. Add the selected Drive Knowledge Workspace and narrow OpenClaw FTS index.
+4. Port OpenWorker's per-run workspace, files/search/shell/todo, and artifact
+   surface.
+5. Create and verify common artifact-format skills; add Google Slides as the
+   first cloud artifact connector.
+6. Replace the hard-coded connector catalog with OpenWorker-style descriptors
+   and real validators; repair Granola/web readiness.
+7. Change delta persistence to the OpenWorker checkpointed semantic trace.
+8. Re-run both golden workflows interactively.
+9. Run an ordinary saved prompt through scheduling and verify the same Agent
+   Run, connector, artifact, approval, and trace paths.
+10. Continue to enrichment, draft creation, and sending only after Fisher
+    approves the exact contacts and messages.
+
+## Existing work disposition
+
+- PR #49's narrow Drive MIME/cache work supports Priority 1 and should be
+  reconciled before new retrieval work.
+- Issue #43 is directly supported by the Knowledge Workspace evidence, but its
+  implementation should follow the approved narrow local-index design.
+- Issue #41 now aligns with Priority 2 when implemented as the OpenWorker-style
+  workspace/files/shell boundary.
+- PR #47's broad generic Board/index ontology is not part of this architecture
+  basis and should not be merged wholesale without product-model review.
+- Issue #40 remains a small scheduler receipt migration/normalization fix.
 
 ## Explicitly deferred
 
 - Generic multi-agent teams and subagent orchestration.
-- A broad CRM/Workboard ontology disconnected from the person-file experience.
-- Arbitrary local filesystem or shell access as a prerequisite.
-- Figma editing before the Google Slides path is proven.
+- A broad CRM/Workboard ontology disconnected from person files.
+- Hosted/team tenancy.
+- Automatic sending or bulk enrichment.
+- Vector retrieval in the first Knowledge Workspace index.
+- Figma editing before local PPTX and Google Slides are proven.
 - More connectors that neither golden workflow requires.
-- Formal automated eval scoring before several accepted/rejected real examples
-  exist.
+- Formal automated scoring before accepted/rejected real examples exist.
 
-## Decision gate
+## Acceptance
 
-Fisher reviews the two local deliverables and this priority order. After that,
-the roadmap becomes executable tickets. Until the review, no enrichment,
-external draft creation, email sending, or Drive/Slides write is authorized.
+The architecture is successful when both golden jobs finish in one Agent Run,
+use the scoped Knowledge Workspace, produce real editable artifacts, degrade
+truthfully when a connector fails, survive interruption/restart, work through
+scheduling, and leave a complete eval-ready semantic trace.

--- a/docs/superpowers/plans/2026-08-26-evidence-reconciled-agent-os-roadmap.md
+++ b/docs/superpowers/plans/2026-08-26-evidence-reconciled-agent-os-roadmap.md
@@ -1,0 +1,207 @@
+# Evidence-Reconciled Agent OS Roadmap
+
+Date: 2026-08-26  
+Status: proposed at the product-validation decision gate  
+Evidence: `docs/qa/2026-08-26-golden-workflow-baseline.md`
+
+## Product conclusion
+
+Keep the sourcing skills. Do not solve their failures with increasingly long
+skill prose. The two runs exposed five shared operating-system capabilities
+that should form the next implementation sequence.
+
+## Priority 0: skill-run contract and convergence
+
+### Problem
+
+Both skills researched successfully but required manual cancellation and a
+second user turn before delivering the requested outcome.
+
+### Build
+
+- Give each skill invocation one durable run record with skill name, validated
+  inputs, source scope, phases, checkpoints, artifact refs, and terminal state.
+- Reserve a synthesis/delivery phase before the tool or time budget is spent.
+- When the research budget ends, require a useful partial deliverable with
+  completed evidence and explicit gaps instead of another tool round.
+- Preserve partial assistant output and completed phase state on stop/error.
+- Expose current phase and progress in the existing run UI.
+
+### Copy
+
+- OpenWorker: mid-turn checkpoint events, persisted compaction state, partial
+  turn preservation, real-file artifact contract.
+- Grok Bot: turn checkpoint/settle boundary and transcript/index workers.
+- OpenClaw: incomplete-turn recovery, detached task status, attempt/terminal
+  records, and final-answer separation from reasoning/tool activity.
+
+### Done when
+
+Each golden skill reaches its director-review deliverable in one run without a
+"stop using tools and answer now" follow-up.
+
+## Priority 1: explicit source scope and canonical source registry
+
+### Problem
+
+The pitch run expanded to 155 evidence items and unrelated duplicate SOPs. Long
+documents truncated before relevant sections. Current search cannot distinguish
+canonical, stale, restricted, and merely matching sources.
+
+### Build
+
+- Resolve and persist an exact source scope before research: folder ids,
+  canonical document ids, company/people scope, and allowed connectors.
+- Add canonical-source metadata: purpose, semester, version, approval status,
+  sensitivity, supersedes/superseded-by, and owner.
+- Make Drive folder ingestion/indexing recursive, resumable, idempotent, and
+  outside the interactive step budget.
+- Query indexed chunks later instead of rereading full source bodies.
+- Exclude results outside the selected tree unless the director expands scope.
+
+### Copy
+
+- Grok Bot: worker-backed search index and corruption/rebuild behavior.
+- OpenClaw: workspace/source scope, bounded memory indexes, provenance, and
+  background-task progress.
+- OpenWorker: explicit roots and per-session workspace boundaries.
+
+### Related work
+
+Issue #43 is now directly product-proven. Drive MIME truth and cache fixes from
+PR #49 support this path. The broad generic record ontology in PR #47 should
+not be accepted wholesale without reconciling it with the person-file product
+model.
+
+### Done when
+
+The Zoox run reads only the approved pitch sources and company evidence, and the
+outreach run reads only the selected semester/campaign materials.
+
+## Priority 2: first-class deliverables and Google Slides
+
+### Problem
+
+The pitch skill produced strong prose but could not create the actual product:
+an editable company deck. Neither workflow emitted a first-class artifact.
+
+### Build
+
+- Add a Sourcecado artifact record with stable id, type, version, run, source
+  refs, review status, external/local location, and provenance.
+- Add Google Slides read/copy/update behind the existing Google connector:
+  inspect template structure, copy an approved template, apply bounded text and
+  image edits, and return an editable Slides URL.
+- Require approval before creating/copying/updating an external presentation.
+- Render deck, campaign-review set, and follow-up package as artifacts, not only
+  assistant Markdown.
+- Keep Figma out of the critical path initially; record its existing links as
+  source refs and migrate the approved template to Google Slides if necessary.
+
+### Copy
+
+- OpenWorker: workspace/scratch artifacts and addressable artifact panel.
+- OpenClaw: Workboard artifact/proof metadata and immutable attempt receipts.
+- Grok Bot: artifact-aware transcript/checkpoint settlement.
+
+### Done when
+
+The pitch skill produces an editable, source-linked deck from an approved
+template, and the outreach skill produces an addressable campaign-review
+artifact.
+
+## Priority 3: connector and capability truth
+
+### Problem
+
+Granola appeared connected but failed at use. Web search was absent from the
+connector preflight and failed for missing Tavily configuration. Drive folder
+listing existed as a tool but was not advertised by the connection catalog.
+
+### Build
+
+- Derive model tools, connection capabilities, and UI labels from one
+  server-owned capability registry.
+- Add safe live verification per connector and report `ready`, `degraded`, or
+  `unavailable` with a tested-at timestamp.
+- Repair Granola list/read error handling and make its failure class useful.
+- Configure a supported web-search provider or expose its missing configuration
+  before the run starts.
+- Fail the workflow preflight when a required capability is unavailable; allow
+  the director to approve a degraded run.
+
+### Copy
+
+- OpenWorker: connector descriptors and readiness/recovery model.
+- OpenClaw: atomic runtime generations and capability publication.
+
+### Done when
+
+A green connector in Sourcecado succeeds in the corresponding skill run, and a
+degraded connector is visible before work begins.
+
+## Priority 4: durable transcript economy and scheduled skill parity
+
+### Problem
+
+Two validation conversations generated thousands of persisted deltas and
+multi-megabyte event logs. Scheduling currently stores a raw prompt rather than
+a skill plus validated inputs, and historical receipts still use legacy status
+`ok`.
+
+### Build
+
+- Coalesce persisted assistant deltas into bounded snapshots/final messages
+  while retaining live streaming over WebSocket.
+- Add event-log compaction or projection checkpoints without deleting audit
+  receipts, tool outcomes, or final artifacts.
+- Store `skill_name`, validated inputs, source scope, and grants on a scheduled
+  job. Invoke the same skill-run path as chat.
+- Normalize scheduler status and artifacts, including historical receipts.
+- Park unattended approvals in the existing inbox and resume the same run after
+  resolution.
+
+### Copy
+
+- OpenWorker: persisted compaction, automation models, approval inbox, and
+  run-once/skip-overlap scheduler.
+- Grok Bot: transcript window/index separation and automation spend state.
+- OpenClaw: database-first transcript projections and detached-task completion.
+
+### Done when
+
+The outreach skill can be scheduled without a second implementation path, its
+approval pauses/resumes durably, and a long artifact run does not grow the
+transcript by one durable row per streamed token.
+
+## Proposed implementation sequence
+
+1. Land the narrow Drive/cache truth fixes; avoid merging overlapping PRs
+   blindly.
+2. Add the skill-run record, phases, checkpoint tool, and forced partial/final
+   delivery behavior.
+3. Add source-scope and canonical-source contracts.
+4. Implement the resumable Drive index for selected folders.
+5. Unify capability publication and repair web/Granola preflight.
+6. Add the artifact store and campaign-review artifact.
+7. Add Google Slides read/copy/update and deck artifact UI.
+8. Coalesce transcript persistence and bind scheduler jobs to skills.
+9. Re-run both golden workflows interactively.
+10. Run outreach through scheduling and continue to enrichment/draft/send only
+    after Fisher approves the exact contacts and messages.
+
+## Explicitly deferred
+
+- Generic multi-agent teams and subagent orchestration.
+- A broad CRM/Workboard ontology disconnected from the person-file experience.
+- Arbitrary local filesystem or shell access as a prerequisite.
+- Figma editing before the Google Slides path is proven.
+- More connectors that neither golden workflow requires.
+- Formal automated eval scoring before several accepted/rejected real examples
+  exist.
+
+## Decision gate
+
+Fisher reviews the two local deliverables and this priority order. After that,
+the roadmap becomes executable tickets. Until the review, no enrichment,
+external draft creation, email sending, or Drive/Slides write is authorized.

--- a/docs/superpowers/plans/2026-08-26-priority-0-durable-agent-run-implementation.md
+++ b/docs/superpowers/plans/2026-08-26-priority-0-durable-agent-run-implementation.md
@@ -1,0 +1,230 @@
+# Priority 0 Durable Agent Run Implementation Plan
+
+Date: 2026-08-26
+Status: Priority 0 in progress; Slice A complete
+Architecture basis: `2026-08-26-evidence-reconciled-agent-os-roadmap.md`
+Primary donor: OpenWorker prompt-driven `TurnEngine` lifecycle
+Contract reference: OpenClaw Session / Agent Run / model-turn distinction
+
+## Engineering judgment
+
+The approved roadmap points in the right direction. Sourcecado already owns a
+strong live-turn substrate: stable event identity, semantic tool receipts,
+cooperative cancellation, durable approvals, restart-safe unknown-outcome
+handling, transcript repair, and a shared low-level `run_turn` path for chat and
+scheduling.
+
+The dependency root is identity and authority. Today the UUID-like `run_id` in
+chat events describes one live turn, while SQLite's integer `runs.id` describes
+only a scheduled receipt. Neither is an authoritative, goal-sized Agent Run.
+Suspension, restart recovery, compaction, usage, and terminal delivery should
+not be added until one durable run record owns them.
+
+Priority 0 therefore lands as narrow vertical slices around the existing loop.
+It does not replace the provider, tool, approval, event, scheduler, or UI
+subsystems wholesale.
+
+## Locked decisions
+
+1. `TurnIdentity.run_id` becomes the canonical Agent Run identity for new work.
+2. A new `agent_runs` table owns execution state. The existing integer `runs`
+   table remains a schedule-receipt projection during migration.
+3. `agent_run_checkpoints` stores ordered semantic checkpoints. Raw token
+   deltas, credentials, authorization headers, private source bodies, and
+   hidden reasoning never enter checkpoints.
+4. `waiting_approval` and `waiting_question` are suspended, nonterminal states.
+5. A completed deliverable is immutable. A later revision starts a new run with
+   `parent_run_id` linking it to the prior result.
+6. Restart recovery never blindly replays an external write. Work is classified
+   as not started, safe to retry, completed, or outcome unknown before resume.
+7. Chat, queued chat, and scheduling invoke one Agent Run engine. Scheduling is
+   a trigger and receipt surface, not a second runtime.
+8. Skills remain optional tool-loaded context recorded in `skills_loaded`; they
+   are not execution boundaries.
+
+## Target flow
+
+```text
+prompt or saved prompt
+        |
+        v
+start Agent Run -----> semantic checkpoint -----> model turn
+        |                                        /          \
+        |                                  final answer     tool call
+        |                                                       |
+        |                         +-----------------------------+
+        |                         v
+        |                 safe tool / approval / ask_user
+        |                         |            |
+        |                         |            +--> suspend durably
+        |                         |                    |
+        |                         +<------ answer or approval
+        |                                      |
+        +<------------- resume same run -------+
+        |
+        v
+terminal delivery checkpoint -> complete / partial / stopped / failed
+```
+
+## Slice A — Canonical run and checkpoint spine
+
+Status: complete and reviewed
+
+Implementation commits: `56d4461..aae4be7`
+
+Verification:
+
+- Agent Run tests: 30 passed.
+- Full Python suite: 373 passed, 1 skipped.
+- GUI suite: 336 passed.
+- Production TypeScript/Vite build: passed.
+- Independent spec review: compliant.
+- Independent code-quality review: ready; no Critical or Important findings.
+
+Add the authoritative `agent_runs` and `agent_run_checkpoints` records, then
+instrument the existing loop without changing its user-visible control flow.
+
+Required behavior:
+
+- Persist run identity, owning session, trigger, original goal, optional parent,
+  current state, provider/model, aggregate skills, source and artifact refs,
+  measurable usage, terminal result, checkpoint sequence, and timestamps.
+- Record semantic checkpoints for start, user input, completed model response,
+  completed tool, approval wait/resolution, interruption, and terminal result.
+- Aggregate only normalized source/artifact references already safe for the UI.
+- Mark an orphaned `running` record `interrupted` on store reopen while leaving
+  waiting states intact for later resume support.
+- Link each legacy scheduled receipt to its canonical `agent_run_id`.
+- Keep all existing schedule status and API behavior compatible.
+
+Acceptance tests:
+
+- Chat event identity and canonical Agent Run identity match.
+- Start is idempotent and terminal checkpointing is exactly once.
+- Checkpoint order, metadata merging, and usage counters survive reopen.
+- Running runs become interrupted on reopen; waiting runs remain waiting.
+- Chat, queued chat, and schedule triggers create the same canonical row shape.
+- Successful skill loads and tool provenance aggregate without storing deltas.
+
+## Slice B — Durable ownership, leases, and restart resume
+
+Make checkpoints authoritative for continuation rather than treating JSONL
+repair as resume.
+
+Required behavior:
+
+- Add compare-and-swap versioning and a bounded execution lease so WebSocket,
+  HTTP approval, scheduler, and startup recovery cannot resume the same run.
+- Checkpoint before model request, after semantic model result, before tool
+  execution, and after tool result.
+- Persist the continuation cursor, visible partial output, pending interaction,
+  completed tool receipts, and remaining work/delivery budget.
+- On restart, resume safe incomplete work under the same `run_id`.
+- Never replay a consequential tool whose outcome is unknown; surface a review
+  state and require an explicit recovery choice.
+- Carry the canonical `run_id` onto person-file ledger events.
+
+Acceptance tests:
+
+- App reconstruction resumes the same run without repeating a completed tool.
+- Two competing resume actors produce one owner and one continuation.
+- A crash during an approved external action becomes outcome-unknown and does
+  not execute again automatically.
+- Torn transcript/event tails recover from the latest committed checkpoint.
+
+## Slice C — Human suspension inside the same run
+
+Generalize the existing durable approval substrate into run interactions while
+preserving the different semantics of questions and permissions.
+
+Required behavior:
+
+- Add engine-controlled `ask_user` with a bounded question and answer contract.
+- Persist `waiting_question` or `waiting_approval` without terminalizing the
+  Agent Run.
+- Route an answer or approval to the owning run and resume from its checkpoint.
+- Resume scheduled runs after interaction rather than executing only the
+  approved tool and closing the workflow.
+- Render and restore question state in Chat; Inbox remains the durable place to
+  recover a missed interaction.
+
+Acceptance tests:
+
+- `ask_user` survives app reconstruction and the answer continues the same run.
+- A scheduled approval continues through final model delivery under one run.
+- Repeated answers/decisions are idempotent and never duplicate external work.
+
+## Slice D — Bounded context, usage, and terminal delivery reserve
+
+Bound the model view without deleting canonical history, and guarantee a useful
+delivery phase when research consumes the work budget.
+
+Required behavior:
+
+- Extend provider chunks/results with finish reason and available token usage.
+- Build an outbound context view that always preserves the original goal,
+  current checkpoint, pending work, relevant source/artifact refs, and recent
+  complete model/tool groups.
+- Compact only the outbound view; canonical messages and checkpoints remain.
+- Separate work/tool budget from terminal-delivery budget.
+- Disable tools during the reserved delivery pass.
+- If delivery cannot finish, return the best useful partial result with explicit
+  gaps instead of starting another research round.
+
+Acceptance tests:
+
+- Large canonical history produces a bounded, valid model request without
+  dangling tool calls.
+- Canonical history remains byte-for-byte available after compaction.
+- Repeated tool choices exhaust only the work budget, then force one
+  tools-disabled delivery pass.
+- Usage totals are monotonic across suspension and resume.
+
+## Slice E — Product acceptance
+
+- Re-run the outreach campaign from one prompt through the director-review
+  package without a second “converge now” message.
+- Re-run the company pitch package through its review deliverable under one run.
+- Exercise at least one saved prompt through scheduling and an interaction wait.
+- Restart during research, approval wait, and delivery; verify the same run ID,
+  no duplicate external action, preserved partial output, and a terminal result.
+- Export the run record and semantic checkpoints and verify they contain no
+  credentials, hidden reasoning, or token-delta rows.
+
+## Not in Priority 0
+
+- Knowledge Workspace indexing or global Drive replacement.
+- Per-run writable artifact workspace, shell, or office-file skills.
+- Connector descriptor migration and provider validators.
+- Semantic trace delta coalescing beyond the checkpoints required for resume.
+- Multi-agent orchestration, team tenancy, or automatic sending.
+
+## Principal risks
+
+- Scheduler receipt IDs and Agent Run IDs must never be silently conflated.
+- SQLite checkpoints and JSONL messages/events are not one atomic write today;
+  Slice B must name which record is authoritative after each crash boundary.
+- Approval recovery must retain the existing “outcome unknown” safety rule.
+- The current Anthropic adapter does not implement the same tool loop as the
+  OpenAI-compatible adapter; provider parity must be explicit before it can be
+  claimed.
+- `turn.py` and `server.py` are already large. New state transitions should live
+  behind a focused Agent Run service rather than growing ad hoc branches.
+
+Non-blocking Slice A follow-ups:
+
+- When the run persistence surface grows in Slice B, extract an
+  `AgentRunRepository` that shares the existing SQLite connection and lock.
+- Extend the migration rollback test so failure occurs after at least one prior
+  row/checkpoint rewrite, proving rollback from partial progress as well as from
+  the first write.
+
+## Session checklist
+
+- [x] Read the approved roadmap, mature-system blueprint, domain language,
+  golden-run evidence, and active desktop code.
+- [x] Verify the clean linked worktree and green baseline test suite.
+- [x] Lock the identity and migration strategy.
+- [x] Land Slice A with focused and full verification.
+- [x] Review Slice A for roadmap compliance and code quality.
+- [ ] Begin Slice B only after the canonical run record is proven.

--- a/docs/superpowers/plans/2026-08-26-product-validation-sprint-roadmap.md
+++ b/docs/superpowers/plans/2026-08-26-product-validation-sprint-roadmap.md
@@ -1,7 +1,7 @@
 # Sourcecado Product Validation Sprint Roadmap
 
 Date: 2026-08-26  
-Status: baseline executed; at roadmap decision gate
+Status: baseline executed; architecture basis approved
 Product source: `docs/superpowers/specs/2026-08-25-sourcecado-sourcing-director-spring.md`
 
 ## Goal
@@ -111,9 +111,11 @@ later conversation can use the resulting memory without repeating the work.
 - Connector preflight: complete.
 - Interactive baselines: complete through the director-review gate.
 - Interruption and reload recovery: verified.
-- Gap map and reconciled roadmap: complete.
-- External writes and scheduled-skill rerun: waiting on the decision gate and
-  exact director approvals.
+- Gap map and evidence reconciliation: complete.
+- Core Agent OS architecture interview: complete and approved.
+- Grounded implementation roadmap: complete.
+- External writes and scheduled rerun: waiting on the implementation slices
+  and exact director approvals.
 
 See `docs/qa/2026-08-26-golden-workflow-baseline.md` and
 `docs/superpowers/plans/2026-08-26-evidence-reconciled-agent-os-roadmap.md`.

--- a/docs/superpowers/plans/2026-08-26-product-validation-sprint-roadmap.md
+++ b/docs/superpowers/plans/2026-08-26-product-validation-sprint-roadmap.md
@@ -1,7 +1,7 @@
 # Sourcecado Product Validation Sprint Roadmap
 
 Date: 2026-08-26  
-Status: baseline executed; at roadmap decision gate  
+Status: baseline executed; at roadmap decision gate
 Product source: `docs/superpowers/specs/2026-08-25-sourcecado-sourcing-director-spring.md`
 
 ## Goal

--- a/docs/superpowers/plans/2026-08-26-product-validation-sprint-roadmap.md
+++ b/docs/superpowers/plans/2026-08-26-product-validation-sprint-roadmap.md
@@ -1,0 +1,104 @@
+# Sourcecado Product Validation Sprint Roadmap
+
+Date: 2026-08-26  
+Status: approved draft, execution started  
+Product source: `docs/superpowers/specs/2026-08-25-sourcecado-sourcing-director-spring.md`
+
+## Goal
+
+Prove that Sourcecado's local agent operating system can complete two valuable
+Sourcing Director jobs: an outreach campaign and a company pitch package. The
+skills are product probes, not isolated features. Real runs determine which
+runtime, connector, memory, approval, artifact, and scheduling work enters the
+roadmap.
+
+## Golden outcomes
+
+### Outreach campaign
+
+A director can move from a natural-language campaign objective to a qualified,
+reviewed, sent, and trackable set of personalized emails. The run preserves the
+people, rationale, sources, approvals, messages, sequence state, and follow-up
+work.
+
+### Company pitch package
+
+A director can move from a named company and objective to a source-grounded,
+editable company deck plus a brief, talking points, knowledge gaps, and a
+follow-up draft. The result uses the correct SOP and approved template.
+
+## Execution order
+
+### 0. Mature-agent-system blueprint
+
+Compare OpenClaw, Grok Bot, and OpenWorker by subsystem. For every subsystem,
+record what Sourcecado copies, adapts, already owns, or rejects. Lock the target
+invariants for durable runs, events, tools, approvals, artifacts, memory,
+skills, connectors, scheduling, recovery, and operator control.
+
+### 1. Test contracts
+
+Choose one real outreach objective and one real company. Record the inputs,
+source scope, constraints, required artifacts, rejection conditions, and
+manual acceptance rubric for each workflow.
+
+### 2. Minimal v0 skills and readiness
+
+Write the smallest executable `outreach-campaign` and
+`company-pitch-package` skills. Verify the model, Apollo, Gmail, Drive,
+Calendar, Granola, web, skill loader, approval inbox, local persistence, and
+scheduler without hiding missing capabilities behind skill prose.
+
+### 3. Baseline product runs
+
+Drive both workflows through the local app. Exercise multi-turn clarification,
+real tools, review and approval, interruption, restart, resume, artifacts,
+memory, Board state, and a scheduled invocation where appropriate. Preserve
+the final deliverables and every manual intervention.
+
+### 4. Evidence-based gap map
+
+Classify each failure as skill logic, tool/connector, durable runtime,
+approval, artifact, memory/provenance, scheduling, UI, domain model, or output
+quality. Every gap needs a reproduction, product impact, relevant reference
+pattern, priority, and dependency.
+
+### 5. Roadmap reconciliation and report
+
+Compare the observed gaps with current code, open issues, and the reference
+blueprint. Retain work that unlocks the two outcomes, re-scope speculative
+platform work, and report the evidence and recommendations to Fisher.
+
+### 6. Final plan and implementation
+
+After the decision gate, implement approved gaps as vertical slices. Prefer
+copying a proven reference pattern over inventing a local mechanism. Re-run the
+affected workflow after every meaningful slice. Interactive and scheduled
+execution must use the same skill and run path.
+
+### 7. Acceptance rerun
+
+The sprint is complete only when Fisher accepts both deliverables; both runs
+survive interruption and restart; at least one executes through scheduling;
+all sources, approvals, artifacts, failures, and outcomes are durable; and a
+later conversation can use the resulting memory without repeating the work.
+
+## Guardrails
+
+- The agent operating system is the product; the skills expose its maturity.
+- Do not add generic platform breadth without evidence from a golden workflow.
+- Do not claim an external action or artifact exists unless a tool receipt proves it.
+- Costly and external actions remain explicit and approval-gated.
+- Use real Codeology sources, but never place secrets in prompts, logs, or plans.
+- Treat unmerged issue branches as experiments until they land and pass the
+  product run.
+
+## Evidence produced by this sprint
+
+- Mature-agent-system reference blueprint.
+- Two scenario contracts and two v0 skills.
+- Connector/readiness report.
+- Full run transcripts, receipts, artifacts, and acceptance notes.
+- Layered gap map with reference implementations.
+- Reconciled implementation roadmap.
+- Final accepted outreach campaign and company pitch package.

--- a/docs/superpowers/plans/2026-08-26-product-validation-sprint-roadmap.md
+++ b/docs/superpowers/plans/2026-08-26-product-validation-sprint-roadmap.md
@@ -1,7 +1,7 @@
 # Sourcecado Product Validation Sprint Roadmap
 
 Date: 2026-08-26  
-Status: approved draft, execution started  
+Status: baseline executed; at roadmap decision gate  
 Product source: `docs/superpowers/specs/2026-08-25-sourcecado-sourcing-director-spring.md`
 
 ## Goal
@@ -102,3 +102,18 @@ later conversation can use the resulting memory without repeating the work.
 - Layered gap map with reference implementations.
 - Reconciled implementation roadmap.
 - Final accepted outreach campaign and company pitch package.
+
+## Current execution status
+
+- Reference blueprint: complete.
+- Scenario contracts: complete.
+- V0 skills: complete and live-loaded.
+- Connector preflight: complete.
+- Interactive baselines: complete through the director-review gate.
+- Interruption and reload recovery: verified.
+- Gap map and reconciled roadmap: complete.
+- External writes and scheduled-skill rerun: waiting on the decision gate and
+  exact director approvals.
+
+See `docs/qa/2026-08-26-golden-workflow-baseline.md` and
+`docs/superpowers/plans/2026-08-26-evidence-reconciled-agent-os-roadmap.md`.

--- a/docs/superpowers/scenarios/2026-08-26-golden-sourcing-workflows.md
+++ b/docs/superpowers/scenarios/2026-08-26-golden-sourcing-workflows.md
@@ -1,0 +1,87 @@
+# Golden Sourcing Workflow Test Contracts
+
+Date: 2026-08-26  
+Status: scenario structure locked; live targets require Fisher's selection
+
+## Shared test protocol
+
+For each workflow, preserve the initial request, clarifying turns, tool calls,
+approvals, artifacts, final answer, runtime receipt, restart/resume evidence,
+manual interventions, and Fisher's accept/reject notes.
+
+Score by inspection on five dimensions: outcome completeness, factual and
+source correctness, usefulness to the director, editability/reviewability, and
+durability after the run.
+
+## Scenario A: outreach campaign
+
+### Director request
+
+Run a real Codeology outreach campaign for an objective and target audience
+selected by Fisher. The initial validation target is a project-partner or
+sponsor campaign with a deliberately bounded contact count.
+
+### Required inputs
+
+- Campaign objective and desired relationship.
+- Target roles, organizations, or company profile.
+- Contact count and deadline.
+- Exclusions and do-not-contact constraints.
+- Canonical outreach SOP/template location.
+- Whether the test may enrich, create drafts, and send after review.
+
+### Required result
+
+- Deduplicated shortlist with why-now and source evidence.
+- Prior-relationship and prior-outreach check.
+- Deliberate enrichment record for chosen contacts only.
+- Personalized drafts following the approved SOP.
+- Human-reviewed sends and durable receipts when authorized.
+- Person files and correct sequence states.
+- Campaign summary, failures, unsent contacts, and next actions.
+
+### Reject when
+
+The list is generic, evidence is invented, the SOP is not used, enrichment or
+send happens without approval, messages are not meaningfully personalized,
+successful work disappears after restart, or the final state cannot support
+follow-up.
+
+## Scenario B: company pitch package
+
+### Director request
+
+Prepare Codeology to approach one real company selected by Fisher for a named
+partnership, sponsorship, speaker, or project objective.
+
+### Required inputs
+
+- Company and concrete objective.
+- Audience, meeting/deadline, and desired ask.
+- Canonical pitch SOP and approved slide template location.
+- Known relationship/contact context.
+- Output location and acceptable slide format.
+
+### Required result
+
+- Source-grounded company and relationship brief.
+- Verified SOP and approved template selection.
+- Editable company-specific deck, or an explicit failed capability result if
+  the current system cannot produce one.
+- Clear ask, talking points, citations, and knowledge gaps.
+- Follow-up email draft.
+- Durable artifact/source references and updated company/person context.
+
+### Reject when
+
+The wrong template or named parties are used, unsupported facts appear, the
+agent claims to have edited a deck without a write receipt, the output is not
+editable, the ask is unclear, or the package cannot be recovered later.
+
+## Live-selection gate
+
+Before baseline execution Fisher selects:
+
+1. One outreach objective, target audience, contact count, and send boundary.
+2. One company, desired ask, deadline, SOP/template folder, and required slide
+   output format.

--- a/docs/superpowers/specs/2026-08-26-sourcecado-mature-agent-system-blueprint.md
+++ b/docs/superpowers/specs/2026-08-26-sourcecado-mature-agent-system-blueprint.md
@@ -1,0 +1,79 @@
+# Sourcecado Mature Agent System Blueprint
+
+Date: 2026-08-26  
+Status: working reference architecture  
+Purpose: define the mature system we are testing toward before local workflow
+failures bias the architecture toward one-off fixes.
+
+## Product boundary
+
+Sourcecado owns the Sourcing Director experience, sourcing domain, person
+files, institutional memory, and opinionated skills. OpenClaw, Grok Bot, and
+OpenWorker are implementation references. They are not product dependencies.
+
+## Reference roles
+
+| Reference | Strongest patterns to copy | Do not copy |
+|---|---|---|
+| OpenClaw | durable run ownership, session recovery, bounded context and compaction, approval ownership and atomic allow-once use, detached tasks, execution attempts and proof | multi-channel Gateway breadth, generic plugin platform, large Workboard ontology |
+| Grok Bot | desktop lifecycle, per-agent transcript state, turn checkpoints, transcript/index workers, request deduplication, interruption and resumption, automation spend state | agent roster, remote box/cloud infrastructure, reconstructed renderer internals |
+| OpenWorker | loopback sidecar, launch-token boundary, connector lifecycle, skill loading, personas, permission decisions, approval inbox, run-once catch-up and skip-on-overlap scheduler | 25-connector breadth, generic coworker product surface, cloud OAuth broker |
+
+## Target subsystem decisions
+
+| Subsystem | Sourcecado decision | Current position |
+|---|---|---|
+| Runtime owner | Keep the FastAPI sidecar as the single local brain. Copy lifecycle invariants, not another framework. | Built |
+| Run identity | Every interactive, scheduled, or background execution has a stable run id, owner session, status, timestamps, and terminal receipt. | Partially built |
+| Checkpoints | A multi-step run can persist progress after meaningful work and resume without replaying external writes. Use idempotency keys at write boundaries. | Gap to prove |
+| Event history | Keep the versioned append-only event spine. Treat UI transcripts as projections of durable events. | Built, must product-test |
+| Context | Bound prompt size. Carry durable facts and artifact references forward instead of replaying an unbounded transcript. | Partial |
+| Tool registry | Sourcecado owns named tools, schemas, risk class, target scope, and result contract. The model never self-grants capability. | Built |
+| Approvals | Approval records are durable, bound to tool/run/target, resolve once, expire safely, and create an immutable receipt. | Built, must product-test |
+| Connectors | One safe status/capability contract feeds model, runtime, and UI. Tokens remain outside prompts and events. | Partial |
+| Skills | Skills are discoverable, loaded on demand, and usable through the same path in chat and scheduling. | Loader built; real skills unproven |
+| Artifacts | Deliverables are first-class, addressable, editable/versioned when appropriate, source-linked, and visible after restart. | Partial |
+| Memory | Store accepted sourcing facts, outcomes, corrections, gaps, and handoff context with provenance. Do not treat the transcript as memory. | Partial |
+| Background work | Long or fan-out jobs run outside the chat step budget with progress, cancellation, checkpoint, and resume. | Gap to prove |
+| Scheduling | Scheduling invokes the same skill/run path as chat, with unattended approvals parked in the inbox. | Skeleton built |
+| Operator control | The director can see progress, stop work, resolve approvals, inspect evidence, recover failures, and open final artifacts. | Broadly built |
+| Evaluation | Begin with preserved run evidence and Fisher's accept/reject feedback. Add formal evals after repeated real examples exist. | Manual now |
+
+## Mature-system invariants
+
+1. The same skill can run interactively or from a schedule.
+2. Every run has one durable identity and one canonical terminal status.
+3. A restart never silently loses successful completed work.
+4. An external write is executed at most once unless the user explicitly retries it.
+5. Approval is attached to the exact action and target, not a vague tool class.
+6. Source scope is explicit; a run cannot compensate for a scoped-source failure
+   by silently searching unrelated material.
+7. Tool results, sources, artifacts, and decisions have stable references.
+8. Model context is bounded; durable state is not reconstructed from an
+   indefinitely growing transcript.
+9. Scheduled work uses the same permission, ledger, artifact, and memory path
+   as an interactive run.
+10. The UI never reports success without a durable receipt.
+11. The agent never claims a capability absent from its active tool registry.
+12. A completed workflow leaves the club in a better future state: people,
+    sources, outcomes, artifacts, and next actions remain usable later.
+
+## How the golden skills exercise the blueprint
+
+| Capability | Outreach campaign | Company pitch package |
+|---|---|---|
+| Run shape | fan-out across many people | deep synthesis into one artifact set |
+| Expensive actions | Apollo enrichment, sending | model/tool time, possible slide write |
+| Approvals | per enrichment, draft review, send | template choice, final artifact approval |
+| Sources | Apollo, Gmail, memory, Drive SOPs, web | Drive SOPs/templates, Gmail, memory, web, meeting notes |
+| Checkpoints | per candidate and per message | research, outline, deck version, final package |
+| Artifacts | shortlist, drafts, send receipts, follow-up list | brief, editable deck, talking points, follow-up draft |
+| Memory | person and campaign outcomes | company relationship, ask, decisions, gaps |
+| Scheduled mode | campaign refresh/follow-up review | optional research refresh before a meeting |
+
+## Copy rule during implementation
+
+When a product run exposes a system gap, first locate the corresponding
+OpenClaw, Grok Bot, and OpenWorker implementation. Record which contract and
+failure behavior we are copying. Adapt it only where Sourcecado's sourcing
+domain or local architecture requires a different interface.

--- a/docs/superpowers/specs/2026-08-26-sourcecado-mature-agent-system-blueprint.md
+++ b/docs/superpowers/specs/2026-08-26-sourcecado-mature-agent-system-blueprint.md
@@ -1,79 +1,121 @@
 # Sourcecado Mature Agent System Blueprint
 
-Date: 2026-08-26  
-Status: working reference architecture  
-Purpose: define the mature system we are testing toward before local workflow
-failures bias the architecture toward one-off fixes.
+Date: 2026-08-26
+Status: approved architecture basis
 
 ## Product boundary
 
-Sourcecado owns the Sourcing Director experience, sourcing domain, person
-files, institutional memory, and opinionated skills. OpenClaw, Grok Bot, and
-OpenWorker are implementation references. They are not product dependencies.
+Sourcecado is the local agent operating system for Codeology. Sourcing is its
+first proven department. Sourcecado owns the product experience, sourcing
+domain, person files, local runtime, and club memory. Reference frameworks are
+implementation donors, not product dependencies.
 
-## Reference roles
+## Architecture rule
 
-| Reference | Strongest patterns to copy | Do not copy |
+For every major subsystem:
+
+1. Start from an observed product failure.
+2. Choose one primary reference implementation.
+3. Name the exact behavior/code boundary being copied.
+4. Adapt only what Sourcecado's local architecture or domain requires.
+5. State what is deliberately not being copied.
+
+Do not create abstract "best-of-three" hybrids. When none of the three systems
+implements a product-specific connector such as Google Slides, ground that
+connector in the official vendor API and keep it behind a Sourcecado-owned
+tool boundary.
+
+## Core concepts
+
+### Prompt-driven execution
+
+Every Agent Run begins from instructions. The instructions may be a freeform
+prompt, may load skills, or may come from scheduling. Skills are optional
+resources; they do not own execution.
+
+### Goal-sized Agent Run
+
+One Agent Run owns one user job through clarification, approvals, tools,
+interruption, resume, and terminal delivery. A later revision to a completed
+deliverable is a new linked run.
+
+### Knowledge Workspace
+
+The director selects one Google Drive sourcing folder. Drive remains the source
+of truth; Sourcecado maintains a local read-only searchable projection.
+
+### Artifact Workspace
+
+Every run receives a writable scratch workspace. The agent uses files, search,
+shell, and skills to create actual deliverables. The workspace's files are the
+initial artifact source of truth.
+
+### Connector truth
+
+Connector availability is proven by a real validator and published from the
+same descriptor that owns its tools. Stored credentials alone do not mean the
+capability is ready.
+
+### Semantic Agent Trace
+
+The Run Ledger preserves all observable decisions, inputs, model turns, tools,
+sources, approvals, artifacts, outcomes, timing, usage, errors, and feedback
+needed for audit and eval. Live token chunks and hidden chain-of-thought are not
+durable records.
+
+## Primary implementation donors
+
+| Priority | Primary donor | Coherent subsystem copied |
 |---|---|---|
-| OpenClaw | durable run ownership, session recovery, bounded context and compaction, approval ownership and atomic allow-once use, detached tasks, execution attempts and proof | multi-channel Gateway breadth, generic plugin platform, large Workboard ontology |
-| Grok Bot | desktop lifecycle, per-agent transcript state, turn checkpoints, transcript/index workers, request deduplication, interruption and resumption, automation spend state | agent roster, remote box/cloud infrastructure, reconstructed renderer internals |
-| OpenWorker | loopback sidecar, launch-token boundary, connector lifecycle, skill loading, personas, permission decisions, approval inbox, run-once catch-up and skip-on-overlap scheduler | 25-connector breadth, generic coworker product surface, cloud OAuth broker |
+| Durable Agent Run | OpenWorker | Prompt-driven TurnEngine lifecycle, ask/approval suspension, partial preservation, durable resume, iteration checkpoints, compaction, same-engine automation |
+| Knowledge Workspace | OpenClaw | Narrow Markdown memory-host index: explicit path, hash/mtime/size, chunks, SQLite FTS, incremental sync, path/line provenance |
+| Workspace and Artifacts | OpenWorker | Cowork scratch workspace, files/search/persistent shell/todo, artifact links, discovery, preview/open, scheduled artifact collection |
+| Connector Truth | OpenWorker | ConnectorDescriptor, real validate call, safe identity, pinned capabilities, status/tool publication |
+| Semantic Agent Trace | OpenWorker | Canonical messages plus semantic checkpoint persistence, live ephemeral deltas, final cleanup save |
 
-## Target subsystem decisions
+OpenClaw remains the contract reference for Session/Run/turn/approval ownership
+and eval-ready trajectories. Grok Bot remains useful prior art for later
+checkpoint or index resilience, but no approved core priority currently requires
+copying its subsystem.
 
-| Subsystem | Sourcecado decision | Current position |
-|---|---|---|
-| Runtime owner | Keep the FastAPI sidecar as the single local brain. Copy lifecycle invariants, not another framework. | Built |
-| Run identity | Every interactive, scheduled, or background execution has a stable run id, owner session, status, timestamps, and terminal receipt. | Partially built |
-| Checkpoints | A multi-step run can persist progress after meaningful work and resume without replaying external writes. Use idempotency keys at write boundaries. | Gap to prove |
-| Event history | Keep the versioned append-only event spine. Treat UI transcripts as projections of durable events. | Built, must product-test |
-| Context | Bound prompt size. Carry durable facts and artifact references forward instead of replaying an unbounded transcript. | Partial |
-| Tool registry | Sourcecado owns named tools, schemas, risk class, target scope, and result contract. The model never self-grants capability. | Built |
-| Approvals | Approval records are durable, bound to tool/run/target, resolve once, expire safely, and create an immutable receipt. | Built, must product-test |
-| Connectors | One safe status/capability contract feeds model, runtime, and UI. Tokens remain outside prompts and events. | Partial |
-| Skills | Skills are discoverable, loaded on demand, and usable through the same path in chat and scheduling. | Loader built; real skills unproven |
-| Artifacts | Deliverables are first-class, addressable, editable/versioned when appropriate, source-linked, and visible after restart. | Partial |
-| Memory | Store accepted sourcing facts, outcomes, corrections, gaps, and handoff context with provenance. Do not treat the transcript as memory. | Partial |
-| Background work | Long or fan-out jobs run outside the chat step budget with progress, cancellation, checkpoint, and resume. | Gap to prove |
-| Scheduling | Scheduling invokes the same skill/run path as chat, with unattended approvals parked in the inbox. | Skeleton built |
-| Operator control | The director can see progress, stop work, resolve approvals, inspect evidence, recover failures, and open final artifacts. | Broadly built |
-| Evaluation | Begin with preserved run evidence and Fisher's accept/reject feedback. Add formal evals after repeated real examples exist. | Manual now |
+## Invariants
 
-## Mature-system invariants
+1. A prompt works whether or not it names or loads a skill.
+2. Chat and scheduling invoke the same Agent Run entry point.
+3. A run can wait for a question or approval without becoming a second run.
+4. Restart never discards completed tools, partial visible output, or artifacts.
+5. Expensive or external actions execute at most once per approved attempt.
+6. Normal sourcing retrieval stays inside the selected Knowledge Workspace.
+7. Google Drive remains authoritative over its local mirror.
+8. A requested file deliverable is not complete until a real editable file or
+   cloud document exists and has a receipt.
+9. Local formats are created through workspace tools plus skills; Google-native
+   formats use connector tools.
+10. A green connector has passed a real provider validator.
+11. A degraded run may continue when the requested outcome remains possible.
+12. Live streaming is ephemeral; the semantic execution trace is durable.
+13. Eval data excludes credentials, hidden chain-of-thought, and unrelated
+    private source bodies.
 
-1. The same skill can run interactively or from a schedule.
-2. Every run has one durable identity and one canonical terminal status.
-3. A restart never silently loses successful completed work.
-4. An external write is executed at most once unless the user explicitly retries it.
-5. Approval is attached to the exact action and target, not a vague tool class.
-6. Source scope is explicit; a run cannot compensate for a scoped-source failure
-   by silently searching unrelated material.
-7. Tool results, sources, artifacts, and decisions have stable references.
-8. Model context is bounded; durable state is not reconstructed from an
-   indefinitely growing transcript.
-9. Scheduled work uses the same permission, ledger, artifact, and memory path
-   as an interactive run.
-10. The UI never reports success without a durable receipt.
-11. The agent never claims a capability absent from its active tool registry.
-12. A completed workflow leaves the club in a better future state: people,
-    sources, outcomes, artifacts, and next actions remain usable later.
+## Golden workflow proof
 
-## How the golden skills exercise the blueprint
+### Outreach campaign
 
-| Capability | Outreach campaign | Company pitch package |
-|---|---|---|
-| Run shape | fan-out across many people | deep synthesis into one artifact set |
-| Expensive actions | Apollo enrichment, sending | model/tool time, possible slide write |
-| Approvals | per enrichment, draft review, send | template choice, final artifact approval |
-| Sources | Apollo, Gmail, memory, Drive SOPs, web | Drive SOPs/templates, Gmail, memory, web, meeting notes |
-| Checkpoints | per candidate and per message | research, outline, deck version, final package |
-| Artifacts | shortlist, drafts, send receipts, follow-up list | brief, editable deck, talking points, follow-up draft |
-| Memory | person and campaign outcomes | company relationship, ask, decisions, gaps |
-| Scheduled mode | campaign refresh/follow-up review | optional research refresh before a meeting |
+One prompt should produce a scoped shortlist, approved enrichments and sends,
+an editable campaign package, person/sequence updates, and next actions. It must
+survive clarification, approval waits, restart, and scheduled execution.
 
-## Copy rule during implementation
+### Company pitch package
 
-When a product run exposes a system gap, first locate the corresponding
-OpenClaw, Grok Bot, and OpenWorker implementation. Record which contract and
-failure behavior we are copying. Adapt it only where Sourcecado's sourcing
-domain or local architecture requires a different interface.
+One prompt should use the scoped Knowledge Workspace, produce a company brief,
+create an editable PPTX and optional Google Slides copy, preserve source refs,
+and stop at a director review gate without claiming unsupported work.
+
+## Explicit boundaries
+
+- Keep the current FastAPI sidecar and React/Tauri product.
+- Keep Sourcecado's provider, tool, approval, person-file, and UI work that
+  already passes real product tests.
+- Do not replace the runtime wholesale with OpenWorker or OpenClaw.
+- Do not make skills, MCP, OpenClaw, or OpenWorker core dependencies.
+- Do not add generic platform breadth without evidence from a real club job.


### PR DESCRIPTION
## Summary

- add a canonical durable Agent Run and ordered semantic checkpoint store without repurposing scheduler receipts
- route chat, queued chat, and scheduled prompts through the same run identity while aggregating safe skill, source, artifact, usage, approval, and terminal metadata
- add versioned secret-scrubbing migrations, immutable goal fingerprints, restart interruption semantics, and the dependency-ordered Priority 0 implementation plan

## Test Plan

- [x] `make test` — 373 Python passed, 1 skipped; 336 GUI passed
- [x] `make build`
- [x] independent spec-compliance review
- [x] independent code-quality review with no Critical or Important findings

## Scope

This PR completes Priority 0 Slice A. Durable leases/restart resume, `ask_user`, bounded context, and terminal-delivery reserve remain in the next slices.