### PR TITLE
feat(desktop): add typed runtime telemetry foundation

### DIFF
--- a/desktop/coworker/telemetry/__init__.py
+++ b/desktop/coworker/telemetry/__init__.py
@@ -1,0 +1,55 @@
+"""Content-free, vendor-neutral runtime telemetry."""
+
+from coworker.telemetry.adapters import (
+    InMemoryTelemetryAdapter,
+    NoOpTelemetryAdapter,
+    SpanHandle,
+    TelemetryAdapter,
+    TelemetryRecorder,
+)
+from coworker.telemetry.metrics import CurrentRunMetrics
+from coworker.telemetry.schema import (
+    SCHEMA_VERSION,
+    AgentTurnSpan,
+    CompactionEvent,
+    CompactionReason,
+    CostEstimate,
+    CostEvent,
+    ErrorKind,
+    ProviderSpan,
+    RetryEvent,
+    RetryReason,
+    SpanStatus,
+    StopReason,
+    TerminalEvent,
+    ToolSpan,
+    TraceContext,
+    UsageEvent,
+    record_to_dict,
+)
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "AgentTurnSpan",
+    "CompactionEvent",
+    "CompactionReason",
+    "CostEstimate",
+    "CostEvent",
+    "CurrentRunMetrics",
+    "ErrorKind",
+    "InMemoryTelemetryAdapter",
+    "NoOpTelemetryAdapter",
+    "ProviderSpan",
+    "RetryEvent",
+    "RetryReason",
+    "SpanHandle",
+    "SpanStatus",
+    "StopReason",
+    "TelemetryAdapter",
+    "TelemetryRecorder",
+    "TerminalEvent",
+    "ToolSpan",
+    "TraceContext",
+    "UsageEvent",
+    "record_to_dict",
+]

--- a/desktop/coworker/telemetry/adapters.py
+++ b/desktop/coworker/telemetry/adapters.py
@@ -1,0 +1,339 @@
+"""Passive telemetry recorder and local adapters."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from threading import Lock, RLock
+from typing import Protocol
+
+from coworker.telemetry.schema import (
+    CostEstimate,
+    ErrorKind,
+    SpanEventRecord,
+    SpanSchema,
+    SpanSettledRecord,
+    SpanStartedRecord,
+    SpanStatus,
+    SPAN_SCHEMA_TYPES,
+    StopReason,
+    TelemetryEvent,
+    TELEMETRY_EVENT_TYPES,
+    TelemetryRecord,
+    TELEMETRY_RECORD_TYPES,
+    TerminalEvent,
+    TraceContext,
+    UsageEvent,
+)
+
+
+class TelemetryAdapter(Protocol):
+    enabled: bool
+
+    def record(self, record: TelemetryRecord) -> None: ...
+
+
+class NoOpTelemetryAdapter:
+    """Disabled sink; the recorder takes a zero-work fast path for this adapter."""
+
+    enabled = False
+
+    def record(self, record: TelemetryRecord) -> None:
+        return None
+
+
+class InMemoryTelemetryAdapter:
+    """Thread-safe ordered record sink for tests and local diagnostics."""
+
+    enabled = True
+
+    def __init__(self) -> None:
+        self._records: list[TelemetryRecord] = []
+        self._lock = Lock()
+
+    def record(self, record: TelemetryRecord) -> None:
+        if type(record) not in TELEMETRY_RECORD_TYPES:
+            return None
+        with self._lock:
+            self._records.append(record)
+
+    @property
+    def records(self) -> tuple[TelemetryRecord, ...]:
+        with self._lock:
+            return tuple(self._records)
+
+    def current_run_metrics(self, *, run_id: str, now_ns: int):
+        from coworker.telemetry.metrics import current_run_metrics
+
+        return current_run_metrics(self.records, run_id=run_id, now_ns=now_ns)
+
+
+class TelemetryRecorder:
+    """Creates deterministic spans while containing all adapter failures."""
+
+    def __init__(
+        self,
+        adapter: TelemetryAdapter | None = None,
+        *,
+        clock: Callable[[], int] = time.monotonic_ns,
+    ) -> None:
+        self._adapter = adapter or NoOpTelemetryAdapter()
+        self._clock = clock
+        self._lock = RLock()
+        self._next_span = 1
+        self._next_record = 1
+        self._last_observed_at_ns = 0
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self._adapter.enabled)
+
+    def start_span(
+        self,
+        span: SpanSchema,
+        context: TraceContext,
+        *,
+        parent: SpanHandle | None = None,
+    ) -> SpanHandle | InertSpanHandle:
+        if not self.enabled:
+            return InertSpanHandle()
+        if type(span) not in SPAN_SCHEMA_TYPES:
+            return InertSpanHandle()
+        if parent is not None and parent.context != context:
+            return InertSpanHandle()
+        with self._lock:
+            span_id = f"span-{self._next_span:06d}"
+            self._next_span += 1
+            observed_at_ns = self._now()
+            record = SpanStartedRecord(
+                sequence=self._sequence(),
+                span_id=span_id,
+                parent_span_id=parent.span_id if parent is not None else None,
+                context=context,
+                observed_at_ns=observed_at_ns,
+                span=span,
+            )
+            self._safe_record(record)
+        return SpanHandle(
+            recorder=self,
+            span_id=span_id,
+            context=context,
+            started_at_ns=observed_at_ns,
+        )
+
+    def _sequence(self) -> int:
+        sequence = self._next_record
+        self._next_record += 1
+        return sequence
+
+    def _now(self) -> int:
+        try:
+            observed_at_ns = self._clock()
+        except Exception:
+            observed_at_ns = self._last_observed_at_ns
+        self._last_observed_at_ns = max(self._last_observed_at_ns, observed_at_ns)
+        return self._last_observed_at_ns
+
+    def _safe_record(self, record: TelemetryRecord) -> None:
+        try:
+            self._adapter.record(record)
+        except Exception:
+            return None
+
+    def _record_event(
+        self,
+        *,
+        span_id: str,
+        context: TraceContext,
+        event: TelemetryEvent,
+    ) -> None:
+        with self._lock:
+            self._safe_record(
+                SpanEventRecord(
+                    sequence=self._sequence(),
+                    span_id=span_id,
+                    context=context,
+                    observed_at_ns=self._now(),
+                    event=event,
+                )
+            )
+
+    def _settle(
+        self,
+        *,
+        span_id: str,
+        context: TraceContext,
+        started_at_ns: int,
+        status: SpanStatus,
+        stop_reason: StopReason | None,
+        retry_count: int,
+        usage: UsageEvent | None,
+        cost: CostEstimate | None,
+        error_kind: ErrorKind | None,
+    ) -> None:
+        with self._lock:
+            observed_at_ns = self._now()
+            terminal = TerminalEvent(
+                status=status,
+                latency_ms=max(0, observed_at_ns - started_at_ns) / 1_000_000,
+                stop_reason=stop_reason,
+                retry_count=retry_count,
+                usage=usage,
+                cost=cost,
+                error_kind=error_kind,
+            )
+            self._safe_record(
+                SpanSettledRecord(
+                    sequence=self._sequence(),
+                    span_id=span_id,
+                    context=context,
+                    observed_at_ns=observed_at_ns,
+                    terminal=terminal,
+                )
+            )
+
+
+class SpanHandle:
+    """A single-settlement handle; all calls after settlement are inert."""
+
+    def __init__(
+        self,
+        *,
+        recorder: TelemetryRecorder,
+        span_id: str,
+        context: TraceContext,
+        started_at_ns: int,
+    ) -> None:
+        self._recorder = recorder
+        self.span_id = span_id
+        self.context = context
+        self._started_at_ns = started_at_ns
+        self._settled = False
+        self._lock = Lock()
+
+    @property
+    def settled(self) -> bool:
+        with self._lock:
+            return self._settled
+
+    def child(self, span: SpanSchema) -> SpanHandle | InertSpanHandle:
+        with self._lock:
+            if self._settled:
+                return InertSpanHandle()
+            return self._recorder.start_span(span, self.context, parent=self)
+
+    def record(self, event: TelemetryEvent) -> bool:
+        if type(event) not in TELEMETRY_EVENT_TYPES:
+            return False
+        with self._lock:
+            if self._settled:
+                return False
+            self._recorder._record_event(
+                span_id=self.span_id,
+                context=self.context,
+                event=event,
+            )
+            return True
+
+    def finish(
+        self,
+        *,
+        status: SpanStatus = SpanStatus.SUCCESS,
+        stop_reason: StopReason | None = StopReason.COMPLETED,
+        retry_count: int = 0,
+        usage: UsageEvent | None = None,
+        cost: CostEstimate | None = None,
+        error_kind: ErrorKind | None = None,
+    ) -> bool:
+        with self._lock:
+            if self._settled:
+                return False
+            self._settled = True
+            try:
+                self._recorder._settle(
+                    span_id=self.span_id,
+                    context=self.context,
+                    started_at_ns=self._started_at_ns,
+                    status=status,
+                    stop_reason=stop_reason,
+                    retry_count=retry_count,
+                    usage=usage,
+                    cost=cost,
+                    error_kind=error_kind,
+                )
+            except Exception:
+                return False
+            return True
+
+    def fail(
+        self,
+        error_kind: ErrorKind,
+        *,
+        retry_count: int = 0,
+        usage: UsageEvent | None = None,
+        cost: CostEstimate | None = None,
+    ) -> bool:
+        return self.finish(
+            status=SpanStatus.FAILED,
+            stop_reason=StopReason.ERROR,
+            retry_count=retry_count,
+            usage=usage,
+            cost=cost,
+            error_kind=error_kind,
+        )
+
+    def cancel(
+        self,
+        *,
+        usage: UsageEvent | None = None,
+        cost: CostEstimate | None = None,
+    ) -> bool:
+        return self.finish(
+            status=SpanStatus.CANCELLED,
+            stop_reason=StopReason.CANCELLED,
+            usage=usage,
+            cost=cost,
+        )
+
+    def partial(
+        self,
+        error_kind: ErrorKind,
+        *,
+        retry_count: int = 0,
+        usage: UsageEvent | None = None,
+        cost: CostEstimate | None = None,
+    ) -> bool:
+        return self.finish(
+            status=SpanStatus.PARTIAL,
+            stop_reason=StopReason.ERROR,
+            retry_count=retry_count,
+            usage=usage,
+            cost=cost,
+            error_kind=error_kind,
+        )
+
+
+class InertSpanHandle:
+    """Shared-shape disabled span that performs no work."""
+
+    span_id = None
+    context = None
+    settled = False
+
+    def child(self, span: SpanSchema) -> InertSpanHandle:
+        return self
+
+    def record(self, event: TelemetryEvent) -> bool:
+        return False
+
+    def finish(self, **kwargs: object) -> bool:
+        return False
+
+    def fail(self, error_kind: ErrorKind, **kwargs: object) -> bool:
+        return False
+
+    def cancel(self, **kwargs: object) -> bool:
+        return False
+
+    def partial(self, error_kind: ErrorKind, **kwargs: object) -> bool:
+        return False

--- a/desktop/coworker/telemetry/metrics.py
+++ b/desktop/coworker/telemetry/metrics.py
@@ -1,0 +1,131 @@
+"""Read-only current-run measurements derived from telemetry records."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from coworker.telemetry.schema import (
+    AgentTurnSpan,
+    CostEvent,
+    ProviderSpan,
+    SpanEventRecord,
+    SpanSettledRecord,
+    SpanStartedRecord,
+    TelemetryRecord,
+    UsageEvent,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CurrentRunMetrics:
+    run_id: str
+    input_tokens: int | None
+    output_tokens: int | None
+    total_tokens: int | None
+    cache_hit_input_tokens: int | None
+    cache_miss_input_tokens: int | None
+    reasoning_tokens: int | None
+    current_context_tokens: int | None
+    context_window_tokens: int | None
+    context_use_ratio: float | None
+    elapsed_ms: float | None
+    estimated_cost_usd: float | None
+
+
+def _sum_known(usages: list[UsageEvent], field_name: str) -> int | None:
+    values = [getattr(usage, field_name) for usage in usages]
+    known = [value for value in values if value is not None]
+    return sum(known) if known else None
+
+
+def current_run_metrics(
+    records: tuple[TelemetryRecord, ...],
+    *,
+    run_id: str,
+    now_ns: int,
+) -> CurrentRunMetrics:
+    run_records = [record for record in records if record.context.run_id == run_id]
+    starts = {
+        record.span_id: record
+        for record in run_records
+        if isinstance(record, SpanStartedRecord)
+    }
+    provider_ids = {
+        span_id
+        for span_id, record in starts.items()
+        if isinstance(record.span, ProviderSpan)
+    }
+
+    usages: dict[str, tuple[int, UsageEvent]] = {}
+    costs: dict[str, tuple[int, float]] = {}
+    settlements: dict[str, SpanSettledRecord] = {}
+    for record in run_records:
+        if isinstance(record, SpanEventRecord) and record.span_id in provider_ids:
+            if isinstance(record.event, UsageEvent):
+                usages[record.span_id] = (record.sequence, record.event)
+            elif isinstance(record.event, CostEvent):
+                costs[record.span_id] = (
+                    record.sequence,
+                    record.event.cost.estimated_cost_usd,
+                )
+        elif isinstance(record, SpanSettledRecord):
+            settlements[record.span_id] = record
+            if record.span_id in provider_ids:
+                if record.terminal.usage is not None:
+                    usages[record.span_id] = (
+                        record.sequence,
+                        record.terminal.usage,
+                    )
+                if record.terminal.cost is not None:
+                    costs[record.span_id] = (
+                        record.sequence,
+                        record.terminal.cost.estimated_cost_usd,
+                    )
+
+    selected_usages = [entry[1] for entry in usages.values()]
+    latest_usage = max(usages.values(), key=lambda entry: entry[0])[1] if usages else None
+
+    agent_starts = [
+        record
+        for record in starts.values()
+        if isinstance(record.span, AgentTurnSpan)
+    ]
+    elapsed_ms: float | None = None
+    if agent_starts:
+        root = min(agent_starts, key=lambda record: record.sequence)
+        settlement = settlements.get(root.span_id)
+        elapsed_ms = (
+            settlement.terminal.latency_ms
+            if settlement is not None
+            else max(0, now_ns - root.observed_at_ns) / 1_000_000
+        )
+
+    current_context_tokens = (
+        latest_usage.current_context_tokens if latest_usage is not None else None
+    )
+    context_window_tokens = (
+        latest_usage.context_window_tokens if latest_usage is not None else None
+    )
+    context_use_ratio = (
+        current_context_tokens / context_window_tokens
+        if current_context_tokens is not None and context_window_tokens
+        else None
+    )
+    estimated_cost_usd = (
+        math.fsum(entry[1] for entry in costs.values()) if costs else None
+    )
+    return CurrentRunMetrics(
+        run_id=run_id,
+        input_tokens=_sum_known(selected_usages, "input_tokens"),
+        output_tokens=_sum_known(selected_usages, "output_tokens"),
+        total_tokens=_sum_known(selected_usages, "total_tokens"),
+        cache_hit_input_tokens=_sum_known(selected_usages, "cache_hit_input_tokens"),
+        cache_miss_input_tokens=_sum_known(selected_usages, "cache_miss_input_tokens"),
+        reasoning_tokens=_sum_known(selected_usages, "reasoning_tokens"),
+        current_context_tokens=current_context_tokens,
+        context_window_tokens=context_window_tokens,
+        context_use_ratio=context_use_ratio,
+        elapsed_ms=elapsed_ms,
+        estimated_cost_usd=estimated_cost_usd,
+    )

--- a/desktop/coworker/telemetry/schema.py
+++ b/desktop/coworker/telemetry/schema.py
@@ -1,0 +1,353 @@
+"""Closed telemetry schemas containing operational measurements only."""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass, field, fields, is_dataclass
+from enum import Enum
+from typing import Any, TypeAlias
+
+SCHEMA_VERSION = 1
+_SYMBOL = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
+_SECRET_PREFIXES = ("sk-", "ghp_", "github_pat_", "ya29.", "aiza")
+
+
+def _require_symbol(value: str, name: str) -> None:
+    if (
+        not isinstance(value, str)
+        or not _SYMBOL.fullmatch(value)
+        or value.lower().startswith(_SECRET_PREFIXES)
+    ):
+        raise ValueError(f"{name} must be a bounded operational identifier")
+
+
+def _require_count(value: int | None, name: str) -> None:
+    if value is not None and (not isinstance(value, int) or isinstance(value, bool) or value < 0):
+        raise ValueError(f"{name} must be a non-negative integer or null")
+
+
+def _require_cost(value: float) -> None:
+    if (
+        not isinstance(value, (int, float))
+        or isinstance(value, bool)
+        or not math.isfinite(value)
+        or value < 0
+    ):
+        raise ValueError("estimated_cost_usd must be finite and non-negative")
+
+
+class SpanStatus(str, Enum):
+    SUCCESS = "success"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    PARTIAL = "partial"
+
+
+class StopReason(str, Enum):
+    COMPLETED = "completed"
+    TOOL_USE = "tool_use"
+    MAX_TOKENS = "max_tokens"
+    CANCELLED = "cancelled"
+    ERROR = "error"
+    UNKNOWN = "unknown"
+
+
+class ErrorKind(str, Enum):
+    AUTHENTICATION = "authentication"
+    RATE_LIMIT = "rate_limit"
+    TIMEOUT = "timeout"
+    CONNECTION = "connection"
+    INVALID_REQUEST = "invalid_request"
+    PROVIDER = "provider"
+    TOOL = "tool"
+    POLICY = "policy"
+    INTERNAL = "internal"
+    UNKNOWN = "unknown"
+
+
+class RetryReason(str, Enum):
+    RATE_LIMIT = "rate_limit"
+    TIMEOUT = "timeout"
+    CONNECTION = "connection"
+    TRANSIENT_PROVIDER = "transient_provider"
+    TRANSIENT_TOOL = "transient_tool"
+
+
+class CompactionReason(str, Enum):
+    CONTEXT_LIMIT = "context_limit"
+    MANUAL = "manual"
+    POLICY = "policy"
+
+
+@dataclass(frozen=True, slots=True)
+class TraceContext:
+    session_id: str
+    run_id: str
+
+    def __post_init__(self) -> None:
+        _require_symbol(self.session_id, "session_id")
+        _require_symbol(self.run_id, "run_id")
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderSpan:
+    span_type: str = field(init=False, default="provider")
+    provider: str
+    model: str
+    operation: str
+    context_window_tokens: int | None = None
+
+    def __post_init__(self) -> None:
+        _require_symbol(self.provider, "provider")
+        _require_symbol(self.model, "model")
+        _require_symbol(self.operation, "operation")
+        _require_count(self.context_window_tokens, "context_window_tokens")
+
+
+@dataclass(frozen=True, slots=True)
+class AgentTurnSpan:
+    span_type: str = field(init=False, default="agent_turn")
+    operation: str
+
+    def __post_init__(self) -> None:
+        _require_symbol(self.operation, "operation")
+
+
+@dataclass(frozen=True, slots=True)
+class ToolSpan:
+    span_type: str = field(init=False, default="tool")
+    tool_name: str
+    operation: str
+
+    def __post_init__(self) -> None:
+        _require_symbol(self.tool_name, "tool_name")
+        _require_symbol(self.operation, "operation")
+
+
+@dataclass(frozen=True, slots=True)
+class RetryEvent:
+    event_type: str = field(init=False, default="retry")
+    operation: str
+    retry_count: int
+    reason: RetryReason
+    delay_ms: int | None = None
+
+    def __post_init__(self) -> None:
+        _require_symbol(self.operation, "operation")
+        _require_count(self.retry_count, "retry_count")
+        if not isinstance(self.reason, RetryReason):
+            raise ValueError("reason must be a RetryReason")
+        _require_count(self.delay_ms, "delay_ms")
+
+
+@dataclass(frozen=True, slots=True)
+class CompactionEvent:
+    event_type: str = field(init=False, default="compaction")
+    operation: str
+    reason: CompactionReason
+    input_tokens: int
+    output_tokens: int
+
+    def __post_init__(self) -> None:
+        _require_symbol(self.operation, "operation")
+        if not isinstance(self.reason, CompactionReason):
+            raise ValueError("reason must be a CompactionReason")
+        _require_count(self.input_tokens, "input_tokens")
+        _require_count(self.output_tokens, "output_tokens")
+
+
+@dataclass(frozen=True, slots=True)
+class UsageEvent:
+    event_type: str = field(init=False, default="usage")
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    total_tokens: int | None = None
+    cache_hit_input_tokens: int | None = None
+    cache_miss_input_tokens: int | None = None
+    reasoning_tokens: int | None = None
+    current_context_tokens: int | None = None
+    context_window_tokens: int | None = None
+
+    def __post_init__(self) -> None:
+        _require_count(self.input_tokens, "input_tokens")
+        _require_count(self.output_tokens, "output_tokens")
+        _require_count(self.total_tokens, "total_tokens")
+        _require_count(self.cache_hit_input_tokens, "cache_hit_input_tokens")
+        _require_count(self.cache_miss_input_tokens, "cache_miss_input_tokens")
+        _require_count(self.reasoning_tokens, "reasoning_tokens")
+        _require_count(self.current_context_tokens, "current_context_tokens")
+        _require_count(self.context_window_tokens, "context_window_tokens")
+        if (
+            self.current_context_tokens is not None
+            and self.context_window_tokens is not None
+            and self.current_context_tokens > self.context_window_tokens
+        ):
+            raise ValueError("current_context_tokens cannot exceed context_window_tokens")
+
+
+@dataclass(frozen=True, slots=True)
+class CostEstimate:
+    estimated_cost_usd: float
+
+    def __post_init__(self) -> None:
+        _require_cost(self.estimated_cost_usd)
+
+
+@dataclass(frozen=True, slots=True)
+class CostEvent:
+    event_type: str = field(init=False, default="cost")
+    cost: CostEstimate
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.cost, CostEstimate):
+            raise ValueError("cost must be a CostEstimate")
+
+
+@dataclass(frozen=True, slots=True)
+class TerminalEvent:
+    event_type: str = field(init=False, default="terminal")
+    status: SpanStatus
+    latency_ms: float
+    stop_reason: StopReason | None = None
+    retry_count: int = 0
+    usage: UsageEvent | None = None
+    cost: CostEstimate | None = None
+    error_kind: ErrorKind | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.status, SpanStatus):
+            raise ValueError("status must be a SpanStatus")
+        if self.stop_reason is not None and not isinstance(self.stop_reason, StopReason):
+            raise ValueError("stop_reason must be a StopReason or null")
+        if self.error_kind is not None and not isinstance(self.error_kind, ErrorKind):
+            raise ValueError("error_kind must be an ErrorKind or null")
+        if self.usage is not None and type(self.usage) is not UsageEvent:
+            raise ValueError("usage must be a UsageEvent or null")
+        if self.cost is not None and type(self.cost) is not CostEstimate:
+            raise ValueError("cost must be a CostEstimate or null")
+        if (
+            not isinstance(self.latency_ms, (int, float))
+            or isinstance(self.latency_ms, bool)
+            or not math.isfinite(self.latency_ms)
+            or self.latency_ms < 0
+        ):
+            raise ValueError("latency_ms must be finite and non-negative")
+        _require_count(self.retry_count, "retry_count")
+        if self.status is SpanStatus.FAILED and self.error_kind is None:
+            raise ValueError("failed terminal events require error_kind")
+        if self.status not in {SpanStatus.FAILED, SpanStatus.PARTIAL} and self.error_kind:
+            raise ValueError("error_kind is only valid for failed or partial spans")
+
+
+SpanSchema: TypeAlias = ProviderSpan | AgentTurnSpan | ToolSpan
+TelemetryEvent: TypeAlias = RetryEvent | CompactionEvent | UsageEvent | CostEvent
+SPAN_SCHEMA_TYPES = (ProviderSpan, AgentTurnSpan, ToolSpan)
+TELEMETRY_EVENT_TYPES = (RetryEvent, CompactionEvent, UsageEvent, CostEvent)
+
+
+@dataclass(frozen=True, slots=True)
+class SpanStartedRecord:
+    version: int = field(init=False, default=SCHEMA_VERSION)
+    record_type: str = field(init=False, default="span_started")
+    sequence: int
+    span_id: str
+    parent_span_id: str | None
+    context: TraceContext
+    observed_at_ns: int
+    span: SpanSchema
+
+    def __post_init__(self) -> None:
+        _require_count(self.sequence, "sequence")
+        _require_symbol(self.span_id, "span_id")
+        if type(self.context) is not TraceContext:
+            raise ValueError("context must be a TraceContext")
+        if self.parent_span_id is not None:
+            _require_symbol(self.parent_span_id, "parent_span_id")
+        _require_count(self.observed_at_ns, "observed_at_ns")
+        if type(self.span) not in SPAN_SCHEMA_TYPES:
+            raise ValueError("span must use a closed span schema")
+
+
+@dataclass(frozen=True, slots=True)
+class SpanEventRecord:
+    version: int = field(init=False, default=SCHEMA_VERSION)
+    record_type: str = field(init=False, default="span_event")
+    sequence: int
+    span_id: str
+    context: TraceContext
+    observed_at_ns: int
+    event: TelemetryEvent
+
+    def __post_init__(self) -> None:
+        _require_count(self.sequence, "sequence")
+        _require_symbol(self.span_id, "span_id")
+        if type(self.context) is not TraceContext:
+            raise ValueError("context must be a TraceContext")
+        _require_count(self.observed_at_ns, "observed_at_ns")
+        if type(self.event) not in TELEMETRY_EVENT_TYPES:
+            raise ValueError("event must use a closed event schema")
+
+
+@dataclass(frozen=True, slots=True)
+class SpanSettledRecord:
+    version: int = field(init=False, default=SCHEMA_VERSION)
+    record_type: str = field(init=False, default="span_settled")
+    sequence: int
+    span_id: str
+    context: TraceContext
+    observed_at_ns: int
+    terminal: TerminalEvent
+
+    def __post_init__(self) -> None:
+        _require_count(self.sequence, "sequence")
+        _require_symbol(self.span_id, "span_id")
+        if type(self.context) is not TraceContext:
+            raise ValueError("context must be a TraceContext")
+        _require_count(self.observed_at_ns, "observed_at_ns")
+        if type(self.terminal) is not TerminalEvent:
+            raise ValueError("terminal must be a TerminalEvent")
+
+
+TelemetryRecord: TypeAlias = SpanStartedRecord | SpanEventRecord | SpanSettledRecord
+TELEMETRY_RECORD_TYPES = (SpanStartedRecord, SpanEventRecord, SpanSettledRecord)
+_SERIALIZABLE_TYPES = (
+    TraceContext,
+    ProviderSpan,
+    AgentTurnSpan,
+    ToolSpan,
+    RetryEvent,
+    CompactionEvent,
+    UsageEvent,
+    CostEstimate,
+    CostEvent,
+    TerminalEvent,
+    *TELEMETRY_RECORD_TYPES,
+)
+_SERIALIZABLE_ENUM_TYPES = (
+    SpanStatus,
+    StopReason,
+    ErrorKind,
+    RetryReason,
+    CompactionReason,
+)
+
+
+def record_to_dict(value: Any) -> Any:
+    """Convert only closed telemetry values to JSON-compatible primitives."""
+    if type(value) not in _SERIALIZABLE_TYPES and type(value) not in _SERIALIZABLE_ENUM_TYPES:
+        raise TypeError(f"unsupported telemetry value {type(value).__name__}")
+    return _to_primitive(value)
+
+
+def _to_primitive(value: Any) -> Any:
+    if type(value) in _SERIALIZABLE_ENUM_TYPES:
+        return value.value
+    if type(value) in _SERIALIZABLE_TYPES and is_dataclass(value):
+        return {
+            item.name: _to_primitive(getattr(value, item.name))
+            for item in fields(value)
+        }
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    raise TypeError(f"unsupported telemetry value {type(value).__name__}")

--- a/desktop/tests/test_telemetry_adapters.py
+++ b/desktop/tests/test_telemetry_adapters.py
@@ -1,0 +1,137 @@
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+
+from coworker.telemetry.adapters import (
+    InMemoryTelemetryAdapter,
+    NoOpTelemetryAdapter,
+    TelemetryRecorder,
+)
+from coworker.telemetry.schema import (
+    AgentTurnSpan,
+    ErrorKind,
+    RetryEvent,
+    RetryReason,
+    SpanSettledRecord,
+    SpanStartedRecord,
+    SpanStatus,
+    StopReason,
+    ToolSpan,
+    TraceContext,
+    UsageEvent,
+)
+
+
+class StepClock:
+    def __init__(self, start: int = 0, step: int = 1_000_000) -> None:
+        self.value = start
+        self.step = step
+
+    def __call__(self) -> int:
+        current = self.value
+        self.value += self.step
+        return current
+
+
+def test_noop_adapter_is_inert_and_does_not_even_read_the_clock():
+    recorder = TelemetryRecorder(
+        NoOpTelemetryAdapter(),
+        clock=lambda: (_ for _ in ()).throw(AssertionError("clock was read")),
+    )
+    context = TraceContext(session_id="session-1", run_id="run-1")
+
+    span = recorder.start_span(AgentTurnSpan(operation="agent.turn"), context)
+    child = span.child(ToolSpan(tool_name="gmail_search", operation="tool.execute"))
+    child.record(
+        RetryEvent(
+            operation="tool.execute",
+            retry_count=1,
+            reason=RetryReason.TIMEOUT,
+        )
+    )
+    child.fail(ErrorKind.TIMEOUT)
+    span.finish()
+
+    assert span.span_id is None
+    assert child.span_id is None
+
+
+def test_in_memory_adapter_assigns_deterministic_ids_parentage_and_order():
+    adapter = InMemoryTelemetryAdapter()
+    recorder = TelemetryRecorder(adapter, clock=StepClock(start=10_000_000))
+    context = TraceContext(session_id="session-1", run_id="run-1")
+
+    turn = recorder.start_span(AgentTurnSpan(operation="agent.turn"), context)
+    tool = turn.child(ToolSpan(tool_name="gmail_search", operation="tool.execute"))
+    tool.record(UsageEvent(input_tokens=5, output_tokens=2))
+    tool.finish(stop_reason=StopReason.COMPLETED)
+    turn.finish(usage=UsageEvent(input_tokens=5, output_tokens=2))
+
+    records = adapter.records
+    assert [record.sequence for record in records] == [1, 2, 3, 4, 5]
+    assert [record.record_type for record in records] == [
+        "span_started",
+        "span_started",
+        "span_event",
+        "span_settled",
+        "span_settled",
+    ]
+    assert turn.span_id == "span-000001"
+    assert tool.span_id == "span-000002"
+    assert isinstance(records[1], SpanStartedRecord)
+    assert records[1].parent_span_id == turn.span_id
+    assert isinstance(records[3], SpanSettledRecord)
+    assert records[3].terminal.latency_ms == 2.0
+
+
+def test_concurrent_children_keep_unique_ordered_records_and_shared_parentage():
+    adapter = InMemoryTelemetryAdapter()
+    recorder = TelemetryRecorder(adapter, clock=StepClock())
+    context = TraceContext(session_id="session-1", run_id="run-1")
+    turn = recorder.start_span(AgentTurnSpan(operation="agent.turn"), context)
+    barrier = Barrier(5)
+
+    def execute_tool(index: int) -> str | None:
+        barrier.wait()
+        span = turn.child(
+            ToolSpan(tool_name=f"tool-{index}", operation="tool.execute")
+        )
+        span.finish()
+        return span.span_id
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = [executor.submit(execute_tool, index) for index in range(4)]
+        barrier.wait()
+        span_ids = [future.result() for future in futures]
+    turn.finish()
+
+    records = adapter.records
+    starts = [record for record in records if isinstance(record, SpanStartedRecord)]
+    assert len(set(span_ids)) == 4
+    assert all(record.parent_span_id == turn.span_id for record in starts[1:])
+    assert [record.sequence for record in records] == list(range(1, len(records) + 1))
+    assert len({record.sequence for record in records}) == len(records)
+
+
+def test_adapter_failures_never_escape_or_change_the_business_result():
+    class ExplodingAdapter:
+        enabled = True
+
+        def record(self, record):
+            raise RuntimeError("adapter unavailable")
+
+    recorder = TelemetryRecorder(ExplodingAdapter(), clock=StepClock())
+    context = TraceContext(session_id="session-1", run_id="run-1")
+
+    def business_operation() -> str:
+        span = recorder.start_span(AgentTurnSpan(operation="agent.turn"), context)
+        span.record(
+            RetryEvent(
+                operation="provider.request",
+                retry_count=1,
+                reason=RetryReason.CONNECTION,
+            )
+        )
+        span.finish(status=SpanStatus.SUCCESS)
+        return "business-result"
+
+    assert business_operation() == "business-result"

--- a/desktop/tests/test_telemetry_conformance.py
+++ b/desktop/tests/test_telemetry_conformance.py
@@ -1,0 +1,189 @@
+import pytest
+
+from coworker.telemetry.adapters import InMemoryTelemetryAdapter, TelemetryRecorder
+from coworker.telemetry.schema import (
+    AgentTurnSpan,
+    CompactionEvent,
+    CompactionReason,
+    ErrorKind,
+    RetryEvent,
+    RetryReason,
+    SpanEventRecord,
+    SpanSettledRecord,
+    SpanStatus,
+    StopReason,
+    ToolSpan,
+    TraceContext,
+    UsageEvent,
+)
+from tests.test_telemetry_adapters import StepClock
+
+
+@pytest.mark.parametrize(
+    ("settle", "status", "stop_reason", "error_kind"),
+    [
+        (lambda span: span.finish(), SpanStatus.SUCCESS, StopReason.COMPLETED, None),
+        (
+            lambda span: span.fail(ErrorKind.PROVIDER, retry_count=2),
+            SpanStatus.FAILED,
+            StopReason.ERROR,
+            ErrorKind.PROVIDER,
+        ),
+        (
+            lambda span: span.cancel(),
+            SpanStatus.CANCELLED,
+            StopReason.CANCELLED,
+            None,
+        ),
+        (
+            lambda span: span.partial(ErrorKind.TOOL),
+            SpanStatus.PARTIAL,
+            StopReason.ERROR,
+            ErrorKind.TOOL,
+        ),
+    ],
+)
+def test_adapter_conformance_records_each_bounded_terminal_outcome(
+    settle, status, stop_reason, error_kind
+):
+    adapter = InMemoryTelemetryAdapter()
+    recorder = TelemetryRecorder(adapter, clock=StepClock())
+    context = TraceContext(session_id="session-1", run_id="run-1")
+    span = recorder.start_span(AgentTurnSpan(operation="agent.turn"), context)
+
+    assert settle(span) is True
+
+    terminal = adapter.records[-1]
+    assert isinstance(terminal, SpanSettledRecord)
+    assert terminal.terminal.status is status
+    assert terminal.terminal.stop_reason is stop_reason
+    assert terminal.terminal.error_kind is error_kind
+
+
+def test_adapter_conformance_makes_every_post_settlement_call_inert():
+    adapter = InMemoryTelemetryAdapter()
+    recorder = TelemetryRecorder(adapter, clock=StepClock())
+    context = TraceContext(session_id="session-1", run_id="run-1")
+    span = recorder.start_span(AgentTurnSpan(operation="agent.turn"), context)
+    assert span.finish() is True
+    settled_records = adapter.records
+
+    assert span.settled is True
+    assert span.record(
+        RetryEvent(
+            operation="provider.request",
+            retry_count=1,
+            reason=RetryReason.TIMEOUT,
+        )
+    ) is False
+    assert span.finish() is False
+    assert span.fail(ErrorKind.UNKNOWN) is False
+    assert span.cancel() is False
+    assert span.partial(ErrorKind.TOOL) is False
+    child = span.child(ToolSpan(tool_name="gmail_search", operation="tool.execute"))
+    assert child.span_id is None
+    assert adapter.records == settled_records
+
+
+def test_adapter_conformance_records_retry_compaction_and_missing_usage():
+    adapter = InMemoryTelemetryAdapter()
+    recorder = TelemetryRecorder(adapter, clock=StepClock())
+    context = TraceContext(session_id="session-1", run_id="run-1")
+    span = recorder.start_span(AgentTurnSpan(operation="agent.turn"), context)
+
+    span.record(
+        RetryEvent(
+            operation="provider.request",
+            retry_count=1,
+            reason=RetryReason.RATE_LIMIT,
+            delay_ms=500,
+        )
+    )
+    span.record(
+        CompactionEvent(
+            operation="agent.context",
+            reason=CompactionReason.CONTEXT_LIMIT,
+            input_tokens=100_000,
+            output_tokens=30_000,
+        )
+    )
+    span.finish(usage=None)
+
+    events = [record.event for record in adapter.records if isinstance(record, SpanEventRecord)]
+    assert [event.event_type for event in events] == ["retry", "compaction"]
+    terminal = adapter.records[-1]
+    assert isinstance(terminal, SpanSettledRecord)
+    assert terminal.terminal.usage is None
+
+
+def test_mismatched_parent_context_is_ignored_without_throwing_or_recording():
+    adapter = InMemoryTelemetryAdapter()
+    recorder = TelemetryRecorder(adapter, clock=StepClock())
+    parent = recorder.start_span(
+        AgentTurnSpan(operation="agent.turn"),
+        TraceContext(session_id="session-1", run_id="run-1"),
+    )
+
+    child = recorder.start_span(
+        ToolSpan(tool_name="gmail_search", operation="tool.execute"),
+        TraceContext(session_id="session-2", run_id="run-2"),
+        parent=parent,
+    )
+
+    assert child.span_id is None
+    assert len(adapter.records) == 1
+
+
+def test_terminal_schema_rejects_untyped_status_values():
+    with pytest.raises(ValueError, match="status"):
+        from coworker.telemetry.schema import TerminalEvent
+
+        TerminalEvent(status="failed", latency_ms=1, error_kind=ErrorKind.TIMEOUT)
+
+
+def test_partial_tool_span_preserves_usage_without_accepting_error_content():
+    adapter = InMemoryTelemetryAdapter()
+    recorder = TelemetryRecorder(adapter, clock=StepClock())
+    context = TraceContext(session_id="session-1", run_id="run-1")
+    span = recorder.start_span(
+        ToolSpan(tool_name="gmail_search", operation="tool.execute"), context
+    )
+    usage = UsageEvent(input_tokens=10, output_tokens=0)
+
+    span.partial(ErrorKind.TOOL, usage=usage)
+
+    terminal = adapter.records[-1]
+    assert isinstance(terminal, SpanSettledRecord)
+    assert terminal.terminal.status is SpanStatus.PARTIAL
+    assert terminal.terminal.usage == usage
+
+
+def test_adapter_containment_does_not_swallow_base_exception_cancellation():
+    class CancellationSignal(BaseException):
+        pass
+
+    class CancellingAdapter:
+        enabled = True
+
+        def record(self, record):
+            raise CancellationSignal()
+
+    recorder = TelemetryRecorder(CancellingAdapter(), clock=StepClock())
+    context = TraceContext(session_id="session-1", run_id="run-1")
+
+    with pytest.raises(CancellationSignal):
+        recorder.start_span(AgentTurnSpan(operation="agent.turn"), context)
+
+
+def test_clock_containment_does_not_swallow_base_exception_cancellation():
+    class CancellationSignal(BaseException):
+        pass
+
+    recorder = TelemetryRecorder(
+        InMemoryTelemetryAdapter(),
+        clock=lambda: (_ for _ in ()).throw(CancellationSignal()),
+    )
+    context = TraceContext(session_id="session-1", run_id="run-1")
+
+    with pytest.raises(CancellationSignal):
+        recorder.start_span(AgentTurnSpan(operation="agent.turn"), context)

--- a/desktop/tests/test_telemetry_content_safety.py
+++ b/desktop/tests/test_telemetry_content_safety.py
@@ -1,0 +1,151 @@
+import json
+from dataclasses import dataclass
+
+import pytest
+
+from coworker.telemetry.adapters import InMemoryTelemetryAdapter, TelemetryRecorder
+from coworker.telemetry.schema import (
+    AgentTurnSpan,
+    ErrorKind,
+    ProviderSpan,
+    SpanSettledRecord,
+    SpanStatus,
+    TerminalEvent,
+    TraceContext,
+    UsageEvent,
+    record_to_dict,
+)
+from tests.test_telemetry_adapters import StepClock
+
+
+PLANTED_SECRET = "sk-live-PLANTED-DO-NOT-CAPTURE"
+FORBIDDEN_KEYS = (
+    "prompt",
+    "messages",
+    "response_text",
+    "source_body",
+    "arguments",
+    "result",
+    "command_output",
+    "credentials",
+    "authorization",
+    "raw_error",
+    "reasoning",
+)
+
+
+@pytest.mark.parametrize("field_name", FORBIDDEN_KEYS)
+def test_closed_provider_schema_rejects_every_content_or_secret_field(field_name):
+    values = {
+        "provider": "deepseek",
+        "model": "deepseek-chat",
+        "operation": "chat.completion",
+        field_name: PLANTED_SECRET,
+    }
+
+    with pytest.raises(TypeError):
+        ProviderSpan(**values)
+
+
+def test_recorder_ignores_runtime_payloads_outside_the_closed_schema():
+    adapter = InMemoryTelemetryAdapter()
+    recorder = TelemetryRecorder(adapter, clock=StepClock())
+    context = TraceContext(session_id="session-1", run_id="run-1")
+    span = recorder.start_span(AgentTurnSpan(operation="agent.turn"), context)
+    initial_records = adapter.records
+
+    assert span.record(
+        {"arguments": {"authorization": PLANTED_SECRET}}
+    ) is False
+    invalid_span = recorder.start_span(
+        {"prompt": PLANTED_SECRET},
+        context,
+    )
+
+    assert invalid_span.span_id is None
+    assert adapter.records == initial_records
+    assert PLANTED_SECRET not in json.dumps(
+        [record_to_dict(record) for record in adapter.records]
+    )
+
+
+def test_error_schema_accepts_only_bounded_error_kinds_not_raw_errors():
+    with pytest.raises(ValueError, match="error_kind"):
+        TerminalEvent(
+            status=SpanStatus.FAILED,
+            latency_ms=1,
+            error_kind=PLANTED_SECRET,
+        )
+
+    terminal = TerminalEvent(
+        status=SpanStatus.FAILED,
+        latency_ms=1,
+        error_kind=ErrorKind.PROVIDER,
+    )
+    assert PLANTED_SECRET not in json.dumps(record_to_dict(terminal))
+
+
+def test_operational_identifiers_reject_common_secret_shapes():
+    with pytest.raises(ValueError, match="tool_name"):
+        from coworker.telemetry.schema import ToolSpan
+
+        ToolSpan(tool_name=PLANTED_SECRET, operation="tool.execute")
+
+
+def test_usage_rejects_content_instead_of_coercing_it_to_a_measurement():
+    with pytest.raises(ValueError, match="input_tokens"):
+        UsageEvent(input_tokens=PLANTED_SECRET)
+
+
+def test_serializer_rejects_non_telemetry_dataclasses_even_when_they_look_typed():
+    @dataclass(frozen=True)
+    class ForbiddenPayload:
+        prompt: str
+
+    with pytest.raises(TypeError, match="unsupported telemetry value"):
+        record_to_dict(ForbiddenPayload(prompt=PLANTED_SECRET))
+
+
+def test_in_memory_adapter_rejects_untyped_records_without_storing_content():
+    adapter = InMemoryTelemetryAdapter()
+
+    adapter.record({"raw_error": PLANTED_SECRET})
+
+    assert adapter.records == ()
+
+
+def test_settled_record_rejects_an_untyped_terminal_payload():
+    context = TraceContext(session_id="session-1", run_id="run-1")
+
+    with pytest.raises(ValueError, match="terminal"):
+        SpanSettledRecord(
+            sequence=1,
+            span_id="span-1",
+            context=context,
+            observed_at_ns=1,
+            terminal={"raw_error": PLANTED_SECRET},
+        )
+
+
+def test_record_envelopes_reject_untyped_context_payloads():
+    terminal = TerminalEvent(status=SpanStatus.SUCCESS, latency_ms=1)
+
+    with pytest.raises(ValueError, match="context"):
+        SpanSettledRecord(
+            sequence=1,
+            span_id="span-1",
+            context={"session_id": PLANTED_SECRET, "run_id": "run-1"},
+            observed_at_ns=1,
+            terminal=terminal,
+        )
+
+
+def test_invalid_settlement_values_are_inert_and_non_throwing():
+    adapter = InMemoryTelemetryAdapter()
+    recorder = TelemetryRecorder(adapter, clock=StepClock())
+    context = TraceContext(session_id="session-1", run_id="run-1")
+    span = recorder.start_span(AgentTurnSpan(operation="agent.turn"), context)
+
+    assert span.finish(status="failed", error_kind=PLANTED_SECRET) is False
+    assert span.settled is True
+    assert len(adapter.records) == 1

--- a/desktop/tests/test_telemetry_metrics.py
+++ b/desktop/tests/test_telemetry_metrics.py
@@ -1,0 +1,103 @@
+from coworker.telemetry.adapters import InMemoryTelemetryAdapter, TelemetryRecorder
+from coworker.telemetry.metrics import CurrentRunMetrics
+from coworker.telemetry.schema import (
+    AgentTurnSpan,
+    CostEstimate,
+    CostEvent,
+    ProviderSpan,
+    TraceContext,
+    UsageEvent,
+)
+from tests.test_telemetry_adapters import StepClock
+
+
+def test_current_run_metrics_aggregate_provider_usage_cost_context_and_elapsed_time():
+    adapter = InMemoryTelemetryAdapter()
+    recorder = TelemetryRecorder(adapter, clock=StepClock())
+    context = TraceContext(session_id="session-1", run_id="run-1")
+    turn = recorder.start_span(AgentTurnSpan(operation="agent.turn"), context)
+
+    first = turn.child(
+        ProviderSpan(
+            provider="deepseek",
+            model="deepseek-chat",
+            operation="chat.completion",
+            context_window_tokens=100,
+        )
+    )
+    first_usage = UsageEvent(
+        input_tokens=10,
+        output_tokens=5,
+        total_tokens=15,
+        cache_hit_input_tokens=4,
+        cache_miss_input_tokens=6,
+        reasoning_tokens=2,
+        current_context_tokens=15,
+        context_window_tokens=100,
+    )
+    first_cost = CostEstimate(estimated_cost_usd=0.0042)
+    first.record(first_usage)
+    first.record(CostEvent(cost=first_cost))
+    first.finish(usage=first_usage, cost=first_cost)
+
+    second = turn.child(
+        ProviderSpan(
+            provider="deepseek",
+            model="deepseek-reasoner",
+            operation="chat.completion",
+            context_window_tokens=100,
+        )
+    )
+    second_usage = UsageEvent(
+        input_tokens=3,
+        output_tokens=2,
+        total_tokens=5,
+        reasoning_tokens=1,
+        current_context_tokens=8,
+        context_window_tokens=100,
+    )
+    second_cost = CostEstimate(estimated_cost_usd=0.002)
+    second.finish(usage=second_usage, cost=second_cost)
+
+    metrics = adapter.current_run_metrics(run_id="run-1", now_ns=8_000_000)
+
+    assert metrics == CurrentRunMetrics(
+        run_id="run-1",
+        input_tokens=13,
+        output_tokens=7,
+        total_tokens=20,
+        cache_hit_input_tokens=4,
+        cache_miss_input_tokens=6,
+        reasoning_tokens=3,
+        current_context_tokens=8,
+        context_window_tokens=100,
+        context_use_ratio=0.08,
+        elapsed_ms=8.0,
+        estimated_cost_usd=0.0062,
+    )
+
+
+def test_current_run_metrics_preserve_missing_usage_as_unknown():
+    adapter = InMemoryTelemetryAdapter()
+    recorder = TelemetryRecorder(adapter, clock=StepClock())
+    context = TraceContext(session_id="session-1", run_id="run-1")
+    turn = recorder.start_span(AgentTurnSpan(operation="agent.turn"), context)
+    provider = turn.child(
+        ProviderSpan(
+            provider="deepseek",
+            model="deepseek-chat",
+            operation="chat.completion",
+        )
+    )
+    provider.finish(usage=None)
+    turn.finish(usage=None)
+
+    metrics = adapter.current_run_metrics(run_id="run-1", now_ns=10_000_000)
+
+    assert metrics.input_tokens is None
+    assert metrics.output_tokens is None
+    assert metrics.total_tokens is None
+    assert metrics.current_context_tokens is None
+    assert metrics.context_use_ratio is None
+    assert metrics.estimated_cost_usd is None
+    assert metrics.elapsed_ms == 3.0

--- a/desktop/tests/test_telemetry_public_api.py
+++ b/desktop/tests/test_telemetry_public_api.py
@@ -1,0 +1,29 @@
+def test_telemetry_package_exposes_the_integration_boundary():
+    from coworker.telemetry import (
+        AgentTurnSpan,
+        CostEstimate,
+        InMemoryTelemetryAdapter,
+        NoOpTelemetryAdapter,
+        ProviderSpan,
+        TelemetryRecorder,
+        ToolSpan,
+        TraceContext,
+        UsageEvent,
+    )
+
+    disabled = TelemetryRecorder(NoOpTelemetryAdapter())
+    local = TelemetryRecorder(InMemoryTelemetryAdapter())
+
+    assert disabled.enabled is False
+    assert local.enabled is True
+    assert all(
+        value is not None
+        for value in (
+            AgentTurnSpan,
+            CostEstimate,
+            ProviderSpan,
+            ToolSpan,
+            TraceContext,
+            UsageEvent,
+        )
+    )

--- a/desktop/tests/test_telemetry_schema.py
+++ b/desktop/tests/test_telemetry_schema.py
@@ -1,0 +1,264 @@
+from dataclasses import fields
+
+import pytest
+
+from coworker.telemetry.schema import (
+    SCHEMA_VERSION,
+    AgentTurnSpan,
+    CompactionEvent,
+    CompactionReason,
+    CostEstimate,
+    CostEvent,
+    ErrorKind,
+    ProviderSpan,
+    RetryEvent,
+    RetryReason,
+    SpanEventRecord,
+    SpanSettledRecord,
+    SpanStartedRecord,
+    SpanStatus,
+    StopReason,
+    TerminalEvent,
+    ToolSpan,
+    TraceContext,
+    UsageEvent,
+    record_to_dict,
+)
+
+
+def test_telemetry_schemas_are_versioned_closed_and_serializable():
+    context = TraceContext(session_id="session-1", run_id="run-1")
+    provider = ProviderSpan(
+        provider="anthropic",
+        model="claude-sonnet-4",
+        operation="chat.completion",
+        context_window_tokens=200_000,
+    )
+    started = SpanStartedRecord(
+        sequence=1,
+        span_id="span-1",
+        parent_span_id=None,
+        context=context,
+        observed_at_ns=10,
+        span=provider,
+    )
+    usage = UsageEvent(
+        input_tokens=120,
+        output_tokens=30,
+        total_tokens=150,
+        cache_hit_input_tokens=20,
+        cache_miss_input_tokens=100,
+        reasoning_tokens=8,
+        current_context_tokens=150,
+        context_window_tokens=200_000,
+    )
+    observed = SpanEventRecord(
+        sequence=2,
+        span_id="span-1",
+        context=context,
+        observed_at_ns=20,
+        event=usage,
+    )
+    settled = SpanSettledRecord(
+        sequence=3,
+        span_id="span-1",
+        context=context,
+        observed_at_ns=30,
+        terminal=TerminalEvent(
+            status=SpanStatus.SUCCESS,
+            latency_ms=0.00002,
+            stop_reason=StopReason.COMPLETED,
+            usage=usage,
+        ),
+    )
+
+    assert record_to_dict(started) == {
+        "version": SCHEMA_VERSION,
+        "record_type": "span_started",
+        "sequence": 1,
+        "span_id": "span-1",
+        "parent_span_id": None,
+        "context": {"session_id": "session-1", "run_id": "run-1"},
+        "observed_at_ns": 10,
+        "span": {
+            "span_type": "provider",
+            "provider": "anthropic",
+            "model": "claude-sonnet-4",
+            "operation": "chat.completion",
+            "context_window_tokens": 200_000,
+        },
+    }
+    assert record_to_dict(observed)["event"] == {
+        "event_type": "usage",
+        "input_tokens": 120,
+        "output_tokens": 30,
+        "total_tokens": 150,
+        "cache_hit_input_tokens": 20,
+        "cache_miss_input_tokens": 100,
+        "reasoning_tokens": 8,
+        "current_context_tokens": 150,
+        "context_window_tokens": 200_000,
+    }
+    assert record_to_dict(settled)["terminal"]["status"] == "success"
+
+    with pytest.raises(TypeError):
+        ProviderSpan(
+            provider="anthropic",
+            model="claude-sonnet-4",
+            operation="chat.completion",
+            prompt="do not capture me",
+        )
+
+
+def test_all_supported_span_and_event_schemas_use_bounded_operational_fields():
+    schemas = (
+        AgentTurnSpan(operation="agent.turn"),
+        ToolSpan(tool_name="gmail_search", operation="tool.execute"),
+        RetryEvent(
+            operation="provider.request",
+            retry_count=1,
+            reason=RetryReason.RATE_LIMIT,
+            delay_ms=250,
+        ),
+        CompactionEvent(
+            operation="agent.context",
+            reason=CompactionReason.CONTEXT_LIMIT,
+            input_tokens=80_000,
+            output_tokens=20_000,
+        ),
+        TerminalEvent(
+            status=SpanStatus.FAILED,
+            latency_ms=12.5,
+            stop_reason=StopReason.ERROR,
+            error_kind=ErrorKind.TIMEOUT,
+            retry_count=2,
+        ),
+    )
+
+    assert [record_to_dict(schema) for schema in schemas] == [
+        {"span_type": "agent_turn", "operation": "agent.turn"},
+        {
+            "span_type": "tool",
+            "tool_name": "gmail_search",
+            "operation": "tool.execute",
+        },
+        {
+            "event_type": "retry",
+            "operation": "provider.request",
+            "retry_count": 1,
+            "reason": "rate_limit",
+            "delay_ms": 250,
+        },
+        {
+            "event_type": "compaction",
+            "operation": "agent.context",
+            "reason": "context_limit",
+            "input_tokens": 80_000,
+            "output_tokens": 20_000,
+        },
+        {
+            "event_type": "terminal",
+            "status": "failed",
+            "latency_ms": 12.5,
+            "stop_reason": "error",
+            "retry_count": 2,
+            "usage": None,
+            "cost": None,
+            "error_kind": "timeout",
+        },
+    ]
+
+    forbidden_fields = {
+        "prompt",
+        "messages",
+        "response",
+        "text",
+        "body",
+        "arguments",
+        "result",
+        "command_output",
+        "credential",
+        "authorization",
+        "error",
+        "reasoning",
+        "metadata",
+    }
+    for schema in schemas:
+        assert forbidden_fields.isdisjoint(field.name for field in fields(schema))
+
+
+@pytest.mark.parametrize(
+    ("constructor", "match"),
+    [
+        (
+            lambda: TraceContext(session_id="contains a space", run_id="run-1"),
+            "session_id",
+        ),
+        (
+            lambda: RetryEvent(
+                operation="provider.request",
+                retry_count=-1,
+                reason=RetryReason.TIMEOUT,
+            ),
+            "retry_count",
+        ),
+        (
+            lambda: UsageEvent(input_tokens=1, output_tokens=-1),
+            "output_tokens",
+        ),
+        (
+            lambda: TerminalEvent(
+                status=SpanStatus.FAILED,
+                latency_ms=1,
+            ),
+            "error_kind",
+        ),
+    ],
+)
+def test_telemetry_schemas_reject_unbounded_or_invalid_values(constructor, match):
+    with pytest.raises(ValueError, match=match):
+        constructor()
+
+
+def test_usage_accepts_partial_provider_reports_without_inventing_missing_counts():
+    usage = UsageEvent(total_tokens=42, reasoning_tokens=7)
+
+    assert record_to_dict(usage) == {
+        "event_type": "usage",
+        "input_tokens": None,
+        "output_tokens": None,
+        "total_tokens": 42,
+        "cache_hit_input_tokens": None,
+        "cache_miss_input_tokens": None,
+        "reasoning_tokens": 7,
+        "current_context_tokens": None,
+        "context_window_tokens": None,
+    }
+
+
+def test_estimated_cost_is_a_separate_closed_measurement_from_provider_usage():
+    cost = CostEstimate(estimated_cost_usd=0.0042)
+
+    assert record_to_dict(CostEvent(cost=cost)) == {
+        "event_type": "cost",
+        "cost": {"estimated_cost_usd": 0.0042},
+    }
+    assert record_to_dict(
+        TerminalEvent(
+            status=SpanStatus.SUCCESS,
+            latency_ms=1,
+            cost=cost,
+        )
+    )["cost"] == {"estimated_cost_usd": 0.0042}
+    assert "estimated_cost_usd" not in {
+        field.name for field in fields(UsageEvent(total_tokens=10))
+    }
+
+    with pytest.raises(TypeError):
+        CostEstimate(estimated_cost_usd=0.0042, pricing_metadata={"secret": "no"})
+
+
+def test_estimated_cost_rejects_missing_or_non_finite_values():
+    for value in (None, float("nan"), float("inf"), -0.01):
+        with pytest.raises(ValueError, match="estimated_cost_usd"):
+            CostEstimate(estimated_cost_usd=value)


### PR DESCRIPTION
## Summary\n\n- add closed, versioned operational schemas for provider, agent-turn, tool, retry, compaction, usage, cost, and terminal telemetry\n- add inert no-op and deterministic in-memory adapters with passive failure containment\n- add single-settlement spans with parentage, concurrent ordering, and inert post-settlement behavior\n- add content and secret exclusion tests so prompts, responses, arguments, results, raw errors, credentials, and reasoning cannot enter telemetry\n- add current-run token, context, elapsed-time, retry, compaction, and estimated-cost projection\n\n## Verification\n\n- focused telemetry suite: 47 passed\n- make test-python: 511 passed, 2 skipped\n- pre-existing Starlette/httpx deprecation warning remains\n\n## Review focus\n\n- schemas accept only bounded operational fields and categorical errors\n- ordinary adapter failures cannot change business results, while cancellation-class signals still propagate\n- usage supports input, output, total, cache-hit, cache-miss, and reasoning tokens; cost remains a separate typed value\n- this PR intentionally avoids live provider, loop, tool, API, and GUI hooks so the provider lane can land without a competing event contract\n\nRefs #81\n\n## Follow-up\n\nIssue #81 remains open for runtime instrumentation and the current-run API/UI surface. The next integration slice will map provider terminal usage into this foundation without recording transient reasoning.