### PR TITLE
fix(desktop): preserve DeepSeek tool reasoning continuity

### DIFF
--- a/desktop/coworker/provider.py
+++ b/desktop/coworker/provider.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import json
 import os
+from collections import OrderedDict
+from copy import deepcopy
 from dataclasses import dataclass, field
+from hashlib import sha256
 from typing import Any, AsyncIterator, Optional, Protocol
 
 
@@ -15,10 +18,32 @@ class ToolCall:
     arguments: dict[str, Any] = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class ToolCallDelta:
+    index: int
+    id: str | None = None
+    name_delta: str | None = None
+    arguments_delta: str | None = None
+
+
+@dataclass(frozen=True)
+class ModelUsage:
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    cached_input_tokens: int
+    uncached_input_tokens: int
+    reasoning_tokens: int
+
+
 @dataclass
 class StreamChunk:
     text_delta: str | None = None
+    transient_reasoning_delta: str | None = None
+    tool_call_deltas: list[ToolCallDelta] | None = None
     tool_calls: list[ToolCall] | None = None
+    finish_reason: str | None = None
+    usage: ModelUsage | None = None
 
 
 class StreamProvider(Protocol):
@@ -29,6 +54,7 @@ class StreamProvider(Protocol):
         *,
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None = None,
+        context_id: str | None = None,
     ) -> AsyncIterator[StreamChunk]: ...
 
 
@@ -51,7 +77,9 @@ class FakeProvider:
         *,
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None = None,
+        context_id: str | None = None,
     ) -> AsyncIterator[StreamChunk]:
+        del context_id
         self.calls.append(list(messages))
         step = self.steps[min(self.i, len(self.steps) - 1)]
         self.i += 1
@@ -116,7 +144,9 @@ class AnthropicProvider:
         *,
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None = None,
+        context_id: str | None = None,
     ) -> AsyncIterator[StreamChunk]:
+        del context_id
         import httpx
 
         system = " ".join(
@@ -163,6 +193,9 @@ class AnthropicProvider:
 
 class OpenAICompatProvider:
     model_id: str
+    strict_tool_arguments = False
+    require_complete_stream = False
+    valid_finish_reasons: frozenset[str] | None = None
 
     def __init__(
         self,
@@ -175,18 +208,12 @@ class OpenAICompatProvider:
         self.model_id = model
         self.base_url = base_url.rstrip("/")
 
-    async def astream(
+    def _request_body(
         self,
         *,
         messages: list[dict[str, Any]],
-        tools: list[dict[str, Any]] | None = None,
-    ) -> AsyncIterator[StreamChunk]:
-        import httpx
-
-        headers = {
-            "authorization": f"Bearer {self.api_key}",
-            "content-type": "application/json",
-        }
+        tools: list[dict[str, Any]] | None,
+    ) -> dict[str, Any]:
         body: dict[str, Any] = {
             "model": self.model_id,
             "stream": True,
@@ -195,7 +222,58 @@ class OpenAICompatProvider:
         if tools:
             body["tools"] = tools
             body["tool_choice"] = "auto"
+        return body
+
+    def _http_error(self, status_code: int, body: str) -> RuntimeError:
+        return RuntimeError(f"openai {status_code}: {body[:400]}")
+
+    def _prepare_messages(
+        self,
+        *,
+        context_id: str | None,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+    ) -> list[dict[str, Any]]:
+        del context_id, tools
+        return messages
+
+    def _record_completed_response(
+        self,
+        *,
+        context_id: str | None,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        reasoning: str,
+        content: str,
+        calls: list[ToolCall],
+        finish_reason: str | None,
+    ) -> None:
+        del context_id, messages, tools, reasoning, content, calls, finish_reason
+
+    async def astream(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        context_id: str | None = None,
+    ) -> AsyncIterator[StreamChunk]:
+        import httpx
+
+        headers = {
+            "authorization": f"Bearer {self.api_key}",
+            "content-type": "application/json",
+        }
+        wire_messages = self._prepare_messages(
+            context_id=context_id,
+            messages=messages,
+            tools=tools,
+        )
+        body = self._request_body(messages=wire_messages, tools=tools)
         acc: dict[int, dict[str, str]] = {}
+        reasoning_parts: list[str] = []
+        answer_parts: list[str] = []
+        saw_done = False
+        terminal_reason: str | None = None
         async with httpx.AsyncClient(timeout=60.0) as client:
             async with client.stream(
                 "POST",
@@ -205,52 +283,328 @@ class OpenAICompatProvider:
             ) as resp:
                 if resp.status_code >= 400:
                     err = (await resp.aread()).decode("utf-8", errors="replace")
-                    raise RuntimeError(f"openai {resp.status_code}: {err[:400]}")
+                    raise self._http_error(resp.status_code, err)
                 async for line in resp.aiter_lines():
                     if not line.startswith("data:"):
                         continue
                     payload = line[5:].strip()
                     if payload == "[DONE]":
+                        saw_done = True
                         break
                     data = json.loads(payload)
+                    usage = _parse_usage(data.get("usage"))
+                    if usage is not None:
+                        yield StreamChunk(usage=usage)
                     choices = data.get("choices") or []
                     if not choices:
                         continue
-                    delta = choices[0].get("delta") or {}
+                    choice = choices[0]
+                    delta = choice.get("delta") or {}
+                    reasoning = delta.get("reasoning_content")
+                    if reasoning:
+                        reasoning_parts.append(str(reasoning))
+                        yield StreamChunk(transient_reasoning_delta=reasoning)
                     text = delta.get("content")
                     if text:
+                        answer_parts.append(str(text))
                         yield StreamChunk(text_delta=text)
                     for raw in delta.get("tool_calls") or []:
-                        idx = int(raw.get("index") or 0)
+                        raw_index = raw.get("index", 0)
+                        if isinstance(raw_index, bool) or not isinstance(raw_index, int):
+                            raise RuntimeError("openai stream returned invalid tool index")
+                        idx = raw_index
                         slot = acc.setdefault(idx, {"id": "", "name": "", "arguments": ""})
-                        if raw.get("id"):
-                            slot["id"] = str(raw["id"])
+                        raw_id = str(raw["id"]) if raw.get("id") else None
+                        if raw_id:
+                            if slot["id"] and slot["id"] != raw_id:
+                                raise RuntimeError(
+                                    f"openai stream changed tool call identity at index {idx}"
+                                )
+                            slot["id"] = raw_id
                         fn = raw.get("function") or {}
-                        if fn.get("name"):
-                            slot["name"] += str(fn["name"])
-                        if fn.get("arguments"):
-                            slot["arguments"] += str(fn["arguments"])
-        calls = [_parse_tool_slot(slot) for slot in acc.values() if slot.get("name")]
+                        name_delta = str(fn["name"]) if fn.get("name") else None
+                        arguments_delta = (
+                            str(fn["arguments"])
+                            if fn.get("arguments") is not None
+                            else None
+                        )
+                        if name_delta:
+                            slot["name"] += name_delta
+                        if arguments_delta:
+                            slot["arguments"] += arguments_delta
+                        yield StreamChunk(
+                            tool_call_deltas=[
+                                ToolCallDelta(
+                                    index=idx,
+                                    id=raw_id,
+                                    name_delta=name_delta,
+                                    arguments_delta=arguments_delta,
+                                )
+                            ]
+                        )
+                    finish_reason = choice.get("finish_reason")
+                    if finish_reason:
+                        reason = str(finish_reason)
+                        if (
+                            self.valid_finish_reasons is not None
+                            and reason not in self.valid_finish_reasons
+                        ):
+                            raise RuntimeError(
+                                f"openai stream returned unknown finish reason: {reason}"
+                            )
+                        if terminal_reason is not None and terminal_reason != reason:
+                            raise RuntimeError("openai stream returned conflicting finish reasons")
+                        terminal_reason = reason
+                        yield StreamChunk(finish_reason=reason)
+        if self.require_complete_stream and not saw_done:
+            raise RuntimeError("deepseek stream ended before data: [DONE]")
+        if self.require_complete_stream and terminal_reason is None:
+            raise RuntimeError("deepseek stream ended without a terminal reason")
+        if (
+            self.require_complete_stream
+            and acc
+            and terminal_reason != "tool_calls"
+        ):
+            raise RuntimeError(
+                f"deepseek stream ended tool assembly with {terminal_reason or 'no'} finish reason"
+            )
+        calls = []
+        seen_call_ids: set[str] = set()
+        for index in sorted(acc):
+            slot = acc[index]
+            if not slot.get("name") and not self.strict_tool_arguments:
+                continue
+            call = _parse_tool_slot(slot, strict=self.strict_tool_arguments)
+            if self.strict_tool_arguments and call.id in seen_call_ids:
+                raise RuntimeError(f"openai stream repeated tool call id: {call.id}")
+            seen_call_ids.add(call.id)
+            calls.append(call)
+        self._record_completed_response(
+            context_id=context_id,
+            messages=messages,
+            tools=tools,
+            reasoning="".join(reasoning_parts),
+            content="".join(answer_parts),
+            calls=calls,
+            finish_reason=terminal_reason,
+        )
         if calls:
             yield StreamChunk(tool_calls=calls)
 
 
-def _parse_tool_slot(slot: dict[str, str]) -> ToolCall:
+class DeepSeekProvider(OpenAICompatProvider):
+    """DeepSeek's OpenAI-compatible endpoint with provider-specific semantics."""
+
+    strict_tool_arguments = True
+    require_complete_stream = True
+    valid_finish_reasons = frozenset(
+        {
+            "stop",
+            "tool_calls",
+            "length",
+            "content_filter",
+            "insufficient_system_resource",
+        }
+    )
+    uses_transient_context = True
+    _MAX_CONTEXTS = 128
+    _MAX_RESPONSES_PER_CONTEXT = 256
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str,
+        base_url: str = "https://api.deepseek.com",
+    ):
+        super().__init__(api_key=api_key, model=model, base_url=base_url)
+        self._transient_reasoning: OrderedDict[
+            str, OrderedDict[str, str]
+        ] = OrderedDict()
+
+    def _http_error(self, status_code: int, body: str) -> RuntimeError:
+        del body
+        return RuntimeError(
+            f"deepseek provider request failed with HTTP {status_code}"
+        )
+
+    def _prepare_messages(
+        self,
+        *,
+        context_id: str | None,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+    ) -> list[dict[str, Any]]:
+        if tools and not context_id:
+            raise RuntimeError("deepseek tool requests require a transient context id")
+        prepared: list[dict[str, Any]] = []
+        cache = self._context_cache(context_id, create=False) if context_id else None
+        for original in messages:
+            message = deepcopy(original)
+            if message.get("role") == "assistant":
+                if message.get("tool_calls") and message.get("content") is None:
+                    message["content"] = ""
+                if tools and "reasoning_content" not in message:
+                    key = _continuity_key(prepared, message)
+                    reasoning = cache.get(key) if cache is not None else None
+                    if reasoning is None:
+                        raise RuntimeError(
+                            "deepseek transient reasoning is unavailable for continuation"
+                        )
+                    message["reasoning_content"] = reasoning
+            prepared.append(message)
+        return prepared
+
+    def _record_completed_response(
+        self,
+        *,
+        context_id: str | None,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        reasoning: str,
+        content: str,
+        calls: list[ToolCall],
+        finish_reason: str | None,
+    ) -> None:
+        if not tools or not context_id or finish_reason not in {"stop", "tool_calls"}:
+            return
+        assistant: dict[str, Any] = {
+            "role": "assistant",
+            "content": content,
+        }
+        if calls:
+            assistant["tool_calls"] = [
+                {
+                    "id": call.id,
+                    "type": "function",
+                    "function": {
+                        "name": call.name,
+                        "arguments": json.dumps(call.arguments),
+                    },
+                }
+                for call in calls
+            ]
+        cache = self._context_cache(context_id, create=True)
+        assert cache is not None
+        key = _continuity_key(messages, assistant)
+        cache[key] = reasoning
+        cache.move_to_end(key)
+        while len(cache) > self._MAX_RESPONSES_PER_CONTEXT:
+            cache.popitem(last=False)
+
+    def _context_cache(
+        self, context_id: str | None, *, create: bool
+    ) -> OrderedDict[str, str] | None:
+        if context_id is None:
+            return None
+        cache = self._transient_reasoning.get(context_id)
+        if cache is None and create:
+            cache = OrderedDict()
+            self._transient_reasoning[context_id] = cache
+        if cache is not None:
+            self._transient_reasoning.move_to_end(context_id)
+        while len(self._transient_reasoning) > self._MAX_CONTEXTS:
+            self._transient_reasoning.popitem(last=False)
+        return cache
+
+    def _request_body(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "model": self.model_id,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            "thinking": {"type": "enabled"},
+            "reasoning_effort": "high",
+            "messages": messages,
+        }
+        if tools:
+            body["tools"] = tools
+        return body
+
+
+def _continuity_key(
+    messages: list[dict[str, Any]], assistant: dict[str, Any]
+) -> str:
+    def durable_shape(message: dict[str, Any]) -> dict[str, Any]:
+        shaped = deepcopy(message)
+        shaped.pop("reasoning_content", None)
+        shaped.pop("message_id", None)
+        if (
+            shaped.get("role") == "assistant"
+            and shaped.get("tool_calls")
+            and shaped.get("content") is None
+        ):
+            shaped["content"] = ""
+        return shaped
+
+    canonical = [
+        durable_shape(message)
+        for message in messages
+        if message.get("role") != "system"
+    ]
+    canonical.append(durable_shape(assistant))
+    encoded = json.dumps(
+        canonical,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return sha256(encoded).hexdigest()
+
+
+def _parse_usage(raw: Any) -> ModelUsage | None:
+    if not isinstance(raw, dict):
+        return None
+
+    def token_count(name: str, source: dict[str, Any] = raw) -> int:
+        value = source.get(name, 0)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise RuntimeError(f"openai stream returned invalid usage field: {name}")
+        return value
+
+    details = raw.get("completion_tokens_details")
+    if not isinstance(details, dict):
+        details = {}
+    return ModelUsage(
+        input_tokens=token_count("prompt_tokens"),
+        output_tokens=token_count("completion_tokens"),
+        total_tokens=token_count("total_tokens"),
+        cached_input_tokens=token_count("prompt_cache_hit_tokens"),
+        uncached_input_tokens=token_count("prompt_cache_miss_tokens"),
+        reasoning_tokens=token_count("reasoning_tokens", details),
+    )
+
+
+def _parse_tool_slot(slot: dict[str, str], *, strict: bool = False) -> ToolCall:
+    call_id = slot.get("id") or ""
+    name = slot.get("name") or ""
+    if strict and not call_id:
+        raise RuntimeError("openai stream returned tool call without an id")
+    if strict and not name:
+        raise RuntimeError("openai stream returned tool call without a name")
     raw_args = slot.get("arguments") or "{}"
     try:
         parsed = json.loads(raw_args)
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as exc:
+        if strict:
+            raise RuntimeError("openai stream returned invalid JSON tool arguments") from exc
         parsed = {}
     if not isinstance(parsed, dict):
+        if strict:
+            raise RuntimeError("openai stream returned non-object tool arguments")
         parsed = {}
-    return ToolCall(id=slot.get("id") or "call_0", name=slot["name"], arguments=parsed)
+    return ToolCall(id=call_id or "call_0", name=name, arguments=parsed)
 
 
 def provider_from_env() -> Optional[StreamProvider]:
     """DeepSeek V4 Pro first, Kimi K3 second. Other keys are last-resort."""
     override = _env("CLUB_MODEL")
     if _deepseek_key():
-        return OpenAICompatProvider(
+        return DeepSeekProvider(
             api_key=_deepseek_key(),
             model=override or DEEPSEEK_MODEL,
             base_url=_env("DEEPSEEK_BASE_URL") or DEEPSEEK_BASE,

--- a/desktop/coworker/provider.py
+++ b/desktop/coworker/provider.py
@@ -533,12 +533,17 @@ def _continuity_key(
         shaped = deepcopy(message)
         shaped.pop("reasoning_content", None)
         shaped.pop("message_id", None)
-        if (
-            shaped.get("role") == "assistant"
-            and shaped.get("tool_calls")
-            and shaped.get("content") is None
-        ):
-            shaped["content"] = ""
+        if shaped.get("role") == "assistant":
+            if shaped.get("tool_calls") and shaped.get("content") is None:
+                shaped["content"] = ""
+            for call in shaped.get("tool_calls") or []:
+                if not isinstance(call, dict):
+                    continue
+                function = call.get("function")
+                if isinstance(function, dict):
+                    function.pop("arguments", None)
+        if shaped.get("role") == "tool":
+            shaped.pop("content", None)
         return shaped
 
     canonical = [

--- a/desktop/coworker/turn.py
+++ b/desktop/coworker/turn.py
@@ -630,9 +630,13 @@ async def run_turn(
                 {k: v for k, v in message.items() if k != "message_id"}
                 for message in history
             ]
-            async for chunk in provider.astream(
-                messages=model_messages, tools=openai_tools
-            ):
+            stream_kwargs: dict[str, Any] = {
+                "messages": model_messages,
+                "tools": openai_tools,
+            }
+            if getattr(provider, "uses_transient_context", False):
+                stream_kwargs["context_id"] = sid
+            async for chunk in provider.astream(**stream_kwargs):
                 if control is not None and control.cancel_requested.is_set():
                     return await _stopped(history, "".join(chunks) or last_text)
                 if chunk.text_delta:

--- a/desktop/tests/test_provider.py
+++ b/desktop/tests/test_provider.py
@@ -14,8 +14,10 @@ from coworker.provider import (
     provider_from_env,
 )
 from coworker.inbox import Inbox
+from coworker.permissions import Decision
 from coworker.store import ConversationStore
 from coworker.turn import run_turn
+from coworker.workspace_runtime import WorkspaceRuntime
 
 
 def _sse(*payloads):
@@ -852,6 +854,324 @@ def test_turn_binds_deepseek_transient_context_without_persisting_reasoning(
     )
     assert private_reasoning not in durable
     assert "second private step" not in durable
+    assert "reasoning_content" not in durable
+
+
+def test_turn_continues_after_workspace_read_without_persisting_reasoning(
+    tmp_path, monkeypatch
+):
+    private_first = "PRIVATE_FS_READ_REASONING"
+    private_final = "PRIVATE_FS_FINAL_REASONING"
+    private_follow = "PRIVATE_FS_FOLLOW_REASONING"
+    file_body = "SECRET_FILE_BODY"
+    requests = []
+
+    async def handler(request):
+        requests.append(json.loads(request.content))
+        if len(requests) == 1:
+            return httpx.Response(
+                200,
+                text=_sse(
+                    {
+                        "choices": [
+                            {
+                                "delta": {"reasoning_content": private_first},
+                                "finish_reason": None,
+                            }
+                        ]
+                    },
+                    {
+                        "choices": [
+                            {
+                                "delta": {
+                                    "tool_calls": [
+                                        {
+                                            "index": 0,
+                                            "id": "call_read",
+                                            "function": {
+                                                "name": "fs_read",
+                                                "arguments": (
+                                                    '{"grant_id":"g1","path":"notes.md"}'
+                                                ),
+                                            },
+                                        }
+                                    ]
+                                },
+                                "finish_reason": None,
+                            }
+                        ]
+                    },
+                    {
+                        "choices": [
+                            {"delta": {}, "finish_reason": "tool_calls"}
+                        ]
+                    },
+                ),
+            )
+        if len(requests) == 2:
+            return httpx.Response(
+                200,
+                text=_sse(
+                    {
+                        "choices": [
+                            {
+                                "delta": {"reasoning_content": private_final},
+                                "finish_reason": None,
+                            }
+                        ]
+                    },
+                    {
+                        "choices": [
+                            {
+                                "delta": {"content": "I read the notes."},
+                                "finish_reason": None,
+                            }
+                        ]
+                    },
+                    {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+                ),
+            )
+        return httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "choices": [
+                        {
+                            "delta": {"reasoning_content": private_follow},
+                            "finish_reason": None,
+                        }
+                    ]
+                },
+                {
+                    "choices": [
+                        {
+                            "delta": {"content": "The notes are ready."},
+                            "finish_reason": None,
+                        }
+                    ]
+                },
+                {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+            ),
+        )
+
+    real_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: real_client(transport=transport, **kwargs),
+    )
+    monkeypatch.setattr(
+        "coworker.turn.decide",
+        lambda *args, **kwargs: Decision(True, False, "auto"),
+    )
+    monkeypatch.setattr(
+        "coworker.turn.execute",
+        lambda name, arguments, **kwargs: (
+            True,
+            {"content": file_body, "path": "notes.md", "truncated": False},
+        ),
+    )
+    provider = DeepSeekProvider(api_key="secret", model=DEEPSEEK_MODEL)
+    store = ConversationStore(tmp_path)
+    sid = "workspace-read-session"
+    store.create_session(sid)
+
+    first = asyncio.run(
+        run_turn(
+            text="read notes.md",
+            sid=sid,
+            store=store,
+            provider=provider,
+            persona=None,
+            skills=None,
+            inbox=Inbox(store),
+            openai_tools=[
+                {"type": "function", "function": {"name": "fs_read"}}
+            ],
+            execute_kwargs={"workspace_runtime": WorkspaceRuntime(tmp_path)},
+        )
+    )
+    follow = asyncio.run(
+        run_turn(
+            text="summarize them",
+            sid=sid,
+            store=store,
+            provider=provider,
+            persona=None,
+            skills=None,
+            inbox=Inbox(store),
+            openai_tools=[
+                {"type": "function", "function": {"name": "fs_read"}}
+            ],
+            execute_kwargs={"workspace_runtime": WorkspaceRuntime(tmp_path)},
+        )
+    )
+
+    assert first == {"status": "ok", "text": "I read the notes."}
+    assert follow == {"status": "ok", "text": "The notes are ready."}
+    assert len(requests) == 3
+    follow_messages = requests[2]["messages"]
+    assert follow_messages[2]["reasoning_content"] == private_first
+    assert follow_messages[4]["reasoning_content"] == private_final
+    durable = json.dumps(
+        {"messages": store.load(sid), "events": store.load_events(sid)}
+    )
+    assert file_body not in durable
+    assert private_first not in durable
+    assert private_final not in durable
+    assert private_follow not in durable
+    assert "reasoning_content" not in durable
+
+
+def test_turn_continues_after_workspace_shell_without_persisting_reasoning(
+    tmp_path, monkeypatch
+):
+    private_first = "PRIVATE_SHELL_REASONING"
+    private_final = "PRIVATE_SHELL_FINAL_REASONING"
+    private_follow = "PRIVATE_SHELL_FOLLOW_REASONING"
+    command_output = "SECRET_SHELL_OUTPUT"
+    requests = []
+
+    async def handler(request):
+        requests.append(json.loads(request.content))
+        if len(requests) == 1:
+            return httpx.Response(
+                200,
+                text=_sse(
+                    {
+                        "choices": [
+                            {
+                                "delta": {"reasoning_content": private_first},
+                                "finish_reason": None,
+                            }
+                        ]
+                    },
+                    {
+                        "choices": [
+                            {
+                                "delta": {
+                                    "tool_calls": [
+                                        {
+                                            "index": 0,
+                                            "id": "call_shell",
+                                            "function": {
+                                                "name": "shell_exec",
+                                                "arguments": (
+                                                    '{"grant_id":"g1","command":"echo hi","cwd":"."}'
+                                                ),
+                                            },
+                                        }
+                                    ]
+                                },
+                                "finish_reason": None,
+                            }
+                        ]
+                    },
+                    {
+                        "choices": [
+                            {"delta": {}, "finish_reason": "tool_calls"}
+                        ]
+                    },
+                ),
+            )
+        if len(requests) == 2:
+            return httpx.Response(
+                200,
+                text=_sse(
+                    {
+                        "choices": [
+                            {
+                                "delta": {"reasoning_content": private_final},
+                                "finish_reason": None,
+                            }
+                        ]
+                    },
+                    {
+                        "choices": [
+                            {
+                                "delta": {"content": "The command finished."},
+                                "finish_reason": None,
+                            }
+                        ]
+                    },
+                    {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+                ),
+            )
+        return httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "choices": [
+                        {
+                            "delta": {"reasoning_content": private_follow},
+                            "finish_reason": None,
+                        }
+                    ]
+                },
+                {
+                    "choices": [
+                        {
+                            "delta": {"content": "Ready for the next step."},
+                            "finish_reason": None,
+                        }
+                    ]
+                },
+                {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+            ),
+        )
+
+    real_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: real_client(transport=transport, **kwargs),
+    )
+    monkeypatch.setattr(
+        "coworker.turn.decide",
+        lambda *args, **kwargs: Decision(True, False, "auto"),
+    )
+    monkeypatch.setattr(
+        "coworker.turn.execute",
+        lambda name, arguments, **kwargs: (
+            True,
+            {"output": command_output, "exit_code": 0},
+        ),
+    )
+    provider = DeepSeekProvider(api_key="secret", model=DEEPSEEK_MODEL)
+    store = ConversationStore(tmp_path)
+    sid = "workspace-shell-session"
+    store.create_session(sid)
+    tools = [{"type": "function", "function": {"name": "shell_exec"}}]
+    kwargs = {
+        "sid": sid,
+        "store": store,
+        "provider": provider,
+        "persona": None,
+        "skills": None,
+        "inbox": Inbox(store),
+        "openai_tools": tools,
+        "execute_kwargs": {"workspace_runtime": WorkspaceRuntime(tmp_path)},
+    }
+
+    first = asyncio.run(run_turn(text="echo hi", **kwargs))
+    follow = asyncio.run(run_turn(text="what next?", **kwargs))
+
+    assert first == {"status": "ok", "text": "The command finished."}
+    assert follow == {"status": "ok", "text": "Ready for the next step."}
+    assert len(requests) == 3
+    follow_messages = requests[2]["messages"]
+    assert follow_messages[2]["reasoning_content"] == private_first
+    assert follow_messages[4]["reasoning_content"] == private_final
+    durable = json.dumps(
+        {"messages": store.load(sid), "events": store.load_events(sid)}
+    )
+    assert command_output not in durable
+    assert "[COMMAND REDACTED]" in durable
+    assert private_first not in durable
+    assert private_final not in durable
+    assert private_follow not in durable
     assert "reasoning_content" not in durable
 
 

--- a/desktop/tests/test_provider.py
+++ b/desktop/tests/test_provider.py
@@ -1,10 +1,25 @@
+import asyncio
+import copy
+import json
+
+import httpx
+import pytest
+
 from coworker.provider import (
     DEEPSEEK_MODEL,
     KIMI_MODEL,
+    DeepSeekProvider,
     OpenAICompatProvider,
     default_model_id,
     provider_from_env,
 )
+from coworker.inbox import Inbox
+from coworker.store import ConversationStore
+from coworker.turn import run_turn
+
+
+def _sse(*payloads):
+    return "".join(f"data: {json.dumps(payload)}\n\n" for payload in payloads) + "data: [DONE]\n\n"
 
 
 def test_deepseek_wins_over_kimi(monkeypatch):
@@ -13,6 +28,7 @@ def test_deepseek_wins_over_kimi(monkeypatch):
     monkeypatch.delenv("CLUB_MODEL", raising=False)
     p = provider_from_env()
     assert isinstance(p, OpenAICompatProvider)
+    assert type(p).__name__ == "DeepSeekProvider"
     assert p.model_id == DEEPSEEK_MODEL
     assert p.base_url == "https://api.deepseek.com"
     assert p.api_key == "ds-key"
@@ -35,6 +51,991 @@ def test_club_model_override(monkeypatch):
     p = provider_from_env()
     assert p is not None
     assert p.model_id == "deepseek-v4-flash"
+
+
+def test_deepseek_explicitly_enables_thinking_and_usage_without_tool_choice(monkeypatch):
+    requests = []
+
+    async def handler(request):
+        requests.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            text=_sse(
+                {"choices": [{"delta": {}, "finish_reason": "stop"}]}
+            ),
+        )
+
+    real_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: real_client(transport=transport, **kwargs),
+    )
+    provider = DeepSeekProvider(api_key="secret", model=DEEPSEEK_MODEL)
+
+    async def consume():
+        return [
+            chunk
+            async for chunk in provider.astream(
+                context_id="request-shape",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[{"type": "function", "function": {"name": "now"}}],
+            )
+        ]
+
+    asyncio.run(consume())
+
+    assert requests == [
+        {
+            "model": DEEPSEEK_MODEL,
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            "thinking": {"type": "enabled"},
+            "reasoning_effort": "high",
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "function", "function": {"name": "now"}}],
+        }
+    ]
+
+
+def test_deepseek_stream_distinguishes_transient_reasoning_from_answer(monkeypatch):
+    async def handler(request):
+        return httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "choices": [
+                        {
+                            "delta": {"reasoning_content": "private analysis"},
+                            "finish_reason": None,
+                        }
+                    ]
+                },
+                {
+                    "choices": [
+                        {
+                            "delta": {"content": "Visible answer"},
+                            "finish_reason": None,
+                        }
+                    ]
+                },
+                {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+            ),
+        )
+
+    real_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: real_client(transport=transport, **kwargs),
+    )
+    provider = DeepSeekProvider(api_key="secret", model=DEEPSEEK_MODEL)
+
+    async def consume():
+        return [
+            chunk
+            async for chunk in provider.astream(
+                messages=[{"role": "user", "content": "hi"}]
+            )
+        ]
+
+    chunks = asyncio.run(consume())
+
+    assert [
+        (chunk.transient_reasoning_delta, chunk.text_delta)
+        for chunk in chunks
+        if chunk.finish_reason is None
+    ] == [
+        ("private analysis", None),
+        (None, "Visible answer"),
+    ]
+
+
+def test_deepseek_stream_emits_terminal_reason_and_content_free_usage(monkeypatch):
+    async def handler(request):
+        return httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "choices": [
+                        {
+                            "delta": {"content": "done"},
+                            "finish_reason": "stop",
+                        }
+                    ]
+                },
+                {
+                    "choices": [],
+                    "usage": {
+                        "prompt_tokens": 11,
+                        "completion_tokens": 7,
+                        "total_tokens": 18,
+                        "prompt_cache_hit_tokens": 4,
+                        "prompt_cache_miss_tokens": 7,
+                        "completion_tokens_details": {"reasoning_tokens": 3},
+                        "unexpected_response_content": "must not escape",
+                    },
+                },
+            ),
+        )
+
+    real_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: real_client(transport=transport, **kwargs),
+    )
+    provider = DeepSeekProvider(api_key="secret", model=DEEPSEEK_MODEL)
+
+    async def consume():
+        return [
+            chunk
+            async for chunk in provider.astream(
+                messages=[{"role": "user", "content": "hi"}]
+            )
+        ]
+
+    chunks = asyncio.run(consume())
+
+    assert chunks[-2].finish_reason == "stop"
+    assert vars(chunks[-1].usage) == {
+        "input_tokens": 11,
+        "output_tokens": 7,
+        "total_tokens": 18,
+        "cached_input_tokens": 4,
+        "uncached_input_tokens": 7,
+        "reasoning_tokens": 3,
+    }
+    assert "unexpected_response_content" not in repr(chunks[-1].usage)
+
+
+def test_deepseek_stream_assembles_interleaved_tool_deltas_by_call_identity(monkeypatch):
+    async def handler(request):
+        return httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "choices": [
+                        {
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 1,
+                                        "id": "call_search",
+                                        "function": {
+                                            "name": "sea",
+                                            "arguments": '{"query":',
+                                        },
+                                    }
+                                ]
+                            },
+                            "finish_reason": None,
+                        }
+                    ]
+                },
+                {
+                    "choices": [
+                        {
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "call_now",
+                                        "function": {
+                                            "name": "now",
+                                            "arguments": "{}",
+                                        },
+                                    },
+                                    {
+                                        "index": 1,
+                                        "function": {
+                                            "name": "rch",
+                                            "arguments": '"founder"}',
+                                        },
+                                    },
+                                ]
+                            },
+                            "finish_reason": None,
+                        }
+                    ]
+                },
+                {
+                    "choices": [
+                        {
+                            "delta": {},
+                            "finish_reason": "tool_calls",
+                        }
+                    ]
+                },
+            ),
+        )
+
+    real_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: real_client(transport=transport, **kwargs),
+    )
+    provider = DeepSeekProvider(api_key="secret", model=DEEPSEEK_MODEL)
+
+    async def consume():
+        return [
+            chunk
+            async for chunk in provider.astream(
+                context_id="multi-tool",
+                messages=[{"role": "user", "content": "use tools"}],
+                tools=[{"type": "function", "function": {"name": "now"}}],
+            )
+        ]
+
+    chunks = asyncio.run(consume())
+    deltas = [
+        delta
+        for chunk in chunks
+        for delta in (chunk.tool_call_deltas or [])
+    ]
+    completed = [call for chunk in chunks for call in (chunk.tool_calls or [])]
+
+    assert [(delta.index, delta.id) for delta in deltas] == [
+        (1, "call_search"),
+        (0, "call_now"),
+        (1, None),
+    ]
+    assert [(call.id, call.name, call.arguments) for call in completed] == [
+        ("call_now", "now", {}),
+        ("call_search", "search", {"query": "founder"}),
+    ]
+
+
+def test_deepseek_rejects_malformed_streamed_tool_arguments(monkeypatch):
+    async def handler(request):
+        return httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "choices": [
+                        {
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "call_bad",
+                                        "function": {
+                                            "name": "search",
+                                            "arguments": '{"query":',
+                                        },
+                                    }
+                                ]
+                            },
+                            "finish_reason": None,
+                        }
+                    ]
+                },
+                {
+                    "choices": [
+                        {"delta": {}, "finish_reason": "tool_calls"}
+                    ]
+                },
+            ),
+        )
+
+    real_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: real_client(transport=transport, **kwargs),
+    )
+    provider = DeepSeekProvider(api_key="secret", model=DEEPSEEK_MODEL)
+    emitted = []
+
+    async def consume():
+        async for chunk in provider.astream(
+            context_id="malformed",
+            messages=[{"role": "user", "content": "use a tool"}],
+            tools=[{"type": "function", "function": {"name": "search"}}],
+        ):
+            emitted.append(chunk)
+
+    with pytest.raises(RuntimeError, match="invalid JSON tool arguments"):
+        asyncio.run(consume())
+
+    assert not [chunk for chunk in emitted if chunk.tool_calls]
+
+
+def test_deepseek_rejects_truncated_stream_before_releasing_tool_calls(monkeypatch):
+    partial = {
+        "choices": [
+            {
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call_partial",
+                            "function": {"name": "now", "arguments": "{}"},
+                        }
+                    ]
+                },
+                "finish_reason": None,
+            }
+        ]
+    }
+
+    async def handler(request):
+        return httpx.Response(
+            200,
+            text=f"data: {json.dumps(partial)}\n\n",
+        )
+
+    real_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: real_client(transport=transport, **kwargs),
+    )
+    provider = DeepSeekProvider(api_key="secret", model=DEEPSEEK_MODEL)
+    emitted = []
+
+    async def consume():
+        async for chunk in provider.astream(
+            context_id="truncated",
+            messages=[{"role": "user", "content": "use a tool"}],
+            tools=[{"type": "function", "function": {"name": "now"}}],
+        ):
+            emitted.append(chunk)
+
+    with pytest.raises(RuntimeError, match="ended before.*DONE"):
+        asyncio.run(consume())
+
+    assert not [chunk for chunk in emitted if chunk.tool_calls]
+
+
+def test_deepseek_length_terminal_never_releases_partial_tool_calls(monkeypatch):
+    async def handler(request):
+        return httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "choices": [
+                        {
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "call_cut_off",
+                                        "function": {
+                                            "name": "search",
+                                            "arguments": '{"query":"founder"}',
+                                        },
+                                    }
+                                ]
+                            },
+                            "finish_reason": None,
+                        }
+                    ]
+                },
+                {
+                    "choices": [
+                        {"delta": {}, "finish_reason": "length"}
+                    ]
+                },
+            ),
+        )
+
+    real_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: real_client(transport=transport, **kwargs),
+    )
+    provider = DeepSeekProvider(api_key="secret", model=DEEPSEEK_MODEL)
+    emitted = []
+
+    async def consume():
+        async for chunk in provider.astream(
+            context_id="length",
+            messages=[{"role": "user", "content": "use a tool"}],
+            tools=[{"type": "function", "function": {"name": "search"}}],
+        ):
+            emitted.append(chunk)
+
+    with pytest.raises(RuntimeError, match="tool assembly.*length"):
+        asyncio.run(consume())
+
+    assert not [chunk for chunk in emitted if chunk.tool_calls]
+
+
+def test_deepseek_provider_error_is_truthful_bounded_and_content_free(monkeypatch):
+    private_body = "PRIVATE_REASONING " + ("x" * 1000)
+
+    async def handler(request):
+        return httpx.Response(429, text=private_body)
+
+    real_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: real_client(transport=transport, **kwargs),
+    )
+    provider = DeepSeekProvider(api_key="secret", model=DEEPSEEK_MODEL)
+
+    async def consume():
+        return [
+            chunk
+            async for chunk in provider.astream(
+                messages=[{"role": "user", "content": "hi"}]
+            )
+        ]
+
+    with pytest.raises(RuntimeError) as captured:
+        asyncio.run(consume())
+
+    assert str(captured.value) == "deepseek provider request failed with HTTP 429"
+    assert private_body not in str(captured.value)
+
+
+def test_deepseek_replays_transient_reasoning_for_next_tool_round_without_mutation(
+    monkeypatch,
+):
+    requests = []
+
+    async def handler(request):
+        requests.append(json.loads(request.content))
+        if len(requests) == 1:
+            return httpx.Response(
+                200,
+                text=_sse(
+                    {
+                        "choices": [
+                            {
+                                "delta": {"reasoning_content": "private round one"},
+                                "finish_reason": None,
+                            }
+                        ]
+                    },
+                    {
+                        "choices": [
+                            {
+                                "delta": {
+                                    "tool_calls": [
+                                        {
+                                            "index": 0,
+                                            "id": "call_search",
+                                            "function": {
+                                                "name": "search",
+                                                "arguments": '{"query":"founder"}',
+                                            },
+                                        }
+                                    ]
+                                },
+                                "finish_reason": None,
+                            }
+                        ]
+                    },
+                    {
+                        "choices": [
+                            {"delta": {}, "finish_reason": "tool_calls"}
+                        ]
+                    },
+                ),
+            )
+        return httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "choices": [
+                        {
+                            "delta": {"reasoning_content": "private round two"},
+                            "finish_reason": None,
+                        }
+                    ]
+                },
+                {
+                    "choices": [
+                        {"delta": {"content": "done"}, "finish_reason": None}
+                    ]
+                },
+                {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+            ),
+        )
+
+    real_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: real_client(transport=transport, **kwargs),
+    )
+    provider = DeepSeekProvider(api_key="secret", model=DEEPSEEK_MODEL)
+    first_messages = [{"role": "user", "content": "find a founder"}]
+
+    async def scenario():
+        first_chunks = [
+            chunk
+            async for chunk in provider.astream(
+                context_id="session-a",
+                messages=first_messages,
+                tools=[{"type": "function", "function": {"name": "search"}}],
+            )
+        ]
+        call = next(
+            call
+            for chunk in first_chunks
+            for call in (chunk.tool_calls or [])
+        )
+        continuation = [
+            *first_messages,
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": call.id,
+                        "type": "function",
+                        "function": {
+                            "name": call.name,
+                            "arguments": json.dumps(call.arguments),
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": call.id,
+                "content": '{"result":"Ada"}',
+            },
+        ]
+        durable_before = copy.deepcopy(continuation)
+        _ = [
+            chunk
+            async for chunk in provider.astream(
+                context_id="session-a",
+                messages=continuation,
+                tools=[{"type": "function", "function": {"name": "search"}}],
+            )
+        ]
+        return continuation, durable_before
+
+    continuation, durable_before = asyncio.run(scenario())
+    replayed_assistant = requests[1]["messages"][1]
+
+    assert replayed_assistant["reasoning_content"] == "private round one"
+    assert replayed_assistant["content"] == ""
+    assert continuation == durable_before
+    assert "reasoning_content" not in continuation[1]
+
+
+def test_deepseek_continuity_survives_a_system_prompt_refresh(monkeypatch):
+    requests = []
+
+    async def handler(request):
+        requests.append(json.loads(request.content))
+        if len(requests) == 1:
+            return httpx.Response(
+                200,
+                text=_sse(
+                    {
+                        "choices": [
+                            {
+                                "delta": {"reasoning_content": "private"},
+                                "finish_reason": None,
+                            }
+                        ]
+                    },
+                    {
+                        "choices": [
+                            {
+                                "delta": {
+                                    "tool_calls": [
+                                        {
+                                            "index": 0,
+                                            "id": "call_memory",
+                                            "function": {
+                                                "name": "remember",
+                                                "arguments": "{}",
+                                            },
+                                        }
+                                    ]
+                                },
+                                "finish_reason": None,
+                            }
+                        ]
+                    },
+                    {
+                        "choices": [
+                            {"delta": {}, "finish_reason": "tool_calls"}
+                        ]
+                    },
+                ),
+            )
+        return httpx.Response(
+            200,
+            text=_sse(
+                {"choices": [{"delta": {}, "finish_reason": "stop"}]}
+            ),
+        )
+
+    real_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: real_client(transport=transport, **kwargs),
+    )
+    provider = DeepSeekProvider(api_key="secret", model=DEEPSEEK_MODEL)
+    tools = [{"type": "function", "function": {"name": "remember"}}]
+    initial = [
+        {"role": "system", "content": "memory before tool"},
+        {"role": "user", "content": "remember this"},
+    ]
+
+    async def scenario():
+        chunks = [
+            chunk
+            async for chunk in provider.astream(
+                context_id="system-refresh",
+                messages=initial,
+                tools=tools,
+            )
+        ]
+        call = next(
+            call for chunk in chunks for call in (chunk.tool_calls or [])
+        )
+        continuation = [
+            {"role": "system", "content": "memory after tool"},
+            initial[1],
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": call.id,
+                        "type": "function",
+                        "function": {
+                            "name": call.name,
+                            "arguments": json.dumps(call.arguments),
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": call.id, "content": "{}"},
+        ]
+        return [
+            chunk
+            async for chunk in provider.astream(
+                context_id="system-refresh",
+                messages=continuation,
+                tools=tools,
+            )
+        ]
+
+    asyncio.run(scenario())
+
+    assert requests[1]["messages"][2]["reasoning_content"] == "private"
+
+
+def test_turn_binds_deepseek_transient_context_without_persisting_reasoning(
+    tmp_path, monkeypatch
+):
+    private_reasoning = "PRIVATE_TRANSIENT_REASONING"
+    requests = []
+
+    async def handler(request):
+        requests.append(json.loads(request.content))
+        if len(requests) == 1:
+            return httpx.Response(
+                200,
+                text=_sse(
+                    {
+                        "choices": [
+                            {
+                                "delta": {"reasoning_content": private_reasoning},
+                                "finish_reason": None,
+                            }
+                        ]
+                    },
+                    {
+                        "choices": [
+                            {
+                                "delta": {
+                                    "tool_calls": [
+                                        {
+                                            "index": 0,
+                                            "id": "call_now",
+                                            "function": {
+                                                "name": "now",
+                                                "arguments": "{}",
+                                            },
+                                        }
+                                    ]
+                                },
+                                "finish_reason": None,
+                            }
+                        ]
+                    },
+                    {
+                        "choices": [
+                            {"delta": {}, "finish_reason": "tool_calls"}
+                        ]
+                    },
+                ),
+            )
+        return httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "choices": [
+                        {
+                            "delta": {"reasoning_content": "second private step"},
+                            "finish_reason": None,
+                        }
+                    ]
+                },
+                {
+                    "choices": [
+                        {"delta": {"content": "It is noon."}, "finish_reason": None}
+                    ]
+                },
+                {"choices": [{"delta": {}, "finish_reason": "stop"}]},
+            ),
+        )
+
+    real_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: real_client(transport=transport, **kwargs),
+    )
+    monkeypatch.setattr(
+        "coworker.turn.execute",
+        lambda name, arguments, **kwargs: (True, {"time": "noon"}),
+    )
+    provider = DeepSeekProvider(api_key="secret", model=DEEPSEEK_MODEL)
+    store = ConversationStore(tmp_path)
+    sid = "deepseek-session"
+    store.create_session(sid)
+    emitted = []
+
+    async def emit(event):
+        emitted.append(event)
+
+    result = asyncio.run(
+        run_turn(
+            text="what time is it?",
+            sid=sid,
+            store=store,
+            provider=provider,
+            persona=None,
+            skills=None,
+            inbox=Inbox(store),
+            openai_tools=[
+                {"type": "function", "function": {"name": "now"}}
+            ],
+            execute_kwargs={},
+            emit=emit,
+        )
+    )
+
+    assert result == {"status": "ok", "text": "It is noon."}
+    assert len(requests) == 2
+    assert requests[1]["messages"][2]["reasoning_content"] == private_reasoning
+    durable = json.dumps(
+        {"messages": store.load(sid), "events": store.load_events(sid)}
+    )
+    assert private_reasoning not in durable
+    assert "second private step" not in durable
+    assert "reasoning_content" not in durable
+
+
+def test_fresh_deepseek_provider_reports_unavailable_transient_continuation(
+    monkeypatch,
+):
+    requests = []
+
+    async def handler(request):
+        requests.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            text=_sse(
+                {"choices": [{"delta": {}, "finish_reason": "stop"}]}
+            ),
+        )
+
+    real_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: real_client(transport=transport, **kwargs),
+    )
+    restarted = DeepSeekProvider(api_key="secret", model=DEEPSEEK_MODEL)
+    durable_messages = [
+        {"role": "user", "content": "find a founder"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_before_restart",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_before_restart",
+            "content": '{"result":"Ada"}',
+        },
+    ]
+    original = copy.deepcopy(durable_messages)
+
+    async def consume():
+        return [
+            chunk
+            async for chunk in restarted.astream(
+                context_id="restored-session",
+                messages=durable_messages,
+                tools=[{"type": "function", "function": {"name": "search"}}],
+            )
+        ]
+
+    with pytest.raises(
+        RuntimeError,
+        match="transient reasoning is unavailable for continuation",
+    ):
+        asyncio.run(consume())
+
+    assert requests == []
+    assert durable_messages == original
+
+
+def test_deepseek_cancellation_propagates_closes_stream_and_discards_partial_call(
+    monkeypatch,
+):
+    tool_delta_seen = asyncio.Event()
+
+    class CancelStream(httpx.AsyncByteStream):
+        def __init__(self):
+            self.closed = False
+
+        async def __aiter__(self):
+            payload = {
+                "choices": [
+                    {
+                        "delta": {
+                            "reasoning_content": "partial private reasoning",
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_cancelled",
+                                    "function": {
+                                        "name": "search",
+                                        "arguments": "{}",
+                                    },
+                                }
+                            ],
+                        },
+                        "finish_reason": None,
+                    }
+                ]
+            }
+            yield f"data: {json.dumps(payload)}\n\n".encode()
+            await asyncio.Event().wait()
+
+        async def aclose(self):
+            self.closed = True
+
+    stream = CancelStream()
+    request_count = 0
+
+    async def handler(request):
+        nonlocal request_count
+        request_count += 1
+        if request_count == 1:
+            return httpx.Response(200, stream=stream)
+        return httpx.Response(
+            200,
+            text=_sse(
+                {"choices": [{"delta": {}, "finish_reason": "stop"}]}
+            ),
+        )
+
+    real_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: real_client(transport=transport, **kwargs),
+    )
+    provider = DeepSeekProvider(api_key="secret", model=DEEPSEEK_MODEL)
+    emitted = []
+    first_messages = [{"role": "user", "content": "find"}]
+
+    async def consume_cancelled():
+        async for chunk in provider.astream(
+            context_id="cancelled-session",
+            messages=first_messages,
+            tools=[{"type": "function", "function": {"name": "search"}}],
+        ):
+            emitted.append(chunk)
+            if chunk.tool_call_deltas:
+                tool_delta_seen.set()
+
+    async def consume_continuation():
+        continuation = [
+            *first_messages,
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_cancelled",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_cancelled",
+                "content": "{}",
+            },
+        ]
+        return [
+            chunk
+            async for chunk in provider.astream(
+                context_id="cancelled-session",
+                messages=continuation,
+                tools=[{"type": "function", "function": {"name": "search"}}],
+            )
+        ]
+
+    async def scenario():
+        task = asyncio.create_task(consume_cancelled())
+        await asyncio.wait_for(tool_delta_seen.wait(), timeout=1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        with pytest.raises(
+            RuntimeError,
+            match="transient reasoning is unavailable for continuation",
+        ):
+            await consume_continuation()
+
+    asyncio.run(scenario())
+
+    assert stream.closed is True
+    assert not [chunk for chunk in emitted if chunk.tool_calls]
+    assert request_count == 1
 
 
 def test_default_model_id_none(monkeypatch):


### PR DESCRIPTION
## Summary\n\n- add a dedicated DeepSeek provider with explicit thinking mode, high reasoning effort, and streamed usage\n- preserve provider-required reasoning continuity in bounded in-memory session state without mutating or persisting durable conversation history\n- strictly assemble tool-call deltas and reject malformed, truncated, or length-stopped partial calls before execution\n- expose typed text, transient reasoning, tool-delta, terminal-reason, and usage fields for the later conformance and telemetry work\n- keep existing providers compatible by passing session context only to providers that advertise the transient-context capability\n\n## Verification\n\n- make test-python: 477 passed, 2 skipped\n- provider and turn-focused suite: 86 passed\n- pre-existing Starlette/httpx deprecation warning remains\n\n## Review focus\n\n- raw reasoning never enters messages, events, person files, logs, approvals, or diagnostics\n- a fresh provider reports unavailable continuation before making a network request\n- cancellation closes the stream and releases neither partial tools nor fabricated continuity\n- DeepSeek thinking-mode requests omit tool_choice and normalize tool-call assistant content to a non-null string\n\nCloses #59\n\n## Follow-up\n\nIssue #80 will turn this stream vocabulary into the cross-provider conformance contract. Issue #81 will observe terminal usage without persisting transient reasoning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for streamed reasoning, tool calls, completion status, and token usage.
  * Added DeepSeek provider support, including reasoning continuity and context handling.
  * Improved tool-call assembly and validation during streaming.
* **Bug Fixes**
  * Improved handling of malformed, incomplete, cancelled, and failed provider streams.
  * Preserved reasoning across tool interactions without including it in saved conversation content.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->