### PR TITLE
feat(desktop): wire live runtime telemetry

### DIFF
--- a/desktop/coworker/server.py
+++ b/desktop/coworker/server.py
@@ -10,6 +10,7 @@ import os
 import re
 import secrets
 import threading
+import time
 import coworker.turn as turn_runtime
 from datetime import UTC, datetime
 from pathlib import Path
@@ -56,6 +57,17 @@ from coworker.skills import BUILTIN_SKILLS, SkillLoader, catalog_text
 from coworker.provider import ToolCall, provider_from_env
 from coworker.secrets import SecretStore
 from coworker.store import ConversationStore, valid_session_id
+from coworker.telemetry import (
+    AgentTurnSpan,
+    ErrorKind,
+    InMemoryTelemetryAdapter,
+    RetryEvent,
+    RetryReason,
+    TelemetryAdapter,
+    TelemetryRecorder,
+    ToolSpan,
+    TraceContext,
+)
 from coworker.tools import OPENAI_TOOLS, execute
 from coworker.workspace import GrantUnavailable
 from coworker.workspace_files import WorkspacePathError
@@ -254,6 +266,7 @@ def create_app(
     mcp: Any = None,
     browser_opener: Callable[[str], bool] | None = None,
     workspace_runtime: WorkspaceRuntime | None = None,
+    telemetry_adapter: TelemetryAdapter | None = None,
 ) -> FastAPI:
     if not token:
         raise ValueError("sidecar token must be non-empty")
@@ -261,6 +274,12 @@ def create_app(
     app = FastAPI(title="Club sidecar", version="0.0.2")
     app.state.token = token
     app.state.provider = provider_from_env() if provider is _UNSET else provider
+    app.state.telemetry_adapter = (
+        telemetry_adapter
+        if telemetry_adapter is not None
+        else InMemoryTelemetryAdapter()
+    )
+    app.state.telemetry_recorder = TelemetryRecorder(app.state.telemetry_adapter)
     root = state if state is not None else state_dir()
     app.state.store = ConversationStore(root)
     app.state.people = PersonStore(root)
@@ -344,6 +363,7 @@ def create_app(
                 emit=None,
                 wait_permission=None,
                 system_prompt_fn=system_prompt,
+                telemetry=app.state.telemetry_recorder,
             )
         )
 
@@ -430,6 +450,29 @@ def create_app(
         item: dict[str, Any], *, claimant: str
     ) -> dict[str, Any] | None:
         """Run an allow-claimed approval server-side and persist its receipt."""
+        approval_span = None
+        approval_tool_span = None
+        try:
+            approval_span = app.state.telemetry_recorder.start_span(
+                AgentTurnSpan(operation="agent.approval"),
+                TraceContext(
+                    session_id=str(item.get("session_id") or ""),
+                    run_id=str(item.get("run_id") or ""),
+                ),
+            )
+            try:
+                tool_schema = ToolSpan(
+                    tool_name=str(item.get("name") or "unknown"),
+                    operation="tool.execute",
+                )
+            except ValueError:
+                tool_schema = ToolSpan(
+                    tool_name="unknown",
+                    operation="tool.execute",
+                )
+            approval_tool_span = approval_span.child(tool_schema)
+        except ValueError:
+            pass
         try:
             ok, result = await asyncio.to_thread(
                 execute,
@@ -458,8 +501,21 @@ def create_app(
                 actor=str(item.get("actor") or "assistant"),
                 run_id=str(item.get("run_id") or "") or None,
             )
+        except asyncio.CancelledError:
+            if approval_tool_span is not None:
+                approval_tool_span.cancel()
+            if approval_span is not None:
+                approval_span.cancel()
+            raise
         except Exception as exc:
             ok, result = False, {"error": str(exc)}
+        if approval_tool_span is not None and approval_span is not None:
+            if ok:
+                approval_tool_span.finish()
+                approval_span.finish()
+            else:
+                approval_tool_span.partial(ErrorKind.TOOL)
+                approval_span.partial(ErrorKind.TOOL)
         receipt = app.state.inbox.complete_execution(
             str(item["id"]),
             claimant=claimant,
@@ -649,6 +705,35 @@ def create_app(
         if claim is None:
             return None
         if decision == "allow" and claim.claimed and claim.owned:
+            recovery_span = None
+            recovery_tool_span = None
+            try:
+                recovery_span = app.state.telemetry_recorder.start_span(
+                    AgentTurnSpan(operation="agent.recovery"),
+                    TraceContext(
+                        session_id=str(item.get("session_id") or ""),
+                        run_id=str(item.get("run_id") or ""),
+                    ),
+                )
+                recovery_span.record(
+                    RetryEvent(
+                        operation="tool.execute",
+                        retry_count=1,
+                        reason=RetryReason.TRANSIENT_TOOL,
+                    )
+                )
+                try:
+                    tool_schema = ToolSpan(
+                        tool_name=str(item.get("name") or "unknown"),
+                        operation="tool.execute",
+                    )
+                except ValueError:
+                    tool_schema = ToolSpan(
+                        tool_name="unknown", operation="tool.execute"
+                    )
+                recovery_tool_span = recovery_span.child(tool_schema)
+            except ValueError:
+                pass
             try:
                 ok, result = await asyncio.to_thread(
                     turn_runtime.execute,
@@ -678,8 +763,21 @@ def create_app(
                     run_id=str(item.get("run_id") or "") or None,
                 )
                 result = dict(result)
+            except asyncio.CancelledError:
+                if recovery_tool_span is not None:
+                    recovery_tool_span.cancel()
+                if recovery_span is not None:
+                    recovery_span.cancel()
+                raise
             except Exception as exc:
                 ok, result = False, {"error": str(exc)}
+            if recovery_tool_span is not None and recovery_span is not None:
+                if ok:
+                    recovery_tool_span.finish(retry_count=1)
+                    recovery_span.finish(retry_count=1)
+                else:
+                    recovery_tool_span.partial(ErrorKind.TOOL, retry_count=1)
+                    recovery_span.partial(ErrorKind.TOOL, retry_count=1)
             receipt = app.state.inbox.complete_execution(
                 item_id,
                 claimant=claimant,
@@ -1428,6 +1526,41 @@ def create_app(
             "queue_paused": store.queue_paused(sid),
         }
 
+    @app.get("/v1/sessions/{sid}/telemetry/current")
+    def session_current_telemetry(sid: str):
+        if app.state.store.index(sid) is None:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        query = getattr(app.state.telemetry_adapter, "current_session_metrics", None)
+        metrics = (
+            query(session_id=sid, now_ns=time.monotonic_ns())
+            if callable(query)
+            else None
+        )
+        current_run = None
+        if metrics is not None:
+            current_run = {
+                "run_id": metrics.run_id,
+                "status": metrics.status,
+                "input_tokens": metrics.input_tokens,
+                "output_tokens": metrics.output_tokens,
+                "total_tokens": metrics.total_tokens,
+                "cache_hit_input_tokens": metrics.cache_hit_input_tokens,
+                "cache_miss_input_tokens": metrics.cache_miss_input_tokens,
+                "reasoning_tokens": metrics.reasoning_tokens,
+                "current_context_tokens": metrics.current_context_tokens,
+                "context_window_tokens": metrics.context_window_tokens,
+                "context_use_ratio": metrics.context_use_ratio,
+                "elapsed_ms": metrics.elapsed_ms,
+                "estimated_cost_usd": metrics.estimated_cost_usd,
+                "retry_count": metrics.retry_count,
+                "compaction_count": metrics.compaction_count,
+            }
+        return {
+            "version": 1,
+            "session_id": sid,
+            "current_run": current_run,
+        }
+
     @app.patch("/v1/sessions/{sid}")
     async def sessions_patch(sid: str, request: Request):
         payload = await request.json()
@@ -1667,6 +1800,22 @@ def create_app(
                 )
                 await _persist_and_send(recovery)
                 return
+            recovery_span = app.state.telemetry_recorder.start_span(
+                AgentTurnSpan(operation="agent.recovery"),
+                TraceContext(session_id=session_id, run_id=run_id),
+            )
+            recovery_span.record(
+                RetryEvent(
+                    operation="tool.execute",
+                    retry_count=1,
+                    reason=RetryReason.TRANSIENT_TOOL,
+                )
+            )
+            try:
+                tool_schema = ToolSpan(tool_name=name, operation="tool.execute")
+            except ValueError:
+                tool_schema = ToolSpan(tool_name="unknown", operation="tool.execute")
+            retry_tool_span = recovery_span.child(tool_schema)
             try:
                 ok, result = await asyncio.to_thread(
                     turn_runtime.execute,
@@ -1685,9 +1834,19 @@ def create_app(
                     workspace_runtime=app.state.workspace_runtime,
                     session_id=session_id,
                 )
+            except asyncio.CancelledError:
+                retry_tool_span.cancel()
+                recovery_span.cancel()
+                raise
             except Exception as exc:
                 # The claim is held: this command must still record an outcome.
                 ok, result = False, {"error": str(exc)}
+            if ok:
+                retry_tool_span.finish(retry_count=1)
+                recovery_span.finish(retry_count=1)
+            else:
+                retry_tool_span.partial(ErrorKind.TOOL, retry_count=1)
+                recovery_span.partial(ErrorKind.TOOL, retry_count=1)
             result = dict(result)
             retried_failure = (
                 _tool_failure(
@@ -1824,6 +1983,7 @@ def create_app(
                     system_prompt_fn=system_prompt,
                     identity=control.identity,
                     control=control,
+                    telemetry=app.state.telemetry_recorder,
                 )
                 status = str(result.get("status") or "error")
                 if queue_item_id is not None:

--- a/desktop/coworker/telemetry/adapters.py
+++ b/desktop/coworker/telemetry/adapters.py
@@ -74,6 +74,7 @@ class InMemoryTelemetryAdapter:
             for record in self.records
             if isinstance(record, SpanStartedRecord)
             and isinstance(record.span, AgentTurnSpan)
+            and record.span.operation == "agent.turn"
             and record.context.session_id == session_id
         ]
         if not starts:

--- a/desktop/coworker/telemetry/adapters.py
+++ b/desktop/coworker/telemetry/adapters.py
@@ -8,6 +8,7 @@ from threading import Lock, RLock
 from typing import Protocol
 
 from coworker.telemetry.schema import (
+    AgentTurnSpan,
     CostEstimate,
     ErrorKind,
     SpanEventRecord,
@@ -66,6 +67,22 @@ class InMemoryTelemetryAdapter:
         from coworker.telemetry.metrics import current_run_metrics
 
         return current_run_metrics(self.records, run_id=run_id, now_ns=now_ns)
+
+    def current_session_metrics(self, *, session_id: str, now_ns: int):
+        starts = [
+            record
+            for record in self.records
+            if isinstance(record, SpanStartedRecord)
+            and isinstance(record.span, AgentTurnSpan)
+            and record.context.session_id == session_id
+        ]
+        if not starts:
+            return None
+        latest = max(starts, key=lambda record: record.sequence)
+        return self.current_run_metrics(
+            run_id=latest.context.run_id,
+            now_ns=now_ns,
+        )
 
 
 class TelemetryRecorder:

--- a/desktop/coworker/telemetry/metrics.py
+++ b/desktop/coworker/telemetry/metrics.py
@@ -7,8 +7,10 @@ from dataclasses import dataclass
 
 from coworker.telemetry.schema import (
     AgentTurnSpan,
+    CompactionEvent,
     CostEvent,
     ProviderSpan,
+    RetryEvent,
     SpanEventRecord,
     SpanSettledRecord,
     SpanStartedRecord,
@@ -20,6 +22,7 @@ from coworker.telemetry.schema import (
 @dataclass(frozen=True, slots=True)
 class CurrentRunMetrics:
     run_id: str
+    status: str
     input_tokens: int | None
     output_tokens: int | None
     total_tokens: int | None
@@ -31,6 +34,8 @@ class CurrentRunMetrics:
     context_use_ratio: float | None
     elapsed_ms: float | None
     estimated_cost_usd: float | None
+    retry_count: int
+    compaction_count: int
 
 
 def _sum_known(usages: list[UsageEvent], field_name: str) -> int | None:
@@ -92,9 +97,12 @@ def current_run_metrics(
         if isinstance(record.span, AgentTurnSpan)
     ]
     elapsed_ms: float | None = None
+    status = "running"
     if agent_starts:
         root = min(agent_starts, key=lambda record: record.sequence)
         settlement = settlements.get(root.span_id)
+        if settlement is not None:
+            status = settlement.terminal.status.value
         elapsed_ms = (
             settlement.terminal.latency_ms
             if settlement is not None
@@ -117,6 +125,7 @@ def current_run_metrics(
     )
     return CurrentRunMetrics(
         run_id=run_id,
+        status=status,
         input_tokens=_sum_known(selected_usages, "input_tokens"),
         output_tokens=_sum_known(selected_usages, "output_tokens"),
         total_tokens=_sum_known(selected_usages, "total_tokens"),
@@ -128,4 +137,14 @@ def current_run_metrics(
         context_use_ratio=context_use_ratio,
         elapsed_ms=elapsed_ms,
         estimated_cost_usd=estimated_cost_usd,
+        retry_count=sum(
+            isinstance(record.event, RetryEvent)
+            for record in run_records
+            if isinstance(record, SpanEventRecord)
+        ),
+        compaction_count=sum(
+            isinstance(record.event, CompactionEvent)
+            for record in run_records
+            if isinstance(record, SpanEventRecord)
+        ),
     )

--- a/desktop/coworker/turn.py
+++ b/desktop/coworker/turn.py
@@ -63,6 +63,13 @@ def _telemetry_provider_span(provider: Any) -> ProviderSpan:
         )
 
 
+def _telemetry_tool_span(name: str) -> ToolSpan:
+    try:
+        return ToolSpan(tool_name=name, operation="tool.execute")
+    except ValueError:
+        return ToolSpan(tool_name="unknown", operation="tool.execute")
+
+
 def _telemetry_usage(usage: ModelUsage) -> UsageEvent:
     return UsageEvent(
         input_tokens=usage.input_tokens,
@@ -934,9 +941,7 @@ async def run_turn(
                         "started_at": _now_iso(),
                     }
                 )
-                tool_span = turn_span.child(
-                    ToolSpan(tool_name=call.name, operation="tool.execute")
-                )
+                tool_span = turn_span.child(_telemetry_tool_span(call.name))
                 try:
                     kw = {
                         k: v for k, v in execute_kwargs.items() if not k.startswith("_")

--- a/desktop/coworker/turn.py
+++ b/desktop/coworker/turn.py
@@ -13,8 +13,18 @@ from coworker.events import TurnEventStream, TurnIdentity, build_event, new_turn
 from coworker.inbox import Inbox
 from coworker.ledger import record_tool_on_person
 from coworker.permissions import RETRY_SAFE, decide
-from coworker.provider import ToolCall
+from coworker.provider import ModelUsage, ToolCall
 from coworker.store import ConversationStore
+from coworker.telemetry import (
+    AgentTurnSpan,
+    ErrorKind,
+    ProviderSpan,
+    StopReason,
+    TelemetryRecorder,
+    TraceContext,
+    ToolSpan,
+    UsageEvent,
+)
 from coworker.tools import execute
 
 MAX_STEPS = 8
@@ -23,6 +33,58 @@ INTERRUPTED_TOOL = '{"error": "tool call interrupted"}'
 
 def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
+
+
+def _telemetry_provider_name(provider: Any) -> str:
+    name = type(provider).__name__.lower()
+    name = name.removesuffix("provider") or "unknown"
+    if name != "openaicompat":
+        return name
+    base_url = str(getattr(provider, "base_url", "")).lower()
+    if "moonshot.ai" in base_url:
+        return "moonshot"
+    if "openai.com" in base_url:
+        return "openai"
+    return "openai_compatible"
+
+
+def _telemetry_provider_span(provider: Any) -> ProviderSpan:
+    try:
+        return ProviderSpan(
+            provider=_telemetry_provider_name(provider),
+            model=str(getattr(provider, "model_id", "unknown")),
+            operation="provider.request",
+        )
+    except ValueError:
+        return ProviderSpan(
+            provider="unknown",
+            model="unknown",
+            operation="provider.request",
+        )
+
+
+def _telemetry_usage(usage: ModelUsage) -> UsageEvent:
+    return UsageEvent(
+        input_tokens=usage.input_tokens,
+        output_tokens=usage.output_tokens,
+        total_tokens=usage.total_tokens,
+        cache_hit_input_tokens=usage.cached_input_tokens,
+        cache_miss_input_tokens=usage.uncached_input_tokens,
+        reasoning_tokens=usage.reasoning_tokens,
+        current_context_tokens=usage.input_tokens,
+    )
+
+
+def _telemetry_stop_reason(reason: str | None, *, used_tools: bool) -> StopReason:
+    if reason == "tool_calls" or (reason is None and used_tools):
+        return StopReason.TOOL_USE
+    if reason == "length":
+        return StopReason.MAX_TOKENS
+    if reason == "stop" or reason is None:
+        return StopReason.COMPLETED
+    if reason == "insufficient_system_resource":
+        return StopReason.ERROR
+    return StopReason.UNKNOWN
 
 
 _TOOL_SOURCES: dict[str, tuple[str | None, str]] = {
@@ -491,6 +553,7 @@ async def run_turn(
     system_prompt_fn: Callable[..., str] | None = None,
     identity: TurnIdentity | None = None,
     control: RunControl | None = None,
+    telemetry: TelemetryRecorder | None = None,
 ) -> dict[str, Any]:
     workspace_runtime = execute_kwargs.get("workspace_runtime")
     events = TurnEventStream(
@@ -503,6 +566,14 @@ async def run_turn(
     )
     if control is not None:
         await control.attach(events)
+    recorder = telemetry or TelemetryRecorder()
+    trace_context = TraceContext(
+        session_id=events.identity.session_id,
+        run_id=events.identity.run_id,
+    )
+    turn_span = recorder.start_span(
+        AgentTurnSpan(operation="agent.turn"), trace_context
+    )
 
     async def _emit(event: dict[str, Any]) -> None:
         await events.send(event)
@@ -568,6 +639,7 @@ async def run_turn(
     async def _stopped(
         history: list[dict[str, Any]], text_so_far: str
     ) -> dict[str, Any]:
+        turn_span.cancel()
         _persist_closed(store, sid, history, workspace_runtime)
         if control is not None:
             await control.finish_stopped(text_so_far)
@@ -584,6 +656,7 @@ async def run_turn(
 
     await _emit({"type": "turn_start", "state": "running"})
     if provider is None:
+        turn_span.fail(ErrorKind.PROVIDER)
         await _terminal(
             {
                 "type": "error",
@@ -625,6 +698,8 @@ async def run_turn(
         for _ in range(MAX_STEPS):
             chunks: list[str] = []
             calls: list[ToolCall] = []
+            provider_usage: UsageEvent | None = None
+            provider_finish_reason: str | None = None
             _persist_closed(store, sid, history, workspace_runtime)
             model_messages = [
                 {k: v for k, v in message.items() if k != "message_id"}
@@ -636,14 +711,39 @@ async def run_turn(
             }
             if getattr(provider, "uses_transient_context", False):
                 stream_kwargs["context_id"] = sid
-            async for chunk in provider.astream(**stream_kwargs):
-                if control is not None and control.cancel_requested.is_set():
-                    return await _stopped(history, "".join(chunks) or last_text)
-                if chunk.text_delta:
-                    chunks.append(chunk.text_delta)
-                    await _emit({"type": "assistant_delta", "delta": chunk.text_delta})
-                if chunk.tool_calls:
-                    calls = chunk.tool_calls
+            provider_span = turn_span.child(
+                _telemetry_provider_span(provider)
+            )
+            try:
+                async for chunk in provider.astream(**stream_kwargs):
+                    if control is not None and control.cancel_requested.is_set():
+                        provider_span.cancel(usage=provider_usage)
+                        return await _stopped(history, "".join(chunks) or last_text)
+                    if chunk.text_delta:
+                        chunks.append(chunk.text_delta)
+                        await _emit({"type": "assistant_delta", "delta": chunk.text_delta})
+                    if chunk.tool_calls:
+                        calls = chunk.tool_calls
+                    if chunk.usage is not None:
+                        provider_usage = _telemetry_usage(chunk.usage)
+                        provider_span.record(provider_usage)
+                    if chunk.finish_reason is not None:
+                        provider_finish_reason = chunk.finish_reason
+            except asyncio.CancelledError:
+                provider_span.cancel(usage=provider_usage)
+                turn_span.cancel()
+                raise
+            except Exception:
+                provider_span.fail(ErrorKind.PROVIDER, usage=provider_usage)
+                turn_span.fail(ErrorKind.PROVIDER)
+                raise
+            provider_span.finish(
+                stop_reason=_telemetry_stop_reason(
+                    provider_finish_reason,
+                    used_tools=bool(calls),
+                ),
+                usage=provider_usage,
+            )
             if control is not None and control.cancel_requested.is_set():
                 return await _stopped(history, "".join(chunks) or last_text)
             last_text = "".join(chunks)
@@ -834,6 +934,9 @@ async def run_turn(
                         "started_at": _now_iso(),
                     }
                 )
+                tool_span = turn_span.child(
+                    ToolSpan(tool_name=call.name, operation="tool.execute")
+                )
                 try:
                     kw = {
                         k: v for k, v in execute_kwargs.items() if not k.startswith("_")
@@ -848,8 +951,15 @@ async def run_turn(
                     ok, result = await asyncio.to_thread(
                         execute, call.name, call.arguments, **kw
                     )
+                except asyncio.CancelledError:
+                    tool_span.cancel()
+                    raise
                 except Exception as exc:
                     ok, result = False, {"error": str(exc)}
+                if ok:
+                    tool_span.finish()
+                else:
+                    tool_span.partial(ErrorKind.TOOL)
                 if (
                     call.name in {"remember", "memory_update", "memory_forget"}
                     and system_prompt_fn
@@ -892,6 +1002,7 @@ async def run_turn(
                         return await _stopped(history, last_text)
                     control.current_action = None
         else:
+            turn_span.cancel()
             await _terminal(
                 {
                     "type": "turn_end",
@@ -901,12 +1012,20 @@ async def run_turn(
                 }
             )
             return {"status": "stopped", "text": last_text}
+    except asyncio.CancelledError:
+        turn_span.cancel()
+        raise
     except Exception as exc:
+        turn_span.fail(ErrorKind.INTERNAL)
         _persist_closed(store, sid, history, workspace_runtime)
         await _terminal({"type": "error", "state": "failed", "message": str(exc)})
         return {"status": "error", "text": last_text}
     final_state = "partial" if had_tool_failure else "complete"
     await _terminal({"type": "turn_end", "text": last_text, "state": final_state})
+    if had_tool_failure:
+        turn_span.partial(ErrorKind.TOOL)
+    else:
+        turn_span.finish()
     return {
         "status": "partial" if had_tool_failure else "ok",
         "text": last_text,

--- a/desktop/surfaces/gui/src/api.ts
+++ b/desktop/surfaces/gui/src/api.ts
@@ -117,6 +117,30 @@ export type Conversation = {
   queue_paused?: boolean;
 };
 
+export type CurrentRunMetrics = {
+  run_id: string;
+  status: "running" | "success" | "failed" | "cancelled" | "partial";
+  input_tokens: number | null;
+  output_tokens: number | null;
+  total_tokens: number | null;
+  cache_hit_input_tokens: number | null;
+  cache_miss_input_tokens: number | null;
+  reasoning_tokens: number | null;
+  current_context_tokens: number | null;
+  context_window_tokens: number | null;
+  context_use_ratio: number | null;
+  elapsed_ms: number | null;
+  estimated_cost_usd: number | null;
+  retry_count: number;
+  compaction_count: number;
+};
+
+export type CurrentRunTelemetry = {
+  version: 1;
+  session_id: string;
+  current_run: CurrentRunMetrics | null;
+};
+
 export type QueueItem = SourcecadoQueueItem;
 
 const httpBase = (): string =>
@@ -210,6 +234,71 @@ export async function getSession(id: string): Promise<Conversation> {
     ...(typeof body.queue_paused === "boolean"
       ? { queue_paused: body.queue_paused }
       : {}),
+  };
+}
+
+const RUN_METRIC_STATUSES = new Set([
+  "running",
+  "success",
+  "failed",
+  "cancelled",
+  "partial",
+]);
+
+function measurement(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : null;
+}
+
+export async function getCurrentRunTelemetry(
+  sessionId: string,
+): Promise<CurrentRunTelemetry> {
+  const res = await get(
+    `/v1/sessions/${encodeURIComponent(sessionId)}/telemetry/current`,
+  );
+  if (!res.ok) throw new Error(`current-run telemetry ${res.status}`);
+  const raw = (await res.json()) as Record<string, unknown>;
+  const candidate =
+    typeof raw.current_run === "object" &&
+    raw.current_run !== null &&
+    !Array.isArray(raw.current_run)
+      ? (raw.current_run as Record<string, unknown>)
+      : null;
+  if (raw.version !== 1 || raw.session_id !== sessionId) {
+    throw new Error("current-run telemetry payload malformed");
+  }
+  if (candidate === null) {
+    return { version: 1, session_id: sessionId, current_run: null };
+  }
+  const status = String(candidate.status);
+  if (
+    typeof candidate.run_id !== "string" ||
+    !candidate.run_id ||
+    !RUN_METRIC_STATUSES.has(status)
+  ) {
+    throw new Error("current-run telemetry payload malformed");
+  }
+  return {
+    version: 1,
+    session_id: sessionId,
+    current_run: {
+      run_id: candidate.run_id,
+      status: status as CurrentRunMetrics["status"],
+      input_tokens: measurement(candidate.input_tokens),
+      output_tokens: measurement(candidate.output_tokens),
+      total_tokens: measurement(candidate.total_tokens),
+      cache_hit_input_tokens: measurement(candidate.cache_hit_input_tokens),
+      cache_miss_input_tokens: measurement(candidate.cache_miss_input_tokens),
+      reasoning_tokens: measurement(candidate.reasoning_tokens),
+      current_context_tokens: measurement(candidate.current_context_tokens),
+      context_window_tokens: measurement(candidate.context_window_tokens),
+      context_use_ratio: measurement(candidate.context_use_ratio),
+      elapsed_ms: measurement(candidate.elapsed_ms),
+      estimated_cost_usd: measurement(candidate.estimated_cost_usd),
+      retry_count: measurement(candidate.retry_count) ?? 0,
+      compaction_count: measurement(candidate.compaction_count) ?? 0,
+    },
   };
 }
 

--- a/desktop/surfaces/gui/src/chat/RunMetrics.tsx
+++ b/desktop/surfaces/gui/src/chat/RunMetrics.tsx
@@ -1,0 +1,46 @@
+import type { CurrentRunMetrics } from "../api";
+
+function tokenLabel(metrics: CurrentRunMetrics): string {
+  const total = metrics.total_tokens;
+  return total === null ? "Tokens —" : `${total.toLocaleString()} tokens`;
+}
+
+function contextLabel(metrics: CurrentRunMetrics): string {
+  if (metrics.context_use_ratio !== null) {
+    return `Context ${Math.round(metrics.context_use_ratio * 100)}%`;
+  }
+  if (metrics.current_context_tokens !== null) {
+    return `Context ${metrics.current_context_tokens.toLocaleString()} tokens`;
+  }
+  return "Context —";
+}
+
+function elapsedLabel(elapsedMs: number | null): string {
+  return elapsedMs === null ? "Elapsed —" : `${(elapsedMs / 1000).toFixed(1)}s`;
+}
+
+function costLabel(cost: number | null): string {
+  if (cost === null) return "Cost —";
+  return `$${cost < 0.01 ? cost.toFixed(4) : cost.toFixed(2)} est.`;
+}
+
+function countLabel(value: number, singular: string): string {
+  const plural = singular === "retry" ? "retries" : `${singular}s`;
+  return `${value} ${value === 1 ? singular : plural}`;
+}
+
+export function RunMetrics({ metrics }: { readonly metrics: CurrentRunMetrics }) {
+  return (
+    <section
+      className={`sourcecado-run-metrics sourcecado-run-metrics-${metrics.status}`}
+      aria-label="Current run metrics"
+    >
+      <span>{tokenLabel(metrics)}</span>
+      <span>{contextLabel(metrics)}</span>
+      <span>{elapsedLabel(metrics.elapsed_ms)}</span>
+      <span>{countLabel(metrics.retry_count, "retry")}</span>
+      <span>{countLabel(metrics.compaction_count, "compaction")}</span>
+      <span>{costLabel(metrics.estimated_cost_usd)}</span>
+    </section>
+  );
+}

--- a/desktop/surfaces/gui/src/chat/ThreadHeader.tsx
+++ b/desktop/surfaces/gui/src/chat/ThreadHeader.tsx
@@ -1,15 +1,21 @@
+import type { CurrentRunMetrics } from "../api";
+import { RunMetrics } from "./RunMetrics";
+
 export function ThreadHeader({
   title,
   personaName,
+  runMetrics,
 }: {
   readonly title: string | null;
   readonly personaName?: string | null;
+  readonly runMetrics?: CurrentRunMetrics | null;
 }) {
   return (
     <header className="sourcecado-thread-header">
       <div>
         <p className="eyebrow">Sourcing workspace</p>
         <h1>{title?.trim() || "New sourcing conversation"}</h1>
+        {runMetrics ? <RunMetrics metrics={runMetrics} /> : null}
       </div>
       {personaName ? (
         <p className="sourcecado-persona-badge">{personaName}</p>

--- a/desktop/surfaces/gui/src/chat/ThreadView.tsx
+++ b/desktop/surfaces/gui/src/chat/ThreadView.tsx
@@ -6,12 +6,13 @@ import { ComposerDraftProvider } from "./ComposerDraftContext";
 import { Queue } from "./Queue";
 import { ThreadHeader } from "./ThreadHeader";
 import { UserMessage } from "./UserMessage";
-import type { QueueItem } from "../api";
+import type { CurrentRunMetrics, QueueItem } from "../api";
 import { Inspector } from "./Inspector";
 
 type ThreadViewProps = {
   readonly title: string | null;
   readonly personaName?: string | null;
+  readonly runMetrics?: CurrentRunMetrics | null;
   readonly loading: boolean;
   readonly loadError: boolean;
   readonly onRetry: () => void;
@@ -53,6 +54,7 @@ function Starter({
 export function ThreadView({
   title,
   personaName,
+  runMetrics,
   loading,
   loadError,
   onRetry,
@@ -76,7 +78,11 @@ export function ThreadView({
     <ComposerDraftProvider populate={populateComposer}>
     <div className="sourcecado-chat-workspace">
     <ThreadPrimitive.Root className="sourcecado-thread">
-      <ThreadHeader title={title} personaName={personaName} />
+      <ThreadHeader
+        title={title}
+        personaName={personaName}
+        runMetrics={runMetrics}
+      />
       <ThreadPrimitive.Viewport
         className="sourcecado-transcript"
         role="log"

--- a/desktop/surfaces/gui/src/routes/ChatPage.tsx
+++ b/desktop/surfaces/gui/src/routes/ChatPage.tsx
@@ -6,12 +6,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   getPersona,
+  getCurrentRunTelemetry,
   getSession,
   getSessions,
   hasToken,
   openChat,
   type CommandDelivery,
   type ConnectionStatus,
+  type CurrentRunMetrics,
   type SourcecadoSocketEvent,
   type QueueItem,
 } from "../api";
@@ -91,9 +93,37 @@ export function ChatPage({ sessionId: requestedSessionId }: { sessionId?: string
   const [loadAttempt, setLoadAttempt] = useState(0);
   const [announcement, setAnnouncement] = useState("");
   const [personaName, setPersonaName] = useState<string | null>(null);
+  const [runMetrics, setRunMetrics] = useState<CurrentRunMetrics | null>(null);
   const [, setRevision] = useState(0);
 
   const refresh = useCallback(() => setRevision((value) => value + 1), []);
+  const currentRunIsActive = runningThreadsRef.current.has(activeThreadId);
+
+  useEffect(() => {
+    if (!hasToken() || !activeThreadId) {
+      setRunMetrics(null);
+      return;
+    }
+    setRunMetrics(null);
+    let active = true;
+    const refreshMetrics = () => {
+      void getCurrentRunTelemetry(activeThreadId)
+        .then((payload) => {
+          if (active) setRunMetrics(payload.current_run);
+        })
+        .catch(() => {
+          // Metrics are passive; chat remains usable when measurement is unavailable.
+        });
+    };
+    refreshMetrics();
+    const interval = currentRunIsActive
+      ? window.setInterval(refreshMetrics, 1000)
+      : undefined;
+    return () => {
+      active = false;
+      if (interval !== undefined) window.clearInterval(interval);
+    };
+  }, [activeThreadId, currentRunIsActive]);
 
   useEffect(() => {
     if (!hasToken()) return;
@@ -428,6 +458,7 @@ export function ChatPage({ sessionId: requestedSessionId }: { sessionId?: string
         <ThreadView
           title={title}
           personaName={personaName}
+          runMetrics={runMetrics}
           loading={loading}
           loadError={loadError}
           onRetry={() => setLoadAttempt((attempt) => attempt + 1)}

--- a/desktop/surfaces/gui/src/styles/chat.css
+++ b/desktop/surfaces/gui/src/styles/chat.css
@@ -272,6 +272,34 @@
   white-space: nowrap;
 }
 
+.sourcecado-run-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 0;
+  margin-top: 7px;
+  color: var(--muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.sourcecado-run-metrics > span {
+  padding: 0 8px;
+  border-right: 1px solid var(--border);
+  white-space: nowrap;
+}
+
+.sourcecado-run-metrics > span:first-child {
+  padding-left: 0;
+}
+
+.sourcecado-run-metrics > span:last-child {
+  border-right: 0;
+}
+
+.sourcecado-run-metrics-running {
+  color: var(--accent-deep);
+}
+
 .sourcecado-persona-badge {
   flex: 0 0 auto;
   margin: 0;

--- a/desktop/surfaces/gui/tests/chatPage.test.tsx
+++ b/desktop/surfaces/gui/tests/chatPage.test.tsx
@@ -13,6 +13,7 @@ const api = vi.hoisted(() => ({
   getSettings: vi.fn(),
   getInbox: vi.fn(),
   getSession: vi.fn(),
+  getCurrentRunTelemetry: vi.fn(),
   openChat: vi.fn(),
 }));
 const writeText = vi.fn();
@@ -46,6 +47,7 @@ vi.mock("../src/api", () => ({
   getSettings: api.getSettings,
   getInbox: api.getInbox,
   getSession: api.getSession,
+  getCurrentRunTelemetry: api.getCurrentRunTelemetry,
   hasToken: () => true,
   openChat: api.openChat,
   resolveInbox: vi.fn(),
@@ -97,6 +99,11 @@ describe("ChatPage Warm Operator thread", () => {
       apollo: { configured: false },
     });
     api.getInbox.mockResolvedValue({ items: [] });
+    api.getCurrentRunTelemetry.mockResolvedValue({
+      version: 1,
+      session_id: "thread-alpha",
+      current_run: null,
+    });
     api.openChat.mockImplementation((callback) => {
       onChatEvent = callback;
       return {
@@ -107,6 +114,112 @@ describe("ChatPage Warm Operator thread", () => {
       recover: chatRecover,
       close: vi.fn(),
       };
+    });
+  });
+
+  it("shows compact allowlisted measurements for the current run", async () => {
+    api.getSession.mockResolvedValue({
+      id: "thread-alpha",
+      title: "Measured run",
+      messages: [],
+      events: [],
+    });
+    api.getCurrentRunTelemetry.mockResolvedValue({
+      version: 1,
+      session_id: "thread-alpha",
+      current_run: {
+        run_id: "run-1",
+        status: "running",
+        input_tokens: 80,
+        output_tokens: 20,
+        total_tokens: 100,
+        cache_hit_input_tokens: 30,
+        cache_miss_input_tokens: 50,
+        reasoning_tokens: 4,
+        current_context_tokens: 80,
+        context_window_tokens: 1000,
+        context_use_ratio: 0.08,
+        elapsed_ms: 1250,
+        estimated_cost_usd: 0.0042,
+        retry_count: 1,
+        compaction_count: 2,
+        prompt: "sk-live-PLANTED",
+        raw_error: "private error",
+      },
+    });
+
+    const { container } = render(<ChatPage sessionId="thread-alpha" />);
+
+    const metrics = await screen.findByRole("region", {
+      name: "Current run metrics",
+    });
+    expect(metrics).toHaveTextContent("100 tokens");
+    expect(metrics).toHaveTextContent("Context 8%");
+    expect(metrics).toHaveTextContent("1.3s");
+    expect(metrics).toHaveTextContent("1 retry");
+    expect(metrics).toHaveTextContent("2 compactions");
+    expect(metrics).toHaveTextContent("$0.0042 est.");
+    expect(container).not.toHaveTextContent("PLANTED");
+    expect(container).not.toHaveTextContent("private error");
+  });
+
+  it("does not carry measurements across threads while the next run loads", async () => {
+    const betaMetrics = deferred<{
+      version: 1;
+      session_id: string;
+      current_run: null;
+    }>();
+    api.getSession.mockImplementation(async (id: string) => ({
+      id,
+      title: id,
+      messages: [],
+      events: [],
+    }));
+    api.getCurrentRunTelemetry.mockImplementation((id: string) =>
+      id === "thread-alpha"
+        ? Promise.resolve({
+            version: 1,
+            session_id: id,
+            current_run: {
+              run_id: "run-alpha",
+              status: "success",
+              input_tokens: 8,
+              output_tokens: 2,
+              total_tokens: 10,
+              cache_hit_input_tokens: 0,
+              cache_miss_input_tokens: 8,
+              reasoning_tokens: 0,
+              current_context_tokens: 8,
+              context_window_tokens: null,
+              context_use_ratio: null,
+              elapsed_ms: 100,
+              estimated_cost_usd: null,
+              retry_count: 0,
+              compaction_count: 0,
+            },
+          })
+        : betaMetrics.promise,
+    );
+
+    const view = render(<ChatPage sessionId="thread-alpha" />);
+    const alphaMetrics = await screen.findByRole("region", {
+      name: "Current run metrics",
+    });
+    expect(alphaMetrics).toHaveTextContent("10 tokens");
+    expect(alphaMetrics).toHaveTextContent("0 retries");
+
+    view.rerender(<ChatPage sessionId="thread-beta" />);
+    await screen.findByRole("heading", { level: 1, name: "thread-beta" });
+    expect(
+      screen.queryByRole("region", { name: "Current run metrics" }),
+    ).not.toBeInTheDocument();
+
+    await act(async () => {
+      betaMetrics.resolve({
+        version: 1,
+        session_id: "thread-beta",
+        current_run: null,
+      });
     });
   });
 

--- a/desktop/surfaces/gui/tests/chatStyles.test.ts
+++ b/desktop/surfaces/gui/tests/chatStyles.test.ts
@@ -51,6 +51,15 @@ describe("Warm Operator thread styles", () => {
     );
   });
 
+  it("keeps current-run measurements compact and numerically stable", () => {
+    expect(styles).toMatch(
+      /\.sourcecado-run-metrics\s*\{[^}]*display:\s*flex;[^}]*flex-wrap:\s*wrap;[^}]*font-variant-numeric:\s*tabular-nums;/,
+    );
+    expect(styles).toMatch(
+      /\.sourcecado-run-metrics > span\s*\{[^}]*border-right:\s*1px solid var\(--border\);/,
+    );
+  });
+
   it("distinguishes pending approval cards from collapsed audit receipts", () => {
     expect(styles).toMatch(
       /\.sourcecado-approval-card\s*\{[^}]*border:\s*1px solid var\(--warn\);/,

--- a/desktop/surfaces/gui/tests/protocol.test.ts
+++ b/desktop/surfaces/gui/tests/protocol.test.ts
@@ -341,3 +341,68 @@ describe("getSession protocol boundary", () => {
     });
   });
 });
+
+describe("current-run telemetry boundary", () => {
+  it("rebuilds only the numeric and bounded-status allowlist", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          version: 1,
+          session_id: "thread-alpha",
+          current_run: {
+            run_id: "run-1",
+            status: "running",
+            input_tokens: 80,
+            output_tokens: 20,
+            total_tokens: 100,
+            cache_hit_input_tokens: 30,
+            cache_miss_input_tokens: 50,
+            reasoning_tokens: 4,
+            current_context_tokens: 80,
+            context_window_tokens: 1000,
+            context_use_ratio: 0.08,
+            elapsed_ms: 1250,
+            estimated_cost_usd: 0.0042,
+            retry_count: 1,
+            compaction_count: 2,
+            prompt: "sk-live-PLANTED",
+            response_text: "private response",
+            raw_error: "private error",
+            arguments: { secret: true },
+            result: { secret: true },
+          },
+        }),
+      }),
+    );
+    const module = await import("../src/api");
+    const getCurrentRunTelemetry = (
+      module as unknown as {
+        getCurrentRunTelemetry: (sessionId: string) => Promise<unknown>;
+      }
+    ).getCurrentRunTelemetry;
+
+    await expect(getCurrentRunTelemetry("thread-alpha")).resolves.toEqual({
+      version: 1,
+      session_id: "thread-alpha",
+      current_run: {
+        run_id: "run-1",
+        status: "running",
+        input_tokens: 80,
+        output_tokens: 20,
+        total_tokens: 100,
+        cache_hit_input_tokens: 30,
+        cache_miss_input_tokens: 50,
+        reasoning_tokens: 4,
+        current_context_tokens: 80,
+        context_window_tokens: 1000,
+        context_use_ratio: 0.08,
+        elapsed_ms: 1250,
+        estimated_cost_usd: 0.0042,
+        retry_count: 1,
+        compaction_count: 2,
+      },
+    });
+  });
+});

--- a/desktop/surfaces/gui/tests/shell.test.tsx
+++ b/desktop/surfaces/gui/tests/shell.test.tsx
@@ -18,6 +18,7 @@ const api = vi.hoisted(() => ({
   createSession: vi.fn(),
   getBoard: vi.fn(),
   getConnectors: vi.fn(),
+  getCurrentRunTelemetry: vi.fn(),
   getGmail: vi.fn(),
   getHealth: vi.fn(),
   getInbox: vi.fn(),
@@ -46,6 +47,7 @@ vi.mock("../src/api", () => ({
   disconnectGmail: vi.fn(),
   getBoard: api.getBoard,
   getConnectors: api.getConnectors,
+  getCurrentRunTelemetry: api.getCurrentRunTelemetry,
   getGmail: api.getGmail,
   getHealth: api.getHealth,
   getInbox: api.getInbox,
@@ -73,6 +75,11 @@ describe("App shell routing", () => {
     window.localStorage.clear();
     window.location.hash = "#/skills";
     api.getConnectors.mockResolvedValue({ connectors: [] });
+    api.getCurrentRunTelemetry.mockResolvedValue({
+      version: 1,
+      session_id: "thread-alpha",
+      current_run: null,
+    });
     api.getBoard.mockResolvedValue({ open: [], in_conversation: [], done: [] });
     api.getGmail.mockResolvedValue({ connected: false, email: null });
     api.getHealth.mockResolvedValue({ status: "ok", piece: "test", slice: 1, model: "test" });

--- a/desktop/tests/test_telemetry_api.py
+++ b/desktop/tests/test_telemetry_api.py
@@ -303,3 +303,46 @@ def test_approved_recovery_records_retry_only_when_the_tool_executes(tmp_path):
     )
     assert agent.span.operation == "agent.recovery"
     assert tool.parent_span_id == agent.span_id
+
+
+def test_later_inbox_allow_does_not_replace_the_current_chat_run(tmp_path):
+    app = create_app(token=TOKEN, provider=UsageProvider(), state=tmp_path)
+    client = TestClient(app)
+    sid = app.state.store.open_session_id()
+
+    with client.websocket_connect("/ws/chat", subprotocols=["club", TOKEN]) as ws:
+        def chat(text: str) -> str:
+            ws.send_json({"type": "chat", "text": text, "session_id": sid})
+            events = []
+            while not events or events[-1]["type"] not in {"turn_end", "error"}:
+                events.append(ws.receive_json())
+            start = next(event for event in events if event["type"] == "turn_start")
+            return start["run_id"]
+
+        first_run_id = chat("first")
+        second_run_id = chat("second")
+    app.state.inbox.park(
+        "now",
+        {},
+        item_id="leftover-allow",
+        reason="leftover approval from the first run",
+        session_id=sid,
+        run_id=first_run_id,
+        message_id="message-first",
+        part_id="part-first",
+    )
+
+    allow = client.post(
+        "/v1/inbox/leftover-allow",
+        headers={TOKEN_HEADER: TOKEN},
+        json={"decision": "allow", "actor": "operator", "scope": "once"},
+    )
+    response = client.get(
+        f"/v1/sessions/{sid}/telemetry/current",
+        headers={TOKEN_HEADER: TOKEN},
+    )
+
+    assert first_run_id != second_run_id
+    assert allow.status_code == 200
+    assert response.status_code == 200
+    assert response.json()["current_run"]["run_id"] == second_run_id

--- a/desktop/tests/test_telemetry_api.py
+++ b/desktop/tests/test_telemetry_api.py
@@ -1,0 +1,305 @@
+import json
+import time
+
+from fastapi.testclient import TestClient
+
+from coworker.provider import FakeProvider, ModelUsage, StreamChunk, ToolCall
+from coworker.server import TOKEN_HEADER, create_app
+from coworker.telemetry import InMemoryTelemetryAdapter, TelemetryRecorder
+from coworker.telemetry.schema import (
+    AgentTurnSpan,
+    RetryEvent,
+    SpanEventRecord,
+    SpanSettledRecord,
+    SpanStartedRecord,
+    SpanStatus,
+    ToolSpan,
+)
+
+TOKEN = "test-token-telemetry"
+
+
+class UsageProvider:
+    model_id = "usage-model"
+
+    async def astream(self, *, messages, tools):
+        yield StreamChunk(text_delta="safe response")
+        yield StreamChunk(
+            usage=ModelUsage(
+                input_tokens=80,
+                output_tokens=20,
+                total_tokens=100,
+                cached_input_tokens=30,
+                uncached_input_tokens=50,
+                reasoning_tokens=4,
+            )
+        )
+        yield StreamChunk(finish_reason="stop")
+
+
+def test_create_app_owns_one_in_memory_telemetry_recorder(tmp_path):
+    app = create_app(token=TOKEN, provider=UsageProvider(), state=tmp_path)
+
+    assert isinstance(app.state.telemetry_adapter, InMemoryTelemetryAdapter)
+    assert isinstance(app.state.telemetry_recorder, TelemetryRecorder)
+
+
+def test_websocket_turn_uses_the_composition_root_recorder(tmp_path):
+    app = create_app(token=TOKEN, provider=UsageProvider(), state=tmp_path)
+    sid = app.state.store.open_session_id()
+
+    with TestClient(app).websocket_connect(
+        "/ws/chat", subprotocols=["club", TOKEN]
+    ) as ws:
+        ws.send_json({"type": "chat", "text": "measure", "session_id": sid})
+        events = []
+        while not events or events[-1]["type"] not in {"turn_end", "error"}:
+            events.append(ws.receive_json())
+
+    started = next(
+        record
+        for record in app.state.telemetry_adapter.records
+        if isinstance(record, SpanStartedRecord)
+        and isinstance(record.span, AgentTurnSpan)
+    )
+    assert started.context.session_id == sid
+    assert started.context.run_id == events[0]["run_id"]
+
+
+def test_current_run_api_returns_only_allowlisted_measurements(tmp_path):
+    app = create_app(token=TOKEN, provider=UsageProvider(), state=tmp_path)
+    client = TestClient(app)
+    sid = app.state.store.open_session_id()
+    with client.websocket_connect("/ws/chat", subprotocols=["club", TOKEN]) as ws:
+        ws.send_json(
+            {
+                "type": "chat",
+                "text": "private prompt sk-live-PLANTED",
+                "session_id": sid,
+            }
+        )
+        events = []
+        while not events or events[-1]["type"] not in {"turn_end", "error"}:
+            events.append(ws.receive_json())
+
+    response = client.get(
+        f"/v1/sessions/{sid}/telemetry/current",
+        headers={TOKEN_HEADER: TOKEN},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["version"] == 1
+    assert body["session_id"] == sid
+    assert body["current_run"] == {
+        "run_id": events[0]["run_id"],
+        "status": "success",
+        "input_tokens": 80,
+        "output_tokens": 20,
+        "total_tokens": 100,
+        "cache_hit_input_tokens": 30,
+        "cache_miss_input_tokens": 50,
+        "reasoning_tokens": 4,
+        "current_context_tokens": 80,
+        "context_window_tokens": None,
+        "context_use_ratio": None,
+        "elapsed_ms": body["current_run"]["elapsed_ms"],
+        "estimated_cost_usd": None,
+        "retry_count": 0,
+        "compaction_count": 0,
+    }
+    assert isinstance(body["current_run"]["elapsed_ms"], (int, float))
+    encoded = json.dumps(body)
+    assert "PLANTED" not in encoded
+    assert "prompt" not in encoded
+    assert "response" not in encoded
+    assert "arguments" not in encoded
+    assert "result" not in encoded
+    assert "raw_error" not in encoded
+
+
+def test_manual_safe_retry_records_one_typed_retry_and_nested_tool_span(
+    tmp_path, monkeypatch
+):
+    provider = FakeProvider(
+        steps=[
+            {
+                "tool_calls": [
+                    ToolCall(
+                        id="call-drive",
+                        name="drive_search",
+                        arguments={"query": "Codeology"},
+                    )
+                ]
+            },
+            {"deltas": ("partial",)},
+        ]
+    )
+    attempts = 0
+
+    def flaky_execute(name, arguments, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return False, {"error": "Drive timed out"}
+        return True, {"files": []}
+
+    monkeypatch.setattr("coworker.turn.execute", flaky_execute)
+    app = create_app(token=TOKEN, provider=provider, state=tmp_path)
+    sid = app.state.store.open_session_id()
+    with TestClient(app).websocket_connect(
+        "/ws/chat", subprotocols=["club", TOKEN]
+    ) as ws:
+        ws.send_json({"type": "chat", "text": "search", "session_id": sid})
+        events = []
+        while not events or events[-1]["type"] not in {"turn_end", "error"}:
+            events.append(ws.receive_json())
+        ws.send_json(
+            {
+                "type": "retry_failed_step",
+                "session_id": sid,
+                "run_id": events[0]["run_id"],
+                "call_id": "call-drive",
+                "command_id": "retry-1",
+            }
+        )
+        time.sleep(0.08)
+
+    records = app.state.telemetry_adapter.records
+    retries = [
+        record.event
+        for record in records
+        if isinstance(record, SpanEventRecord)
+        and isinstance(record.event, RetryEvent)
+    ]
+    assert len(retries) == 1
+    assert retries[0].retry_count == 1
+    agents = [
+        record
+        for record in records
+        if isinstance(record, SpanStartedRecord)
+        and isinstance(record.span, AgentTurnSpan)
+    ]
+    assert [record.span.operation for record in agents] == [
+        "agent.turn",
+        "agent.recovery",
+    ]
+    tools = [
+        record
+        for record in records
+        if isinstance(record, SpanStartedRecord)
+        and isinstance(record.span, ToolSpan)
+    ]
+    assert len(tools) == 2
+    assert tools[-1].parent_span_id == agents[-1].span_id
+    retry_terminal = next(
+        record.terminal
+        for record in records
+        if isinstance(record, SpanSettledRecord)
+        and record.span_id == tools[-1].span_id
+    )
+    assert retry_terminal.status is SpanStatus.SUCCESS
+    assert retry_terminal.retry_count == 1
+    metrics = app.state.telemetry_adapter.current_session_metrics(
+        session_id=sid,
+        now_ns=time.monotonic_ns(),
+    )
+    assert metrics.retry_count == 1
+    assert metrics.compaction_count == 0
+
+
+def test_http_claimed_tool_execution_has_session_run_parentage(tmp_path):
+    app = create_app(token=TOKEN, provider=UsageProvider(), state=tmp_path)
+    sid = app.state.store.open_session_id()
+    app.state.inbox.park(
+        "now",
+        {},
+        item_id="approval-now",
+        reason="approval test",
+        session_id=sid,
+        run_id="run-approved",
+        message_id="message-approved",
+        part_id="part-approved",
+    )
+
+    response = TestClient(app).post(
+        "/v1/inbox/approval-now",
+        headers={TOKEN_HEADER: TOKEN},
+        json={"decision": "allow", "actor": "operator", "scope": "once"},
+    )
+
+    assert response.status_code == 200
+    records = app.state.telemetry_adapter.records
+    agent = next(
+        record
+        for record in records
+        if isinstance(record, SpanStartedRecord)
+        and isinstance(record.span, AgentTurnSpan)
+    )
+    tool = next(
+        record
+        for record in records
+        if isinstance(record, SpanStartedRecord)
+        and isinstance(record.span, ToolSpan)
+    )
+    assert agent.span.operation == "agent.approval"
+    assert agent.context.session_id == sid
+    assert agent.context.run_id == "run-approved"
+    assert tool.parent_span_id == agent.span_id
+    assert tool.span.tool_name == "now"
+    terminals = {
+        record.span_id: record.terminal.status
+        for record in records
+        if isinstance(record, SpanSettledRecord)
+    }
+    assert terminals[agent.span_id] is SpanStatus.SUCCESS
+    assert terminals[tool.span_id] is SpanStatus.SUCCESS
+
+
+def test_approved_recovery_records_retry_only_when_the_tool_executes(tmp_path):
+    app = create_app(token=TOKEN, provider=UsageProvider(), state=tmp_path)
+    sid = app.state.store.open_session_id()
+    app.state.inbox.park(
+        "now",
+        {},
+        item_id="recovery-now",
+        reason="retry approval test",
+        session_id=sid,
+        run_id="run-recovery",
+        message_id="message-recovery",
+        part_id="part-recovery",
+        kind="recovery_approval",
+        recovery_command_id="recovery-command",
+        original_call_id="original-call",
+    )
+
+    response = TestClient(app).post(
+        "/v1/inbox/recovery-now",
+        headers={TOKEN_HEADER: TOKEN},
+        json={"decision": "allow", "actor": "operator", "scope": "once"},
+    )
+
+    assert response.status_code == 200
+    records = app.state.telemetry_adapter.records
+    retry = next(
+        record.event
+        for record in records
+        if isinstance(record, SpanEventRecord)
+        and isinstance(record.event, RetryEvent)
+    )
+    assert retry.operation == "tool.execute"
+    assert retry.retry_count == 1
+    agent = next(
+        record
+        for record in records
+        if isinstance(record, SpanStartedRecord)
+        and isinstance(record.span, AgentTurnSpan)
+    )
+    tool = next(
+        record
+        for record in records
+        if isinstance(record, SpanStartedRecord)
+        and isinstance(record.span, ToolSpan)
+    )
+    assert agent.span.operation == "agent.recovery"
+    assert tool.parent_span_id == agent.span_id

--- a/desktop/tests/test_telemetry_live.py
+++ b/desktop/tests/test_telemetry_live.py
@@ -5,6 +5,7 @@ import pytest
 
 from coworker.events import TurnIdentity
 from coworker.inbox import Inbox
+from coworker.permissions import decide
 from coworker.provider import ModelUsage, StreamChunk, ToolCall
 from coworker.store import ConversationStore
 from coworker.telemetry import InMemoryTelemetryAdapter, TelemetryRecorder
@@ -355,6 +356,55 @@ def test_unsafe_provider_model_identifier_cannot_change_the_turn_outcome(tmp_pat
     assert "PLANTED" not in json.dumps(
         [record_to_dict(record) for record in adapter.records]
     )
+
+
+def test_invalid_auto_allowed_tool_name_cannot_change_the_turn_outcome(tmp_path):
+    name = "mcp__granola__list meetings"
+    assert decide(name).allowed is True
+
+    def make_provider():
+        return StepProvider(
+            [
+                [
+                    StreamChunk(
+                        tool_calls=[
+                            ToolCall(id="call-1", name=name, arguments={})
+                        ]
+                    ),
+                    StreamChunk(finish_reason="tool_calls"),
+                ],
+                [
+                    StreamChunk(text_delta="recovered"),
+                    StreamChunk(finish_reason="stop"),
+                ],
+            ]
+        )
+
+    recorded, _adapter = run_with_telemetry(tmp_path / "recorded", make_provider())
+    store = ConversationStore(tmp_path / "noop")
+    store.create_session("session-1")
+    noop = asyncio.run(
+        run_turn(
+            text="find private candidates",
+            sid="session-1",
+            store=store,
+            provider=make_provider(),
+            persona=None,
+            skills=None,
+            inbox=Inbox(store),
+            openai_tools=[],
+            execute_kwargs={},
+            identity=TurnIdentity(
+                session_id="session-1",
+                run_id="run-1",
+                message_id="message-1",
+                part_id="part-1",
+            ),
+        )
+    )
+
+    assert recorded == {"status": "partial", "text": "recovered"}
+    assert noop == {"status": "partial", "text": "recovered"}
 
 
 def test_task_cancellation_settles_the_active_tool_and_agent_spans(

--- a/desktop/tests/test_telemetry_live.py
+++ b/desktop/tests/test_telemetry_live.py
@@ -1,0 +1,448 @@
+import asyncio
+import json
+
+import pytest
+
+from coworker.events import TurnIdentity
+from coworker.inbox import Inbox
+from coworker.provider import ModelUsage, StreamChunk, ToolCall
+from coworker.store import ConversationStore
+from coworker.telemetry import InMemoryTelemetryAdapter, TelemetryRecorder
+from coworker.telemetry.schema import (
+    AgentTurnSpan,
+    ErrorKind,
+    ProviderSpan,
+    SpanEventRecord,
+    SpanSettledRecord,
+    SpanStartedRecord,
+    SpanStatus,
+    StopReason,
+    ToolSpan,
+    UsageEvent,
+    record_to_dict,
+)
+from coworker.turn import RunControl, _telemetry_provider_name, run_turn
+
+
+class ContractProvider:
+    model_id = "contract-model"
+
+    def __init__(self, chunks: list[StreamChunk]) -> None:
+        self.chunks = chunks
+
+    async def astream(self, *, messages, tools):
+        for chunk in self.chunks:
+            yield chunk
+
+
+class StepProvider:
+    model_id = "step-model"
+
+    def __init__(self, steps: list[list[StreamChunk]]) -> None:
+        self.steps = steps
+        self.index = 0
+
+    async def astream(self, *, messages, tools):
+        chunks = self.steps[self.index]
+        self.index += 1
+        for chunk in chunks:
+            yield chunk
+
+
+def test_openai_compatible_provider_identity_uses_the_configured_vendor_host():
+    MoonshotAdapter = type(
+        "OpenAICompatProvider",
+        (),
+        {"base_url": "https://api.moonshot.ai/v1"},
+    )
+    OpenAIAdapter = type(
+        "OpenAICompatProvider",
+        (),
+        {"base_url": "https://api.openai.com/v1"},
+    )
+
+    assert _telemetry_provider_name(MoonshotAdapter()) == "moonshot"
+    assert _telemetry_provider_name(OpenAIAdapter()) == "openai"
+
+
+def run_with_telemetry(tmp_path, provider, *, control=None, text="find private candidates"):
+    store = ConversationStore(tmp_path)
+    store.create_session("session-1")
+    adapter = InMemoryTelemetryAdapter()
+    recorder = TelemetryRecorder(adapter)
+    result = asyncio.run(
+        run_turn(
+            text=text,
+            sid="session-1",
+            store=store,
+            provider=provider,
+            persona=None,
+            skills=None,
+            inbox=Inbox(store),
+            openai_tools=[],
+            execute_kwargs={},
+            identity=TurnIdentity(
+                session_id="session-1",
+                run_id="run-1",
+                message_id="message-1",
+                part_id="part-1",
+            ),
+            telemetry=recorder,
+            control=control,
+        )
+    )
+    return result, adapter
+
+
+def test_run_turn_records_provider_usage_under_the_authoritative_agent_span(tmp_path):
+    usage = ModelUsage(
+        input_tokens=120,
+        output_tokens=30,
+        total_tokens=150,
+        cached_input_tokens=20,
+        uncached_input_tokens=100,
+        reasoning_tokens=8,
+    )
+    result, adapter = run_with_telemetry(
+        tmp_path,
+        ContractProvider(
+            [
+                StreamChunk(text_delta="done"),
+                StreamChunk(usage=usage),
+                StreamChunk(finish_reason="stop"),
+            ]
+        ),
+    )
+
+    assert result == {"status": "ok", "text": "done"}
+    starts = [
+        record for record in adapter.records if isinstance(record, SpanStartedRecord)
+    ]
+    assert [type(record.span) for record in starts] == [AgentTurnSpan, ProviderSpan]
+    assert starts[0].context.session_id == "session-1"
+    assert starts[0].context.run_id == "run-1"
+    assert starts[1].parent_span_id == starts[0].span_id
+    assert starts[1].span.provider == "contract"
+    assert starts[1].span.model == "contract-model"
+    assert starts[1].span.operation == "provider.request"
+
+    usage_records = [
+        record
+        for record in adapter.records
+        if isinstance(record, SpanEventRecord)
+        and isinstance(record.event, UsageEvent)
+    ]
+    assert [record.event for record in usage_records] == [
+        UsageEvent(
+            input_tokens=120,
+            output_tokens=30,
+            total_tokens=150,
+            cache_hit_input_tokens=20,
+            cache_miss_input_tokens=100,
+            reasoning_tokens=8,
+            current_context_tokens=120,
+        )
+    ]
+    terminals = [
+        record
+        for record in adapter.records
+        if isinstance(record, SpanSettledRecord)
+    ]
+    assert terminals[0].terminal.status is SpanStatus.SUCCESS
+    assert terminals[0].terminal.stop_reason is StopReason.COMPLETED
+    assert terminals[0].terminal.usage == usage_records[0].event
+    assert terminals[1].terminal.status is SpanStatus.SUCCESS
+
+
+def test_live_telemetry_never_captures_prompt_response_or_transient_reasoning(tmp_path):
+    planted = "sk-live-PLANTED-DO-NOT-CAPTURE"
+    result, adapter = run_with_telemetry(
+        tmp_path,
+        ContractProvider(
+            [
+                StreamChunk(transient_reasoning_delta=f"reasoning {planted}"),
+                StreamChunk(text_delta=f"response {planted}"),
+                StreamChunk(finish_reason="stop"),
+            ]
+        ),
+        text=f"prompt {planted}",
+    )
+
+    assert result["status"] == "ok"
+    serialized = json.dumps([record_to_dict(record) for record in adapter.records])
+    assert planted not in serialized
+    assert "prompt" not in serialized
+    assert "response" not in serialized
+    assert "reasoning " not in serialized
+
+
+def test_run_turn_records_successful_tool_execution_as_an_agent_child(tmp_path):
+    provider = StepProvider(
+        [
+            [
+                StreamChunk(
+                    tool_calls=[ToolCall(id="call-1", name="now", arguments={})]
+                ),
+                StreamChunk(finish_reason="tool_calls"),
+            ],
+            [StreamChunk(text_delta="done"), StreamChunk(finish_reason="stop")],
+        ]
+    )
+
+    result, adapter = run_with_telemetry(tmp_path, provider)
+
+    assert result["status"] == "ok"
+    starts = [
+        record for record in adapter.records if isinstance(record, SpanStartedRecord)
+    ]
+    agent = next(record for record in starts if isinstance(record.span, AgentTurnSpan))
+    tool = next(record for record in starts if isinstance(record.span, ToolSpan))
+    assert tool.parent_span_id == agent.span_id
+    assert tool.span.tool_name == "now"
+    assert tool.span.operation == "tool.execute"
+    terminal = next(
+        record
+        for record in adapter.records
+        if isinstance(record, SpanSettledRecord) and record.span_id == tool.span_id
+    )
+    assert terminal.terminal.status is SpanStatus.SUCCESS
+
+
+def test_run_turn_marks_failed_tool_and_agent_spans_partial(tmp_path):
+    provider = StepProvider(
+        [
+            [
+                StreamChunk(
+                    tool_calls=[
+                        ToolCall(
+                            id="call-1",
+                            name="drive_read",
+                            arguments={"file_id": "private-file"},
+                        )
+                    ]
+                ),
+                StreamChunk(finish_reason="tool_calls"),
+            ],
+            [StreamChunk(text_delta="partial"), StreamChunk(finish_reason="stop")],
+        ]
+    )
+
+    result, adapter = run_with_telemetry(tmp_path, provider)
+
+    assert result["status"] == "partial"
+    starts = [
+        record for record in adapter.records if isinstance(record, SpanStartedRecord)
+    ]
+    tool = next(record for record in starts if isinstance(record.span, ToolSpan))
+    agent = next(record for record in starts if isinstance(record.span, AgentTurnSpan))
+    terminals = {
+        record.span_id: record.terminal
+        for record in adapter.records
+        if isinstance(record, SpanSettledRecord)
+    }
+    assert terminals[tool.span_id].status is SpanStatus.PARTIAL
+    assert terminals[tool.span_id].error_kind is ErrorKind.TOOL
+    assert terminals[agent.span_id].status is SpanStatus.PARTIAL
+
+
+def test_run_turn_settles_provider_and_agent_spans_on_provider_failure(tmp_path):
+    planted = "raw provider error sk-live-PLANTED-DO-NOT-CAPTURE"
+
+    class FailingProvider:
+        model_id = "failing-model"
+
+        async def astream(self, *, messages, tools):
+            if False:
+                yield StreamChunk()
+            raise RuntimeError(planted)
+
+    result, adapter = run_with_telemetry(tmp_path, FailingProvider())
+
+    assert result["status"] == "error"
+    terminals = [
+        record.terminal
+        for record in adapter.records
+        if isinstance(record, SpanSettledRecord)
+    ]
+    assert [terminal.status for terminal in terminals] == [
+        SpanStatus.FAILED,
+        SpanStatus.FAILED,
+    ]
+    assert [terminal.error_kind for terminal in terminals] == [
+        ErrorKind.PROVIDER,
+        ErrorKind.PROVIDER,
+    ]
+    assert planted not in json.dumps(
+        [record_to_dict(record) for record in adapter.records]
+    )
+
+
+def test_run_turn_settles_provider_and_agent_spans_when_cancelled(tmp_path):
+    identity = TurnIdentity(
+        session_id="session-1",
+        run_id="run-1",
+        message_id="message-1",
+        part_id="part-1",
+    )
+    control = RunControl(identity)
+    control.cancel_requested.set()
+    result, adapter = run_with_telemetry(
+        tmp_path,
+        ContractProvider([StreamChunk(text_delta="must not finish")]),
+        control=control,
+    )
+
+    assert result["status"] == "stopped"
+    terminals = [
+        record.terminal
+        for record in adapter.records
+        if isinstance(record, SpanSettledRecord)
+    ]
+    assert [terminal.status for terminal in terminals] == [
+        SpanStatus.CANCELLED,
+        SpanStatus.CANCELLED,
+    ]
+
+
+def test_run_turn_preserves_missing_provider_usage_as_unknown(tmp_path):
+    result, adapter = run_with_telemetry(
+        tmp_path,
+        ContractProvider(
+            [StreamChunk(text_delta="done"), StreamChunk(finish_reason="stop")]
+        ),
+    )
+
+    assert result["status"] == "ok"
+    provider_terminal = next(
+        record.terminal
+        for record in adapter.records
+        if isinstance(record, SpanSettledRecord)
+        and record.terminal.stop_reason is StopReason.COMPLETED
+        and record.terminal.usage is None
+    )
+    assert provider_terminal.usage is None
+
+
+def test_run_turn_settles_the_agent_span_when_no_provider_is_configured(tmp_path):
+    result, adapter = run_with_telemetry(tmp_path, None)
+
+    assert result["status"] == "error"
+    terminal = next(
+        record.terminal
+        for record in adapter.records
+        if isinstance(record, SpanSettledRecord)
+    )
+    assert terminal.status is SpanStatus.FAILED
+    assert terminal.error_kind is ErrorKind.PROVIDER
+
+
+def test_unsafe_provider_model_identifier_cannot_change_the_turn_outcome(tmp_path):
+    provider = ContractProvider(
+        [StreamChunk(text_delta="done"), StreamChunk(finish_reason="stop")]
+    )
+    provider.model_id = "sk-live-PLANTED-DO-NOT-CAPTURE"
+
+    result, adapter = run_with_telemetry(tmp_path, provider)
+
+    assert result == {"status": "ok", "text": "done"}
+    provider_start = next(
+        record
+        for record in adapter.records
+        if isinstance(record, SpanStartedRecord)
+        and isinstance(record.span, ProviderSpan)
+    )
+    assert provider_start.span.model == "unknown"
+    assert "PLANTED" not in json.dumps(
+        [record_to_dict(record) for record in adapter.records]
+    )
+
+
+def test_task_cancellation_settles_the_active_tool_and_agent_spans(
+    tmp_path, monkeypatch
+):
+    def cancelled_execute(name, arguments, **kwargs):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr("coworker.turn.execute", cancelled_execute)
+    provider = StepProvider(
+        [
+            [
+                StreamChunk(
+                    tool_calls=[ToolCall(id="call-1", name="now", arguments={})]
+                ),
+                StreamChunk(finish_reason="tool_calls"),
+            ]
+        ]
+    )
+    store = ConversationStore(tmp_path)
+    store.create_session("session-1")
+    adapter = InMemoryTelemetryAdapter()
+    recorder = TelemetryRecorder(adapter)
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(
+            run_turn(
+                text="cancel",
+                sid="session-1",
+                store=store,
+                provider=provider,
+                persona=None,
+                skills=None,
+                inbox=Inbox(store),
+                openai_tools=[],
+                execute_kwargs={},
+                identity=TurnIdentity(
+                    session_id="session-1",
+                    run_id="run-1",
+                    message_id="message-1",
+                    part_id="part-1",
+                ),
+                telemetry=recorder,
+            )
+        )
+
+    starts = {
+        type(record.span): record.span_id
+        for record in adapter.records
+        if isinstance(record, SpanStartedRecord)
+    }
+    terminals = {
+        record.span_id: record.terminal.status
+        for record in adapter.records
+        if isinstance(record, SpanSettledRecord)
+    }
+    assert terminals[starts[ToolSpan]] is SpanStatus.CANCELLED
+    assert terminals[starts[AgentTurnSpan]] is SpanStatus.CANCELLED
+
+
+def test_step_limit_settles_the_agent_span_instead_of_leaving_it_running(tmp_path):
+    provider = StepProvider(
+        [
+            [
+                StreamChunk(
+                    tool_calls=[
+                        ToolCall(id=f"call-{index}", name="now", arguments={})
+                    ]
+                ),
+                StreamChunk(finish_reason="tool_calls"),
+            ]
+            for index in range(8)
+        ]
+    )
+
+    result, adapter = run_with_telemetry(tmp_path, provider)
+
+    assert result["status"] == "stopped"
+    agent_start = next(
+        record
+        for record in adapter.records
+        if isinstance(record, SpanStartedRecord)
+        and isinstance(record.span, AgentTurnSpan)
+    )
+    agent_terminal = next(
+        record.terminal
+        for record in adapter.records
+        if isinstance(record, SpanSettledRecord)
+        and record.span_id == agent_start.span_id
+    )
+    assert agent_terminal.status is SpanStatus.CANCELLED

--- a/desktop/tests/test_telemetry_metrics.py
+++ b/desktop/tests/test_telemetry_metrics.py
@@ -2,9 +2,13 @@ from coworker.telemetry.adapters import InMemoryTelemetryAdapter, TelemetryRecor
 from coworker.telemetry.metrics import CurrentRunMetrics
 from coworker.telemetry.schema import (
     AgentTurnSpan,
+    CompactionEvent,
+    CompactionReason,
     CostEstimate,
     CostEvent,
     ProviderSpan,
+    RetryEvent,
+    RetryReason,
     TraceContext,
     UsageEvent,
 )
@@ -63,6 +67,7 @@ def test_current_run_metrics_aggregate_provider_usage_cost_context_and_elapsed_t
 
     assert metrics == CurrentRunMetrics(
         run_id="run-1",
+        status="running",
         input_tokens=13,
         output_tokens=7,
         total_tokens=20,
@@ -74,6 +79,8 @@ def test_current_run_metrics_aggregate_provider_usage_cost_context_and_elapsed_t
         context_use_ratio=0.08,
         elapsed_ms=8.0,
         estimated_cost_usd=0.0062,
+        retry_count=0,
+        compaction_count=0,
     )
 
 
@@ -101,3 +108,51 @@ def test_current_run_metrics_preserve_missing_usage_as_unknown():
     assert metrics.context_use_ratio is None
     assert metrics.estimated_cost_usd is None
     assert metrics.elapsed_ms == 3.0
+    assert metrics.status == "success"
+
+
+def test_current_run_metrics_count_only_events_that_were_actually_recorded():
+    adapter = InMemoryTelemetryAdapter()
+    recorder = TelemetryRecorder(adapter, clock=StepClock())
+    context = TraceContext(session_id="session-1", run_id="run-1")
+    turn = recorder.start_span(AgentTurnSpan(operation="agent.turn"), context)
+    turn.record(
+        RetryEvent(
+            operation="provider.request",
+            retry_count=1,
+            reason=RetryReason.TIMEOUT,
+        )
+    )
+    turn.record(
+        CompactionEvent(
+            operation="agent.context",
+            reason=CompactionReason.CONTEXT_LIMIT,
+            input_tokens=100,
+            output_tokens=40,
+        )
+    )
+
+    metrics = adapter.current_run_metrics(run_id="run-1", now_ns=5_000_000)
+
+    assert metrics.retry_count == 1
+    assert metrics.compaction_count == 1
+
+
+def test_in_memory_adapter_returns_the_latest_run_for_a_session():
+    adapter = InMemoryTelemetryAdapter()
+    recorder = TelemetryRecorder(adapter, clock=StepClock())
+    first_context = TraceContext(session_id="session-1", run_id="run-1")
+    recorder.start_span(AgentTurnSpan(operation="agent.turn"), first_context).finish()
+    second_context = TraceContext(session_id="session-1", run_id="run-2")
+    recorder.start_span(AgentTurnSpan(operation="agent.turn"), second_context)
+
+    metrics = adapter.current_session_metrics(
+        session_id="session-1", now_ns=5_000_000
+    )
+
+    assert metrics is not None
+    assert metrics.run_id == "run-2"
+    assert metrics.status == "running"
+    assert adapter.current_session_metrics(
+        session_id="missing", now_ns=5_000_000
+    ) is None


### PR DESCRIPTION
## Summary\n\n- create one in-memory telemetry recorder at the sidecar composition root\n- instrument authoritative agent-turn, provider-request, tool-execution, approval, cancellation, partial, step-limit, and manual-retry paths with session/run parentage\n- map provider usage and terminal state into the closed content-free telemetry vocabulary from PR #85\n- add an authenticated current-run telemetry endpoint\n- show a compact current-run metrics strip in chat for tokens, context use, elapsed time, retries, compactions, and cost availability\n- rebuild explicit API and GUI allowlists so prompts, responses, reasoning, arguments, results, command output, credentials, and raw errors cannot escape\n\n## Verification\n\n- focused Python runtime, approval, and retry suite: 108 passed\n- focused GUI suite: 65 passed\n- make test: 546 Python passed, 2 skipped; 363 GUI passed\n- make build: passed\n- existing Starlette/httpx deprecation warning and Vite large-chunk advisory remain\n\n## Review focus\n\n- telemetry cannot change business outcomes or leak content\n- all run and tool paths settle exactly once with authoritative session/run identity\n- metrics remain isolated when navigating between threads\n- manual retry increments only when execution actually occurs\n- cost and context-window percentages remain explicitly unavailable until provider metadata supplies them\n\nRefs #81\n\n## Follow-up\n\nIssue #81 remains open until the #80 provider contract supplies stable provider identity, context-window metadata, and estimated-cost data where pricing is known.