### PR TITLE
feat(desktop): add provider conformance contract

### DIFF
--- a/desktop/coworker/provider.py
+++ b/desktop/coworker/provider.py
@@ -7,8 +7,11 @@ import os
 from collections import OrderedDict
 from copy import deepcopy
 from dataclasses import dataclass, field
+from enum import Enum
 from hashlib import sha256
-from typing import Any, AsyncIterator, Optional, Protocol
+from time import monotonic
+from typing import Any, AsyncIterator, Mapping, Optional, Protocol
+from urllib.parse import urlparse
 
 
 @dataclass
@@ -34,6 +37,138 @@ class ModelUsage:
     cached_input_tokens: int
     uncached_input_tokens: int
     reasoning_tokens: int
+    cache_write_input_tokens: int = 0
+
+    def __post_init__(self) -> None:
+        counts = (
+            self.input_tokens,
+            self.output_tokens,
+            self.total_tokens,
+            self.cached_input_tokens,
+            self.uncached_input_tokens,
+            self.reasoning_tokens,
+            self.cache_write_input_tokens,
+        )
+        if any(
+            isinstance(value, bool) or not isinstance(value, int) or value < 0
+            for value in counts
+        ):
+            raise ValueError("usage counts must be non-negative integers")
+        if self.cached_input_tokens + self.uncached_input_tokens != self.input_tokens:
+            raise ValueError("cached and uncached input counts must equal input tokens")
+        if self.cache_write_input_tokens > self.uncached_input_tokens:
+            raise ValueError("cache write input cannot exceed uncached input tokens")
+        if self.input_tokens + self.output_tokens != self.total_tokens:
+            raise ValueError("input and output counts must equal total tokens")
+
+
+class StreamKind(str, Enum):
+    START = "start"
+    TEXT = "text"
+    REASONING = "reasoning"
+    TOOL_DELTA = "tool_delta"
+    TOOL_CALLS = "tool_calls"
+    USAGE = "usage"
+    TERMINAL = "terminal"
+    ERROR = "error"
+
+
+class ProviderErrorKind(str, Enum):
+    AUTHENTICATION = "authentication"
+    RATE_LIMIT = "rate_limit"
+    TIMEOUT = "timeout"
+    CONNECTION = "connection"
+    INVALID_REQUEST = "invalid_request"
+    PROTOCOL = "protocol"
+    PROVIDER = "provider"
+    CONFIGURATION = "configuration"
+
+
+@dataclass(frozen=True)
+class ProviderStart:
+    provider: str
+    model: str
+
+
+@dataclass(frozen=True)
+class ProviderCapabilities:
+    text: bool
+    transient_reasoning: bool
+    tool_calling: bool
+    terminal_usage: bool
+    cache_usage: bool
+    reasoning_usage: bool
+
+
+@dataclass(frozen=True)
+class ProviderVerification:
+    provider: str
+    model: str
+    eligible: bool
+    failures: tuple[str, ...]
+    capabilities: ProviderCapabilities
+
+
+@dataclass(frozen=True)
+class ProviderTerminal:
+    stop_reason: str
+    usage: ModelUsage | None
+    latency_ms: float
+    estimated_cost_usd: float | None
+
+
+@dataclass(frozen=True)
+class ModelPricing:
+    uncached_input_per_million: float
+    cached_input_per_million: float
+    output_per_million: float
+    cache_write_input_per_million: float | None = None
+
+
+class ProviderStreamError(RuntimeError):
+    kind = StreamKind.ERROR
+
+    def __init__(
+        self,
+        *,
+        provider: str,
+        model: str,
+        kind: ProviderErrorKind,
+        message: str,
+        retryable: bool,
+        http_status: int | None = None,
+    ) -> None:
+        super().__init__(f"{provider} {message}")
+        self.provider = provider
+        self.model = model
+        self.error_kind = kind
+        self.retryable = retryable
+        self.http_status = http_status
+
+
+def _http_error_kind(status_code: int) -> ProviderErrorKind:
+    if status_code in {401, 403}:
+        return ProviderErrorKind.AUTHENTICATION
+    if status_code == 429:
+        return ProviderErrorKind.RATE_LIMIT
+    if status_code == 408:
+        return ProviderErrorKind.TIMEOUT
+    if status_code in {400, 404, 409, 422}:
+        return ProviderErrorKind.INVALID_REQUEST
+    return ProviderErrorKind.PROVIDER
+
+
+def _provider_http_error(
+    *, provider: str, model: str, status_code: int
+) -> ProviderStreamError:
+    return ProviderStreamError(
+        provider=provider,
+        model=model,
+        kind=_http_error_kind(status_code),
+        message=f"provider request failed with HTTP {status_code}",
+        retryable=status_code in {408, 409, 429} or status_code >= 500,
+        http_status=status_code,
+    )
 
 
 @dataclass
@@ -44,9 +179,51 @@ class StreamChunk:
     tool_calls: list[ToolCall] | None = None
     finish_reason: str | None = None
     usage: ModelUsage | None = None
+    kind: StreamKind | None = None
+    start: ProviderStart | None = None
+    terminal: ProviderTerminal | None = None
+
+    def __post_init__(self) -> None:
+        payload_count = sum(
+            (
+                self.text_delta is not None,
+                self.transient_reasoning_delta is not None,
+                self.tool_call_deltas is not None,
+                self.tool_calls is not None,
+                self.usage is not None,
+                self.finish_reason is not None or self.terminal is not None,
+                self.start is not None,
+            )
+        )
+        if payload_count > 1:
+            raise ValueError("stream chunks require exactly one lifecycle payload")
+        if self.kind is not None:
+            return
+        if self.text_delta is not None:
+            self.kind = StreamKind.TEXT
+        elif self.transient_reasoning_delta is not None:
+            self.kind = StreamKind.REASONING
+        elif self.tool_call_deltas is not None:
+            self.kind = StreamKind.TOOL_DELTA
+        elif self.tool_calls is not None:
+            self.kind = StreamKind.TOOL_CALLS
+        elif self.usage is not None:
+            self.kind = StreamKind.USAGE
+        elif self.finish_reason is not None or self.terminal is not None:
+            self.kind = StreamKind.TERMINAL
+        elif self.start is not None:
+            self.kind = StreamKind.START
+
+    @classmethod
+    def started(cls, *, provider: str, model: str) -> StreamChunk:
+        return cls(
+            kind=StreamKind.START,
+            start=ProviderStart(provider=provider, model=model),
+        )
 
 
 class StreamProvider(Protocol):
+    provider_id: str
     model_id: str
 
     def astream(
@@ -61,6 +238,7 @@ class StreamProvider(Protocol):
 class FakeProvider:
     """Deterministic stream for tests. Never hits a network."""
 
+    provider_id = "fake"
     model_id = "fake"
 
     def __init__(
@@ -83,8 +261,35 @@ class FakeProvider:
         self.calls.append(list(messages))
         step = self.steps[min(self.i, len(self.steps) - 1)]
         self.i += 1
+        started_at = monotonic()
+        yield StreamChunk.started(provider=self.provider_id, model=self.model_id)
+        failure = step.get("error")
+        if isinstance(failure, ProviderStreamError):
+            raise failure
+        for delta in step.get("reasoning_deltas") or ():
+            yield StreamChunk(transient_reasoning_delta=str(delta))
         for delta in step.get("deltas") or ():
             yield StreamChunk(text_delta=delta)
+        for delta in step.get("tool_call_deltas") or ():
+            yield StreamChunk(tool_call_deltas=[delta])
+        usage = step.get("usage")
+        if isinstance(usage, ModelUsage):
+            yield StreamChunk(usage=usage)
+        finish_reason = step.get("finish_reason")
+        if finish_reason:
+            reason = str(finish_reason)
+            yield StreamChunk(
+                finish_reason=reason,
+                terminal=ProviderTerminal(
+                    stop_reason=reason,
+                    usage=usage if isinstance(usage, ModelUsage) else None,
+                    latency_ms=max(0.0, monotonic() - started_at) * 1000,
+                    estimated_cost_usd=_estimate_cost(
+                        self.model_id,
+                        usage if isinstance(usage, ModelUsage) else None,
+                    ),
+                ),
+            )
         calls = step.get("tool_calls")
         if calls:
             yield StreamChunk(tool_calls=list(calls))
@@ -94,6 +299,117 @@ DEEPSEEK_MODEL = "deepseek-v4-pro"
 KIMI_MODEL = "kimi-k3"
 DEEPSEEK_BASE = "https://api.deepseek.com"
 KIMI_BASE = "https://api.moonshot.ai/v1"
+
+_PROVIDER_DEFAULTS: tuple[tuple[str, str, str], ...] = (
+    ("deepseek", DEEPSEEK_MODEL, "DEEPSEEK_API_KEY"),
+    ("kimi", KIMI_MODEL, "MOONSHOT_API_KEY"),
+    ("anthropic", "claude-sonnet-4-6", "ANTHROPIC_API_KEY"),
+    ("openai", "gpt-4o-mini", "OPENAI_API_KEY"),
+)
+
+_PROVIDER_CAPABILITIES = {
+    "deepseek": ProviderCapabilities(True, True, True, True, True, True),
+    "kimi": ProviderCapabilities(True, True, True, True, True, False),
+    "anthropic": ProviderCapabilities(True, True, True, True, True, False),
+    "openai": ProviderCapabilities(True, True, True, True, True, True),
+}
+
+_MODEL_PRICING = {
+    "deepseek-v4-flash": ModelPricing(0.14, 0.0028, 0.28),
+    "deepseek-v4-pro": ModelPricing(0.435, 0.003625, 0.87),
+    "claude-sonnet-4-6": ModelPricing(3.0, 0.30, 15.0, 3.75),
+    "gpt-4o-mini": ModelPricing(0.15, 0.075, 0.60),
+}
+
+
+def _estimate_cost(model: str, usage: ModelUsage | None) -> float | None:
+    pricing = _MODEL_PRICING.get(model)
+    if pricing is None or usage is None:
+        return None
+    cache_write_rate = (
+        pricing.cache_write_input_per_million
+        if pricing.cache_write_input_per_million is not None
+        else pricing.uncached_input_per_million
+    )
+    ordinary_input = usage.uncached_input_tokens - usage.cache_write_input_tokens
+    return (
+        ordinary_input * pricing.uncached_input_per_million
+        + usage.cache_write_input_tokens * cache_write_rate
+        + usage.cached_input_tokens * pricing.cached_input_per_million
+        + usage.output_tokens * pricing.output_per_million
+    ) / 1_000_000
+
+
+def provider_verifications(
+    environment: Mapping[str, str] | None = None,
+) -> tuple[ProviderVerification, ...]:
+    env = os.environ if environment is None else environment
+    override = str(env.get("CLUB_MODEL") or "").strip()
+    first_configured = next(
+        (
+            provider
+            for provider, _model, key_name in _PROVIDER_DEFAULTS
+            if str(env.get(key_name) or "").strip()
+            or (
+                provider == "kimi"
+                and str(env.get("KIMI_API_KEY") or "").strip()
+            )
+        ),
+        None,
+    )
+    reports: list[ProviderVerification] = []
+    for provider, default_model, key_name in _PROVIDER_DEFAULTS:
+        model = override if override and provider == first_configured else default_model
+        key = str(env.get(key_name) or "").strip()
+        if provider == "kimi" and not key:
+            key = str(env.get("KIMI_API_KEY") or "").strip()
+        failures: list[str] = []
+        if not key:
+            failures.append("missing_api_key")
+        base_url = ""
+        if provider == "deepseek":
+            base_url = str(env.get("DEEPSEEK_BASE_URL") or "").strip()
+        elif provider == "kimi":
+            base_url = str(
+                env.get("KIMI_BASE_URL") or env.get("MOONSHOT_BASE_URL") or ""
+            ).strip()
+        elif provider == "openai":
+            base_url = str(env.get("OPENAI_BASE_URL") or "").strip()
+        if base_url and not _safe_provider_base_url(base_url):
+            failures.append("invalid_base_url")
+        if provider == "deepseek" and model not in {
+            "deepseek-v4-pro",
+            "deepseek-v4-flash",
+        }:
+            failures.append("unsupported_model")
+        elif provider == "kimi" and model != "kimi-k3":
+            failures.append("unsupported_model")
+        elif provider == "anthropic" and not model.startswith("claude-"):
+            failures.append("unsupported_model")
+        capabilities = _PROVIDER_CAPABILITIES[provider]
+        if key and not capabilities.tool_calling:
+            failures.append("provider_contract_unverified")
+        reports.append(
+            ProviderVerification(
+                provider=provider,
+                model=model,
+                eligible=not failures,
+                failures=tuple(failures),
+                capabilities=capabilities,
+            )
+        )
+    return tuple(reports)
+
+
+def _safe_provider_base_url(value: str) -> bool:
+    parsed = urlparse(value)
+    if parsed.scheme == "https" and parsed.netloc:
+        return True
+    return parsed.scheme == "http" and parsed.hostname in {
+        "127.0.0.1",
+        "localhost",
+        "::1",
+    }
 
 
 def _env(name: str) -> str:
@@ -117,27 +433,129 @@ def _openai_key() -> str:
 
 
 def default_model_id() -> Optional[str]:
-    override = _env("CLUB_MODEL")
-    if override:
-        return override
-    if _deepseek_key():
-        return DEEPSEEK_MODEL
-    if _kimi_key():
-        return KIMI_MODEL
-    if _anthropic_key():
-        return "claude-sonnet-4-6"
-    if _openai_key():
-        return "gpt-4o-mini"
-    return None
+    provider = provider_from_env()
+    return provider.model_id if provider is not None else None
 
 
 class AnthropicProvider:
+    provider_id = "anthropic"
     model_id: str
 
     def __init__(self, *, api_key: str, model: str, max_tokens: int = 1024):
         self.api_key = api_key
         self.model_id = model
         self.max_tokens = max_tokens
+
+    def _protocol_error(self, message: str) -> ProviderStreamError:
+        return ProviderStreamError(
+            provider=self.provider_id,
+            model=self.model_id,
+            kind=ProviderErrorKind.PROTOCOL,
+            message=message,
+            retryable=False,
+        )
+
+    def _wire_tools(
+        self, tools: list[dict[str, Any]] | None
+    ) -> list[dict[str, Any]]:
+        wire: list[dict[str, Any]] = []
+        for raw in tools or []:
+            function = raw.get("function")
+            if not isinstance(function, dict) or not function.get("name"):
+                raise self._protocol_error("tool definition is missing a function name")
+            schema = function.get("parameters")
+            if not isinstance(schema, dict):
+                schema = {"type": "object", "properties": {}}
+            item: dict[str, Any] = {
+                "name": str(function["name"]),
+                "input_schema": deepcopy(schema),
+            }
+            if function.get("description"):
+                item["description"] = str(function["description"])
+            wire.append(item)
+        return wire
+
+    def _wire_messages(
+        self, messages: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        wire: list[dict[str, Any]] = []
+        pending_results: list[dict[str, Any]] = []
+
+        def flush_results() -> None:
+            if pending_results:
+                wire.append(
+                    {"role": "user", "content": list(pending_results)}
+                )
+                pending_results.clear()
+
+        for original in messages:
+            role = original.get("role")
+            if role == "system":
+                continue
+            if role == "tool":
+                call_id = str(original.get("tool_call_id") or "")
+                if not call_id:
+                    raise self._protocol_error("tool result is missing tool_call_id")
+                pending_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": call_id,
+                        "content": str(original.get("content") or ""),
+                    }
+                )
+                continue
+            flush_results()
+            if role == "user":
+                wire.append(
+                    {"role": "user", "content": deepcopy(original.get("content") or "")}
+                )
+                continue
+            if role != "assistant":
+                continue
+            calls = original.get("tool_calls") or []
+            if not calls:
+                wire.append(
+                    {
+                        "role": "assistant",
+                        "content": deepcopy(original.get("content") or ""),
+                    }
+                )
+                continue
+            blocks: list[dict[str, Any]] = []
+            content = original.get("content")
+            if content:
+                blocks.append({"type": "text", "text": str(content)})
+            for raw_call in calls:
+                if not isinstance(raw_call, dict):
+                    raise self._protocol_error("assistant tool call is malformed")
+                function = raw_call.get("function")
+                if not isinstance(function, dict):
+                    raise self._protocol_error("assistant tool call is missing function")
+                call_id = str(raw_call.get("id") or "")
+                name = str(function.get("name") or "")
+                if not call_id or not name:
+                    raise self._protocol_error("assistant tool call is missing identity")
+                try:
+                    arguments = json.loads(str(function.get("arguments") or "{}"))
+                except json.JSONDecodeError as exc:
+                    raise self._protocol_error(
+                        "assistant tool call has invalid JSON arguments"
+                    ) from exc
+                if not isinstance(arguments, dict):
+                    raise self._protocol_error(
+                        "assistant tool call arguments are not an object"
+                    )
+                blocks.append(
+                    {
+                        "type": "tool_use",
+                        "id": call_id,
+                        "name": name,
+                        "input": arguments,
+                    }
+                )
+            wire.append({"role": "assistant", "content": blocks})
+        flush_results()
+        return wire
 
     async def astream(
         self,
@@ -152,7 +570,7 @@ class AnthropicProvider:
         system = " ".join(
             str(m.get("content") or "") for m in messages if m.get("role") == "system"
         )
-        wire = [m for m in messages if m.get("role") in ("user", "assistant", "tool")]
+        wire = self._wire_messages(messages)
         headers = {
             "x-api-key": self.api_key,
             "anthropic-version": "2023-06-01",
@@ -162,10 +580,20 @@ class AnthropicProvider:
             "model": self.model_id,
             "max_tokens": self.max_tokens,
             "stream": True,
-            "messages": [m for m in wire if m.get("role") in ("user", "assistant")],
+            "messages": wire,
         }
         if system:
             body["system"] = system
+        wire_tools = self._wire_tools(tools)
+        if wire_tools:
+            body["tools"] = wire_tools
+        started_at = monotonic()
+        yield StreamChunk.started(provider=self.provider_id, model=self.model_id)
+        slots: dict[int, dict[str, str]] = {}
+        initial_usage: dict[str, Any] = {}
+        final_usage: dict[str, Any] = {}
+        stop_reason: str | None = None
+        saw_message_stop = False
         async with httpx.AsyncClient(timeout=60.0) as client:
             async with client.stream(
                 "POST",
@@ -174,28 +602,196 @@ class AnthropicProvider:
                 json=body,
             ) as resp:
                 if resp.status_code >= 400:
-                    err = (await resp.aread()).decode("utf-8", errors="replace")
-                    raise RuntimeError(f"anthropic {resp.status_code}: {err[:400]}")
+                    await resp.aread()
+                    raise _provider_http_error(
+                        provider=self.provider_id,
+                        model=self.model_id,
+                        status_code=resp.status_code,
+                    )
                 async for line in resp.aiter_lines():
                     if not line.startswith("data:"):
                         continue
                     payload = line[5:].strip()
                     if not payload:
                         continue
-                    data = json.loads(payload)
-                    if data.get("type") != "content_block_delta":
+                    try:
+                        data = json.loads(payload)
+                    except json.JSONDecodeError as exc:
+                        raise self._protocol_error(
+                            "stream event is malformed JSON"
+                        ) from exc
+                    event_type = data.get("type")
+                    if event_type == "message_start":
+                        message = data.get("message")
+                        if isinstance(message, dict) and isinstance(
+                            message.get("usage"), dict
+                        ):
+                            initial_usage = dict(message["usage"])
                         continue
-                    delta = data.get("delta") or {}
-                    text = delta.get("text")
-                    if text:
-                        yield StreamChunk(text_delta=text)
+                    if event_type == "content_block_start":
+                        block = data.get("content_block")
+                        if not isinstance(block, dict) or block.get("type") != "tool_use":
+                            continue
+                        index = data.get("index")
+                        if isinstance(index, bool) or not isinstance(index, int):
+                            raise self._protocol_error("tool block has invalid index")
+                        call_id = str(block.get("id") or "")
+                        name = str(block.get("name") or "")
+                        if not call_id or not name:
+                            raise self._protocol_error("tool block is missing identity")
+                        initial_input = block.get("input")
+                        arguments = (
+                            json.dumps(initial_input)
+                            if isinstance(initial_input, dict) and initial_input
+                            else ""
+                        )
+                        slots[index] = {
+                            "id": call_id,
+                            "name": name,
+                            "arguments": arguments,
+                        }
+                        yield StreamChunk(
+                            tool_call_deltas=[
+                                ToolCallDelta(index=index, id=call_id, name_delta=name)
+                            ]
+                        )
+                        continue
+                    if event_type == "content_block_delta":
+                        delta = data.get("delta")
+                        if not isinstance(delta, dict):
+                            continue
+                        delta_type = delta.get("type")
+                        if delta_type == "text_delta" and delta.get("text"):
+                            yield StreamChunk(text_delta=str(delta["text"]))
+                            continue
+                        if delta_type == "thinking_delta" and delta.get("thinking"):
+                            yield StreamChunk(
+                                transient_reasoning_delta=str(delta["thinking"])
+                            )
+                            continue
+                        if delta_type != "input_json_delta":
+                            continue
+                        index = data.get("index")
+                        if not isinstance(index, int) or isinstance(index, bool):
+                            raise self._protocol_error("tool delta has invalid index")
+                        if index not in slots:
+                            raise self._protocol_error("tool delta has no matching block")
+                        arguments_delta = str(delta.get("partial_json") or "")
+                        slots[index]["arguments"] += arguments_delta
+                        yield StreamChunk(
+                            tool_call_deltas=[
+                                ToolCallDelta(
+                                    index=index,
+                                    arguments_delta=arguments_delta,
+                                )
+                            ]
+                        )
+                        continue
+                    if event_type == "message_delta":
+                        delta = data.get("delta")
+                        if isinstance(delta, dict) and delta.get("stop_reason"):
+                            stop_reason = str(delta["stop_reason"])
+                        if isinstance(data.get("usage"), dict):
+                            final_usage = dict(data["usage"])
+                        continue
+                    if event_type == "error":
+                        error = data.get("error")
+                        error_type = (
+                            str(error.get("type") or "provider_error")
+                            if isinstance(error, dict)
+                            else "provider_error"
+                        )
+                        raise ProviderStreamError(
+                            provider=self.provider_id,
+                            model=self.model_id,
+                            kind=ProviderErrorKind.PROVIDER,
+                            message=f"stream failed: {error_type}",
+                            retryable=error_type in {"overloaded_error", "rate_limit_error"},
+                        )
+                    if event_type == "message_stop":
+                        saw_message_stop = True
+                        continue
+        if not saw_message_stop:
+            raise self._protocol_error("stream ended before message_stop")
+        finish_reason = _anthropic_finish_reason(stop_reason)
+        if finish_reason is None:
+            raise self._protocol_error("stream ended without a terminal reason")
+        if slots and finish_reason != "tool_calls":
+            raise self._protocol_error(
+                f"stream ended tool assembly with {finish_reason} finish reason"
+            )
+        calls: list[ToolCall] = []
+        for index in sorted(slots):
+            try:
+                call = _parse_tool_slot(slots[index], strict=True)
+                _validate_tool_call(call, tools)
+                calls.append(call)
+            except RuntimeError as exc:
+                raise self._protocol_error(str(exc)) from exc
+        usage = _parse_anthropic_usage(initial_usage, final_usage)
+        yield StreamChunk(usage=usage)
+        yield StreamChunk(
+            finish_reason=finish_reason,
+            terminal=ProviderTerminal(
+                stop_reason=finish_reason,
+                usage=usage,
+                latency_ms=max(0.0, monotonic() - started_at) * 1000,
+                estimated_cost_usd=_estimate_cost(self.model_id, usage),
+            ),
+        )
+        if calls:
+            yield StreamChunk(tool_calls=calls)
+
+
+def _anthropic_finish_reason(reason: str | None) -> str | None:
+    return {
+        "end_turn": "stop",
+        "stop_sequence": "stop",
+        "tool_use": "tool_calls",
+        "max_tokens": "length",
+        "refusal": "content_filter",
+    }.get(reason) if reason is not None else None
+
+
+def _parse_anthropic_usage(
+    initial: dict[str, Any], final: dict[str, Any]
+) -> ModelUsage:
+    def count(source: dict[str, Any], name: str) -> int:
+        value = source.get(name, 0)
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise ProviderStreamError(
+                provider="anthropic",
+                model="unknown",
+                kind=ProviderErrorKind.PROTOCOL,
+                message=f"usage field is invalid: {name}",
+                retryable=False,
+            )
+        return value
+
+    cache_write = count(initial, "cache_creation_input_tokens")
+    uncached = count(initial, "input_tokens") + cache_write
+    cached = count(initial, "cache_read_input_tokens")
+    output = count(final or initial, "output_tokens")
+    input_tokens = cached + uncached
+    return ModelUsage(
+        input_tokens=input_tokens,
+        output_tokens=output,
+        total_tokens=input_tokens + output,
+        cached_input_tokens=cached,
+        uncached_input_tokens=uncached,
+        reasoning_tokens=0,
+        cache_write_input_tokens=cache_write,
+    )
 
 
 class OpenAICompatProvider:
+    provider_id = "openai"
     model_id: str
-    strict_tool_arguments = False
-    require_complete_stream = False
-    valid_finish_reasons: frozenset[str] | None = None
+    strict_tool_arguments = True
+    require_complete_stream = True
+    valid_finish_reasons: frozenset[str] | None = frozenset(
+        {"stop", "tool_calls", "length", "content_filter", "function_call"}
+    )
 
     def __init__(
         self,
@@ -217,6 +813,7 @@ class OpenAICompatProvider:
         body: dict[str, Any] = {
             "model": self.model_id,
             "stream": True,
+            "stream_options": {"include_usage": True},
             "messages": messages,
         }
         if tools:
@@ -225,7 +822,21 @@ class OpenAICompatProvider:
         return body
 
     def _http_error(self, status_code: int, body: str) -> RuntimeError:
-        return RuntimeError(f"openai {status_code}: {body[:400]}")
+        del body
+        return _provider_http_error(
+            provider=self.provider_id,
+            model=self.model_id,
+            status_code=status_code,
+        )
+
+    def _protocol_error(self, message: str) -> ProviderStreamError:
+        return ProviderStreamError(
+            provider=self.provider_id,
+            model=self.model_id,
+            kind=ProviderErrorKind.PROTOCOL,
+            message=message,
+            retryable=False,
+        )
 
     def _prepare_messages(
         self,
@@ -235,7 +846,13 @@ class OpenAICompatProvider:
         tools: list[dict[str, Any]] | None,
     ) -> list[dict[str, Any]]:
         del context_id, tools
-        return messages
+        prepared = deepcopy(messages)
+        for message in prepared:
+            if message.get("role") == "assistant":
+                message.pop("reasoning_content", None)
+                message.pop("thinking", None)
+                message.pop("reasoning", None)
+        return prepared
 
     def _record_completed_response(
         self,
@@ -259,6 +876,8 @@ class OpenAICompatProvider:
     ) -> AsyncIterator[StreamChunk]:
         import httpx
 
+        started_at = monotonic()
+        yield StreamChunk.started(provider=self.provider_id, model=self.model_id)
         headers = {
             "authorization": f"Bearer {self.api_key}",
             "content-type": "application/json",
@@ -274,6 +893,7 @@ class OpenAICompatProvider:
         answer_parts: list[str] = []
         saw_done = False
         terminal_reason: str | None = None
+        latest_usage: ModelUsage | None = None
         async with httpx.AsyncClient(timeout=60.0) as client:
             async with client.stream(
                 "POST",
@@ -291,9 +911,15 @@ class OpenAICompatProvider:
                     if payload == "[DONE]":
                         saw_done = True
                         break
-                    data = json.loads(payload)
-                    usage = _parse_usage(data.get("usage"))
+                    try:
+                        data = json.loads(payload)
+                        usage = _parse_usage(data.get("usage"))
+                    except (json.JSONDecodeError, RuntimeError) as exc:
+                        raise self._protocol_error(
+                            "stream payload or usage is malformed"
+                        ) from exc
                     if usage is not None:
+                        latest_usage = usage
                         yield StreamChunk(usage=usage)
                     choices = data.get("choices") or []
                     if not choices:
@@ -311,14 +937,16 @@ class OpenAICompatProvider:
                     for raw in delta.get("tool_calls") or []:
                         raw_index = raw.get("index", 0)
                         if isinstance(raw_index, bool) or not isinstance(raw_index, int):
-                            raise RuntimeError("openai stream returned invalid tool index")
+                            raise self._protocol_error(
+                                "stream returned invalid tool index"
+                            )
                         idx = raw_index
                         slot = acc.setdefault(idx, {"id": "", "name": "", "arguments": ""})
                         raw_id = str(raw["id"]) if raw.get("id") else None
                         if raw_id:
                             if slot["id"] and slot["id"] != raw_id:
-                                raise RuntimeError(
-                                    f"openai stream changed tool call identity at index {idx}"
+                                raise self._protocol_error(
+                                    f"stream changed tool call identity at index {idx}"
                                 )
                             slot["id"] = raw_id
                         fn = raw.get("function") or {}
@@ -349,24 +977,25 @@ class OpenAICompatProvider:
                             self.valid_finish_reasons is not None
                             and reason not in self.valid_finish_reasons
                         ):
-                            raise RuntimeError(
-                                f"openai stream returned unknown finish reason: {reason}"
+                            raise self._protocol_error(
+                                f"stream returned unknown finish reason: {reason}"
                             )
                         if terminal_reason is not None and terminal_reason != reason:
-                            raise RuntimeError("openai stream returned conflicting finish reasons")
+                            raise self._protocol_error(
+                                "stream returned conflicting finish reasons"
+                            )
                         terminal_reason = reason
-                        yield StreamChunk(finish_reason=reason)
         if self.require_complete_stream and not saw_done:
-            raise RuntimeError("deepseek stream ended before data: [DONE]")
+            raise self._protocol_error("stream ended before data: [DONE]")
         if self.require_complete_stream and terminal_reason is None:
-            raise RuntimeError("deepseek stream ended without a terminal reason")
+            raise self._protocol_error("stream ended without a terminal reason")
         if (
             self.require_complete_stream
             and acc
             and terminal_reason != "tool_calls"
         ):
-            raise RuntimeError(
-                f"deepseek stream ended tool assembly with {terminal_reason or 'no'} finish reason"
+            raise self._protocol_error(
+                f"stream ended tool assembly with {terminal_reason or 'no'} finish reason"
             )
         calls = []
         seen_call_ids: set[str] = set()
@@ -374,9 +1003,13 @@ class OpenAICompatProvider:
             slot = acc[index]
             if not slot.get("name") and not self.strict_tool_arguments:
                 continue
-            call = _parse_tool_slot(slot, strict=self.strict_tool_arguments)
+            try:
+                call = _parse_tool_slot(slot, strict=self.strict_tool_arguments)
+                _validate_tool_call(call, tools)
+            except RuntimeError as exc:
+                raise self._protocol_error(str(exc)) from exc
             if self.strict_tool_arguments and call.id in seen_call_ids:
-                raise RuntimeError(f"openai stream repeated tool call id: {call.id}")
+                raise self._protocol_error(f"stream repeated tool call id: {call.id}")
             seen_call_ids.add(call.id)
             calls.append(call)
         self._record_completed_response(
@@ -388,6 +1021,16 @@ class OpenAICompatProvider:
             calls=calls,
             finish_reason=terminal_reason,
         )
+        assert terminal_reason is not None
+        yield StreamChunk(
+            finish_reason=terminal_reason,
+            terminal=ProviderTerminal(
+                stop_reason=terminal_reason,
+                usage=latest_usage,
+                latency_ms=max(0.0, monotonic() - started_at) * 1000,
+                estimated_cost_usd=_estimate_cost(self.model_id, latest_usage),
+            ),
+        )
         if calls:
             yield StreamChunk(tool_calls=calls)
 
@@ -395,6 +1038,7 @@ class OpenAICompatProvider:
 class DeepSeekProvider(OpenAICompatProvider):
     """DeepSeek's OpenAI-compatible endpoint with provider-specific semantics."""
 
+    provider_id = "deepseek"
     strict_tool_arguments = True
     require_complete_stream = True
     valid_finish_reasons = frozenset(
@@ -424,8 +1068,10 @@ class DeepSeekProvider(OpenAICompatProvider):
 
     def _http_error(self, status_code: int, body: str) -> RuntimeError:
         del body
-        return RuntimeError(
-            f"deepseek provider request failed with HTTP {status_code}"
+        return _provider_http_error(
+            provider=self.provider_id,
+            model=self.model_id,
+            status_code=status_code,
         )
 
     def _prepare_messages(
@@ -526,6 +1172,37 @@ class DeepSeekProvider(OpenAICompatProvider):
         return body
 
 
+class KimiProvider(DeepSeekProvider):
+    """Moonshot's Kimi API with provider-owned compatibility behavior."""
+
+    provider_id = "kimi"
+    valid_finish_reasons = frozenset(
+        {"stop", "tool_calls", "length", "content_filter"}
+    )
+
+    def _http_error(self, status_code: int, body: str) -> RuntimeError:
+        del body
+        return _provider_http_error(
+            provider=self.provider_id,
+            model=self.model_id,
+            status_code=status_code,
+        )
+
+    def _request_body(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+    ) -> dict[str, Any]:
+        body = OpenAICompatProvider._request_body(
+            self,
+            messages=messages,
+            tools=tools,
+        )
+        body["reasoning_effort"] = "max"
+        return body
+
+
 def _continuity_key(
     messages: list[dict[str, Any]], assistant: dict[str, Any]
 ) -> str:
@@ -574,12 +1251,26 @@ def _parse_usage(raw: Any) -> ModelUsage | None:
     details = raw.get("completion_tokens_details")
     if not isinstance(details, dict):
         details = {}
+    prompt_details = raw.get("prompt_tokens_details")
+    if not isinstance(prompt_details, dict):
+        prompt_details = {}
+    input_tokens = token_count("prompt_tokens")
+    if "prompt_cache_hit_tokens" in raw:
+        cached_input_tokens = token_count("prompt_cache_hit_tokens")
+    elif "cached_tokens" in raw:
+        cached_input_tokens = token_count("cached_tokens")
+    else:
+        cached_input_tokens = token_count("cached_tokens", prompt_details)
+    if "prompt_cache_miss_tokens" in raw:
+        uncached_input_tokens = token_count("prompt_cache_miss_tokens")
+    else:
+        uncached_input_tokens = max(0, input_tokens - cached_input_tokens)
     return ModelUsage(
-        input_tokens=token_count("prompt_tokens"),
+        input_tokens=input_tokens,
         output_tokens=token_count("completion_tokens"),
         total_tokens=token_count("total_tokens"),
-        cached_input_tokens=token_count("prompt_cache_hit_tokens"),
-        uncached_input_tokens=token_count("prompt_cache_miss_tokens"),
+        cached_input_tokens=cached_input_tokens,
+        uncached_input_tokens=uncached_input_tokens,
         reasoning_tokens=token_count("reasoning_tokens", details),
     )
 
@@ -605,30 +1296,85 @@ def _parse_tool_slot(slot: dict[str, str], *, strict: bool = False) -> ToolCall:
     return ToolCall(id=call_id or "call_0", name=name, arguments=parsed)
 
 
+def _validate_tool_call(
+    call: ToolCall, tools: list[dict[str, Any]] | None
+) -> None:
+    schemas: dict[str, dict[str, Any]] = {}
+    for raw in tools or []:
+        function = raw.get("function")
+        if not isinstance(function, dict) or not function.get("name"):
+            continue
+        parameters = function.get("parameters")
+        schemas[str(function["name"])] = (
+            parameters if isinstance(parameters, dict) else {}
+        )
+    if call.name not in schemas:
+        raise RuntimeError(f"tool call referenced unavailable tool: {call.name}")
+    schema = schemas[call.name]
+    for required in schema.get("required") or []:
+        if str(required) not in call.arguments:
+            raise RuntimeError(
+                f"tool arguments required property missing: {required}"
+            )
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return
+    for name, value in call.arguments.items():
+        definition = properties.get(name)
+        if not isinstance(definition, dict):
+            continue
+        expected = definition.get("type")
+        if expected and not _matches_json_type(value, str(expected)):
+            raise RuntimeError(
+                f"tool argument has wrong type for {name}: expected {expected}"
+            )
+        allowed = definition.get("enum")
+        if isinstance(allowed, list) and value not in allowed:
+            raise RuntimeError(f"tool argument is outside enum for {name}")
+
+
+def _matches_json_type(value: Any, expected: str) -> bool:
+    if expected == "string":
+        return isinstance(value, str)
+    if expected == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected == "number":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if expected == "boolean":
+        return isinstance(value, bool)
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "object":
+        return isinstance(value, dict)
+    if expected == "null":
+        return value is None
+    return False
+
+
 def provider_from_env() -> Optional[StreamProvider]:
     """DeepSeek V4 Pro first, Kimi K3 second. Other keys are last-resort."""
-    override = _env("CLUB_MODEL")
-    if _deepseek_key():
+    reports = {report.provider: report for report in provider_verifications()}
+    if _deepseek_key() and reports["deepseek"].eligible:
         return DeepSeekProvider(
             api_key=_deepseek_key(),
-            model=override or DEEPSEEK_MODEL,
+            model=reports["deepseek"].model,
             base_url=_env("DEEPSEEK_BASE_URL") or DEEPSEEK_BASE,
         )
-    if _kimi_key():
-        return OpenAICompatProvider(
+    if _kimi_key() and reports["kimi"].eligible:
+        return KimiProvider(
             api_key=_kimi_key(),
-            model=override or KIMI_MODEL,
+            model=reports["kimi"].model,
             base_url=_env("KIMI_BASE_URL") or _env("MOONSHOT_BASE_URL") or KIMI_BASE,
         )
-    if _anthropic_key():
+    if _anthropic_key() and reports["anthropic"].eligible:
         return AnthropicProvider(
             api_key=_anthropic_key(),
-            model=override or "claude-sonnet-4-6",
+            model=reports["anthropic"].model,
         )
-    if _openai_key():
+    if _openai_key() and reports["openai"].eligible:
         return OpenAICompatProvider(
             api_key=_openai_key(),
-            model=override or "gpt-4o-mini",
+            model=reports["openai"].model,
             base_url=_env("OPENAI_BASE_URL") or "https://api.openai.com/v1",
         )
     return None

--- a/desktop/coworker/provider.py
+++ b/desktop/coworker/provider.py
@@ -1324,7 +1324,7 @@ def _validate_tool_call(
         if not isinstance(definition, dict):
             continue
         expected = definition.get("type")
-        if expected and not _matches_json_type(value, str(expected)):
+        if expected and not _matches_json_type(value, expected):
             raise RuntimeError(
                 f"tool argument has wrong type for {name}: expected {expected}"
             )
@@ -1333,7 +1333,9 @@ def _validate_tool_call(
             raise RuntimeError(f"tool argument is outside enum for {name}")
 
 
-def _matches_json_type(value: Any, expected: str) -> bool:
+def _matches_json_type(value: Any, expected: Any) -> bool:
+    if isinstance(expected, list):
+        return any(_matches_json_type(value, option) for option in expected)
     if expected == "string":
         return isinstance(value, str)
     if expected == "integer":

--- a/desktop/tests/test_provider.py
+++ b/desktop/tests/test_provider.py
@@ -10,6 +10,7 @@ from coworker.provider import (
     KIMI_MODEL,
     DeepSeekProvider,
     OpenAICompatProvider,
+    StreamKind,
     default_model_id,
     provider_from_env,
 )
@@ -148,7 +149,7 @@ def test_deepseek_stream_distinguishes_transient_reasoning_from_answer(monkeypat
     assert [
         (chunk.transient_reasoning_delta, chunk.text_delta)
         for chunk in chunks
-        if chunk.finish_reason is None
+        if chunk.kind in {StreamKind.REASONING, StreamKind.TEXT}
     ] == [
         ("private analysis", None),
         (None, "Visible answer"),
@@ -202,16 +203,19 @@ def test_deepseek_stream_emits_terminal_reason_and_content_free_usage(monkeypatc
 
     chunks = asyncio.run(consume())
 
-    assert chunks[-2].finish_reason == "stop"
-    assert vars(chunks[-1].usage) == {
+    terminal = next(chunk for chunk in chunks if chunk.kind is StreamKind.TERMINAL)
+    usage = next(chunk.usage for chunk in chunks if chunk.kind is StreamKind.USAGE)
+    assert terminal.finish_reason == "stop"
+    assert vars(usage) == {
         "input_tokens": 11,
         "output_tokens": 7,
         "total_tokens": 18,
         "cached_input_tokens": 4,
         "uncached_input_tokens": 7,
         "reasoning_tokens": 3,
+        "cache_write_input_tokens": 0,
     }
-    assert "unexpected_response_content" not in repr(chunks[-1].usage)
+    assert "unexpected_response_content" not in repr(usage)
 
 
 def test_deepseek_stream_assembles_interleaved_tool_deltas_by_call_identity(monkeypatch):
@@ -290,7 +294,10 @@ def test_deepseek_stream_assembles_interleaved_tool_deltas_by_call_identity(monk
             async for chunk in provider.astream(
                 context_id="multi-tool",
                 messages=[{"role": "user", "content": "use tools"}],
-                tools=[{"type": "function", "function": {"name": "now"}}],
+                tools=[
+                    {"type": "function", "function": {"name": "now"}},
+                    {"type": "function", "function": {"name": "search"}},
+                ],
             )
         ]
 

--- a/desktop/tests/test_provider_conformance.py
+++ b/desktop/tests/test_provider_conformance.py
@@ -1,0 +1,1460 @@
+import asyncio
+import copy
+import json
+
+import httpx
+import pytest
+
+from coworker import provider as provider_module
+
+
+def _sse(*payloads):
+    return (
+        "".join(f"data: {json.dumps(payload)}\n\n" for payload in payloads)
+        + "data: [DONE]\n\n"
+    )
+
+
+def _install_http(monkeypatch, handler):
+    real_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: real_client(transport=transport, **kwargs),
+    )
+
+
+def test_stream_chunks_use_one_closed_lifecycle_vocabulary():
+    assert {kind.value for kind in provider_module.StreamKind} == {
+        "start",
+        "text",
+        "reasoning",
+        "tool_delta",
+        "tool_calls",
+        "usage",
+        "terminal",
+        "error",
+    }
+    assert (
+        provider_module.StreamChunk(text_delta="hello").kind
+        is provider_module.StreamKind.TEXT
+    )
+
+
+def test_start_and_error_are_typed_content_free_lifecycle_values():
+    started = provider_module.StreamChunk.started(
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+    )
+    failure = provider_module.ProviderStreamError(
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+        kind=provider_module.ProviderErrorKind.RATE_LIMIT,
+        message="provider request was rate limited",
+        retryable=True,
+        http_status=429,
+    )
+
+    assert started.kind is provider_module.StreamKind.START
+    assert started.start == provider_module.ProviderStart(
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+    )
+    assert failure.kind is provider_module.StreamKind.ERROR
+    assert failure.retryable is True
+    assert failure.http_status == 429
+    assert str(failure) == "anthropic provider request was rate limited"
+    assert not hasattr(failure, "response_body")
+
+
+def test_stream_chunk_rejects_ambiguous_mixed_payloads():
+    usage = provider_module.ModelUsage(1, 1, 2, 0, 1, 0)
+
+    with pytest.raises(ValueError, match="exactly one lifecycle payload"):
+        provider_module.StreamChunk(text_delta="answer", usage=usage)
+
+
+def test_model_usage_rejects_negative_or_inconsistent_counts():
+    with pytest.raises(ValueError, match="non-negative"):
+        provider_module.ModelUsage(-1, 1, 0, 0, 0, 0)
+
+    with pytest.raises(ValueError, match="cached.*uncached"):
+        provider_module.ModelUsage(10, 2, 12, 8, 3, 0)
+
+
+def test_provider_verification_reports_eligibility_without_credentials():
+    reports = provider_module.provider_verifications(
+        {
+            "DEEPSEEK_API_KEY": "deepseek-private-key",
+            "MOONSHOT_BASE_URL": "https://api.moonshot.ai/v1",
+            "ANTHROPIC_API_KEY": "",
+            "OPENAI_API_KEY": " ",
+        }
+    )
+
+    assert [report.provider for report in reports] == [
+        "deepseek",
+        "kimi",
+        "anthropic",
+        "openai",
+    ]
+    assert reports[0].eligible is True
+    assert reports[0].model == "deepseek-v4-pro"
+    assert reports[0].failures == ()
+    assert reports[0].capabilities.tool_calling is True
+    assert reports[1].eligible is False
+    assert reports[1].failures == ("missing_api_key",)
+    assert reports[2].failures == ("missing_api_key",)
+    assert reports[3].failures == ("missing_api_key",)
+    assert "deepseek-private-key" not in repr(reports)
+
+
+def test_all_fully_configured_advertised_providers_are_eligible():
+    reports = provider_module.provider_verifications(
+        {
+            "DEEPSEEK_API_KEY": "deepseek-secret",
+            "MOONSHOT_API_KEY": "kimi-secret",
+            "ANTHROPIC_API_KEY": "anthropic-secret",
+            "OPENAI_API_KEY": "openai-secret",
+        }
+    )
+
+    assert [report.eligible for report in reports] == [True, True, True, True]
+    assert [report.failures for report in reports] == [(), (), (), ()]
+    assert all(report.capabilities.tool_calling for report in reports)
+    assert all(report.capabilities.terminal_usage for report in reports)
+    assert [report.capabilities.reasoning_usage for report in reports] == [
+        True,
+        False,
+        False,
+        True,
+    ]
+
+
+def test_unsupported_configured_model_is_rejected_before_provider_creation(
+    monkeypatch,
+):
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "deepseek-secret")
+    monkeypatch.setenv("CLUB_MODEL", "not-a-deepseek-model")
+    for key in (
+        "MOONSHOT_API_KEY",
+        "KIMI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    assert provider_module.provider_from_env() is None
+    assert provider_module.default_model_id() is None
+
+
+@pytest.mark.parametrize(
+    ("key_name", "bad_model"),
+    [
+        ("MOONSHOT_API_KEY", "deepseek-v4-pro"),
+        ("ANTHROPIC_API_KEY", "kimi-k3"),
+    ],
+)
+def test_vendor_provider_rejects_model_from_another_backend(
+    key_name, bad_model, monkeypatch
+):
+    for key in (
+        "DEEPSEEK_API_KEY",
+        "MOONSHOT_API_KEY",
+        "KIMI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv(key_name, "provider-secret")
+    monkeypatch.setenv("CLUB_MODEL", bad_model)
+
+    assert provider_module.provider_from_env() is None
+
+
+def test_partial_generic_provider_config_rejects_unsafe_base_url():
+    report = next(
+        report
+        for report in provider_module.provider_verifications(
+            {
+                "OPENAI_API_KEY": "openai-secret",
+                "OPENAI_BASE_URL": "http://provider.example.test/v1",
+            }
+        )
+        if report.provider == "openai"
+    )
+
+    assert report.eligible is False
+    assert report.failures == ("invalid_base_url",)
+
+
+def test_invalid_primary_provider_is_not_selected_over_verified_fallback(
+    monkeypatch,
+):
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "deepseek-secret")
+    monkeypatch.setenv("MOONSHOT_API_KEY", "kimi-secret")
+    monkeypatch.setenv("CLUB_MODEL", "not-a-deepseek-model")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    provider = provider_module.provider_from_env()
+
+    assert isinstance(provider, provider_module.KimiProvider)
+    assert provider.model_id == "kimi-k3"
+
+
+def test_deepseek_stream_starts_with_provider_and_model_identity(monkeypatch):
+    async def handler(request):
+        terminal = {
+            "choices": [{"delta": {"content": "ok"}, "finish_reason": "stop"}],
+            "usage": {
+                "prompt_tokens": 2,
+                "completion_tokens": 1,
+                "total_tokens": 3,
+            },
+        }
+        return httpx.Response(
+            200,
+            text=f"data: {json.dumps(terminal)}\n\ndata: [DONE]\n\n",
+        )
+
+    real_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: real_client(transport=transport, **kwargs),
+    )
+    provider = provider_module.DeepSeekProvider(
+        api_key="secret",
+        model="deepseek-v4-pro",
+    )
+
+    async def consume():
+        return [
+            event
+            async for event in provider.astream(
+                messages=[{"role": "user", "content": "hello"}]
+            )
+        ]
+
+    events = asyncio.run(consume())
+
+    assert events[0] == provider_module.StreamChunk.started(
+        provider="deepseek",
+        model="deepseek-v4-pro",
+    )
+
+
+def test_generic_openai_rejects_malformed_tool_arguments_as_protocol_error(
+    monkeypatch,
+):
+    async def handler(request):
+        return httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "call_bad",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "search",
+                                            "arguments": '{"query":',
+                                        },
+                                    }
+                                ]
+                            },
+                            "finish_reason": None,
+                        }
+                    ]
+                },
+                {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {},
+                            "finish_reason": "tool_calls",
+                        }
+                    ]
+                },
+            ),
+        )
+
+    _install_http(monkeypatch, handler)
+    provider = provider_module.OpenAICompatProvider(
+        api_key="secret",
+        model="gpt-4o-mini",
+    )
+
+    async def consume():
+        return [
+            event
+            async for event in provider.astream(
+                messages=[{"role": "user", "content": "search"}],
+                tools=[{"type": "function", "function": {"name": "search"}}],
+            )
+        ]
+
+    with pytest.raises(provider_module.ProviderStreamError) as captured:
+        asyncio.run(consume())
+
+    assert captured.value.error_kind is provider_module.ProviderErrorKind.PROTOCOL
+    assert captured.value.retryable is False
+
+
+def test_generic_openai_structural_stream_error_is_typed(monkeypatch):
+    async def handler(request):
+        return httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": "not-an-integer",
+                                        "id": "call_bad_index",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "search",
+                                            "arguments": "{}",
+                                        },
+                                    }
+                                ]
+                            },
+                            "finish_reason": None,
+                        }
+                    ]
+                }
+            ),
+        )
+
+    _install_http(monkeypatch, handler)
+    provider = provider_module.OpenAICompatProvider(
+        api_key="secret", model="gpt-4o-mini"
+    )
+
+    async def consume():
+        return [
+            event
+            async for event in provider.astream(
+                messages=[{"role": "user", "content": "search"}],
+                tools=[{"type": "function", "function": {"name": "search"}}],
+            )
+        ]
+
+    with pytest.raises(provider_module.ProviderStreamError) as captured:
+        asyncio.run(consume())
+
+    assert captured.value.error_kind is provider_module.ProviderErrorKind.PROTOCOL
+
+
+def test_generic_openai_length_stop_never_releases_salvageable_tool_call(
+    monkeypatch,
+):
+    async def handler(request):
+        return httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "call_partial",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "search",
+                                            "arguments": '{"query":"complete-json"}',
+                                        },
+                                    }
+                                ]
+                            },
+                            "finish_reason": None,
+                        }
+                    ]
+                },
+                {
+                    "choices": [
+                        {"index": 0, "delta": {}, "finish_reason": "length"}
+                    ]
+                },
+            ),
+        )
+
+    _install_http(monkeypatch, handler)
+    provider = provider_module.OpenAICompatProvider(
+        api_key="secret",
+        model="gpt-4o-mini",
+    )
+    emitted = []
+
+    async def consume():
+        async for event in provider.astream(
+            messages=[{"role": "user", "content": "search"}],
+            tools=[{"type": "function", "function": {"name": "search"}}],
+        ):
+            emitted.append(event)
+
+    with pytest.raises(provider_module.ProviderStreamError) as captured:
+        asyncio.run(consume())
+
+    assert captured.value.error_kind is provider_module.ProviderErrorKind.PROTOCOL
+    assert not [event for event in emitted if event.kind is provider_module.StreamKind.TOOL_CALLS]
+
+
+def test_generic_openai_history_drops_opaque_reasoning_and_preserves_tools(
+    monkeypatch,
+):
+    requests = []
+
+    async def handler(request):
+        requests.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "choices": [
+                        {"index": 0, "delta": {"content": "done"}, "finish_reason": "stop"}
+                    ]
+                }
+            ),
+        )
+
+    _install_http(monkeypatch, handler)
+    provider = provider_module.OpenAICompatProvider(
+        api_key="secret",
+        model="gpt-4o-mini",
+    )
+    messages = [
+        {"role": "user", "content": "search"},
+        {
+            "role": "assistant",
+            "content": None,
+            "reasoning_content": "deepseek-private-reasoning",
+            "tool_calls": [
+                {
+                    "id": "call_exact",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": '{"query":"Ada"}'},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_exact",
+            "content": '{"name":"Ada"}',
+        },
+    ]
+    original = copy.deepcopy(messages)
+
+    async def consume():
+        return [event async for event in provider.astream(messages=messages)]
+
+    asyncio.run(consume())
+
+    assert requests[0]["messages"] == [
+        messages[0],
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": messages[1]["tool_calls"],
+        },
+        messages[2],
+    ]
+    assert messages == original
+
+
+def test_generic_openai_usage_maps_cache_and_reasoning_token_details(monkeypatch):
+    async def handler(request):
+        return httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "choices": [
+                        {"index": 0, "delta": {"content": "ok"}, "finish_reason": "stop"}
+                    ],
+                    "usage": {
+                        "prompt_tokens": 10,
+                        "completion_tokens": 5,
+                        "total_tokens": 15,
+                        "prompt_tokens_details": {"cached_tokens": 4},
+                        "completion_tokens_details": {"reasoning_tokens": 3},
+                    },
+                }
+            ),
+        )
+
+    _install_http(monkeypatch, handler)
+    provider = provider_module.OpenAICompatProvider(
+        api_key="secret",
+        model="gpt-4o-mini",
+    )
+
+    async def consume():
+        return [
+            event
+            async for event in provider.astream(
+                messages=[{"role": "user", "content": "hello"}]
+            )
+        ]
+
+    usage = next(
+        event.usage
+        for event in asyncio.run(consume())
+        if event.kind is provider_module.StreamKind.USAGE
+    )
+
+    assert usage == provider_module.ModelUsage(
+        input_tokens=10,
+        output_tokens=5,
+        total_tokens=15,
+        cached_input_tokens=4,
+        uncached_input_tokens=6,
+        reasoning_tokens=3,
+    )
+
+
+def test_generic_openai_requests_terminal_usage_explicitly(monkeypatch):
+    requests = []
+
+    async def handler(request):
+        requests.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "choices": [
+                        {"index": 0, "delta": {"content": "ok"}, "finish_reason": "stop"}
+                    ]
+                }
+            ),
+        )
+
+    _install_http(monkeypatch, handler)
+    provider = provider_module.OpenAICompatProvider(
+        api_key="secret",
+        model="gpt-4o-mini",
+    )
+
+    async def consume():
+        return [
+            event
+            async for event in provider.astream(
+                messages=[{"role": "user", "content": "hello"}]
+            )
+        ]
+
+    asyncio.run(consume())
+
+    assert requests[0]["stream_options"] == {"include_usage": True}
+
+
+def test_kimi_environment_selects_provider_with_its_own_contract(monkeypatch):
+    monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+    monkeypatch.setenv("MOONSHOT_API_KEY", "kimi-secret")
+    monkeypatch.delenv("KIMI_API_KEY", raising=False)
+    monkeypatch.delenv("CLUB_MODEL", raising=False)
+
+    provider = provider_module.provider_from_env()
+
+    assert type(provider).__name__ == "KimiProvider"
+    assert provider.provider_id == "kimi"
+    assert provider.model_id == "kimi-k3"
+
+
+def test_kimi_replays_reasoning_for_tool_results_without_mutating_history(
+    monkeypatch,
+):
+    requests = []
+
+    async def handler(request):
+        requests.append(json.loads(request.content))
+        if len(requests) == 1:
+            return httpx.Response(
+                200,
+                text=_sse(
+                    {
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {"reasoning_content": "kimi-private"},
+                                "finish_reason": None,
+                            }
+                        ]
+                    },
+                    {
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {
+                                    "tool_calls": [
+                                        {
+                                            "index": 0,
+                                            "id": "call_kimi",
+                                            "type": "function",
+                                            "function": {
+                                                "name": "search",
+                                                "arguments": '{"query":"Ada"}',
+                                            },
+                                        }
+                                    ]
+                                },
+                                "finish_reason": None,
+                            }
+                        ]
+                    },
+                    {
+                        "choices": [
+                            {"index": 0, "delta": {}, "finish_reason": "tool_calls"}
+                        ]
+                    },
+                ),
+            )
+        return httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "choices": [
+                        {"index": 0, "delta": {"content": "done"}, "finish_reason": "stop"}
+                    ]
+                }
+            ),
+        )
+
+    _install_http(monkeypatch, handler)
+    provider = provider_module.KimiProvider(
+        api_key="secret",
+        model="kimi-k3",
+        base_url="https://api.moonshot.ai/v1",
+    )
+    first_messages = [{"role": "user", "content": "find Ada"}]
+
+    async def scenario():
+        first = [
+            event
+            async for event in provider.astream(
+                context_id="kimi-session",
+                messages=first_messages,
+                tools=[{"type": "function", "function": {"name": "search"}}],
+            )
+        ]
+        call = next(
+            call for event in first for call in (event.tool_calls or [])
+        )
+        continuation = [
+            *first_messages,
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": call.id,
+                        "type": "function",
+                        "function": {
+                            "name": call.name,
+                            "arguments": json.dumps(call.arguments),
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": call.id, "content": "Ada"},
+        ]
+        original = copy.deepcopy(continuation)
+        _ = [
+            event
+            async for event in provider.astream(
+                context_id="kimi-session",
+                messages=continuation,
+                tools=[{"type": "function", "function": {"name": "search"}}],
+            )
+        ]
+        return continuation, original
+
+    continuation, original = asyncio.run(scenario())
+
+    assert requests[0]["reasoning_effort"] == "max"
+    assert requests[1]["messages"][1]["reasoning_content"] == "kimi-private"
+    assert requests[1]["messages"][1]["content"] == ""
+    assert continuation == original
+    assert "reasoning_content" not in continuation[1]
+
+
+def test_anthropic_transforms_tool_history_with_exact_call_identity(monkeypatch):
+    requests = []
+
+    async def handler(request):
+        requests.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"message_start","message":{"id":"msg_1",'
+                '"type":"message","role":"assistant","content":[],"model":'
+                '"claude-sonnet-4-6","stop_reason":null,"usage":'
+                '{"input_tokens":10,"output_tokens":1}}}\n\n'
+                'data: {"type":"content_block_start","index":0,"content_block":'
+                '{"type":"text","text":""}}\n\n'
+                'data: {"type":"content_block_delta","index":0,"delta":'
+                '{"type":"text_delta","text":"done"}}\n\n'
+                'data: {"type":"content_block_stop","index":0}\n\n'
+                'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},'
+                '"usage":{"output_tokens":2}}\n\n'
+                'data: {"type":"message_stop"}\n\n'
+            ),
+        )
+
+    _install_http(monkeypatch, handler)
+    provider = provider_module.AnthropicProvider(
+        api_key="secret",
+        model="claude-sonnet-4-6",
+    )
+    messages = [
+        {"role": "system", "content": "Be precise."},
+        {"role": "user", "content": "Find Ada"},
+        {
+            "role": "assistant",
+            "content": "I will search.",
+            "reasoning_content": "opaque-provider-reasoning",
+            "tool_calls": [
+                {
+                    "id": "call_exact",
+                    "type": "function",
+                    "function": {
+                        "name": "search",
+                        "arguments": '{"query":"Ada"}',
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_exact",
+            "content": '{"name":"Ada Lovelace"}',
+        },
+    ]
+    original = copy.deepcopy(messages)
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "search",
+                "description": "Search people",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+            },
+        }
+    ]
+
+    async def consume():
+        return [
+            event
+            async for event in provider.astream(messages=messages, tools=tools)
+        ]
+
+    asyncio.run(consume())
+
+    assert requests[0]["tools"] == [
+        {
+            "name": "search",
+            "description": "Search people",
+            "input_schema": tools[0]["function"]["parameters"],
+        }
+    ]
+    assert requests[0]["messages"] == [
+        {"role": "user", "content": "Find Ada"},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "I will search."},
+                {
+                    "type": "tool_use",
+                    "id": "call_exact",
+                    "name": "search",
+                    "input": {"query": "Ada"},
+                },
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call_exact",
+                    "content": '{"name":"Ada Lovelace"}',
+                }
+            ],
+        },
+    ]
+    assert messages == original
+
+
+def test_anthropic_stream_assembles_tool_deltas_terminal_and_usage(monkeypatch):
+    async def handler(request):
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"message_start","message":{"id":"msg_1",'
+                '"type":"message","role":"assistant","content":[],"model":'
+                '"claude-sonnet-4-6","stop_reason":null,"usage":'
+                '{"input_tokens":6,"output_tokens":1,"cache_read_input_tokens":3,'
+                '"cache_creation_input_tokens":1}}}\n\n'
+                'data: {"type":"content_block_start","index":1,"content_block":'
+                '{"type":"tool_use","id":"toolu_exact","name":"search","input":{}}}\n\n'
+                'data: {"type":"content_block_delta","index":1,"delta":'
+                '{"type":"input_json_delta","partial_json":"{\\"query\\":"}}\n\n'
+                'data: {"type":"content_block_delta","index":1,"delta":'
+                '{"type":"input_json_delta","partial_json":"\\"Ada\\"}"}}\n\n'
+                'data: {"type":"content_block_stop","index":1}\n\n'
+                'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},'
+                '"usage":{"output_tokens":4}}\n\n'
+                'data: {"type":"message_stop"}\n\n'
+            ),
+        )
+
+    _install_http(monkeypatch, handler)
+    provider = provider_module.AnthropicProvider(
+        api_key="secret",
+        model="claude-sonnet-4-6",
+    )
+
+    async def consume():
+        return [
+            event
+            async for event in provider.astream(
+                messages=[{"role": "user", "content": "find Ada"}],
+                tools=[{"type": "function", "function": {"name": "search"}}],
+            )
+        ]
+
+    events = asyncio.run(consume())
+    deltas = [
+        delta for event in events for delta in (event.tool_call_deltas or [])
+    ]
+    calls = [call for event in events for call in (event.tool_calls or [])]
+    usage = next(event.usage for event in events if event.usage is not None)
+    terminal = next(
+        event.terminal
+        for event in events
+        if event.kind is provider_module.StreamKind.TERMINAL
+    )
+
+    assert events[0] == provider_module.StreamChunk.started(
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+    )
+    assert [(delta.index, delta.id, delta.name_delta, delta.arguments_delta) for delta in deltas] == [
+        (1, "toolu_exact", "search", None),
+        (1, None, None, '{"query":'),
+        (1, None, None, '"Ada"}'),
+    ]
+    assert calls == [
+        provider_module.ToolCall(
+            id="toolu_exact",
+            name="search",
+            arguments={"query": "Ada"},
+        )
+    ]
+    assert next(event.finish_reason for event in events if event.finish_reason) == "tool_calls"
+    assert usage == provider_module.ModelUsage(
+        input_tokens=10,
+        output_tokens=4,
+        total_tokens=14,
+        cached_input_tokens=3,
+        uncached_input_tokens=7,
+        reasoning_tokens=0,
+        cache_write_input_tokens=1,
+    )
+    assert terminal.stop_reason == "tool_calls"
+    assert terminal.usage == usage
+    assert terminal.latency_ms >= 0
+    assert terminal.estimated_cost_usd == pytest.approx(0.00008265)
+
+
+def test_anthropic_rejects_arguments_that_violate_tool_schema(monkeypatch):
+    async def handler(request):
+        return httpx.Response(
+            200,
+            text=(
+                'data: {"type":"message_start","message":{"usage":'
+                '{"input_tokens":1,"output_tokens":1}}}\n\n'
+                'data: {"type":"content_block_start","index":0,"content_block":'
+                '{"type":"tool_use","id":"toolu_schema","name":"search","input":{}}}\n\n'
+                'data: {"type":"content_block_delta","index":0,"delta":'
+                '{"type":"input_json_delta","partial_json":"{\\"limit\\":1}"}}\n\n'
+                'data: {"type":"content_block_stop","index":0}\n\n'
+                'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},'
+                '"usage":{"output_tokens":2}}\n\n'
+                'data: {"type":"message_stop"}\n\n'
+            ),
+        )
+
+    _install_http(monkeypatch, handler)
+    provider = provider_module.AnthropicProvider(
+        api_key="secret", model="claude-sonnet-4-6"
+    )
+    emitted = []
+
+    async def consume():
+        async for event in provider.astream(
+            messages=[{"role": "user", "content": "search"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "search",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "query": {"type": "string"},
+                                "limit": {"type": "integer"},
+                            },
+                            "required": ["query"],
+                        },
+                    },
+                }
+            ],
+        ):
+            emitted.append(event)
+
+    with pytest.raises(provider_module.ProviderStreamError, match="required.*query"):
+        asyncio.run(consume())
+
+    assert not [event for event in emitted if event.tool_calls]
+
+
+def test_anthropic_malformed_stream_event_is_typed(monkeypatch):
+    async def handler(request):
+        return httpx.Response(200, text="data: {malformed-json}\n\n")
+
+    _install_http(monkeypatch, handler)
+    provider = provider_module.AnthropicProvider(
+        api_key="secret", model="claude-sonnet-4-6"
+    )
+
+    async def consume():
+        return [
+            event
+            async for event in provider.astream(
+                messages=[{"role": "user", "content": "hello"}]
+            )
+        ]
+
+    with pytest.raises(provider_module.ProviderStreamError) as captured:
+        asyncio.run(consume())
+
+    assert captured.value.error_kind is provider_module.ProviderErrorKind.PROTOCOL
+
+
+def test_fake_provider_covers_the_complete_success_lifecycle():
+    usage = provider_module.ModelUsage(
+        input_tokens=8,
+        output_tokens=4,
+        total_tokens=12,
+        cached_input_tokens=2,
+        uncached_input_tokens=6,
+        reasoning_tokens=1,
+    )
+    call = provider_module.ToolCall(
+        id="call_fake",
+        name="search",
+        arguments={"query": "Ada"},
+    )
+    provider = provider_module.FakeProvider(
+        steps=[
+            {
+                "reasoning_deltas": ("private",),
+                "deltas": ("visible",),
+                "tool_call_deltas": [
+                    provider_module.ToolCallDelta(
+                        index=0,
+                        id="call_fake",
+                        name_delta="search",
+                        arguments_delta='{"query":"Ada"}',
+                    )
+                ],
+                "usage": usage,
+                "finish_reason": "tool_calls",
+                "tool_calls": [call],
+            }
+        ]
+    )
+
+    async def consume():
+        return [
+            event
+            async for event in provider.astream(
+                messages=[{"role": "user", "content": "find Ada"}]
+            )
+        ]
+
+    events = asyncio.run(consume())
+
+    assert [event.kind for event in events] == [
+        provider_module.StreamKind.START,
+        provider_module.StreamKind.REASONING,
+        provider_module.StreamKind.TEXT,
+        provider_module.StreamKind.TOOL_DELTA,
+        provider_module.StreamKind.USAGE,
+        provider_module.StreamKind.TERMINAL,
+        provider_module.StreamKind.TOOL_CALLS,
+    ]
+    assert events[0].start == provider_module.ProviderStart(
+        provider="fake",
+        model="fake",
+    )
+    assert events[5].terminal.stop_reason == "tool_calls"
+    assert events[5].terminal.usage == usage
+    assert events[5].terminal.latency_ms >= 0
+    assert events[5].terminal.estimated_cost_usd is None
+    assert events[-1].tool_calls == [call]
+
+
+def test_fake_provider_covers_typed_error_lifecycle():
+    failure = provider_module.ProviderStreamError(
+        provider="fake",
+        model="fake",
+        kind=provider_module.ProviderErrorKind.CONNECTION,
+        message="provider connection failed",
+        retryable=True,
+    )
+    provider = provider_module.FakeProvider(steps=[{"error": failure}])
+    emitted = []
+
+    async def consume():
+        async for event in provider.astream(
+            messages=[{"role": "user", "content": "hello"}]
+        ):
+            emitted.append(event)
+
+    with pytest.raises(provider_module.ProviderStreamError) as captured:
+        asyncio.run(consume())
+
+    assert captured.value is failure
+    assert [event.kind for event in emitted] == [provider_module.StreamKind.START]
+
+
+@pytest.mark.parametrize(
+    "provider",
+    [
+        provider_module.DeepSeekProvider(
+            api_key="secret", model="deepseek-v4-pro"
+        ),
+        provider_module.KimiProvider(api_key="secret", model="kimi-k3"),
+        provider_module.AnthropicProvider(
+            api_key="secret", model="claude-sonnet-4-6"
+        ),
+        provider_module.OpenAICompatProvider(
+            api_key="secret", model="gpt-4o-mini"
+        ),
+    ],
+    ids=lambda provider: provider.provider_id,
+)
+def test_every_http_provider_uses_typed_content_free_rate_limit_errors(
+    provider, monkeypatch
+):
+    private_body = "PRIVATE_PROVIDER_BODY " + ("x" * 500)
+
+    async def handler(request):
+        return httpx.Response(429, text=private_body)
+
+    _install_http(monkeypatch, handler)
+
+    async def consume():
+        return [
+            event
+            async for event in provider.astream(
+                context_id="rate-limit",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+        ]
+
+    with pytest.raises(provider_module.ProviderStreamError) as captured:
+        asyncio.run(consume())
+
+    assert captured.value.provider == provider.provider_id
+    assert captured.value.model == provider.model_id
+    assert captured.value.error_kind is provider_module.ProviderErrorKind.RATE_LIMIT
+    assert captured.value.retryable is True
+    assert captured.value.http_status == 429
+    assert private_body not in str(captured.value)
+
+
+@pytest.mark.parametrize(
+    "provider",
+    [
+        provider_module.DeepSeekProvider(
+            api_key="secret", model="deepseek-v4-pro"
+        ),
+        provider_module.KimiProvider(api_key="secret", model="kimi-k3"),
+        provider_module.AnthropicProvider(
+            api_key="secret", model="claude-sonnet-4-6"
+        ),
+        provider_module.OpenAICompatProvider(
+            api_key="secret", model="gpt-4o-mini"
+        ),
+    ],
+    ids=lambda provider: provider.provider_id,
+)
+def test_cancellation_propagates_and_closes_every_http_provider_stream(
+    provider, monkeypatch
+):
+    first_delta_seen = asyncio.Event()
+
+    class CancelStream(httpx.AsyncByteStream):
+        def __init__(self):
+            self.closed = False
+
+        async def __aiter__(self):
+            if provider.provider_id == "anthropic":
+                payload = {
+                    "type": "content_block_delta",
+                    "index": 0,
+                    "delta": {"type": "text_delta", "text": "partial"},
+                }
+            else:
+                payload = {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"content": "partial"},
+                            "finish_reason": None,
+                        }
+                    ]
+                }
+            yield f"data: {json.dumps(payload)}\n\n".encode()
+            await asyncio.Event().wait()
+
+        async def aclose(self):
+            self.closed = True
+
+    stream = CancelStream()
+
+    async def handler(request):
+        return httpx.Response(200, stream=stream)
+
+    _install_http(monkeypatch, handler)
+    emitted = []
+
+    async def consume():
+        async for event in provider.astream(
+            context_id="cancel-session",
+            messages=[{"role": "user", "content": "hello"}],
+        ):
+            emitted.append(event)
+            if event.kind is provider_module.StreamKind.TEXT:
+                first_delta_seen.set()
+
+    async def scenario():
+        task = asyncio.create_task(consume())
+        await asyncio.wait_for(first_delta_seen.wait(), timeout=1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(scenario())
+
+    assert stream.closed is True
+    assert not [
+        event
+        for event in emitted
+        if event.kind
+        in {provider_module.StreamKind.TERMINAL, provider_module.StreamKind.TOOL_CALLS}
+    ]
+
+
+@pytest.mark.parametrize(
+    "provider",
+    [
+        provider_module.DeepSeekProvider(
+            api_key="secret", model="deepseek-v4-pro"
+        ),
+        provider_module.KimiProvider(api_key="secret", model="kimi-k3"),
+        provider_module.AnthropicProvider(
+            api_key="secret", model="claude-sonnet-4-6"
+        ),
+        provider_module.OpenAICompatProvider(
+            api_key="secret", model="gpt-4o-mini"
+        ),
+    ],
+    ids=lambda provider: provider.provider_id,
+)
+def test_truncated_stream_never_releases_tool_calls_for_any_provider(
+    provider, monkeypatch
+):
+    if provider.provider_id == "anthropic":
+        partial = (
+            'data: {"type":"content_block_start","index":0,"content_block":'
+            '{"type":"tool_use","id":"call_cut","name":"search","input":{}}}\n\n'
+            'data: {"type":"content_block_delta","index":0,"delta":'
+            '{"type":"input_json_delta","partial_json":"{}"}}\n\n'
+        )
+    else:
+        partial = (
+            "data: "
+            + json.dumps(
+                {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "call_cut",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "search",
+                                            "arguments": "{}",
+                                        },
+                                    }
+                                ]
+                            },
+                            "finish_reason": None,
+                        }
+                    ]
+                }
+            )
+            + "\n\n"
+        )
+
+    async def handler(request):
+        return httpx.Response(200, text=partial)
+
+    _install_http(monkeypatch, handler)
+    emitted = []
+
+    async def consume():
+        async for event in provider.astream(
+            context_id="truncated-session",
+            messages=[{"role": "user", "content": "search"}],
+            tools=[{"type": "function", "function": {"name": "search"}}],
+        ):
+            emitted.append(event)
+
+    with pytest.raises(provider_module.ProviderStreamError):
+        asyncio.run(consume())
+
+    assert not [event for event in emitted if event.tool_calls]
+
+
+@pytest.mark.parametrize(
+    "provider",
+    [
+        provider_module.DeepSeekProvider(
+            api_key="secret", model="deepseek-v4-pro"
+        ),
+        provider_module.KimiProvider(api_key="secret", model="kimi-k3"),
+        provider_module.AnthropicProvider(
+            api_key="secret", model="claude-sonnet-4-6"
+        ),
+        provider_module.OpenAICompatProvider(
+            api_key="secret", model="gpt-4o-mini"
+        ),
+    ],
+    ids=lambda provider: provider.provider_id,
+)
+def test_non_object_tool_arguments_are_rejected_by_every_provider(
+    provider, monkeypatch
+):
+    if provider.provider_id == "anthropic":
+        response = (
+            'data: {"type":"message_start","message":{"usage":'
+            '{"input_tokens":1,"output_tokens":1}}}\n\n'
+            'data: {"type":"content_block_start","index":0,"content_block":'
+            '{"type":"tool_use","id":"call_array","name":"search","input":{}}}\n\n'
+            'data: {"type":"content_block_delta","index":0,"delta":'
+            '{"type":"input_json_delta","partial_json":"[]"}}\n\n'
+            'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},'
+            '"usage":{"output_tokens":2}}\n\n'
+            'data: {"type":"message_stop"}\n\n'
+        )
+    else:
+        response = _sse(
+            {
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_array",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "search",
+                                        "arguments": "[]",
+                                    },
+                                }
+                            ]
+                        },
+                        "finish_reason": None,
+                    }
+                ]
+            },
+            {
+                "choices": [
+                    {"index": 0, "delta": {}, "finish_reason": "tool_calls"}
+                ]
+            },
+        )
+
+    async def handler(request):
+        return httpx.Response(200, text=response)
+
+    _install_http(monkeypatch, handler)
+    emitted = []
+
+    async def consume():
+        async for event in provider.astream(
+            context_id="non-object",
+            messages=[{"role": "user", "content": "search"}],
+            tools=[{"type": "function", "function": {"name": "search"}}],
+        ):
+            emitted.append(event)
+
+    with pytest.raises(provider_module.ProviderStreamError, match="non-object"):
+        asyncio.run(consume())
+
+    assert not [event for event in emitted if event.tool_calls]
+
+
+def test_terminal_metadata_has_latency_usage_and_known_model_cost(
+    monkeypatch,
+):
+    ticks = iter((10.0, 10.125))
+    monkeypatch.setattr(provider_module, "monotonic", lambda: next(ticks))
+
+    async def handler(request):
+        return httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "choices": [
+                        {"index": 0, "delta": {"content": "ok"}, "finish_reason": "stop"}
+                    ],
+                    "usage": {
+                        "prompt_tokens": 1_000_000,
+                        "completion_tokens": 1_000_000,
+                        "total_tokens": 2_000_000,
+                        "prompt_tokens_details": {"cached_tokens": 0},
+                    },
+                }
+            ),
+        )
+
+    _install_http(monkeypatch, handler)
+    provider = provider_module.OpenAICompatProvider(
+        api_key="secret",
+        model="gpt-4o-mini",
+    )
+
+    async def consume():
+        return [
+            event
+            async for event in provider.astream(
+                messages=[{"role": "user", "content": "hello"}]
+            )
+        ]
+
+    terminal = next(
+        event.terminal
+        for event in asyncio.run(consume())
+        if event.kind is provider_module.StreamKind.TERMINAL
+    )
+
+    assert terminal == provider_module.ProviderTerminal(
+        stop_reason="stop",
+        usage=provider_module.ModelUsage(
+            input_tokens=1_000_000,
+            output_tokens=1_000_000,
+            total_tokens=2_000_000,
+            cached_input_tokens=0,
+            uncached_input_tokens=1_000_000,
+            reasoning_tokens=0,
+        ),
+        latency_ms=125.0,
+        estimated_cost_usd=0.75,
+    )
+
+
+def test_generic_openai_rejects_arguments_that_violate_tool_schema(monkeypatch):
+    async def handler(request):
+        return httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "call_schema",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "search",
+                                            "arguments": '{"limit":1}',
+                                        },
+                                    }
+                                ]
+                            },
+                            "finish_reason": None,
+                        }
+                    ]
+                },
+                {
+                    "choices": [
+                        {"index": 0, "delta": {}, "finish_reason": "tool_calls"}
+                    ]
+                },
+            ),
+        )
+
+    _install_http(monkeypatch, handler)
+    provider = provider_module.OpenAICompatProvider(
+        api_key="secret", model="gpt-4o-mini"
+    )
+    emitted = []
+
+    async def consume():
+        async for event in provider.astream(
+            messages=[{"role": "user", "content": "search"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "search",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "query": {"type": "string"},
+                                "limit": {"type": "integer"},
+                            },
+                            "required": ["query"],
+                        },
+                    },
+                }
+            ],
+        ):
+            emitted.append(event)
+
+    with pytest.raises(provider_module.ProviderStreamError, match="required.*query"):
+        asyncio.run(consume())
+
+    assert not [event for event in emitted if event.tool_calls]

--- a/desktop/tests/test_provider_conformance.py
+++ b/desktop/tests/test_provider_conformance.py
@@ -6,6 +6,7 @@ import httpx
 import pytest
 
 from coworker import provider as provider_module
+from coworker.workspace_runtime import WORKSPACE_TOOL_SCHEMAS
 
 
 def _sse(*payloads):
@@ -1458,3 +1459,83 @@ def test_generic_openai_rejects_arguments_that_violate_tool_schema(monkeypatch):
         asyncio.run(consume())
 
     assert not [event for event in emitted if event.tool_calls]
+
+
+@pytest.mark.parametrize(
+    "expected_before_hash",
+    ["abc123", None],
+    ids=["string-hash", "json-null"],
+)
+def test_deepseek_releases_workspace_write_with_expected_before_hash(
+    expected_before_hash, monkeypatch
+):
+    arguments = {
+        "grant_id": "grant-1",
+        "path": "notes.md",
+        "content": "hello",
+        "expected_before_hash": expected_before_hash,
+    }
+
+    async def handler(request):
+        return httpx.Response(
+            200,
+            text=_sse(
+                {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "call_write",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "fs_write",
+                                            "arguments": json.dumps(arguments),
+                                        },
+                                    }
+                                ]
+                            },
+                            "finish_reason": None,
+                        }
+                    ]
+                },
+                {
+                    "choices": [
+                        {"index": 0, "delta": {}, "finish_reason": "tool_calls"}
+                    ]
+                },
+            ),
+        )
+
+    _install_http(monkeypatch, handler)
+    provider = provider_module.DeepSeekProvider(
+        api_key="secret", model="deepseek-v4-pro"
+    )
+
+    async def consume():
+        return [
+            event
+            async for event in provider.astream(
+                context_id="workspace-write",
+                messages=[{"role": "user", "content": "write notes.md"}],
+                tools=WORKSPACE_TOOL_SCHEMAS,
+            )
+        ]
+
+    events = asyncio.run(consume())
+    calls = next(event.tool_calls for event in events if event.tool_calls)
+
+    assert calls == [
+        provider_module.ToolCall(
+            id="call_write",
+            name="fs_write",
+            arguments={
+                "grant_id": "grant-1",
+                "path": "notes.md",
+                "content": "hello",
+                "expected_before_hash": expected_before_hash,
+            },
+        )
+    ]

--- a/desktop/tests/test_provider_live_smoke.py
+++ b/desktop/tests/test_provider_live_smoke.py
@@ -1,0 +1,44 @@
+"""Opt-in live provider smoke; excluded from normal deterministic verification."""
+
+import asyncio
+import json
+import os
+
+import pytest
+
+from coworker.provider import StreamKind, provider_from_env
+
+
+@pytest.mark.skipif(
+    os.environ.get("SOURCECADO_LIVE_PROVIDER_SMOKE") != "1",
+    reason="set SOURCECADO_LIVE_PROVIDER_SMOKE=1 to call the configured provider",
+)
+def test_configured_provider_live_smoke_records_reproducibility_metadata():
+    provider = provider_from_env()
+    assert provider is not None, "configure one verified provider before live smoke"
+
+    async def consume():
+        return [
+            event
+            async for event in provider.astream(
+                context_id="live-provider-smoke",
+                messages=[
+                    {
+                        "role": "user",
+                        "content": "Reply exactly SOURCECADO_PROVIDER_SMOKE_OK.",
+                    }
+                ],
+            )
+        ]
+
+    events = asyncio.run(consume())
+    record = {
+        "provider": provider.provider_id,
+        "model": provider.model_id,
+        "prompt_version": "provider-conformance-v1",
+        "nondeterministic": True,
+    }
+
+    print(json.dumps(record, sort_keys=True))
+    assert events[0].kind is StreamKind.START
+    assert any(event.kind is StreamKind.TERMINAL for event in events)


### PR DESCRIPTION
## Summary\n\n- add a Sourcecado-owned typed provider lifecycle for deterministic fakes, DeepSeek, Kimi/Moonshot, Anthropic, and generic OpenAI-compatible backends\n- enforce exact tool identity, strict JSON-object and schema validation, allowlisted tool names, and safe length/truncation/cancellation behavior\n- transform multi-round tool and tool-result history correctly across provider wire formats while dropping opaque foreign reasoning\n- normalize token usage, cache reads/writes, reasoning tokens, latency, and documented cost estimates\n- reject missing, unsafe, unsupported, cross-vendor, or unverified provider configurations before selection\n- add credential-free provider capability and setup reports plus opt-in live smoke tests\n\n## Verification\n\n- focused provider and turn-adjacent suite: 132 passed, 1 skipped\n- make test-python: 570 passed, 3 skipped\n- pre-existing Starlette/httpx deprecation warning remains\n\n## Review focus\n\n- completed tool calls are never released after malformed, length-stopped, truncated, or cancelled streams\n- DeepSeek and Kimi reasoning remains bounded transient state and never becomes durable history\n- Anthropic tool-use and tool-result transforms preserve exact call identity across rounds\n- provider eligibility fails closed without exposing credentials\n- provider errors and usage remain content-free and typed\n\nRefs #80\n\n## Follow-up\n\nIssue #80 remains open for Settings/API/UI exposure of provider_verifications(). Retry and backoff semantics remain in #71; this PR proves request cancellation and transport closure but adds no retry loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the Kimi AI provider.
  - Improved provider availability checks and automatic provider selection.
  - Added structured streaming updates for start, usage, and completion states.
  - Added token usage, caching, latency, and cost details to streamed responses.

- **Bug Fixes**
  - Improved handling of rate limits, incomplete responses, invalid tool calls, and malformed data.
  - Strengthened validation for tool arguments and stream completion.
  - Provider errors now include clearer, more specific classifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->