### PR TITLE
fix(desktop): harden provider model identifiers

### DIFF
--- a/desktop/coworker/provider.py
+++ b/desktop/coworker/provider.py
@@ -349,7 +349,19 @@ _MODEL_METADATA: dict[tuple[str, str], tuple[int, ModelPricing]] = {
     ),
 }
 _MODEL_IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
-_SECRET_MODEL_PREFIXES = ("sk-", "ghp_", "github_pat_", "ya29.", "aiza")
+_WINDOWS_ABSOLUTE_MODEL = re.compile(r"^[A-Za-z]:/")
+_SECRET_MODEL_PREFIXES = (
+    "sk-",
+    "ghp_",
+    "github_pat_",
+    "ya29.",
+    "aiza",
+    "xoxb-",
+    "xoxp-",
+    "xoxa-",
+    "xoxr-",
+    "xapp-",
+)
 
 
 def provider_model_metadata(provider: str, model: str) -> ProviderModelMetadata:
@@ -385,10 +397,16 @@ def estimate_model_cost(
 
 
 def safe_model_identifier(value: str) -> bool:
-    return bool(
-        _MODEL_IDENTIFIER.fullmatch(value)
-        and not value.lower().startswith(_SECRET_MODEL_PREFIXES)
-    )
+    if not _MODEL_IDENTIFIER.fullmatch(value):
+        return False
+    lowered = value.lower()
+    if lowered.startswith(_SECRET_MODEL_PREFIXES):
+        return False
+    if lowered.startswith("file:/") or "://" in lowered:
+        return False
+    if _WINDOWS_ABSOLUTE_MODEL.match(value):
+        return False
+    return all(segment not in {"", ".", ".."} for segment in value.split("/"))
 
 
 def _first_configured_provider(env: Mapping[str, str]) -> str | None:

--- a/desktop/surfaces/gui/src/api.ts
+++ b/desktop/surfaces/gui/src/api.ts
@@ -638,14 +638,31 @@ const PROVIDER_FAILURES = new Set([
   "invalid_model_identifier",
 ]);
 const SAFE_MODEL = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$/;
-const SECRET_MODEL_PREFIXES = ["sk-", "ghp_", "github_pat_", "ya29.", "aiza"];
+const SECRET_MODEL_PREFIXES = [
+  "sk-",
+  "ghp_",
+  "github_pat_",
+  "ya29.",
+  "aiza",
+  "xoxb-",
+  "xoxp-",
+  "xoxa-",
+  "xoxr-",
+  "xapp-",
+];
 
 function safeModel(value: unknown): string | null {
   if (typeof value !== "string" || !SAFE_MODEL.test(value)) return null;
   const lowered = value.toLowerCase();
-  return SECRET_MODEL_PREFIXES.some((prefix) => lowered.startsWith(prefix))
-    ? null
-    : value;
+  if (SECRET_MODEL_PREFIXES.some((prefix) => lowered.startsWith(prefix))) {
+    return null;
+  }
+  if (lowered.startsWith("file:/") || lowered.includes("://")) return null;
+  if (/^[A-Za-z]:\//.test(value)) return null;
+  if (value.split("/").some((segment) => ["", ".", ".."].includes(segment))) {
+    return null;
+  }
+  return value;
 }
 
 function providerVerification(value: unknown): ProviderVerification | null {

--- a/desktop/surfaces/gui/tests/settingsApi.test.ts
+++ b/desktop/surfaces/gui/tests/settingsApi.test.ts
@@ -14,7 +14,7 @@ describe("settings provider verification boundary", () => {
         ok: true,
         json: async () => ({
           persona: { id: "sourcing", name: "Sourcing agent" },
-          model: "sk-settings-PLANTED",
+          model: "xoxb-PLANTED-SENTINEL",
           gmail: { connected: false, email: null },
           apollo: { configured: false },
           providers: [
@@ -36,6 +36,22 @@ describe("settings provider verification boundary", () => {
               },
               api_key: "provider-secret",
               raw_error: "private path",
+            },
+            {
+              provider: "openai",
+              model: "xoxb-PLANTED-SENTINEL",
+              selected: true,
+              eligible: true,
+              failures: [],
+              context_window_tokens: null,
+              capabilities: {
+                text: true,
+                transient_reasoning: true,
+                tool_calling: true,
+                terminal_usage: true,
+                cache_usage: true,
+                reasoning_usage: true,
+              },
             },
             {
               provider: "unknown-provider",
@@ -73,7 +89,107 @@ describe("settings provider verification boundary", () => {
             reasoning_usage: true,
           },
         },
+        {
+          provider: "openai",
+          model: null,
+          selected: false,
+          eligible: false,
+          failures: [],
+          context_window_tokens: null,
+          capabilities: {
+            text: true,
+            transient_reasoning: true,
+            tool_calling: true,
+            terminal_usage: true,
+            cache_usage: true,
+            reasoning_usage: true,
+          },
+        },
       ],
+    });
+  });
+
+  it.each([
+    "xoxb-PLANTED-SENTINEL",
+    "xoxp-PLANTED-SENTINEL",
+    "xapp-PLANTED-SENTINEL",
+    "C:/Users/operator/model",
+    "file:/private/model",
+    "https://provider.example/model",
+    "org/../model",
+    "org/./model",
+    "org//model",
+    "model with spaces",
+    "model\nwith-control",
+  ])("rejects unsafe model shape %s symmetrically", async (unsafeModel) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          persona: { id: "sourcing", name: "Sourcing agent" },
+          model: unsafeModel,
+          gmail: { connected: false, email: null },
+          apollo: { configured: false },
+          providers: [
+            {
+              provider: "openai",
+              model: unsafeModel,
+              selected: true,
+              eligible: true,
+              failures: [],
+              context_window_tokens: null,
+              capabilities: {},
+            },
+          ],
+        }),
+      }),
+    );
+
+    const settings = await getSettings();
+
+    expect(settings.model).toBeNull();
+    expect(settings.providers[0]).toMatchObject({
+      model: null,
+      selected: false,
+      eligible: false,
+    });
+    expect(JSON.stringify(settings)).not.toContain(unsafeModel);
+  });
+
+  it("preserves a safe custom OpenAI-compatible model identifier", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          persona: { id: "sourcing", name: "Sourcing agent" },
+          model: "vendor/custom-model:v2",
+          gmail: { connected: false, email: null },
+          apollo: { configured: false },
+          providers: [
+            {
+              provider: "openai",
+              model: "vendor/custom-model:v2",
+              selected: true,
+              eligible: true,
+              failures: [],
+              context_window_tokens: null,
+              capabilities: {},
+            },
+          ],
+        }),
+      }),
+    );
+
+    const settings = await getSettings();
+
+    expect(settings.model).toBe("vendor/custom-model:v2");
+    expect(settings.providers[0]).toMatchObject({
+      provider: "openai",
+      model: "vendor/custom-model:v2",
+      selected: true,
+      eligible: true,
     });
   });
 });

--- a/desktop/tests/test_provider_conformance.py
+++ b/desktop/tests/test_provider_conformance.py
@@ -171,8 +171,20 @@ def test_public_model_metadata_is_the_single_context_and_pricing_lookup():
     "unsafe_model",
     (
         "sk-settings-PLANTED",
+        "xoxb-PLANTED-SENTINEL",
+        "xoxp-PLANTED-SENTINEL",
+        "xapp-PLANTED-SENTINEL",
         "/private/operator/model",
+        "C:/Users/operator/model",
+        "file:/private/operator/model",
+        "https://provider.example/model",
+        "org/../model",
+        "org/./model",
+        "org//model",
         "model with spaces",
+        "model\nwith-control",
+        "model\x00with-null",
+        "m" * 129,
     ),
 )
 def test_provider_verification_rejects_and_redacts_unsafe_model_identifiers(
@@ -193,6 +205,69 @@ def test_provider_verification_rejects_and_redacts_unsafe_model_identifiers(
     assert report.model == "gpt-4o-mini"
     assert report.failures == ("invalid_model_identifier",)
     assert unsafe_model not in repr(report)
+
+
+def test_xoxb_explicit_model_is_never_selected_or_returned(monkeypatch):
+    planted = "xoxb-PLANTED-SENTINEL"
+    for key in (
+        "DEEPSEEK_API_KEY",
+        "MOONSHOT_API_KEY",
+        "KIMI_API_KEY",
+        "ANTHROPIC_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "real-key")
+    monkeypatch.setenv("CLUB_MODEL", planted)
+
+    reports = provider_module.provider_verifications()
+    openai = next(report for report in reports if report.provider == "openai")
+
+    assert provider_module.provider_from_env() is None
+    assert openai.eligible is False
+    assert openai.model == "gpt-4o-mini"
+    assert openai.failures == ("invalid_model_identifier",)
+    assert planted not in repr(reports)
+
+
+@pytest.mark.parametrize(
+    "custom_model",
+    (
+        "deepseek-v4-pro",
+        "kimi-k3",
+        "claude-sonnet-4-6",
+        "gpt-4o-mini",
+        "openrouter/meta-llama/llama-3.3-70b-instruct",
+        "accounts/fireworks/models/deepseek-v3",
+        "ft:gpt-4o-mini:org:project:suffix",
+        "vendor/model.v1",
+        "gpt-4o-mini-2024-07-18",
+        "us.anthropic.claude-sonnet-4-6-v1:0",
+    ),
+)
+def test_safe_custom_openai_compatible_model_identifier_remains_supported(
+    monkeypatch, custom_model
+):
+    for key in (
+        "DEEPSEEK_API_KEY",
+        "MOONSHOT_API_KEY",
+        "KIMI_API_KEY",
+        "ANTHROPIC_API_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "real-key")
+    monkeypatch.setenv("CLUB_MODEL", custom_model)
+
+    report = next(
+        report
+        for report in provider_module.provider_verifications()
+        if report.provider == "openai"
+    )
+    provider = provider_module.provider_from_env()
+
+    assert report.eligible is True
+    assert report.model == custom_model
+    assert isinstance(provider, provider_module.OpenAICompatProvider)
+    assert provider.model_id == custom_model
 
 
 def test_unsupported_configured_model_is_rejected_before_provider_creation(

--- a/desktop/tests/test_settings.py
+++ b/desktop/tests/test_settings.py
@@ -141,7 +141,7 @@ def test_settings_exposes_provider_verification_without_credentials(
 def test_settings_redacts_invalid_explicit_model_from_legacy_and_provider_fields(
     tmp_path, monkeypatch
 ):
-    planted = "sk-settings-PLANTED"
+    planted = "xoxb-PLANTED-SENTINEL"
     for key in (
         "DEEPSEEK_API_KEY",
         "MOONSHOT_API_KEY",


### PR DESCRIPTION
## Summary\n\n- reject and redact Slack token families and existing secret-shaped model prefixes\n- reject absolute paths, URLs, traversal or repeated path segments, whitespace, control characters, invalid characters, and overlong model identifiers\n- preserve valid advertised and safe custom OpenAI-compatible model IDs\n- make unsafe explicit overrides fail closed across provider verification, provider selection, Settings API, and GUI parsing\n- ensure planted values are never logged or persisted\n\n## Verification\n\n- focused provider and Settings Python suite: 123 passed\n- focused Settings, API, and chat GUI suite: 78 passed\n- make test: 628 Python passed, 3 skipped; 380 GUI passed\n- make build: passed\n- independent xoxb sentinel reproduction confirms redaction, ineligibility, and fail-closed selection\n- existing Starlette/httpx deprecation and Vite chunk-size warnings remain\n\nCloses #80\nCloses #81\n\n## Review focus\n\n- xoxb-style and other credential-shaped values never cross provider or Settings boundaries\n- valid vendor namespaces, snapshots, fine-tunes, dots, slashes, and colons remain supported\n- backend and browser validation stay symmetric\n- unsafe explicit overrides cannot silently select another provider or model