### PR TITLE
feat(desktop): add bounded provider retry and failover

### DIFF
--- a/desktop/coworker/events.py
+++ b/desktop/coworker/events.py
@@ -19,6 +19,7 @@ EVENT_TYPES = frozenset(
         "tool_started",
         "tool_finished",
         "tool_recovery",
+        "provider_recovery",
         "turn_end",
         "error",
     }
@@ -141,6 +142,16 @@ def validate_event(event: object) -> str | None:
                 return f"tool_recovery.{field} must be a non-empty string"
         if event.get("action") not in {"retry", "repair", "continue"}:
             return "tool_recovery.action is invalid"
+    if event_type == "provider_recovery":
+        for field in ("action", "provider", "model", "reason", "message"):
+            if not isinstance(event.get(field), str) or not event[field]:
+                return f"provider_recovery.{field} must be a non-empty string"
+        if event.get("action") not in {"retry", "failover"}:
+            return "provider_recovery.action is invalid"
+        if not isinstance(event.get("attempt"), int) or event["attempt"] < 1:
+            return "provider_recovery.attempt must be a positive integer"
+        if not isinstance(event.get("delay_ms"), int) or event["delay_ms"] < 0:
+            return "provider_recovery.delay_ms must be a non-negative integer"
     return None
 
 

--- a/desktop/coworker/provider.py
+++ b/desktop/coworker/provider.py
@@ -8,6 +8,8 @@ import re
 from collections import OrderedDict
 from copy import deepcopy
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
 from enum import Enum
 from hashlib import sha256
 from time import monotonic
@@ -146,6 +148,7 @@ class ProviderStreamError(RuntimeError):
         message: str,
         retryable: bool,
         http_status: int | None = None,
+        retry_after_seconds: float | None = None,
     ) -> None:
         super().__init__(f"{provider} {message}")
         self.provider = provider
@@ -153,6 +156,7 @@ class ProviderStreamError(RuntimeError):
         self.error_kind = kind
         self.retryable = retryable
         self.http_status = http_status
+        self.retry_after_seconds = retry_after_seconds
 
 
 def _http_error_kind(status_code: int) -> ProviderErrorKind:
@@ -168,7 +172,11 @@ def _http_error_kind(status_code: int) -> ProviderErrorKind:
 
 
 def _provider_http_error(
-    *, provider: str, model: str, status_code: int
+    *,
+    provider: str,
+    model: str,
+    status_code: int,
+    retry_after_seconds: float | None = None,
 ) -> ProviderStreamError:
     return ProviderStreamError(
         provider=provider,
@@ -177,7 +185,28 @@ def _provider_http_error(
         message=f"provider request failed with HTTP {status_code}",
         retryable=status_code in {408, 409, 429} or status_code >= 500,
         http_status=status_code,
+        retry_after_seconds=retry_after_seconds,
     )
+
+
+def _retry_after_seconds(
+    headers: Mapping[str, str],
+    *,
+    now: datetime | None = None,
+) -> float | None:
+    raw = str(headers.get("retry-after") or "").strip()
+    try:
+        value = float(raw)
+    except ValueError:
+        try:
+            target = parsedate_to_datetime(raw)
+        except (TypeError, ValueError, OverflowError):
+            return None
+        if target.tzinfo is None:
+            target = target.replace(tzinfo=UTC)
+        current = now or datetime.now(UTC)
+        return max(0.0, (target - current).total_seconds())
+    return value if value >= 0 else None
 
 
 @dataclass
@@ -689,6 +718,7 @@ class AnthropicProvider:
                         provider=self.provider_id,
                         model=self.model_id,
                         status_code=resp.status_code,
+                        retry_after_seconds=_retry_after_seconds(resp.headers),
                     )
                 async for line in resp.aiter_lines():
                     if not line.startswith("data:"):
@@ -905,12 +935,18 @@ class OpenAICompatProvider:
             body["tool_choice"] = "auto"
         return body
 
-    def _http_error(self, status_code: int, body: str) -> RuntimeError:
+    def _http_error(
+        self,
+        status_code: int,
+        body: str,
+        retry_after_seconds: float | None = None,
+    ) -> RuntimeError:
         del body
         return _provider_http_error(
             provider=self.provider_id,
             model=self.model_id,
             status_code=status_code,
+            retry_after_seconds=retry_after_seconds,
         )
 
     def _protocol_error(self, message: str) -> ProviderStreamError:
@@ -987,7 +1023,11 @@ class OpenAICompatProvider:
             ) as resp:
                 if resp.status_code >= 400:
                     err = (await resp.aread()).decode("utf-8", errors="replace")
-                    raise self._http_error(resp.status_code, err)
+                    raise self._http_error(
+                        resp.status_code,
+                        err,
+                        _retry_after_seconds(resp.headers),
+                    )
                 async for line in resp.aiter_lines():
                     if not line.startswith("data:"):
                         continue
@@ -1152,12 +1192,18 @@ class DeepSeekProvider(OpenAICompatProvider):
             str, OrderedDict[str, str]
         ] = OrderedDict()
 
-    def _http_error(self, status_code: int, body: str) -> RuntimeError:
+    def _http_error(
+        self,
+        status_code: int,
+        body: str,
+        retry_after_seconds: float | None = None,
+    ) -> RuntimeError:
         del body
         return _provider_http_error(
             provider=self.provider_id,
             model=self.model_id,
             status_code=status_code,
+            retry_after_seconds=retry_after_seconds,
         )
 
     def _prepare_messages(
@@ -1266,12 +1312,18 @@ class KimiProvider(DeepSeekProvider):
         {"stop", "tool_calls", "length", "content_filter"}
     )
 
-    def _http_error(self, status_code: int, body: str) -> RuntimeError:
+    def _http_error(
+        self,
+        status_code: int,
+        body: str,
+        retry_after_seconds: float | None = None,
+    ) -> RuntimeError:
         del body
         return _provider_http_error(
             provider=self.provider_id,
             model=self.model_id,
             status_code=status_code,
+            retry_after_seconds=retry_after_seconds,
         )
 
     def _prepare_messages(
@@ -1281,22 +1333,25 @@ class KimiProvider(DeepSeekProvider):
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None,
     ) -> list[dict[str, Any]]:
-        if context_id or not tools:
-            return super()._prepare_messages(
-                context_id=context_id,
-                messages=messages,
-                tools=tools,
-            )
-        prepared = deepcopy(messages)
-        for message in prepared:
-            if message.get("role") != "assistant" or not message.get("tool_calls"):
+        prepared: list[dict[str, Any]] = []
+        cache = self._context_cache(context_id, create=False) if context_id else None
+        for original in messages:
+            message = deepcopy(original)
+            if message.get("role") != "assistant":
+                prepared.append(message)
                 continue
-            if message.get("content") is None:
+            if message.get("tool_calls") and message.get("content") is None:
                 message["content"] = ""
-            if "reasoning_content" not in message:
-                raise self._protocol_error(
-                    "kimi tool continuation requires retained reasoning"
-                )
+            if tools and "reasoning_content" not in message:
+                key = _continuity_key(prepared, message)
+                reasoning = cache.get(key) if cache is not None else None
+                if reasoning is not None:
+                    message["reasoning_content"] = reasoning
+                elif message.get("tool_calls"):
+                    raise self._protocol_error(
+                        "kimi tool continuation requires retained reasoning"
+                    )
+            prepared.append(message)
         return prepared
 
     def _request_body(

--- a/desktop/coworker/provider_retry.py
+++ b/desktop/coworker/provider_retry.py
@@ -1,0 +1,421 @@
+"""Bounded retry decisions for one Sourcecado model request."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from enum import Enum
+import math
+import os
+import random
+from collections.abc import Awaitable, Callable
+from typing import Any, AsyncIterator, Mapping
+
+import httpx
+
+from coworker.provider import (
+    DEEPSEEK_BASE,
+    KIMI_BASE,
+    AnthropicProvider,
+    DeepSeekProvider,
+    KimiProvider,
+    OpenAICompatProvider,
+    ProviderErrorKind,
+    ProviderStreamError,
+    StreamProvider,
+    provider_verifications,
+)
+from coworker.telemetry import RetryReason
+
+
+class RetryAction(str, Enum):
+    RETRY = "retry"
+    FAIL = "fail"
+    REVIEW = "review"
+
+
+class RecoveryAction(str, Enum):
+    RETRY = "retry"
+    FAILOVER = "failover"
+    FAIL = "fail"
+    REVIEW = "review"
+    CANCELLED = "cancelled"
+
+
+class ProviderRequestCancelled(Exception):
+    """Cooperative cancellation while waiting on the provider stream."""
+
+
+@dataclass(frozen=True)
+class RetryDecision:
+    action: RetryAction
+    reason: RetryReason | None = None
+    retry_after_seconds: float | None = None
+
+
+@dataclass(frozen=True)
+class RetryPolicy:
+    max_attempts_per_provider: int = 3
+    base_delay_seconds: float = 0.25
+    max_delay_seconds: float = 4.0
+    max_retry_after_seconds: float = 30.0
+    jitter_ratio: float = 0.2
+
+    def __post_init__(self) -> None:
+        if self.max_attempts_per_provider < 1:
+            raise ValueError("max_attempts_per_provider must be positive")
+        if not 0 <= self.jitter_ratio <= 1:
+            raise ValueError("jitter_ratio must be between zero and one")
+        for value in (
+            self.base_delay_seconds,
+            self.max_delay_seconds,
+            self.max_retry_after_seconds,
+        ):
+            if not math.isfinite(value) or value < 0:
+                raise ValueError("retry delays must be finite and non-negative")
+
+    def delay_seconds(
+        self,
+        retry_number: int,
+        *,
+        retry_after_seconds: float | None,
+        jitter_value: float,
+    ) -> float:
+        if (
+            retry_after_seconds is not None
+            and math.isfinite(retry_after_seconds)
+            and retry_after_seconds >= 0
+        ):
+            return min(retry_after_seconds, self.max_retry_after_seconds)
+        exponent = max(0, retry_number - 1)
+        base = min(
+            self.max_delay_seconds,
+            self.base_delay_seconds * (2**exponent),
+        )
+        jitter = min(1.0, max(0.0, jitter_value))
+        multiplier = 1 + self.jitter_ratio * ((2 * jitter) - 1)
+        return min(self.max_delay_seconds, base * multiplier)
+
+
+@dataclass(frozen=True)
+class RecoveryDirective:
+    action: RecoveryAction
+    provider: Any
+    attempt_number: int
+    reason: RetryReason | None
+    delay_seconds: float = 0
+    exhausted: bool = False
+
+
+class RetryController:
+    def __init__(
+        self,
+        providers: tuple[Any, ...],
+        *,
+        policy: RetryPolicy | None = None,
+        sleep: Callable[[float], Awaitable[None]],
+        random_value: Callable[[], float] = random.random,
+        cancel_event: asyncio.Event | None = None,
+    ) -> None:
+        if not providers:
+            raise ValueError("retry controller requires at least one provider")
+        self.providers = providers
+        self.policy = policy or RetryPolicy()
+        self._sleep = sleep
+        self._random_value = random_value
+        self._cancel_event = cancel_event
+        self.provider_index = 0
+        self.attempt_number = 1
+
+    @property
+    def provider(self) -> Any:
+        return self.providers[self.provider_index]
+
+    async def recover(
+        self,
+        error: BaseException,
+        *,
+        partial_stream: bool,
+    ) -> RecoveryDirective:
+        decision = classify_provider_failure(error, partial_stream=partial_stream)
+        if decision.action is RetryAction.REVIEW:
+            return RecoveryDirective(
+                RecoveryAction.REVIEW,
+                self.provider,
+                self.attempt_number,
+                decision.reason,
+            )
+        if decision.action is RetryAction.FAIL:
+            return RecoveryDirective(
+                RecoveryAction.FAIL,
+                self.provider,
+                self.attempt_number,
+                decision.reason,
+            )
+        if self.attempt_number < self.policy.max_attempts_per_provider:
+            delay = self.policy.delay_seconds(
+                self.attempt_number,
+                retry_after_seconds=decision.retry_after_seconds,
+                jitter_value=self._random_value(),
+            )
+            if not await self._sleep_or_cancel(delay):
+                return RecoveryDirective(
+                    RecoveryAction.CANCELLED,
+                    self.provider,
+                    self.attempt_number,
+                    decision.reason,
+                    delay,
+                )
+            self.attempt_number += 1
+            return RecoveryDirective(
+                RecoveryAction.RETRY,
+                self.provider,
+                self.attempt_number,
+                decision.reason,
+                delay,
+            )
+        if self.provider_index + 1 < len(self.providers):
+            self.provider_index += 1
+            self.attempt_number = 1
+            return RecoveryDirective(
+                RecoveryAction.FAILOVER,
+                self.provider,
+                self.attempt_number,
+                decision.reason,
+            )
+        return RecoveryDirective(
+            RecoveryAction.FAIL,
+            self.provider,
+            self.attempt_number,
+            decision.reason,
+            exhausted=True,
+        )
+
+    async def _sleep_or_cancel(self, delay: float) -> bool:
+        if self._cancel_event is None:
+            await self._sleep(delay)
+            return True
+        if self._cancel_event.is_set():
+            return False
+        sleep_task = asyncio.create_task(self._sleep(delay))
+        cancel_task = asyncio.create_task(self._cancel_event.wait())
+        done, pending = await asyncio.wait(
+            {sleep_task, cancel_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        if cancel_task in done and self._cancel_event.is_set():
+            return False
+        await sleep_task
+        return True
+
+
+_RETRYABLE_STATUS = frozenset({408, 409, 429, 500, 502, 503, 504})
+_PROVIDER_KEYS = (
+    ("deepseek", "DEEPSEEK_API_KEY"),
+    ("kimi", "MOONSHOT_API_KEY"),
+    ("anthropic", "ANTHROPIC_API_KEY"),
+    ("openai", "OPENAI_API_KEY"),
+)
+
+
+def verified_provider_chain(
+    environment: Mapping[str, str] | None = None,
+) -> tuple[StreamProvider, ...]:
+    env = os.environ if environment is None else environment
+    reports = {report.provider: report for report in provider_verifications(env)}
+
+    def key_for(provider: str, key_name: str) -> str:
+        value = str(env.get(key_name) or "").strip()
+        if provider == "kimi" and not value:
+            value = str(env.get("KIMI_API_KEY") or "").strip()
+        return value
+
+    configured = [
+        provider
+        for provider, key_name in _PROVIDER_KEYS
+        if key_for(provider, key_name)
+    ]
+    if (
+        str(env.get("CLUB_MODEL") or "").strip()
+        and configured
+        and not reports[configured[0]].eligible
+    ):
+        return ()
+
+    providers: list[StreamProvider] = []
+    for provider_id, key_name in _PROVIDER_KEYS:
+        key = key_for(provider_id, key_name)
+        report = reports[provider_id]
+        if not key or not report.eligible:
+            continue
+        if provider_id == "deepseek":
+            provider = DeepSeekProvider(
+                api_key=key,
+                model=report.model,
+                base_url=str(env.get("DEEPSEEK_BASE_URL") or DEEPSEEK_BASE),
+            )
+        elif provider_id == "kimi":
+            provider = KimiProvider(
+                api_key=key,
+                model=report.model,
+                base_url=str(
+                    env.get("KIMI_BASE_URL")
+                    or env.get("MOONSHOT_BASE_URL")
+                    or KIMI_BASE
+                ),
+            )
+        elif provider_id == "anthropic":
+            provider = AnthropicProvider(api_key=key, model=report.model)
+        else:
+            provider = OpenAICompatProvider(
+                api_key=key,
+                model=report.model,
+                base_url=str(
+                    env.get("OPENAI_BASE_URL") or "https://api.openai.com/v1"
+                ),
+            )
+        providers.append(provider)
+    return tuple(providers)
+
+
+def compatible_failover_chain(
+    providers: tuple[Any, ...],
+    *,
+    selected_provider: Any,
+    messages: list[dict[str, Any]],
+) -> tuple[Any, ...]:
+    missing_reasoning = any(
+        message.get("role") == "assistant"
+        and "reasoning_content" not in message
+        for message in messages
+    )
+    missing_tool_reasoning = any(
+        message.get("role") == "assistant"
+        and message.get("tool_calls")
+        and "reasoning_content" not in message
+        for message in messages
+    )
+    return tuple(
+        provider
+        for provider in providers
+        if provider is selected_provider
+        or not (
+            (
+                missing_tool_reasoning
+                if getattr(provider, "provider_id", "") == "kimi"
+                else missing_reasoning
+            )
+            and getattr(provider, "uses_transient_context", False)
+        )
+    )
+
+
+def classify_provider_failure(
+    error: BaseException,
+    *,
+    partial_stream: bool,
+) -> RetryDecision:
+    reason: RetryReason | None = None
+    retryable = False
+    retry_after_seconds: float | None = None
+    if isinstance(error, ProviderStreamError):
+        raw_retry_after = getattr(error, "retry_after_seconds", None)
+        if (
+            isinstance(raw_retry_after, (int, float))
+            and not isinstance(raw_retry_after, bool)
+            and math.isfinite(raw_retry_after)
+            and raw_retry_after >= 0
+        ):
+            retry_after_seconds = float(raw_retry_after)
+        if error.http_status in _RETRYABLE_STATUS:
+            retryable = True
+        elif error.http_status is None and error.retryable and error.error_kind in {
+            ProviderErrorKind.TIMEOUT,
+            ProviderErrorKind.CONNECTION,
+            ProviderErrorKind.PROVIDER,
+            ProviderErrorKind.RATE_LIMIT,
+        }:
+            retryable = True
+        if error.error_kind is ProviderErrorKind.RATE_LIMIT:
+            reason = RetryReason.RATE_LIMIT
+        elif error.error_kind is ProviderErrorKind.TIMEOUT:
+            reason = RetryReason.TIMEOUT
+        elif error.error_kind is ProviderErrorKind.CONNECTION:
+            reason = RetryReason.CONNECTION
+        elif retryable:
+            reason = RetryReason.TRANSIENT_PROVIDER
+    elif isinstance(error, (TimeoutError, httpx.TimeoutException)):
+        retryable = True
+        reason = RetryReason.TIMEOUT
+    elif isinstance(error, (ConnectionError, httpx.TransportError)):
+        retryable = True
+        reason = RetryReason.CONNECTION
+
+    if partial_stream:
+        return RetryDecision(RetryAction.REVIEW, reason, retry_after_seconds)
+    if not retryable:
+        return RetryDecision(RetryAction.FAIL)
+    return RetryDecision(RetryAction.RETRY, reason, retry_after_seconds)
+
+
+def safe_provider_failure_message(
+    error: BaseException,
+    *,
+    review_required: bool = False,
+) -> str:
+    if review_required:
+        return (
+            "The model provider stopped after partial output. "
+            "Review the partial response before retrying."
+        )
+    if isinstance(error, ProviderStreamError):
+        if error.error_kind is ProviderErrorKind.AUTHENTICATION:
+            return "Model provider authentication failed. Review provider setup in Settings."
+        if error.error_kind is ProviderErrorKind.RATE_LIMIT:
+            return "The model provider remained rate limited after bounded retries."
+        if error.error_kind is ProviderErrorKind.CONFIGURATION:
+            return "Model provider configuration is unavailable. Review Settings."
+        if error.error_kind in {
+            ProviderErrorKind.INVALID_REQUEST,
+            ProviderErrorKind.PROTOCOL,
+        }:
+            return "The model provider rejected the request. Review before retrying."
+    return "The model provider failed after bounded recovery attempts."
+
+
+async def cancellable_stream(
+    stream: AsyncIterator[Any],
+    *,
+    cancel_event: asyncio.Event | None,
+) -> AsyncIterator[Any]:
+    if cancel_event is None:
+        async for item in stream:
+            yield item
+        return
+    iterator = stream.__aiter__()
+    while True:
+        if cancel_event.is_set():
+            await iterator.aclose()
+            raise ProviderRequestCancelled()
+        next_task = asyncio.create_task(anext(iterator))
+        cancel_task = asyncio.create_task(cancel_event.wait())
+        done, pending = await asyncio.wait(
+            {next_task, cancel_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        if cancel_task in done and cancel_event.is_set():
+            next_task.cancel()
+            await asyncio.gather(next_task, return_exceptions=True)
+            await iterator.aclose()
+            raise ProviderRequestCancelled()
+        try:
+            item = next_task.result()
+        except StopAsyncIteration:
+            return
+        yield item

--- a/desktop/coworker/server.py
+++ b/desktop/coworker/server.py
@@ -56,11 +56,11 @@ from coworker.persona import ManifestError, Persona, load_persona
 from coworker.skills import BUILTIN_SKILLS, SkillLoader, catalog_text
 from coworker.provider import (
     ToolCall,
-    provider_from_env,
     provider_model_metadata,
     provider_verifications,
     safe_model_identifier,
 )
+from coworker.provider_retry import verified_provider_chain
 from coworker.secrets import SecretStore
 from coworker.store import ConversationStore, valid_session_id
 from coworker.telemetry import (
@@ -273,13 +273,20 @@ def create_app(
     browser_opener: Callable[[str], bool] | None = None,
     workspace_runtime: WorkspaceRuntime | None = None,
     telemetry_adapter: TelemetryAdapter | None = None,
+    provider_failovers: tuple[Any, ...] | None = None,
 ) -> FastAPI:
     if not token:
         raise ValueError("sidecar token must be non-empty")
 
     app = FastAPI(title="Club sidecar", version="0.0.2")
     app.state.token = token
-    app.state.provider = provider_from_env() if provider is _UNSET else provider
+    if provider is _UNSET:
+        provider_chain = verified_provider_chain()
+        app.state.provider = provider_chain[0] if provider_chain else None
+        app.state.provider_failovers = provider_chain[1:]
+    else:
+        app.state.provider = provider
+        app.state.provider_failovers = tuple(provider_failovers or ())
     app.state.telemetry_adapter = (
         telemetry_adapter
         if telemetry_adapter is not None
@@ -349,6 +356,7 @@ def create_app(
                 sid=sid,
                 store=app.state.store,
                 provider=app.state.provider,
+                failover_providers=app.state.provider_failovers,
                 persona=app.state.persona,
                 skills=app.state.skills,
                 inbox=app.state.inbox,
@@ -2005,6 +2013,7 @@ def create_app(
                     sid=run_sid,
                     store=store,
                     provider=app.state.provider,
+                    failover_providers=app.state.provider_failovers,
                     persona=app.state.persona,
                     skills=app.state.skills,
                     inbox=app.state.inbox,

--- a/desktop/coworker/turn.py
+++ b/desktop/coworker/turn.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import random
 import threading
 import uuid
 from datetime import UTC, datetime
@@ -22,12 +23,23 @@ from coworker.provider import (
     ToolCall,
     provider_model_metadata,
 )
+from coworker.provider_retry import (
+    ProviderRequestCancelled,
+    RecoveryAction,
+    RetryController,
+    RetryPolicy,
+    cancellable_stream,
+    compatible_failover_chain,
+    safe_provider_failure_message,
+)
 from coworker.store import ConversationStore
 from coworker.telemetry import (
     AgentTurnSpan,
     CostEstimate,
     ErrorKind,
     ProviderSpan,
+    RetryEvent,
+    RetryReason,
     StopReason,
     TelemetryRecorder,
     TraceContext,
@@ -613,6 +625,10 @@ async def run_turn(
     identity: TurnIdentity | None = None,
     control: RunControl | None = None,
     telemetry: TelemetryRecorder | None = None,
+    failover_providers: tuple[Any, ...] = (),
+    retry_policy: RetryPolicy | None = None,
+    retry_sleep: Callable[[float], Awaitable[None]] | None = None,
+    retry_random: Callable[[], float] = random.random,
 ) -> dict[str, Any]:
     workspace_runtime = execute_kwargs.get("workspace_runtime")
     events = TurnEventStream(
@@ -725,8 +741,18 @@ async def run_turn(
         )
         return {"status": "error", "text": ""}
 
+    provider_chain = (provider,) + tuple(
+        candidate
+        for candidate in failover_providers
+        if candidate is not provider
+    )
+    selected_provider = provider
+    retry_count = 0
+
     last_text = ""
     had_tool_failure = False
+    turn_error_kind = ErrorKind.INTERNAL
+    turn_error_message: str | None = None
     history: list[dict[str, Any]] = []
     try:
         raw = store.load(sid)
@@ -755,97 +781,202 @@ async def run_turn(
             history.append(user_msg)
             _persist_message(user_msg)
         for _ in range(MAX_STEPS):
-            chunks: list[str] = []
-            calls: list[ToolCall] = []
-            provider_usage: UsageEvent | None = None
-            provider_finish_reason: str | None = None
-            provider_cost: CostEstimate | None = None
-            provider_span = None
-            provider_context_window: int | None = None
             _persist_closed(store, sid, history, workspace_runtime)
             model_messages = [
                 {k: v for k, v in message.items() if k != "message_id"}
                 for message in history
             ]
-            stream_kwargs: dict[str, Any] = {
-                "messages": model_messages,
-                "tools": openai_tools,
-            }
-            if getattr(provider, "uses_transient_context", False):
-                stream_kwargs["context_id"] = sid
-            def _ensure_provider_span(start: ProviderStart | None = None):
-                nonlocal provider_span, provider_context_window
-                if provider_span is None:
-                    schema = _telemetry_provider_span(provider, start)
-                    provider_context_window = schema.context_window_tokens
-                    provider_span = turn_span.child(schema)
-                return provider_span
+            selected_index = provider_chain.index(selected_provider)
+            attempt_chain = compatible_failover_chain(
+                provider_chain[selected_index:],
+                selected_provider=selected_provider,
+                messages=model_messages,
+            )
+            controller = RetryController(
+                attempt_chain,
+                policy=retry_policy or RetryPolicy(),
+                sleep=retry_sleep or asyncio.sleep,
+                random_value=retry_random,
+                cancel_event=(control.cancel_requested if control is not None else None),
+            )
+            while True:
+                attempt_provider = controller.provider
+                chunks: list[str] = []
+                calls: list[ToolCall] = []
+                provider_usage: UsageEvent | None = None
+                provider_finish_reason: str | None = None
+                provider_cost: CostEstimate | None = None
+                provider_span = None
+                provider_context_window: int | None = None
+                meaningful_stream = False
+                stream_kwargs: dict[str, Any] = {
+                    "messages": model_messages,
+                    "tools": openai_tools,
+                }
+                if getattr(attempt_provider, "uses_transient_context", False):
+                    stream_kwargs["context_id"] = sid
 
-            try:
-                async for chunk in provider.astream(**stream_kwargs):
-                    if chunk.kind is StreamKind.START and chunk.start is not None:
-                        _ensure_provider_span(chunk.start)
-                        continue
-                    active_provider_span = _ensure_provider_span()
-                    if control is not None and control.cancel_requested.is_set():
-                        active_provider_span.cancel(usage=provider_usage, cost=provider_cost)
-                        return await _stopped(history, "".join(chunks) or last_text)
-                    if chunk.text_delta:
-                        chunks.append(chunk.text_delta)
-                        await _emit({"type": "assistant_delta", "delta": chunk.text_delta})
-                    if chunk.tool_calls:
-                        calls = chunk.tool_calls
-                    if chunk.usage is not None:
-                        provider_usage = _telemetry_usage(
-                            chunk.usage,
-                            context_window_tokens=provider_context_window,
-                        )
-                        active_provider_span.record(provider_usage)
-                    if chunk.kind is StreamKind.TERMINAL and chunk.terminal is not None:
-                        provider_finish_reason = chunk.terminal.stop_reason
-                        if chunk.terminal.usage is not None:
-                            terminal_usage = _telemetry_usage(
-                                chunk.terminal.usage,
+                def _ensure_provider_span(start: ProviderStart | None = None):
+                    nonlocal provider_span, provider_context_window
+                    if provider_span is None:
+                        schema = _telemetry_provider_span(attempt_provider, start)
+                        provider_context_window = schema.context_window_tokens
+                        provider_span = turn_span.child(schema)
+                    return provider_span
+
+                try:
+                    async for chunk in cancellable_stream(
+                        attempt_provider.astream(**stream_kwargs),
+                        cancel_event=(
+                            control.cancel_requested if control is not None else None
+                        ),
+                    ):
+                        if chunk.kind is StreamKind.START and chunk.start is not None:
+                            _ensure_provider_span(chunk.start)
+                            continue
+                        if chunk.kind is not None:
+                            meaningful_stream = True
+                        active_provider_span = _ensure_provider_span()
+                        if control is not None and control.cancel_requested.is_set():
+                            active_provider_span.cancel(
+                                usage=provider_usage,
+                                cost=provider_cost,
+                            )
+                            return await _stopped(
+                                history, "".join(chunks) or last_text
+                            )
+                        if chunk.text_delta:
+                            chunks.append(chunk.text_delta)
+                            await _emit(
+                                {"type": "assistant_delta", "delta": chunk.text_delta}
+                            )
+                        if chunk.tool_calls:
+                            calls = chunk.tool_calls
+                        if chunk.usage is not None:
+                            provider_usage = _telemetry_usage(
+                                chunk.usage,
                                 context_window_tokens=provider_context_window,
                             )
-                            if provider_usage is None:
-                                active_provider_span.record(terminal_usage)
-                            provider_usage = terminal_usage
-                        if chunk.terminal.estimated_cost_usd is not None:
-                            try:
-                                provider_cost = CostEstimate(
-                                    estimated_cost_usd=(
-                                        chunk.terminal.estimated_cost_usd
-                                    )
+                            active_provider_span.record(provider_usage)
+                        if (
+                            chunk.kind is StreamKind.TERMINAL
+                            and chunk.terminal is not None
+                        ):
+                            provider_finish_reason = chunk.terminal.stop_reason
+                            if chunk.terminal.usage is not None:
+                                terminal_usage = _telemetry_usage(
+                                    chunk.terminal.usage,
+                                    context_window_tokens=provider_context_window,
                                 )
-                            except ValueError:
-                                provider_cost = None
-                    if chunk.finish_reason is not None:
-                        provider_finish_reason = chunk.finish_reason
-            except asyncio.CancelledError:
-                _ensure_provider_span().cancel(
+                                if provider_usage is None:
+                                    active_provider_span.record(terminal_usage)
+                                provider_usage = terminal_usage
+                            if chunk.terminal.estimated_cost_usd is not None:
+                                try:
+                                    provider_cost = CostEstimate(
+                                        estimated_cost_usd=(
+                                            chunk.terminal.estimated_cost_usd
+                                        )
+                                    )
+                                except ValueError:
+                                    provider_cost = None
+                        if chunk.finish_reason is not None:
+                            provider_finish_reason = chunk.finish_reason
+                except ProviderRequestCancelled:
+                    _ensure_provider_span().cancel(
+                        usage=provider_usage,
+                        cost=provider_cost,
+                    )
+                    return await _stopped(
+                        history, "".join(chunks) or last_text
+                    )
+                except asyncio.CancelledError:
+                    _ensure_provider_span().cancel(
+                        usage=provider_usage,
+                        cost=provider_cost,
+                    )
+                    turn_span.cancel()
+                    raise
+                except Exception as exc:
+                    error_kind = _telemetry_provider_error_kind(exc)
+                    _ensure_provider_span().fail(
+                        error_kind,
+                        usage=provider_usage,
+                        cost=provider_cost,
+                    )
+                    directive = await controller.recover(
+                        exc,
+                        partial_stream=meaningful_stream,
+                    )
+                    if directive.action in {
+                        RecoveryAction.RETRY,
+                        RecoveryAction.FAILOVER,
+                    }:
+                        retry_count += 1
+                        turn_span.record(
+                            RetryEvent(
+                                operation="provider.request",
+                                retry_count=retry_count,
+                                reason=(
+                                    directive.reason
+                                    or RetryReason.TRANSIENT_PROVIDER
+                                ),
+                                delay_ms=round(directive.delay_seconds * 1000),
+                            )
+                        )
+                        recovery_provider = _telemetry_provider_span(
+                            directive.provider
+                        )
+                        await _emit(
+                            {
+                                "type": "provider_recovery",
+                                "action": directive.action.value,
+                                "provider": recovery_provider.provider,
+                                "model": recovery_provider.model,
+                                "attempt": directive.attempt_number,
+                                "reason": (
+                                    directive.reason
+                                    or RetryReason.TRANSIENT_PROVIDER
+                                ).value,
+                                "delay_ms": round(
+                                    directive.delay_seconds * 1000
+                                ),
+                                "message": (
+                                    "Switching to a verified fallback model provider."
+                                    if directive.action is RecoveryAction.FAILOVER
+                                    else "Retrying the model provider after a temporary failure."
+                                ),
+                            }
+                        )
+                        if directive.action is RecoveryAction.FAILOVER:
+                            selected_provider = directive.provider
+                        continue
+                    if directive.action is RecoveryAction.CANCELLED:
+                        return await _stopped(
+                            history, "".join(chunks) or last_text
+                        )
+                    if directive.action is RecoveryAction.REVIEW:
+                        turn_error_kind = error_kind
+                        turn_error_message = safe_provider_failure_message(
+                            exc,
+                            review_required=True,
+                        )
+                        raise RuntimeError(
+                            turn_error_message
+                        ) from exc
+                    turn_error_kind = error_kind
+                    turn_error_message = safe_provider_failure_message(exc)
+                    raise
+                _ensure_provider_span().finish(
+                    stop_reason=_telemetry_stop_reason(
+                        provider_finish_reason,
+                        used_tools=bool(calls),
+                    ),
                     usage=provider_usage,
                     cost=provider_cost,
                 )
-                turn_span.cancel()
-                raise
-            except Exception as exc:
-                error_kind = _telemetry_provider_error_kind(exc)
-                _ensure_provider_span().fail(
-                    error_kind,
-                    usage=provider_usage,
-                    cost=provider_cost,
-                )
-                turn_span.fail(error_kind)
-                raise
-            _ensure_provider_span().finish(
-                stop_reason=_telemetry_stop_reason(
-                    provider_finish_reason,
-                    used_tools=bool(calls),
-                ),
-                usage=provider_usage,
-                cost=provider_cost,
-            )
+                selected_provider = attempt_provider
+                break
             if control is not None and control.cancel_requested.is_set():
                 return await _stopped(history, "".join(chunks) or last_text)
             last_text = "".join(chunks)
@@ -1116,9 +1247,15 @@ async def run_turn(
         turn_span.cancel()
         raise
     except Exception as exc:
-        turn_span.fail(ErrorKind.INTERNAL)
+        turn_span.fail(turn_error_kind)
         _persist_closed(store, sid, history, workspace_runtime)
-        await _terminal({"type": "error", "state": "failed", "message": str(exc)})
+        await _terminal(
+            {
+                "type": "error",
+                "state": "failed",
+                "message": turn_error_message or str(exc),
+            }
+        )
         return {"status": "error", "text": last_text}
     final_state = "partial" if had_tool_failure else "complete"
     await _terminal({"type": "turn_end", "text": last_text, "state": final_state})

--- a/desktop/coworker/turn.py
+++ b/desktop/coworker/turn.py
@@ -834,6 +834,8 @@ async def run_turn(
                         if chunk.kind is StreamKind.START and chunk.start is not None:
                             _ensure_provider_span(chunk.start)
                             continue
+                        if chunk.kind is StreamKind.REASONING:
+                            continue
                         if chunk.kind is not None:
                             meaningful_stream = True
                         active_provider_span = _ensure_provider_span()

--- a/desktop/surfaces/gui/src/chat/protocol.ts
+++ b/desktop/surfaces/gui/src/chat/protocol.ts
@@ -142,6 +142,16 @@ export type ProtocolChatEvent = ChatEventEnvelope &
         readonly approval_id?: string;
       }
     | {
+        readonly type: "provider_recovery";
+        readonly action: "retry" | "failover";
+        readonly provider: string;
+        readonly model: string;
+        readonly attempt: number;
+        readonly reason: string;
+        readonly delay_ms: number;
+        readonly message: string;
+      }
+    | {
         readonly type: "turn_end";
         readonly text: string;
         readonly state: "complete" | "partial" | "stopped" | "interrupted";
@@ -422,8 +432,36 @@ export function parseChatEvent(value: unknown): ChatEvent {
         typeof value.call_id === "string" &&
         typeof value.name === "string" &&
         ["retry", "repair", "continue"].includes(String(value.action)) &&
-        typeof value.status === "string");
+        typeof value.status === "string") ||
+      (value.type === "provider_recovery" &&
+        ["retry", "failover"].includes(String(value.action)) &&
+        typeof value.provider === "string" &&
+        typeof value.model === "string" &&
+        typeof value.attempt === "number" &&
+        value.attempt >= 1 &&
+        typeof value.reason === "string" &&
+        typeof value.delay_ms === "number" &&
+        value.delay_ms >= 0 &&
+        typeof value.message === "string");
     if (valid) {
+      if (value.type === "provider_recovery") {
+        return {
+          version: 2,
+          type: "provider_recovery",
+          session_id: value.session_id as string,
+          run_id: value.run_id as string,
+          event_id: value.event_id as string,
+          message_id: value.message_id as string,
+          part_id: value.part_id as string,
+          action: value.action as "retry" | "failover",
+          provider: value.provider as string,
+          model: value.model as string,
+          attempt: value.attempt as number,
+          reason: value.reason as string,
+          delay_ms: value.delay_ms as number,
+          message: value.message as string,
+        };
+      }
       if (value.type === "permission_required" && "resource" in value) {
         const resource = approvalResource(value.resource);
         const sanitized: Record<string, unknown> = { ...value };

--- a/desktop/surfaces/gui/src/routes/ChatPage.tsx
+++ b/desktop/surfaces/gui/src/routes/ChatPage.tsx
@@ -235,6 +235,10 @@ export function ChatPage({ sessionId: requestedSessionId }: { sessionId?: string
               setAnnouncement("Run started.");
             }
           }
+        } else if (applied.type === "provider_recovery") {
+          if (threadId === activeThreadRef.current) {
+            setAnnouncement(applied.message);
+          }
         } else if (applied.type === "turn_stopping") {
           if (threadId === activeThreadRef.current) {
             setAnnouncement(applied.message);

--- a/desktop/surfaces/gui/tests/chatPage.test.tsx
+++ b/desktop/surfaces/gui/tests/chatPage.test.tsx
@@ -890,6 +890,43 @@ describe("ChatPage Warm Operator thread", () => {
     );
   });
 
+  it("announces model-provider recovery outside the transcript", async () => {
+    api.getSession.mockResolvedValue({
+      id: "thread-alpha",
+      title: "Alpha",
+      messages: [],
+      events: [],
+    });
+    render(<ChatPage sessionId="thread-alpha" />);
+    await screen.findByRole("heading", { level: 1, name: "Alpha" });
+
+    act(() => {
+      onChatEvent?.({
+        version: 2,
+        type: "provider_recovery",
+        session_id: "thread-alpha",
+        run_id: "run-1",
+        event_id: "provider-retry-1",
+        message_id: "assistant-1",
+        part_id: "assistant-part-1",
+        action: "retry",
+        provider: "openai",
+        model: "gpt-4o-mini",
+        attempt: 2,
+        reason: "rate_limit",
+        delay_ms: 250,
+        message: "Retrying the model provider after a temporary failure.",
+      });
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Retrying the model provider after a temporary failure.",
+    );
+    expect(screen.getByRole("log", { name: "Conversation" })).not.toHaveTextContent(
+      "gpt-4o-mini",
+    );
+  });
+
   it("keeps background deltas isolated and restores them when returning to the thread", async () => {
     api.getSession.mockImplementation(async (id: string) => ({
       id,

--- a/desktop/surfaces/gui/tests/protocol.test.ts
+++ b/desktop/surfaces/gui/tests/protocol.test.ts
@@ -125,6 +125,29 @@ describe("parseChatEvent", () => {
 
     expect(events.map(parseChatEvent)).toEqual(events);
   });
+
+  it("keeps only the safe provider recovery contract", () => {
+    const event = {
+      version: 2,
+      type: "provider_recovery",
+      session_id: "thread-alpha",
+      run_id: "run-1",
+      event_id: "event-provider-retry",
+      message_id: "message-1",
+      part_id: "part-1",
+      action: "retry",
+      provider: "openai",
+      model: "gpt-4o-mini",
+      attempt: 2,
+      reason: "rate_limit",
+      delay_ms: 250,
+      message: "Retrying the model provider after a temporary failure.",
+    } as const;
+
+    expect(
+      parseChatEvent({ ...event, raw_provider_body: "PRIVATE_BODY" }),
+    ).toEqual(event);
+  });
 });
 
 describe("parseChatEvent additive fields", () => {

--- a/desktop/tests/test_chat.py
+++ b/desktop/tests/test_chat.py
@@ -548,7 +548,10 @@ def test_ws_persists_a_failed_terminal_event_with_the_turn_identity(tmp_path):
     failed = events[-1]
     assert failed["type"] == "error"
     assert failed["state"] == "failed"
-    assert failed["message"] == "provider stream failed"
+    assert failed["message"] == (
+        "The model provider failed after bounded recovery attempts."
+    )
+    assert "provider stream failed" not in failed["message"]
     assert failed["run_id"] == events[0]["run_id"]
     assert failed["message_id"] == events[0]["message_id"]
     assert failed["part_id"] == events[0]["part_id"]

--- a/desktop/tests/test_provider_retry.py
+++ b/desktop/tests/test_provider_retry.py
@@ -1157,6 +1157,89 @@ def test_partial_stream_requires_review_without_retry_or_failover(tmp_path):
     assert "must not concatenate" not in str(emitted)
 
 
+@pytest.mark.parametrize(
+    "failure",
+    [
+        _error(ProviderErrorKind.RATE_LIMIT, status=429, retryable=True),
+        TimeoutError(),
+    ],
+    ids=["rate_limit", "timeout"],
+)
+def test_hidden_reasoning_still_retries_and_fails_over(tmp_path, failure):
+    retry = importlib.import_module("coworker.provider_retry")
+
+    class HiddenReasoningThenFailure:
+        provider_id = "deepseek"
+        model_id = "deepseek-v4-pro"
+
+        def __init__(self):
+            self.attempts = 0
+
+        async def astream(self, *, messages, tools, context_id=None):
+            self.attempts += 1
+            yield StreamChunk.started(
+                provider=self.provider_id,
+                model=self.model_id,
+            )
+            yield StreamChunk(transient_reasoning_delta="hidden plan")
+            raise failure
+
+    class FallbackProvider:
+        provider_id = "openai"
+        model_id = "gpt-4o-mini"
+
+        def __init__(self):
+            self.attempts = 0
+
+        async def astream(self, *, messages, tools):
+            self.attempts += 1
+            yield StreamChunk(text_delta="fallback answer")
+            yield StreamChunk(finish_reason="stop")
+
+    async def no_sleep(delay):
+        return None
+
+    emitted = []
+
+    async def emit(event):
+        emitted.append(event)
+
+    active = HiddenReasoningThenFailure()
+    fallback = FallbackProvider()
+    store = ConversationStore(tmp_path)
+    sid = "hidden-reasoning-failover"
+    store.create_session(sid)
+    result = asyncio.run(
+        run_turn(
+            text="hello",
+            sid=sid,
+            store=store,
+            provider=active,
+            failover_providers=(fallback,),
+            persona=None,
+            skills=None,
+            inbox=Inbox(store),
+            openai_tools=[],
+            execute_kwargs={},
+            emit=emit,
+            retry_policy=retry.RetryPolicy(max_attempts_per_provider=1),
+            retry_sleep=no_sleep,
+        )
+    )
+
+    assert result == {"status": "ok", "text": "fallback answer"}
+    assert active.attempts == 1
+    assert fallback.attempts == 1
+    assert [
+        event.get("delta")
+        for event in emitted
+        if event["type"] == "assistant_delta"
+    ] == ["fallback answer"]
+    assert [event["type"] for event in emitted if event["type"] == "error"] == []
+    assert "hidden plan" not in str(emitted)
+    assert "Review the partial response" not in str(emitted)
+
+
 def test_cancellable_stream_interrupts_blocked_provider_request():
     retry = importlib.import_module("coworker.provider_retry")
     assert hasattr(retry, "cancellable_stream")

--- a/desktop/tests/test_provider_retry.py
+++ b/desktop/tests/test_provider_retry.py
@@ -1,0 +1,1295 @@
+import asyncio
+from datetime import UTC, datetime
+import importlib
+import json
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from coworker.inbox import Inbox
+from coworker.permissions import Decision
+from coworker.provider import (
+    KimiProvider,
+    OpenAICompatProvider,
+    ProviderErrorKind,
+    ProviderStreamError,
+)
+from coworker.provider import StreamChunk, ToolCall
+from coworker import provider as provider_module
+from coworker.store import ConversationStore
+from coworker.server import TOKEN_HEADER, create_app
+from coworker.telemetry import InMemoryTelemetryAdapter, TelemetryRecorder
+from coworker.telemetry.schema import RetryEvent, SpanEventRecord
+from coworker.turn import RunControl, new_turn_identity, run_turn
+
+
+def _error(
+    kind: ProviderErrorKind,
+    *,
+    status: int | None = None,
+    retryable: bool = False,
+) -> ProviderStreamError:
+    return ProviderStreamError(
+        provider="deepseek",
+        model="deepseek-v4-pro",
+        kind=kind,
+        message="safe provider failure",
+        retryable=retryable,
+        http_status=status,
+    )
+
+
+@pytest.mark.parametrize(
+    ("error", "expected_action", "expected_reason"),
+    [
+        (_error(ProviderErrorKind.TIMEOUT, status=408, retryable=True), "retry", "timeout"),
+        (_error(ProviderErrorKind.INVALID_REQUEST, status=409, retryable=True), "retry", "transient_provider"),
+        (_error(ProviderErrorKind.RATE_LIMIT, status=429, retryable=True), "retry", "rate_limit"),
+        (_error(ProviderErrorKind.PROVIDER, status=500, retryable=True), "retry", "transient_provider"),
+        (_error(ProviderErrorKind.PROVIDER, status=502, retryable=True), "retry", "transient_provider"),
+        (_error(ProviderErrorKind.PROVIDER, status=503, retryable=True), "retry", "transient_provider"),
+        (_error(ProviderErrorKind.PROVIDER, status=504, retryable=True), "retry", "transient_provider"),
+        (_error(ProviderErrorKind.AUTHENTICATION, status=401), "fail", None),
+        (_error(ProviderErrorKind.INVALID_REQUEST, status=400), "fail", None),
+        (_error(ProviderErrorKind.PROTOCOL), "fail", None),
+        (_error(ProviderErrorKind.CONFIGURATION), "fail", None),
+        (_error(ProviderErrorKind.PROVIDER, status=501, retryable=True), "fail", None),
+    ],
+)
+def test_provider_failure_classification_is_bounded(
+    error, expected_action, expected_reason
+):
+    retry = importlib.import_module("coworker.provider_retry")
+
+    decision = retry.classify_provider_failure(error, partial_stream=False)
+
+    assert decision.action.value == expected_action
+    assert (
+        decision.reason.value if decision.reason is not None else None
+    ) == expected_reason
+
+
+def test_any_failure_after_meaningful_stream_requires_review():
+    retry = importlib.import_module("coworker.provider_retry")
+    error = _error(ProviderErrorKind.AUTHENTICATION, status=401)
+
+    decision = retry.classify_provider_failure(error, partial_stream=True)
+
+    assert decision.action.value == "review"
+    assert decision.reason is None
+
+
+def test_retry_policy_bounds_retry_after_and_exponential_jitter():
+    retry = importlib.import_module("coworker.provider_retry")
+    policy = retry.RetryPolicy(
+        max_attempts_per_provider=3,
+        base_delay_seconds=0.5,
+        max_delay_seconds=4.0,
+        max_retry_after_seconds=30.0,
+        jitter_ratio=0.2,
+    )
+
+    assert policy.delay_seconds(1, retry_after_seconds=10, jitter_value=0.0) == 10
+    assert policy.delay_seconds(1, retry_after_seconds=99, jitter_value=1.0) == 30
+    assert policy.delay_seconds(1, retry_after_seconds=None, jitter_value=0.5) == 0.5
+    assert policy.delay_seconds(2, retry_after_seconds=None, jitter_value=0.5) == 1.0
+    assert policy.delay_seconds(1, retry_after_seconds=None, jitter_value=0.0) == 0.4
+    assert policy.delay_seconds(1, retry_after_seconds=None, jitter_value=1.0) == 0.6
+    assert policy.delay_seconds(9, retry_after_seconds=None, jitter_value=1.0) == 4.0
+
+
+def test_retry_decision_carries_provider_retry_after_hint():
+    retry = importlib.import_module("coworker.provider_retry")
+    error = _error(ProviderErrorKind.RATE_LIMIT, status=429, retryable=True)
+    error.retry_after_seconds = 12.0
+
+    decision = retry.classify_provider_failure(error, partial_stream=False)
+
+    assert decision.retry_after_seconds == 12.0
+
+
+def test_openai_provider_captures_numeric_retry_after_without_body(monkeypatch):
+    async def handler(request):
+        return httpx.Response(
+            429,
+            headers={"Retry-After": "7"},
+            text="PRIVATE_PROVIDER_BODY",
+        )
+
+    real_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: real_client(transport=transport, **kwargs),
+    )
+    provider = OpenAICompatProvider(api_key="secret", model="gpt-4o-mini")
+
+    async def consume():
+        return [
+            event
+            async for event in provider.astream(
+                messages=[{"role": "user", "content": "hello"}]
+            )
+        ]
+
+    with pytest.raises(ProviderStreamError) as captured:
+        asyncio.run(consume())
+
+    assert captured.value.retry_after_seconds == 7.0
+    assert "PRIVATE_PROVIDER_BODY" not in str(captured.value)
+
+
+def test_retry_after_accepts_http_date_with_deterministic_utc_clock():
+    now = datetime(2037, 10, 21, 7, 27, tzinfo=UTC)
+
+    assert provider_module._retry_after_seconds(
+        {"retry-after": "Wed, 21 Oct 2037 07:28:00 GMT"},
+        now=now,
+    ) == 60.0
+    assert provider_module._retry_after_seconds(
+        {"retry-after": "Wed, 21 Oct 2037 07:26:00 GMT"},
+        now=now,
+    ) == 0.0
+    assert provider_module._retry_after_seconds(
+        {"retry-after": "not-a-date"},
+        now=now,
+    ) is None
+
+
+def test_failover_chain_contains_only_verified_configured_providers():
+    retry = importlib.import_module("coworker.provider_retry")
+
+    providers = retry.verified_provider_chain(
+        {
+            "DEEPSEEK_API_KEY": "deepseek-secret",
+            "MOONSHOT_API_KEY": "kimi-secret",
+            "ANTHROPIC_API_KEY": "anthropic-secret",
+            "OPENAI_API_KEY": "openai-secret",
+        }
+    )
+
+    assert [(provider.provider_id, provider.model_id) for provider in providers] == [
+        ("deepseek", "deepseek-v4-pro"),
+        ("kimi", "kimi-k3"),
+        ("anthropic", "claude-sonnet-4-6"),
+        ("openai", "gpt-4o-mini"),
+    ]
+
+
+def test_app_composition_uses_verified_provider_chain(monkeypatch, tmp_path):
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "deepseek-secret")
+    monkeypatch.setenv("MOONSHOT_API_KEY", "kimi-secret")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("CLUB_MODEL", raising=False)
+
+    app = create_app(token="token", state=tmp_path)
+
+    assert app.state.provider.provider_id == "deepseek"
+    assert [provider.provider_id for provider in app.state.provider_failovers] == [
+        "kimi"
+    ]
+
+
+def test_invalid_explicit_primary_model_produces_no_failover_chain():
+    retry = importlib.import_module("coworker.provider_retry")
+
+    providers = retry.verified_provider_chain(
+        {
+            "DEEPSEEK_API_KEY": "deepseek-secret",
+            "MOONSHOT_API_KEY": "kimi-secret",
+            "CLUB_MODEL": "not-a-deepseek-model",
+        }
+    )
+
+    assert providers == ()
+
+
+def test_failover_candidates_skip_reasoning_provider_without_durable_continuity():
+    retry = importlib.import_module("coworker.provider_retry")
+
+    class Provider:
+        def __init__(self, provider_id, transient=False):
+            self.provider_id = provider_id
+            self.model_id = f"{provider_id}-model"
+            self.uses_transient_context = transient
+
+    selected = Provider("deepseek", transient=True)
+    kimi = Provider("kimi", transient=True)
+    anthropic = Provider("anthropic")
+    history = [
+        {"role": "user", "content": "perform a tool"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "now", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "{}"},
+    ]
+
+    candidates = retry.compatible_failover_chain(
+        (selected, kimi, anthropic),
+        selected_provider=selected,
+        messages=history,
+    )
+
+    assert [provider.provider_id for provider in candidates] == [
+        "deepseek",
+        "anthropic",
+    ]
+
+
+def test_kimi_failover_remains_eligible_after_plain_assistant_history():
+    retry = importlib.import_module("coworker.provider_retry")
+
+    class Provider:
+        def __init__(self, provider_id, transient=False):
+            self.provider_id = provider_id
+            self.model_id = f"{provider_id}-model"
+            self.uses_transient_context = transient
+
+    selected = Provider("deepseek", transient=True)
+    kimi = Provider("kimi", transient=True)
+    anthropic = Provider("anthropic")
+    history = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hello back"},
+        {"role": "user", "content": "continue"},
+    ]
+
+    candidates = retry.compatible_failover_chain(
+        (selected, kimi, anthropic),
+        selected_provider=selected,
+        messages=history,
+    )
+
+    assert [provider.provider_id for provider in candidates] == [
+        "deepseek",
+        "kimi",
+        "anthropic",
+    ]
+
+
+def test_kimi_failover_accepts_tool_history_with_retained_reasoning():
+    retry = importlib.import_module("coworker.provider_retry")
+    selected = OpenAICompatProvider(api_key="active", model="gpt-4o-mini")
+    kimi = KimiProvider(api_key="fallback", model="kimi-k3")
+    history = [
+        {"role": "user", "content": "perform a tool"},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "retained reasoning",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "now", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "{}"},
+    ]
+
+    candidates = retry.compatible_failover_chain(
+        (selected, kimi),
+        selected_provider=selected,
+        messages=history,
+    )
+    prepared = kimi._prepare_messages(
+        context_id=None,
+        messages=history,
+        tools=[{"type": "function", "function": {"name": "now"}}],
+    )
+
+    assert candidates == (selected, kimi)
+    assert prepared[1]["reasoning_content"] == "retained reasoning"
+
+
+def test_kimi_fallback_context_tolerates_plain_history_and_caches_own_tool_reasoning():
+    kimi = KimiProvider(api_key="fallback", model="kimi-k3")
+    sid = "kimi-fallback-context"
+    prior = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "plain answer from another provider"},
+        {"role": "user", "content": "use a tool"},
+    ]
+    tools = [{"type": "function", "function": {"name": "now"}}]
+
+    first_prepared = kimi._prepare_messages(
+        context_id=sid,
+        messages=prior,
+        tools=tools,
+    )
+    call = ToolCall(id="call_kimi", name="now", arguments={})
+    kimi._record_completed_response(
+        context_id=sid,
+        messages=prior,
+        tools=tools,
+        reasoning="kimi private reasoning",
+        content="",
+        calls=[call],
+        finish_reason="tool_calls",
+    )
+    continuation = [
+        *prior,
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": call.id,
+                    "type": "function",
+                    "function": {"name": call.name, "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": call.id, "content": "{}"},
+    ]
+    second_prepared = kimi._prepare_messages(
+        context_id=sid,
+        messages=continuation,
+        tools=tools,
+    )
+
+    assert "reasoning_content" not in first_prepared[1]
+    assert second_prepared[-2]["reasoning_content"] == "kimi private reasoning"
+    assert "reasoning_content" not in continuation[-2]
+
+
+def test_kimi_cross_provider_failover_uses_retained_history_path(tmp_path):
+    retry = importlib.import_module("coworker.provider_retry")
+
+    class ActiveProvider:
+        provider_id = "deepseek"
+        model_id = "deepseek-v4-pro"
+
+        async def astream(self, *, messages, tools, context_id=None):
+            raise _error(ProviderErrorKind.TIMEOUT, status=408, retryable=True)
+            yield
+
+    class KimiFallback:
+        provider_id = "kimi"
+        model_id = "kimi-k3"
+        uses_transient_context = True
+
+        def __init__(self):
+            self.context_ids = []
+
+        async def astream(self, *, messages, tools, context_id=None):
+            self.context_ids.append(context_id)
+            if context_id is None:
+                raise RuntimeError("fresh Kimi fallback did not receive a local cache id")
+            yield StreamChunk(text_delta="kimi continued")
+            yield StreamChunk(finish_reason="stop")
+
+    store = ConversationStore(tmp_path)
+    sid = "plain-history-failover"
+    store.create_session(sid)
+    store.append(sid, {"role": "user", "content": "hello"})
+    store.append(sid, {"role": "assistant", "content": "hello back"})
+    fallback = KimiFallback()
+
+    result = asyncio.run(
+        run_turn(
+            text="continue",
+            sid=sid,
+            store=store,
+            provider=ActiveProvider(),
+            failover_providers=(fallback,),
+            persona=None,
+            skills=None,
+            inbox=Inbox(store),
+            openai_tools=[],
+            execute_kwargs={},
+            retry_policy=retry.RetryPolicy(max_attempts_per_provider=1),
+        )
+    )
+
+    assert result == {"status": "ok", "text": "kimi continued"}
+    assert fallback.context_ids == [sid]
+
+
+def test_actual_kimi_failover_can_call_tool_and_continue_with_cached_reasoning(
+    tmp_path, monkeypatch
+):
+    retry = importlib.import_module("coworker.provider_retry")
+    requests = []
+
+    def sse(*payloads):
+        return "".join(
+            f"data: {json.dumps(payload)}\n\n" for payload in payloads
+        ) + "data: [DONE]\n\n"
+
+    async def handler(request):
+        requests.append(json.loads(request.content))
+        if len(requests) == 1:
+            return httpx.Response(
+                200,
+                text=sse(
+                    {
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {"reasoning_content": "kimi own reasoning"},
+                                "finish_reason": None,
+                            }
+                        ]
+                    },
+                    {
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {
+                                    "tool_calls": [
+                                        {
+                                            "index": 0,
+                                            "id": "call_kimi_now",
+                                            "type": "function",
+                                            "function": {
+                                                "name": "now",
+                                                "arguments": "{}",
+                                            },
+                                        }
+                                    ]
+                                },
+                                "finish_reason": None,
+                            }
+                        ]
+                    },
+                    {
+                        "choices": [
+                            {"index": 0, "delta": {}, "finish_reason": "tool_calls"}
+                        ]
+                    },
+                ),
+            )
+        return httpx.Response(
+            200,
+            text=sse(
+                {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"content": "kimi finished"},
+                            "finish_reason": "stop",
+                        }
+                    ]
+                }
+            ),
+        )
+
+    real_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx,
+        "AsyncClient",
+        lambda **kwargs: real_client(transport=transport, **kwargs),
+    )
+    executions = []
+
+    def execute_now(name, arguments, **kwargs):
+        executions.append(name)
+        return True, {"time": "now"}
+
+    monkeypatch.setattr("coworker.turn.execute", execute_now)
+
+    class FailingPrimary:
+        provider_id = "deepseek"
+        model_id = "deepseek-v4-pro"
+
+        async def astream(self, *, messages, tools, context_id=None):
+            raise _error(ProviderErrorKind.TIMEOUT, status=408, retryable=True)
+            yield
+
+    store = ConversationStore(tmp_path)
+    sid = "kimi-tool-failover"
+    store.create_session(sid)
+    store.append(sid, {"role": "user", "content": "hello"})
+    store.append(sid, {"role": "assistant", "content": "plain prior answer"})
+    result = asyncio.run(
+        run_turn(
+            text="use now",
+            sid=sid,
+            store=store,
+            provider=FailingPrimary(),
+            failover_providers=(
+                KimiProvider(api_key="kimi-secret", model="kimi-k3"),
+            ),
+            persona=None,
+            skills=None,
+            inbox=Inbox(store),
+            openai_tools=[{"type": "function", "function": {"name": "now"}}],
+            execute_kwargs={},
+            retry_policy=retry.RetryPolicy(max_attempts_per_provider=1),
+        )
+    )
+
+    tool_assistant = next(
+        message
+        for message in requests[1]["messages"]
+        if message.get("role") == "assistant" and message.get("tool_calls")
+    )
+    assert result == {"status": "ok", "text": "kimi finished"}
+    assert executions == ["now"]
+    assert len(requests) == 2
+    assert tool_assistant["reasoning_content"] == "kimi own reasoning"
+
+
+def test_retry_controller_exhausts_active_attempts_before_failover():
+    retry = importlib.import_module("coworker.provider_retry")
+
+    class Provider:
+        def __init__(self, provider_id):
+            self.provider_id = provider_id
+            self.model_id = f"{provider_id}-model"
+
+    sleeps = []
+
+    async def sleep(delay):
+        sleeps.append(delay)
+
+    controller = retry.RetryController(
+        (Provider("primary"), Provider("fallback")),
+        policy=retry.RetryPolicy(
+            max_attempts_per_provider=2,
+            base_delay_seconds=0.5,
+            max_delay_seconds=4,
+            max_retry_after_seconds=30,
+            jitter_ratio=0,
+        ),
+        sleep=sleep,
+        random_value=lambda: 0.5,
+    )
+    error = _error(ProviderErrorKind.RATE_LIMIT, status=429, retryable=True)
+
+    first = asyncio.run(controller.recover(error, partial_stream=False))
+    second = asyncio.run(controller.recover(error, partial_stream=False))
+
+    assert first.action.value == "retry"
+    assert first.provider.provider_id == "primary"
+    assert first.attempt_number == 2
+    assert first.delay_seconds == 0.5
+    assert second.action.value == "failover"
+    assert second.provider.provider_id == "fallback"
+    assert second.attempt_number == 1
+    assert second.delay_seconds == 0
+    assert sleeps == [0.5]
+
+
+def test_retry_controller_cancels_during_backoff_without_next_attempt():
+    retry = importlib.import_module("coworker.provider_retry")
+
+    class Provider:
+        provider_id = "primary"
+        model_id = "primary-model"
+
+    async def scenario():
+        sleep_started = asyncio.Event()
+        cancel = asyncio.Event()
+
+        async def blocked_sleep(delay):
+            sleep_started.set()
+            await asyncio.Event().wait()
+
+        controller = retry.RetryController(
+            (Provider(),),
+            policy=retry.RetryPolicy(max_attempts_per_provider=2),
+            sleep=blocked_sleep,
+            cancel_event=cancel,
+        )
+        error = _error(ProviderErrorKind.TIMEOUT, status=408, retryable=True)
+        task = asyncio.create_task(controller.recover(error, partial_stream=False))
+        await asyncio.wait_for(sleep_started.wait(), timeout=1)
+        cancel.set()
+        directive = await asyncio.wait_for(task, timeout=1)
+        return controller, directive
+
+    controller, directive = asyncio.run(scenario())
+
+    assert directive.action.value == "cancelled"
+    assert directive.attempt_number == 1
+    assert controller.attempt_number == 1
+
+
+def test_run_turn_retries_one_model_request_before_success(tmp_path):
+    retry = importlib.import_module("coworker.provider_retry")
+
+    class RetryThenSuccess:
+        provider_id = "deepseek"
+        model_id = "deepseek-v4-pro"
+
+        def __init__(self):
+            self.attempts = 0
+
+        async def astream(self, *, messages, tools, context_id=None):
+            self.attempts += 1
+            if self.attempts == 1:
+                raise _error(
+                    ProviderErrorKind.TIMEOUT,
+                    status=408,
+                    retryable=True,
+                )
+            yield StreamChunk(text_delta="recovered")
+            yield StreamChunk(finish_reason="stop")
+
+    async def no_sleep(delay):
+        return None
+
+    provider = RetryThenSuccess()
+    store = ConversationStore(tmp_path)
+    sid = "retry-session"
+    store.create_session(sid)
+    adapter = InMemoryTelemetryAdapter()
+    recorder = TelemetryRecorder(adapter)
+
+    result = asyncio.run(
+        run_turn(
+            text="hello",
+            sid=sid,
+            store=store,
+            provider=provider,
+            persona=None,
+            skills=None,
+            inbox=Inbox(store),
+            openai_tools=[],
+            execute_kwargs={},
+            telemetry=recorder,
+            retry_policy=retry.RetryPolicy(
+                max_attempts_per_provider=2,
+                base_delay_seconds=0,
+                jitter_ratio=0,
+            ),
+            retry_sleep=no_sleep,
+        )
+    )
+
+    retries = [
+        record.event
+        for record in adapter.records
+        if isinstance(record, SpanEventRecord)
+        and isinstance(record.event, RetryEvent)
+    ]
+    assert result == {"status": "ok", "text": "recovered"}
+    assert provider.attempts == 2
+    assert len(retries) == 1
+    assert retries[0].reason.value == "timeout"
+    assert retries[0].delay_ms == 0
+
+
+def test_run_turn_fails_over_after_active_provider_attempts_exhaust(tmp_path):
+    retry = importlib.import_module("coworker.provider_retry")
+
+    class FailingProvider:
+        provider_id = "deepseek"
+        model_id = "deepseek-v4-pro"
+
+        def __init__(self):
+            self.attempts = 0
+
+        async def astream(self, *, messages, tools, context_id=None):
+            self.attempts += 1
+            raise _error(
+                ProviderErrorKind.CONNECTION,
+                retryable=True,
+            )
+            yield
+
+    class FallbackProvider:
+        provider_id = "openai"
+        model_id = "gpt-4o-mini"
+
+        def __init__(self):
+            self.attempts = 0
+
+        async def astream(self, *, messages, tools):
+            self.attempts += 1
+            yield StreamChunk(text_delta="fallback answer")
+            yield StreamChunk(finish_reason="stop")
+
+    async def no_sleep(delay):
+        return None
+
+    active = FailingProvider()
+    fallback = FallbackProvider()
+    store = ConversationStore(tmp_path)
+    sid = "failover-session"
+    store.create_session(sid)
+
+    result = asyncio.run(
+        run_turn(
+            text="hello",
+            sid=sid,
+            store=store,
+            provider=active,
+            failover_providers=(fallback,),
+            persona=None,
+            skills=None,
+            inbox=Inbox(store),
+            openai_tools=[],
+            execute_kwargs={},
+            retry_policy=retry.RetryPolicy(max_attempts_per_provider=1),
+            retry_sleep=no_sleep,
+        )
+    )
+
+    assert result == {"status": "ok", "text": "fallback answer"}
+    assert active.attempts == 1
+    assert fallback.attempts == 1
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "arguments", "tool_result"),
+    [
+        ("now", {}, {"time": "now"}),
+        (
+            "fs_write",
+            {"grant_id": "grant-1", "path": "notes.txt", "content": "written"},
+            {"status": "written", "path": "notes.txt"},
+        ),
+    ],
+)
+def test_failover_continues_from_completed_tool_result_without_reexecution(
+    tmp_path, monkeypatch, tool_name, arguments, tool_result
+):
+    retry = importlib.import_module("coworker.provider_retry")
+
+    class ActiveProvider:
+        provider_id = "deepseek"
+        model_id = "deepseek-v4-pro"
+
+        def __init__(self):
+            self.attempts = 0
+
+        async def astream(self, *, messages, tools, context_id=None):
+            self.attempts += 1
+            if self.attempts == 1:
+                yield StreamChunk(
+                    tool_calls=[
+                        ToolCall(
+                            id="call_effect",
+                            name=tool_name,
+                            arguments=arguments,
+                        )
+                    ]
+                )
+                yield StreamChunk(finish_reason="tool_calls")
+                return
+            raise _error(ProviderErrorKind.TIMEOUT, status=408, retryable=True)
+            yield
+
+    class FallbackProvider:
+        provider_id = "openai"
+        model_id = "gpt-4o-mini"
+
+        def __init__(self):
+            self.calls = []
+
+        async def astream(self, *, messages, tools):
+            self.calls.append(messages)
+            yield StreamChunk(text_delta="continued safely")
+            yield StreamChunk(finish_reason="stop")
+
+    executions = []
+
+    def execute_once(name, arguments, **kwargs):
+        executions.append((name, arguments))
+        return True, tool_result
+
+    monkeypatch.setattr("coworker.turn.execute", execute_once)
+    monkeypatch.setattr(
+        "coworker.turn.decide",
+        lambda *args, **kwargs: Decision(True, False, "test-authorized"),
+    )
+    active = ActiveProvider()
+    fallback = FallbackProvider()
+    store = ConversationStore(tmp_path)
+    sid = "tool-failover-session"
+    store.create_session(sid)
+
+    result = asyncio.run(
+        run_turn(
+            text="perform one effect",
+            sid=sid,
+            store=store,
+            provider=active,
+            failover_providers=(fallback,),
+            persona=None,
+            skills=None,
+            inbox=Inbox(store),
+            openai_tools=[
+                {"type": "function", "function": {"name": tool_name}}
+            ],
+            execute_kwargs={},
+            retry_policy=retry.RetryPolicy(max_attempts_per_provider=1),
+        )
+    )
+
+    assert result == {"status": "ok", "text": "continued safely"}
+    assert executions == [(tool_name, arguments)]
+    assert active.attempts == 2
+    assert len(fallback.calls) == 1
+    continued = fallback.calls[0]
+    assert [message["role"] for message in continued[-2:]] == ["assistant", "tool"]
+    assert continued[-1]["tool_call_id"] == "call_effect"
+    assert json.loads(continued[-1]["content"]) == tool_result
+
+
+def test_failover_does_not_repeat_completed_approval_or_send(tmp_path, monkeypatch):
+    retry = importlib.import_module("coworker.provider_retry")
+
+    class ActiveProvider:
+        provider_id = "openai"
+        model_id = "gpt-4o-mini"
+
+        def __init__(self):
+            self.attempts = 0
+
+        async def astream(self, *, messages, tools):
+            self.attempts += 1
+            if self.attempts == 1:
+                yield StreamChunk(
+                    tool_calls=[
+                        ToolCall(
+                            id="call_send",
+                            name="gmail_send",
+                            arguments={"draft_id": "draft-1"},
+                        )
+                    ]
+                )
+                yield StreamChunk(finish_reason="tool_calls")
+                return
+            raise _error(ProviderErrorKind.TIMEOUT, status=408, retryable=True)
+            yield
+
+    class FallbackProvider:
+        provider_id = "anthropic"
+        model_id = "claude-sonnet-4-6"
+
+        async def astream(self, *, messages, tools):
+            yield StreamChunk(text_delta="send already completed")
+            yield StreamChunk(finish_reason="stop")
+
+    approvals = []
+    sends = []
+
+    async def approve(call_id):
+        approvals.append(call_id)
+        return "allow"
+
+    def execute_send(name, arguments, **kwargs):
+        sends.append((name, arguments, kwargs["approval_granted"]))
+        return True, {"message_id": "sent-1", "status": "sent"}
+
+    monkeypatch.setattr("coworker.turn.execute", execute_send)
+    store = ConversationStore(tmp_path)
+    sid = "approval-failover"
+    store.create_session(sid)
+    result = asyncio.run(
+        run_turn(
+            text="send it",
+            sid=sid,
+            store=store,
+            provider=ActiveProvider(),
+            failover_providers=(FallbackProvider(),),
+            persona=None,
+            skills=None,
+            inbox=Inbox(store),
+            openai_tools=[
+                {"type": "function", "function": {"name": "gmail_send"}}
+            ],
+            execute_kwargs={},
+            wait_permission=approve,
+            retry_policy=retry.RetryPolicy(max_attempts_per_provider=1),
+        )
+    )
+
+    assert result == {"status": "ok", "text": "send already completed"}
+    assert approvals == ["call_send"]
+    assert sends == [("gmail_send", {"draft_id": "draft-1"}, True)]
+
+
+def test_final_provider_failure_emits_safe_message_without_raw_body(tmp_path):
+    retry = importlib.import_module("coworker.provider_retry")
+    planted = "PRIVATE_PROVIDER_BODY sk-PLANTED"
+
+    class FailingProvider:
+        provider_id = "deepseek"
+        model_id = "deepseek-v4-pro"
+
+        async def astream(self, *, messages, tools, context_id=None):
+            raise ProviderStreamError(
+                provider=self.provider_id,
+                model=self.model_id,
+                kind=ProviderErrorKind.AUTHENTICATION,
+                message=planted,
+                retryable=False,
+                http_status=401,
+            )
+            yield
+
+    emitted = []
+
+    async def emit(event):
+        emitted.append(event)
+
+    store = ConversationStore(tmp_path)
+    sid = "safe-final-failure"
+    store.create_session(sid)
+    result = asyncio.run(
+        run_turn(
+            text="hello",
+            sid=sid,
+            store=store,
+            provider=FailingProvider(),
+            persona=None,
+            skills=None,
+            inbox=Inbox(store),
+            openai_tools=[],
+            execute_kwargs={},
+            emit=emit,
+            retry_policy=retry.RetryPolicy(max_attempts_per_provider=1),
+        )
+    )
+
+    terminal = next(event for event in emitted if event["type"] == "error")
+    assert result["status"] == "error"
+    assert planted not in terminal["message"]
+    assert "authentication" in terminal["message"].lower()
+
+
+def test_exhausted_provider_chain_is_bounded_and_telemetried(tmp_path):
+    retry = importlib.import_module("coworker.provider_retry")
+
+    class AlwaysTimeout:
+        def __init__(self, provider_id):
+            self.provider_id = provider_id
+            self.model_id = f"{provider_id}-model"
+            self.attempts = 0
+
+        async def astream(self, *, messages, tools):
+            self.attempts += 1
+            raise _error(ProviderErrorKind.TIMEOUT, status=408, retryable=True)
+            yield
+
+    async def no_sleep(delay):
+        return None
+
+    active = AlwaysTimeout("openai")
+    fallback = AlwaysTimeout("anthropic")
+    store = ConversationStore(tmp_path)
+    sid = "exhausted-chain"
+    store.create_session(sid)
+    adapter = InMemoryTelemetryAdapter()
+    result = asyncio.run(
+        run_turn(
+            text="hello",
+            sid=sid,
+            store=store,
+            provider=active,
+            failover_providers=(fallback,),
+            persona=None,
+            skills=None,
+            inbox=Inbox(store),
+            openai_tools=[],
+            execute_kwargs={},
+            telemetry=TelemetryRecorder(adapter),
+            retry_policy=retry.RetryPolicy(
+                max_attempts_per_provider=2,
+                base_delay_seconds=0,
+            ),
+            retry_sleep=no_sleep,
+        )
+    )
+
+    retry_events = [
+        record.event
+        for record in adapter.records
+        if isinstance(record, SpanEventRecord)
+        and isinstance(record.event, RetryEvent)
+    ]
+    assert result["status"] == "error"
+    assert active.attempts == 2
+    assert fallback.attempts == 2
+    assert [event.retry_count for event in retry_events] == [1, 2, 3]
+    assert all(event.reason.value == "timeout" for event in retry_events)
+
+
+def test_recovered_websocket_turn_reports_retry_without_provider_body(tmp_path):
+    planted = "PRIVATE_RATE_LIMIT_BODY sk-PLANTED"
+
+    class RecoveringProvider:
+        provider_id = "openai"
+        model_id = "gpt-4o-mini"
+
+        def __init__(self):
+            self.attempts = 0
+
+        async def astream(self, *, messages, tools):
+            self.attempts += 1
+            if self.attempts == 1:
+                raise ProviderStreamError(
+                    provider=self.provider_id,
+                    model=self.model_id,
+                    kind=ProviderErrorKind.RATE_LIMIT,
+                    message=planted,
+                    retryable=True,
+                    http_status=429,
+                )
+            yield StreamChunk(text_delta="recovered answer")
+            yield StreamChunk(finish_reason="stop")
+
+    provider = RecoveringProvider()
+    app = create_app(token="token", provider=provider, state=tmp_path)
+    client = TestClient(app)
+    sid = app.state.store.open_session_id()
+    with client.websocket_connect("/ws/chat", subprotocols=["club", "token"]) as ws:
+        ws.send_json({"type": "chat", "text": "hello", "session_id": sid})
+        events = []
+        while not events or events[-1]["type"] not in {"turn_end", "error"}:
+            events.append(ws.receive_json())
+
+    metrics = client.get(
+        f"/v1/sessions/{sid}/telemetry/current",
+        headers={TOKEN_HEADER: "token"},
+    ).json()["current_run"]
+    encoded = json.dumps({"events": events, "metrics": metrics})
+    recovery = next(event for event in events if event["type"] == "provider_recovery")
+    assert events[-1]["type"] == "turn_end"
+    assert events[-1]["text"] == "recovered answer"
+    assert recovery == {
+        **{
+            key: recovery[key]
+            for key in (
+                "version",
+                "type",
+                "session_id",
+                "run_id",
+                "event_id",
+                "message_id",
+                "part_id",
+            )
+        },
+        "action": "retry",
+        "provider": "openai",
+        "model": "gpt-4o-mini",
+        "attempt": 2,
+        "reason": "rate_limit",
+        "delay_ms": recovery["delay_ms"],
+        "message": "Retrying the model provider after a temporary failure.",
+    }
+    assert 0 <= recovery["delay_ms"] <= 4_000
+    assert metrics["retry_count"] == 1
+    assert provider.attempts == 2
+    assert planted not in encoded
+
+
+def test_partial_stream_requires_review_without_retry_or_failover(tmp_path):
+    retry = importlib.import_module("coworker.provider_retry")
+
+    class PartialProvider:
+        provider_id = "deepseek"
+        model_id = "deepseek-v4-pro"
+
+        def __init__(self):
+            self.attempts = 0
+
+        async def astream(self, *, messages, tools, context_id=None):
+            self.attempts += 1
+            yield StreamChunk(text_delta="partial answer")
+            raise _error(ProviderErrorKind.RATE_LIMIT, status=429, retryable=True)
+
+    class FallbackProvider:
+        provider_id = "openai"
+        model_id = "gpt-4o-mini"
+
+        def __init__(self):
+            self.attempts = 0
+
+        async def astream(self, *, messages, tools):
+            self.attempts += 1
+            yield StreamChunk(text_delta="must not concatenate")
+
+    emitted = []
+
+    async def emit(event):
+        emitted.append(event)
+
+    active = PartialProvider()
+    fallback = FallbackProvider()
+    store = ConversationStore(tmp_path)
+    sid = "partial-review"
+    store.create_session(sid)
+    result = asyncio.run(
+        run_turn(
+            text="hello",
+            sid=sid,
+            store=store,
+            provider=active,
+            failover_providers=(fallback,),
+            persona=None,
+            skills=None,
+            inbox=Inbox(store),
+            openai_tools=[],
+            execute_kwargs={},
+            emit=emit,
+        )
+    )
+
+    terminal = next(event for event in emitted if event["type"] == "error")
+    assert result["status"] == "error"
+    assert active.attempts == 1
+    assert fallback.attempts == 0
+    assert [
+        event.get("delta")
+        for event in emitted
+        if event["type"] == "assistant_delta"
+    ] == ["partial answer"]
+    assert "review" in terminal["message"].lower()
+    assert "must not concatenate" not in str(emitted)
+
+
+def test_cancellable_stream_interrupts_blocked_provider_request():
+    retry = importlib.import_module("coworker.provider_retry")
+    assert hasattr(retry, "cancellable_stream")
+
+    async def scenario():
+        started = asyncio.Event()
+        cancel = asyncio.Event()
+        closed = asyncio.Event()
+
+        async def blocked_stream():
+            try:
+                started.set()
+                await asyncio.Event().wait()
+                yield StreamChunk(text_delta="late")
+            finally:
+                closed.set()
+
+        async def consume():
+            return [
+                event
+                async for event in retry.cancellable_stream(
+                    blocked_stream(),
+                    cancel_event=cancel,
+                )
+            ]
+
+        task = asyncio.create_task(consume())
+        await asyncio.wait_for(started.wait(), timeout=1)
+        cancel.set()
+        with pytest.raises(retry.ProviderRequestCancelled):
+            await asyncio.wait_for(task, timeout=1)
+        await asyncio.wait_for(closed.wait(), timeout=1)
+
+    asyncio.run(scenario())
+
+
+def test_run_turn_cancels_while_provider_request_is_blocked(tmp_path):
+    class BlockedProvider:
+        provider_id = "deepseek"
+        model_id = "deepseek-v4-pro"
+
+        def __init__(self):
+            self.started = asyncio.Event()
+            self.closed = asyncio.Event()
+
+        async def astream(self, *, messages, tools, context_id=None):
+            try:
+                self.started.set()
+                await asyncio.Event().wait()
+                yield StreamChunk(text_delta="late")
+            finally:
+                self.closed.set()
+
+    async def scenario():
+        provider = BlockedProvider()
+        store = ConversationStore(tmp_path)
+        sid = "blocked-request"
+        store.create_session(sid)
+        control = RunControl(new_turn_identity(sid))
+        task = asyncio.create_task(
+            run_turn(
+                text="hello",
+                sid=sid,
+                store=store,
+                provider=provider,
+                persona=None,
+                skills=None,
+                inbox=Inbox(store),
+                openai_tools=[],
+                execute_kwargs={},
+                identity=control.identity,
+                control=control,
+            )
+        )
+        await asyncio.wait_for(provider.started.wait(), timeout=1)
+        control.cancel_requested.set()
+        result = await asyncio.wait_for(task, timeout=1)
+        await asyncio.wait_for(provider.closed.wait(), timeout=1)
+        return result
+
+    assert asyncio.run(scenario()) == {"status": "stopped", "text": ""}
+
+
+def test_run_turn_cancels_during_retry_backoff(tmp_path):
+    retry = importlib.import_module("coworker.provider_retry")
+
+    class FailingProvider:
+        provider_id = "deepseek"
+        model_id = "deepseek-v4-pro"
+
+        def __init__(self):
+            self.attempts = 0
+
+        async def astream(self, *, messages, tools, context_id=None):
+            self.attempts += 1
+            raise _error(ProviderErrorKind.TIMEOUT, status=408, retryable=True)
+            yield
+
+    async def scenario():
+        sleep_started = asyncio.Event()
+
+        async def blocked_sleep(delay):
+            sleep_started.set()
+            await asyncio.Event().wait()
+
+        provider = FailingProvider()
+        store = ConversationStore(tmp_path)
+        sid = "backoff-cancel"
+        store.create_session(sid)
+        control = RunControl(new_turn_identity(sid))
+        task = asyncio.create_task(
+            run_turn(
+                text="hello",
+                sid=sid,
+                store=store,
+                provider=provider,
+                persona=None,
+                skills=None,
+                inbox=Inbox(store),
+                openai_tools=[],
+                execute_kwargs={},
+                identity=control.identity,
+                control=control,
+                retry_policy=retry.RetryPolicy(max_attempts_per_provider=2),
+                retry_sleep=blocked_sleep,
+            )
+        )
+        await asyncio.wait_for(sleep_started.wait(), timeout=1)
+        control.cancel_requested.set()
+        result = await asyncio.wait_for(task, timeout=1)
+        return provider, result
+
+    provider, result = asyncio.run(scenario())
+
+    assert result == {"status": "stopped", "text": ""}
+    assert provider.attempts == 1

--- a/desktop/tests/test_telemetry_live.py
+++ b/desktop/tests/test_telemetry_live.py
@@ -396,6 +396,8 @@ def test_run_turn_maps_typed_provider_error_kind_without_raw_error_content(tmp_p
     assert [terminal.error_kind for terminal in terminals] == [
         ErrorKind.RATE_LIMIT,
         ErrorKind.RATE_LIMIT,
+        ErrorKind.RATE_LIMIT,
+        ErrorKind.RATE_LIMIT,
     ]
     assert planted not in json.dumps(
         [record_to_dict(record) for record in adapter.records]


### PR DESCRIPTION
## Summary\n\n- classify retryable transport, timeout, 408, 409, 429, and selected 5xx provider failures\n- honor bounded numeric and HTTP-date Retry-After with capped exponential jitter\n- fail immediately on authentication, validation, policy, protocol, and malformed-response errors\n- fail over only after current-provider attempts are exhausted and only to verified eligible providers\n- continue from durable completed tool results without replaying tools, approvals, sends, filesystem writes, shell actions, or other effects\n- surface ambiguous partial streams for review instead of concatenating fresh output\n- record typed attempt, provider/model, latency, usage/cache, reason, and final selection telemetry\n- add content-free provider recovery and final-failure UI with cancellation-aware request/backoff behavior\n- preserve Kimi plain-history and fallback tool-call continuity without durable reasoning\n\n## Verification\n\n- focused Python: 234 passed\n- focused GUI: 82 passed\n- make test: 668 Python passed, 3 skipped; 382 GUI passed\n- make build: passed\n- independent post-rebase review: SHIP; 191 focused Python and 58 GUI tests passed\n- git diff --check: passed\n\nCloses #71\n\n## Residual risk\n\nCredentialed live-provider smoke was not run. Retry schedules remain process-local, while completed tool results remain durable and authoritative after restart.