### PR TITLE
feat(desktop): add isolated agent evaluation harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ prove-and-plain-english-skills.zip
 .gstack/
 .impeccable/
 .pytest_cache/
+desktop/.eval-artifacts/
 __pycache__/
 *.pyc
 *.log

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PYTHON ?= python3
 VENV := desktop/.venv
 GUI := desktop/surfaces/gui
 
-.PHONY: setup sidecar gui native test test-python test-gui build
+.PHONY: setup sidecar gui native test test-python test-gui eval build
 
 setup:
 	$(PYTHON) -m venv $(VENV)
@@ -25,6 +25,9 @@ test-python:
 
 test-gui:
 	npm --prefix $(GUI) test
+
+eval:
+	cd desktop && .venv/bin/python -m coworker.evals --artifacts .eval-artifacts
 
 build:
 	npm --prefix $(GUI) run build

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ make build
 
 `make test` runs the Python sidecar suite and the GUI Vitest suite. `make build` type-checks and bundles the GUI. CI runs the same active-stack checks; the archived hosted app is intentionally excluded.
 
+Run the deterministic baseline/candidate agent harness separately with `make eval`. It writes ignored, potentially sensitive local artifacts under `desktop/.eval-artifacts/`; see [the evaluation harness guide](desktop/docs/evaluations.md).
+
 ## Repository map
 
 - `desktop/coworker/` — local FastAPI sidecar, agent loop, tools, connectors, permissions, and persistence

--- a/TODOS.md
+++ b/TODOS.md
@@ -15,7 +15,7 @@ This file tracks product-level gaps only. Implementation checklists belong in da
 - Shared login, multi-operator tenancy, and hosted deployment.
 - Autonomous follow-up sending or background bulk enrichment.
 - LinkedIn/Apify v2.
-- Formal routine/agent versioning and evaluation suites beyond the local run ledger.
+- Large benchmark corpora and release-gating policy beyond the isolated baseline harness.
 
 ## Completed transitions
 

--- a/desktop/coworker/evals/__init__.py
+++ b/desktop/coworker/evals/__init__.py
@@ -1,0 +1,24 @@
+"""Isolated evaluation support for Sourcecado's active desktop agent."""
+
+from coworker.evals.environment import EvalEnvironment
+from coworker.evals.compare import ComparisonReport, compare_runs
+from coworker.evals.models import (
+    CompactionPolicy,
+    EvalRunResult,
+    EvalVariant,
+    JudgeObservation,
+    RunBudget,
+)
+from coworker.evals.runner import EvalRunner
+
+__all__ = [
+    "CompactionPolicy",
+    "ComparisonReport",
+    "EvalEnvironment",
+    "EvalRunResult",
+    "EvalRunner",
+    "EvalVariant",
+    "JudgeObservation",
+    "RunBudget",
+    "compare_runs",
+]

--- a/desktop/coworker/evals/__main__.py
+++ b/desktop/coworker/evals/__main__.py
@@ -1,0 +1,187 @@
+"""Command-line entry point for Sourcecado's isolated agent evaluations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Sequence
+
+from coworker.evals.compare import ComparisonReport, compare_runs
+from coworker.evals.environment import private_artifact_root, write_private_text
+from coworker.evals.models import EvalRunResult, EvalVariant
+from coworker.evals.runner import ARTIFACT_WARNING, EvalRunner
+from coworker.evals.scenarios import baseline_scenarios
+from coworker.provider import provider_from_env
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run isolated Sourcecado agent evals")
+    parser.add_argument("--artifacts", type=Path, default=Path(".eval-artifacts"))
+    parser.add_argument("--repetitions", type=int, default=1)
+    parser.add_argument("--baseline-name", default="baseline")
+    parser.add_argument("--candidate-name", default="candidate")
+    parser.add_argument("--baseline-prompt-version", default="sourcing-v1")
+    parser.add_argument("--candidate-prompt-version", default="sourcing-v2")
+    parser.add_argument(
+        "--tools",
+        default="people_keep",
+        help="comma-separated active Sourcecado tool names",
+    )
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="explicitly opt into nondeterministic live-provider execution",
+    )
+    return parser
+
+
+def _tools(raw: str) -> tuple[str, ...]:
+    return tuple(name.strip() for name in raw.split(",") if name.strip())
+
+
+def _fake_variants(args: argparse.Namespace) -> tuple[EvalVariant, EvalVariant]:
+    catalog = _tools(args.tools)
+    baseline = EvalVariant(
+        name=args.baseline_name,
+        prompt_version=args.baseline_prompt_version,
+        system_prompt=(
+            "You are Sourcecado's sourcing assistant. Keep only people the director "
+            "explicitly names."
+        ),
+        tool_catalog=catalog,
+        provider="fake",
+        model="sourcecado-scenario-v1",
+    )
+    candidate = EvalVariant(
+        name=args.candidate_name,
+        prompt_version=args.candidate_prompt_version,
+        system_prompt=(
+            "You are Sourcecado's sourcing assistant. Never invent a target, enrich, "
+            "or send. Keep only the people the director explicitly names."
+        ),
+        tool_catalog=catalog,
+        provider="fake",
+        model="sourcecado-scenario-v1",
+    )
+    return baseline, candidate
+
+
+def _delta(metric: object) -> str:
+    value = getattr(metric, "mean_delta")
+    if value is None:
+        return "unavailable"
+    eligible = getattr(metric, "eligible_pairs")
+    total = getattr(metric, "total_pairs")
+    return f"{value:+.6g} ({eligible}/{total} pairs)"
+
+
+def _print_comparison(report: ComparisonReport) -> None:
+    for comparison in report.comparisons:
+        correctness = comparison.correctness
+        lift = (
+            "unavailable"
+            if correctness.pass_rate_lift is None
+            else f"{correctness.pass_rate_lift * 100:+.1f} pp"
+        )
+        print(f"{comparison.baseline} -> {comparison.candidate}")
+        print(
+            f"  pass-rate lift: {lift} "
+            f"({correctness.eligible_pairs}/{correctness.total_pairs} pairs)"
+        )
+        print(f"  tokens delta: {_delta(comparison.tokens)}")
+        print(f"  latency-ms delta: {_delta(comparison.latency_ms)}")
+        print(f"  estimated-cost-usd delta: {_delta(comparison.estimated_cost_usd)}")
+        print(f"  retries delta: {_delta(comparison.retries)}")
+        print(f"  compactions delta: {_delta(comparison.compactions)}")
+        print(f"  judge score (observational): {_delta(comparison.judge_scores)}")
+
+
+def _write_summary(
+    artifact_root: Path,
+    *,
+    mode: str,
+    runs: list[EvalRunResult],
+    comparison: ComparisonReport | None,
+) -> None:
+    private_artifact_root(artifact_root)
+    payload = {
+        "warning": ARTIFACT_WARNING,
+        "mode": mode,
+        "runs": [asdict(run) for run in runs],
+        "comparison": asdict(comparison) if comparison is not None else None,
+    }
+    write_private_text(
+        artifact_root / "summary.json",
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.repetitions < 1:
+        print("--repetitions must be positive", file=sys.stderr)
+        return 2
+    print(f"WARNING: {ARTIFACT_WARNING}", file=sys.stderr)
+    runner = EvalRunner(args.artifacts)
+    runs: list[EvalRunResult] = []
+    comparison: ComparisonReport | None = None
+    if args.live:
+        provider = provider_from_env()
+        if provider is None:
+            print(
+                "No eligible live provider is configured; live eval did not run.",
+                file=sys.stderr,
+            )
+            return 2
+        variant = EvalVariant(
+            name=args.candidate_name,
+            prompt_version=args.candidate_prompt_version,
+            system_prompt=(
+                "You are Sourcecado's sourcing assistant. Never invent a target, "
+                "enrich, or send. Keep only people the director explicitly names."
+            ),
+            tool_catalog=_tools(args.tools),
+            provider=str(getattr(provider, "provider_id", "unknown")),
+            model=str(getattr(provider, "model_id", "unknown")),
+        )
+        for repetition in range(1, args.repetitions + 1):
+            for scenario in baseline_scenarios():
+                runs.append(
+                    runner.run_live(
+                        scenario,
+                        variant,
+                        provider=provider,
+                        repetition=repetition,
+                        opt_in=True,
+                    )
+                )
+        print(
+            f"live nondeterministic runs: {len(runs)}; provider={variant.provider}; "
+            f"model={variant.model}; prompt={variant.prompt_version}"
+        )
+    else:
+        baseline, candidate = _fake_variants(args)
+        for repetition in range(1, args.repetitions + 1):
+            for scenario in baseline_scenarios():
+                runs.append(runner.run_fake(scenario, baseline, repetition=repetition))
+                runs.append(runner.run_fake(scenario, candidate, repetition=repetition))
+        comparison = compare_runs(
+            runs,
+            baseline_name=baseline.name,
+            candidate_names=(candidate.name,),
+        )
+        _print_comparison(comparison)
+    _write_summary(
+        args.artifacts,
+        mode="live" if args.live else "fake",
+        runs=runs,
+        comparison=comparison,
+    )
+    return int(any(not run.passed for run in runs))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/desktop/coworker/evals/compare.py
+++ b/desktop/coworker/evals/compare.py
@@ -1,0 +1,268 @@
+"""Paired baseline/candidate summaries without conflating quality and cost."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import fsum
+from typing import Callable
+
+from coworker.evals.models import EvalRunResult
+
+
+@dataclass(frozen=True, slots=True)
+class CorrectnessSummary:
+    total_pairs: int
+    eligible_pairs: int
+    baseline_pass_rate: float | None
+    candidate_pass_rate: float | None
+    pass_rate_lift: float | None
+    baseline_wins: int
+    candidate_wins: int
+    ties: int
+
+
+@dataclass(frozen=True, slots=True)
+class MetricSummary:
+    total_pairs: int
+    eligible_pairs: int
+    baseline_mean: float | None
+    candidate_mean: float | None
+    mean_delta: float | None
+
+
+@dataclass(frozen=True, slots=True)
+class JudgeScoreSummary(MetricSummary):
+    observational: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class PairComparison:
+    baseline: str
+    candidate: str
+    correctness: CorrectnessSummary
+    tokens: MetricSummary
+    latency_ms: MetricSummary
+    estimated_cost_usd: MetricSummary
+    retries: MetricSummary
+    compactions: MetricSummary
+    judge_scores: JudgeScoreSummary
+
+
+@dataclass(frozen=True, slots=True)
+class ComparisonDiagnostic:
+    pair_key: str
+    variant_name: str
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class ComparisonReport:
+    baseline: str
+    candidates: tuple[str, ...]
+    comparisons: tuple[PairComparison, ...]
+    diagnostics: tuple[ComparisonDiagnostic, ...]
+
+
+def _mean(values: list[float]) -> float | None:
+    return fsum(values) / len(values) if values else None
+
+
+def _metric(
+    pairs: list[tuple[EvalRunResult, EvalRunResult]],
+    *,
+    total_pairs: int,
+    select: Callable[[EvalRunResult], int | float | None],
+) -> MetricSummary:
+    baseline_values: list[float] = []
+    candidate_values: list[float] = []
+    for baseline, candidate in pairs:
+        left = select(baseline)
+        right = select(candidate)
+        if left is None or right is None:
+            continue
+        baseline_values.append(float(left))
+        candidate_values.append(float(right))
+    baseline_mean = _mean(baseline_values)
+    candidate_mean = _mean(candidate_values)
+    return MetricSummary(
+        total_pairs=total_pairs,
+        eligible_pairs=len(baseline_values),
+        baseline_mean=baseline_mean,
+        candidate_mean=candidate_mean,
+        mean_delta=(
+            None
+            if baseline_mean is None or candidate_mean is None
+            else candidate_mean - baseline_mean
+        ),
+    )
+
+
+def _correctness(
+    pairs: list[tuple[EvalRunResult, EvalRunResult]], *, total_pairs: int
+) -> CorrectnessSummary:
+    baseline_passes = 0
+    candidate_passes = 0
+    baseline_wins = 0
+    candidate_wins = 0
+    ties = 0
+    for baseline, candidate in pairs:
+        left = baseline.passed
+        right = candidate.passed
+        baseline_passes += int(left)
+        candidate_passes += int(right)
+        if left == right:
+            ties += 1
+        elif left:
+            baseline_wins += 1
+        else:
+            candidate_wins += 1
+    eligible = len(pairs)
+    baseline_rate = baseline_passes / eligible if eligible else None
+    candidate_rate = candidate_passes / eligible if eligible else None
+    return CorrectnessSummary(
+        total_pairs=total_pairs,
+        eligible_pairs=eligible,
+        baseline_pass_rate=baseline_rate,
+        candidate_pass_rate=candidate_rate,
+        pass_rate_lift=(
+            None
+            if baseline_rate is None or candidate_rate is None
+            else candidate_rate - baseline_rate
+        ),
+        baseline_wins=baseline_wins,
+        candidate_wins=candidate_wins,
+        ties=ties,
+    )
+
+
+def _judge(
+    pairs: list[tuple[EvalRunResult, EvalRunResult]], *, total_pairs: int
+) -> JudgeScoreSummary:
+    metric = _metric(
+        [
+            pair
+            for pair in pairs
+            if pair[0].judge is not None
+            and pair[1].judge is not None
+            and pair[0].judge.judge == pair[1].judge.judge
+        ],
+        total_pairs=total_pairs,
+        select=lambda result: result.judge.score if result.judge is not None else None,
+    )
+    return JudgeScoreSummary(
+        total_pairs=metric.total_pairs,
+        eligible_pairs=metric.eligible_pairs,
+        baseline_mean=metric.baseline_mean,
+        candidate_mean=metric.candidate_mean,
+        mean_delta=metric.mean_delta,
+        observational=True,
+    )
+
+
+def compare_runs(
+    runs: list[EvalRunResult] | tuple[EvalRunResult, ...],
+    *,
+    baseline_name: str,
+    candidate_names: tuple[str, ...],
+) -> ComparisonReport:
+    if not baseline_name:
+        raise ValueError("baseline_name must be non-empty")
+    if not candidate_names:
+        raise ValueError("at least one candidate name is required")
+    grouped: dict[tuple[str, str], list[EvalRunResult]] = {}
+    pair_keys: set[str] = set()
+    relevant_names = {baseline_name, *candidate_names}
+    for run in runs:
+        if run.variant_name not in relevant_names:
+            continue
+        grouped.setdefault((run.variant_name, run.pair_key), []).append(run)
+        pair_keys.add(run.pair_key)
+    diagnostics: list[ComparisonDiagnostic] = []
+    comparisons: list[PairComparison] = []
+    for candidate_name in candidate_names:
+        eligible_pairs: list[tuple[EvalRunResult, EvalRunResult]] = []
+        for pair_key in sorted(pair_keys):
+            baseline = grouped.get((baseline_name, pair_key), [])
+            candidate = grouped.get((candidate_name, pair_key), [])
+            for variant_name, observations in (
+                (baseline_name, baseline),
+                (candidate_name, candidate),
+            ):
+                if not observations:
+                    diagnostics.append(
+                        ComparisonDiagnostic(pair_key, variant_name, "missing-run")
+                    )
+                elif len(observations) > 1:
+                    diagnostics.append(
+                        ComparisonDiagnostic(pair_key, variant_name, "duplicate-run")
+                    )
+                elif observations[0].infrastructure_error is not None:
+                    diagnostics.append(
+                        ComparisonDiagnostic(
+                            pair_key, variant_name, "infrastructure-error"
+                        )
+                    )
+            if (
+                len(baseline) == 1
+                and len(candidate) == 1
+                and baseline[0].infrastructure_error is None
+                and candidate[0].infrastructure_error is None
+            ):
+                eligible_pairs.append((baseline[0], candidate[0]))
+                if (
+                    baseline[0].judge is not None
+                    and candidate[0].judge is not None
+                    and baseline[0].judge.judge != candidate[0].judge.judge
+                ):
+                    diagnostics.append(
+                        ComparisonDiagnostic(
+                            pair_key,
+                            candidate_name,
+                            "judge-contract-mismatch",
+                        )
+                    )
+        total_pairs = len(pair_keys)
+        comparisons.append(
+            PairComparison(
+                baseline=baseline_name,
+                candidate=candidate_name,
+                correctness=_correctness(eligible_pairs, total_pairs=total_pairs),
+                tokens=_metric(
+                    eligible_pairs,
+                    total_pairs=total_pairs,
+                    select=lambda result: result.measurements.total_tokens,
+                ),
+                latency_ms=_metric(
+                    eligible_pairs,
+                    total_pairs=total_pairs,
+                    select=lambda result: result.measurements.latency_ms,
+                ),
+                estimated_cost_usd=_metric(
+                    eligible_pairs,
+                    total_pairs=total_pairs,
+                    select=lambda result: result.measurements.estimated_cost_usd,
+                ),
+                retries=_metric(
+                    eligible_pairs,
+                    total_pairs=total_pairs,
+                    select=lambda result: result.measurements.retry_count,
+                ),
+                compactions=_metric(
+                    eligible_pairs,
+                    total_pairs=total_pairs,
+                    select=lambda result: result.measurements.compaction_count,
+                ),
+                judge_scores=_judge(eligible_pairs, total_pairs=total_pairs),
+            )
+        )
+    return ComparisonReport(
+        baseline=baseline_name,
+        candidates=candidate_names,
+        comparisons=tuple(comparisons),
+        diagnostics=tuple(
+            sorted(
+                set(diagnostics),
+                key=lambda item: (item.pair_key, item.variant_name, item.reason),
+            )
+        ),
+    )

--- a/desktop/coworker/evals/environment.py
+++ b/desktop/coworker/evals/environment.py
@@ -1,0 +1,204 @@
+"""Per-run state and connector isolation for evaluations."""
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+import tempfile
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from coworker.apollo import FakeHttp
+from coworker.gmail import FakeGmail
+from coworker.inbox import Inbox
+from coworker.mcp import FakeMcp
+from coworker.people import PersonStore
+from coworker.store import ConversationStore
+from coworker.workspace import GrantAccess
+from coworker.workspace_runtime import WorkspaceRuntime
+
+
+def private_directory(path: str | Path, *, description: str = "private directory") -> Path:
+    directory = Path(path)
+    if directory.is_symlink():
+        raise ValueError(f"{description} cannot be a symlink")
+    if directory.exists():
+        if not directory.is_dir():
+            raise ValueError(f"{description} must be a directory")
+        mode = stat.S_IMODE(directory.stat().st_mode)
+        if mode != 0o700:
+            raise ValueError(
+                f"existing {description} must already use mode 0700; got {mode:04o}"
+            )
+        return directory
+    if not directory.parent.is_dir():
+        raise ValueError(f"{description} parent must already exist")
+    try:
+        directory.mkdir(mode=0o700)
+    except FileExistsError:
+        return private_directory(directory, description=description)
+    os.chmod(directory, 0o700)
+    return directory
+
+
+def private_artifact_root(path: str | Path) -> Path:
+    root = Path(path)
+    if root.exists() and (
+        root.resolve() in {Path("/").resolve(), Path.home().resolve()}
+        or (root / ".git").exists()
+    ):
+        raise ValueError("private artifact root cannot be a broad system or repository root")
+    return private_directory(root, description="private artifact root")
+
+
+def write_private_text(path: str | Path, content: str) -> None:
+    target = Path(path)
+    if target.is_symlink():
+        raise ValueError("private artifact file cannot be a symlink")
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{target.name}-", suffix=".tmp", dir=target.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            descriptor = -1
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, target)
+        directory_descriptor = os.open(target.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_descriptor)
+        finally:
+            os.close(directory_descriptor)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        temporary.unlink(missing_ok=True)
+
+
+class CredentialFreeConnector:
+    """Network-inert connector whose calls are visible and fail closed."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.calls: list[dict[str, Any]] = []
+
+    def __getattr__(self, operation: str):
+        def unavailable(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            self.calls.append(
+                {"operation": operation, "args": list(args), "kwargs": dict(kwargs)}
+            )
+            raise RuntimeError(f"{self.name} eval fake has no fixture for {operation}")
+
+        return unavailable
+
+
+@dataclass(slots=True)
+class ConnectorFakes:
+    gmail: FakeGmail
+    drive: CredentialFreeConnector
+    calendar: CredentialFreeConnector
+    http: FakeHttp
+    mcp: FakeMcp
+
+    @classmethod
+    def create(cls) -> "ConnectorFakes":
+        def environment_probe(_arguments: dict[str, Any]) -> dict[str, Any]:
+            return {"sensitive_keys": sensitive_environment_keys()}
+
+        return cls(
+            gmail=FakeGmail(),
+            drive=CredentialFreeConnector("drive"),
+            calendar=CredentialFreeConnector("calendar"),
+            http=FakeHttp(),
+            mcp=FakeMcp(
+                [
+                    {
+                        "name": "mcp__eval__environment_probe",
+                        "description": "Report sensitive environment variable names.",
+                        "handler": environment_probe,
+                    }
+                ]
+            ),
+        )
+
+
+def sensitive_environment_keys() -> list[str]:
+    markers = ("KEY", "TOKEN", "SECRET", "PASSWORD", "AUTHORIZATION")
+    return sorted(
+        name for name in os.environ if any(marker in name.upper() for marker in markers)
+    )
+
+
+@dataclass(slots=True)
+class EvalEnvironment:
+    root: Path
+    state_dir: Path
+    workspace_dir: Path
+    home_dir: Path
+    store: ConversationStore
+    people: PersonStore
+    inbox: Inbox
+    workspace_runtime: WorkspaceRuntime
+    workspace_grant: dict[str, Any]
+    connectors: ConnectorFakes
+    credential_environment: dict[str, str]
+
+    @classmethod
+    def create(
+        cls,
+        artifact_root: Path,
+        *,
+        label: str,
+        apply_environment: bool = False,
+    ) -> "EvalEnvironment":
+        safe_label = re.sub(r"[^A-Za-z0-9._-]+", "-", label).strip("-.") or "run"
+        artifact_root = private_artifact_root(artifact_root)
+        runs_dir = private_directory(artifact_root / "runs")
+        root = runs_dir / f"{safe_label}-{uuid.uuid4().hex[:12]}"
+        state_dir = root / "state"
+        workspace_dir = root / "workspace"
+        home_dir = root / "home"
+        for path in (root, state_dir, workspace_dir, home_dir):
+            private_directory(path)
+        credential_environment = {
+            "CLUB_STATE_DIR": str(state_dir),
+            "HOME": str(home_dir),
+            "PATH": os.defpath,
+            "LANG": "C.UTF-8",
+        }
+        if apply_environment:
+            os.environ.clear()
+            os.environ.update(credential_environment)
+        store = ConversationStore(state_dir)
+        people = PersonStore(state_dir)
+        workspace_runtime = WorkspaceRuntime(state_dir)
+        workspace_grant = workspace_runtime.add_grant(
+            workspace_dir,
+            label="Evaluation workspace",
+            access=GrantAccess.READ_WRITE,
+            allow_shell=False,
+        )
+        return cls(
+            root=root,
+            state_dir=state_dir,
+            workspace_dir=workspace_dir,
+            home_dir=home_dir,
+            store=store,
+            people=people,
+            inbox=Inbox(store),
+            workspace_runtime=workspace_runtime,
+            workspace_grant=workspace_grant,
+            connectors=ConnectorFakes.create(),
+            credential_environment=credential_environment,
+        )
+
+    def close(self) -> None:
+        self.workspace_runtime.close()
+        self.store._conn.close()
+        self.people._conn.close()

--- a/desktop/coworker/evals/models.py
+++ b/desktop/coworker/evals/models.py
@@ -1,0 +1,142 @@
+"""Typed contracts for reproducible Sourcecado evaluation variants."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any
+
+
+def _required(value: str, field_name: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+
+
+@dataclass(frozen=True, slots=True)
+class CompactionPolicy:
+    enabled: bool = False
+    threshold_messages: int = 24
+    retain_messages: int = 12
+
+    def __post_init__(self) -> None:
+        if self.threshold_messages < 1:
+            raise ValueError("threshold_messages must be positive")
+        if self.retain_messages < 1:
+            raise ValueError("retain_messages must be positive")
+        if self.retain_messages > self.threshold_messages:
+            raise ValueError("retain_messages cannot exceed threshold_messages")
+
+
+@dataclass(frozen=True, slots=True)
+class RunBudget:
+    max_provider_calls: int = 8
+    max_total_tokens: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.max_provider_calls < 1:
+            raise ValueError("max_provider_calls must be positive")
+        if self.max_total_tokens is not None and self.max_total_tokens < 1:
+            raise ValueError("max_total_tokens must be positive or null")
+
+
+@dataclass(frozen=True, slots=True)
+class EvalVariant:
+    name: str
+    prompt_version: str
+    system_prompt: str
+    tool_catalog: tuple[str, ...]
+    provider: str
+    model: str
+    compaction: CompactionPolicy = field(default_factory=CompactionPolicy)
+    run_budget: RunBudget = field(default_factory=RunBudget)
+
+    def __post_init__(self) -> None:
+        for field_name in ("name", "prompt_version", "provider", "model"):
+            _required(getattr(self, field_name), field_name)
+        if not isinstance(self.system_prompt, str):
+            raise ValueError("system_prompt must be a string")
+        if not isinstance(self.tool_catalog, tuple) or any(
+            not isinstance(name, str) or not name.strip()
+            for name in self.tool_catalog
+        ):
+            raise ValueError("tool_catalog must contain non-empty tool names")
+        if len(set(self.tool_catalog)) != len(self.tool_catalog):
+            raise ValueError("tool_catalog must not contain duplicates")
+
+
+@dataclass(frozen=True, slots=True)
+class InvariantResult:
+    name: str
+    passed: bool
+    detail: str
+    kind: str = "deterministic"
+
+
+@dataclass(frozen=True, slots=True)
+class RunMeasurements:
+    input_tokens: int | None
+    output_tokens: int | None
+    total_tokens: int | None
+    latency_ms: float | None
+    estimated_cost_usd: float | None
+    retry_count: int
+    compaction_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class RunArtifacts:
+    root: str
+    state_dir: str
+    workspace_dir: str
+    conversation_jsonl: str
+    events_jsonl: str
+    telemetry_jsonl: str
+    result_json: str
+
+
+@dataclass(frozen=True, slots=True)
+class JudgeObservation:
+    judge: str
+    score: float
+    rationale: str = ""
+
+    def __post_init__(self) -> None:
+        _required(self.judge, "judge")
+        if isinstance(self.score, bool) or not isinstance(self.score, (int, float)):
+            raise ValueError("score must be numeric")
+        if not math.isfinite(self.score) or not 0 <= self.score <= 1:
+            raise ValueError("score must be finite and between 0 and 1")
+
+
+@dataclass(frozen=True, slots=True)
+class EvalRunResult:
+    scenario_id: str
+    variant_name: str
+    repetition: int
+    pair_key: str
+    execution_mode: str
+    provider: str
+    model: str
+    prompt_version: str
+    nondeterministic: bool
+    session_id: str
+    run_id: str
+    terminal_state: str
+    tool_sequence: tuple[str, ...]
+    provider_calls: int
+    invariants: tuple[InvariantResult, ...]
+    measurements: RunMeasurements
+    variant: dict[str, Any]
+    session_artifact: dict[str, Any]
+    telemetry: tuple[dict[str, Any], ...]
+    persisted_effects: dict[str, Any]
+    execution_environment: dict[str, Any]
+    artifacts: RunArtifacts
+    infrastructure_error: str | None = None
+    judge: JudgeObservation | None = None
+
+    @property
+    def passed(self) -> bool:
+        return self.infrastructure_error is None and all(
+            item.passed for item in self.invariants
+        )

--- a/desktop/coworker/evals/runner.py
+++ b/desktop/coworker/evals/runner.py
@@ -1,0 +1,893 @@
+"""Execution engine for isolated deterministic and explicitly live evaluations."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import multiprocessing
+import os
+import queue
+import time
+import uuid
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, AsyncIterator
+
+from coworker.events import TurnIdentity
+from coworker.evals.environment import (
+    EvalEnvironment,
+    sensitive_environment_keys,
+    write_private_text,
+)
+from coworker.evals.models import (
+    EvalRunResult,
+    EvalVariant,
+    InvariantResult,
+    JudgeObservation,
+    RunArtifacts,
+    RunBudget,
+    RunMeasurements,
+)
+from coworker.evals.scenarios import EvalScenario, ProviderStep
+from coworker.evals.transcript import compact_transcript, transcript_issues
+from coworker.provider import (
+    ProviderErrorKind,
+    ProviderStreamError,
+    ProviderTerminal,
+    StreamChunk,
+    StreamKind,
+)
+from coworker.telemetry import (
+    CompactionEvent,
+    CompactionReason,
+    InMemoryTelemetryAdapter,
+    TelemetryRecorder,
+    ToolSpan,
+    TraceContext,
+    record_to_dict,
+)
+from coworker.tools import OPENAI_TOOLS
+from coworker.turn import run_turn
+
+ARTIFACT_WARNING = (
+    "Evaluation artifacts may contain prompts, responses, tool arguments, and tool "
+    "output. Keep them local, review before sharing, and never commit them."
+)
+_ENVIRONMENT_PROBE_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "mcp__eval__environment_probe",
+        "description": "Report sensitive environment variable names in an eval child.",
+        "parameters": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+class EvalBudgetExceeded(RuntimeError):
+    pass
+
+
+class EvalToolCatalogViolation(RuntimeError):
+    pass
+
+
+class LiveRunNotAuthorized(RuntimeError):
+    pass
+
+
+class BudgetedProvider:
+    """Apply the eval run budget to any injected live provider."""
+
+    def __init__(self, provider: Any, budget: RunBudget) -> None:
+        self.provider = provider
+        self.provider_id = str(getattr(provider, "provider_id", "unknown"))
+        self.model_id = str(getattr(provider, "model_id", "unknown"))
+        self.uses_transient_context = bool(
+            getattr(provider, "uses_transient_context", False)
+        )
+        self._budget = budget
+        self._provider_calls = 0
+        self._total_tokens = 0
+        self._budget_error: str | None = None
+        self._tool_catalog_error: str | None = None
+        self.environment_samples: list[list[str]] = []
+        self.transcript_issues: list[str] = []
+
+    @property
+    def budget_error(self) -> str | None:
+        return self._budget_error or getattr(self.provider, "budget_error", None)
+
+    @property
+    def tool_catalog_error(self) -> str | None:
+        return self._tool_catalog_error
+
+    def bind_workspace(self, grant_id: str) -> None:
+        bind = getattr(self.provider, "bind_workspace", None)
+        if callable(bind):
+            bind(grant_id)
+
+    async def astream(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        context_id: str | None = None,
+    ) -> AsyncIterator[StreamChunk]:
+        self.environment_samples.append(sensitive_environment_keys())
+        self._provider_calls += 1
+        self.transcript_issues.extend(
+            f"provider call {self._provider_calls}: {issue}"
+            for issue in transcript_issues(messages)
+        )
+        if self._provider_calls > self._budget.max_provider_calls:
+            self._budget_error = (
+                f"provider calls {self._provider_calls} exceed budget "
+                f"{self._budget.max_provider_calls}"
+            )
+            raise EvalBudgetExceeded(self._budget_error)
+        stream_kwargs: dict[str, Any] = {"messages": messages, "tools": tools}
+        active_tools = {
+            str((schema.get("function") or {}).get("name") or "")
+            for schema in tools or []
+            if isinstance(schema, dict)
+        }
+        if self.uses_transient_context:
+            stream_kwargs["context_id"] = context_id
+        latest_total: int | None = None
+        try:
+            async for chunk in self.provider.astream(**stream_kwargs):
+                usage = chunk.usage
+                if chunk.terminal is not None and chunk.terminal.usage is not None:
+                    usage = chunk.terminal.usage
+                if usage is not None:
+                    latest_total = usage.total_tokens
+                    maximum = self._budget.max_total_tokens
+                    if (
+                        maximum is not None
+                        and self._total_tokens + latest_total > maximum
+                    ):
+                        self._budget_error = (
+                            f"total tokens {self._total_tokens + latest_total} exceed "
+                            f"budget {maximum}"
+                        )
+                        raise EvalBudgetExceeded(self._budget_error)
+                unauthorized = sorted(
+                    {
+                        call.name
+                        for call in chunk.tool_calls or []
+                        if call.name not in active_tools
+                    }
+                )
+                if unauthorized:
+                    self._tool_catalog_error = (
+                        "provider called tools outside the active catalog: "
+                        + ", ".join(unauthorized)
+                    )
+                    raise EvalToolCatalogViolation(self._tool_catalog_error)
+                yield chunk
+        except (EvalBudgetExceeded, EvalToolCatalogViolation, ProviderStreamError):
+            raise
+        except Exception as exc:
+            raise ProviderStreamError(
+                provider=self.provider_id,
+                model=self.model_id,
+                kind=ProviderErrorKind.PROVIDER,
+                message="provider request failed",
+                retryable=False,
+            ) from exc
+        if latest_total is not None:
+            self._total_tokens += latest_total
+
+
+class ScenarioProvider:
+    """Deterministic provider whose transcript is fixed by an eval scenario."""
+
+    def __init__(self, *, variant: EvalVariant, steps: tuple[ProviderStep, ...]) -> None:
+        self.provider_id = variant.provider
+        self.model_id = variant.model
+        self.steps = steps
+        self.calls: list[dict[str, Any]] = []
+        self._index = 0
+        self._total_tokens = 0
+        self._budget = variant.run_budget
+        self.budget_error: str | None = None
+        self.workspace_grant_id: str | None = None
+        self.environment_samples: list[list[str]] = []
+
+    def bind_workspace(self, grant_id: str) -> None:
+        self.workspace_grant_id = grant_id
+
+    def _arguments(self, value: Any) -> Any:
+        if value == "$EVAL_WORKSPACE_GRANT":
+            if self.workspace_grant_id is None:
+                raise RuntimeError("eval workspace grant is not bound")
+            return self.workspace_grant_id
+        if isinstance(value, dict):
+            return {key: self._arguments(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [self._arguments(item) for item in value]
+        return value
+
+    async def astream(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None = None,
+        context_id: str | None = None,
+    ) -> AsyncIterator[StreamChunk]:
+        del context_id
+        self.environment_samples.append(sensitive_environment_keys())
+        call_number = len(self.calls) + 1
+        if call_number > self._budget.max_provider_calls:
+            self.budget_error = (
+                f"provider calls {call_number} exceed budget "
+                f"{self._budget.max_provider_calls}"
+            )
+            raise EvalBudgetExceeded(self.budget_error)
+        self.calls.append(
+            {
+                "messages": [dict(message) for message in messages],
+                "tools": [dict(tool) for tool in tools or ()],
+            }
+        )
+        if self._index >= len(self.steps):
+            self.budget_error = "scenario provider exhausted its scripted steps"
+            raise EvalBudgetExceeded(self.budget_error)
+        step = self.steps[self._index]
+        self._index += 1
+        if step.usage is not None:
+            next_total = self._total_tokens + step.usage.total_tokens
+            maximum = self._budget.max_total_tokens
+            if maximum is not None and next_total > maximum:
+                self.budget_error = f"total tokens {next_total} exceed budget {maximum}"
+                raise EvalBudgetExceeded(self.budget_error)
+            self._total_tokens = next_total
+        yield StreamChunk.started(provider=self.provider_id, model=self.model_id)
+        if step.error is not None:
+            raise RuntimeError(step.error)
+        for delta in step.text_deltas:
+            yield StreamChunk(text_delta=delta)
+        if step.usage is not None:
+            yield StreamChunk(usage=step.usage)
+        finish_reason = "tool_calls" if step.tool_calls else "stop"
+        yield StreamChunk(
+            kind=StreamKind.TERMINAL,
+            finish_reason=finish_reason,
+            terminal=ProviderTerminal(
+                stop_reason=finish_reason,
+                usage=step.usage,
+                latency_ms=0.0,
+                estimated_cost_usd=step.estimated_cost_usd,
+            ),
+        )
+        if step.tool_calls:
+            yield StreamChunk(
+                tool_calls=[
+                    type(call)(
+                        id=call.id,
+                        name=call.name,
+                        arguments=self._arguments(call.arguments),
+                    )
+                    for call in step.tool_calls
+                ]
+            )
+
+
+def _selected_tools(names: tuple[str, ...]) -> list[dict[str, Any]]:
+    by_name = {schema["function"]["name"]: schema for schema in OPENAI_TOOLS}
+    by_name["mcp__eval__environment_probe"] = _ENVIRONMENT_PROBE_SCHEMA
+    unknown = [name for name in names if name not in by_name]
+    if unknown:
+        raise ValueError(f"unknown eval tool: {unknown[0]}")
+    return [by_name[name] for name in names]
+
+
+def _prompt(variant: EvalVariant):
+    def render(*_args: Any, **_kwargs: Any) -> str:
+        return variant.system_prompt
+
+    return render
+
+
+def _terminal_state(events: list[dict[str, Any]], run_result: dict[str, Any]) -> str:
+    terminal = next(
+        (
+            event
+            for event in reversed(events)
+            if event.get("type") in {"turn_end", "turn_stopped", "error"}
+        ),
+        None,
+    )
+    if terminal is not None:
+        return str(terminal.get("state") or "unknown")
+    return str(run_result.get("status") or "unknown")
+
+
+def _spawned_run(
+    output: Any,
+    artifact_root: str,
+    scenario: EvalScenario,
+    variant: EvalVariant,
+    repetition: int,
+    provider: Any,
+    execution_mode: str,
+    nondeterministic: bool,
+    judge: JudgeObservation | None,
+) -> None:
+    try:
+        result = EvalRunner(Path(artifact_root))._run_local(
+            scenario,
+            variant,
+            repetition=repetition,
+            provider=provider,
+            execution_mode=execution_mode,
+            nondeterministic=nondeterministic,
+            judge=judge,
+            process_isolated=True,
+        )
+        output.put(("ok", result))
+    except BaseException as exc:
+        output.put(
+            (
+                "error",
+                f"{type(exc).__name__}: eval child failed",
+            )
+        )
+
+
+class EvalRunner:
+    def __init__(self, artifact_root: str | Path) -> None:
+        self.artifact_root = Path(artifact_root)
+
+    def run_fake(
+        self,
+        scenario: EvalScenario,
+        variant: EvalVariant,
+        *,
+        repetition: int,
+        judge: JudgeObservation | None = None,
+    ) -> EvalRunResult:
+        provider = ScenarioProvider(variant=variant, steps=scenario.provider_steps)
+        return self._run(
+            scenario,
+            variant,
+            repetition=repetition,
+            provider=provider,
+            execution_mode="fake",
+            nondeterministic=False,
+            judge=judge,
+        )
+
+    def run_live(
+        self,
+        scenario: EvalScenario,
+        variant: EvalVariant,
+        *,
+        provider: Any,
+        repetition: int,
+        opt_in: bool,
+        judge: JudgeObservation | None = None,
+    ) -> EvalRunResult:
+        if not opt_in:
+            raise LiveRunNotAuthorized(
+                "live evaluations require explicit opt-in for every invocation"
+            )
+        if provider is None:
+            raise ValueError("live provider is unavailable")
+        return self._run(
+            scenario,
+            variant,
+            repetition=repetition,
+            provider=BudgetedProvider(provider, variant.run_budget),
+            execution_mode="live",
+            nondeterministic=True,
+            judge=judge,
+        )
+
+    def _run(
+        self,
+        scenario: EvalScenario,
+        variant: EvalVariant,
+        *,
+        repetition: int,
+        provider: Any,
+        execution_mode: str,
+        nondeterministic: bool,
+        judge: JudgeObservation | None,
+    ) -> EvalRunResult:
+        _selected_tools(variant.tool_catalog)
+        context = multiprocessing.get_context("spawn")
+        output = context.Queue()
+        process = context.Process(
+            target=_spawned_run,
+            args=(
+                output,
+                str(self.artifact_root),
+                scenario,
+                variant,
+                repetition,
+                provider,
+                execution_mode,
+                nondeterministic,
+                judge,
+            ),
+        )
+        process.start()
+        try:
+            status, payload = output.get(timeout=120)
+        except queue.Empty as exc:
+            process.terminate()
+            process.join(timeout=5)
+            output.close()
+            output.join_thread()
+            raise RuntimeError("eval child did not report within 120 seconds") from exc
+        process.join(timeout=10)
+        output.close()
+        output.join_thread()
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=5)
+            raise RuntimeError("eval child did not exit after reporting")
+        if status != "ok":
+            raise RuntimeError(str(payload))
+        if process.exitcode != 0:
+            raise RuntimeError(f"eval child exited with status {process.exitcode}")
+        return payload
+
+    def _run_local(
+        self,
+        scenario: EvalScenario,
+        variant: EvalVariant,
+        *,
+        repetition: int,
+        provider: Any,
+        execution_mode: str,
+        nondeterministic: bool,
+        judge: JudgeObservation | None,
+        process_isolated: bool,
+    ) -> EvalRunResult:
+        if repetition < 1:
+            raise ValueError("repetition must be positive")
+        tools = _selected_tools(variant.tool_catalog)
+        if not isinstance(provider, BudgetedProvider):
+            provider = BudgetedProvider(provider, variant.run_budget)
+        label = f"{scenario.scenario_id}-{variant.name}-r{repetition}"
+        environment = EvalEnvironment.create(
+            self.artifact_root,
+            label=label,
+            apply_environment=process_isolated,
+        )
+        session_id = f"eval-{uuid.uuid4().hex}"
+        run_id = f"run-{uuid.uuid4().hex}"
+        identity = TurnIdentity(
+            session_id=session_id,
+            run_id=run_id,
+            message_id=f"message-{uuid.uuid4().hex}",
+            part_id=f"part-{uuid.uuid4().hex}",
+        )
+        environment.store.create_session(session_id)
+        bind_workspace = getattr(provider, "bind_workspace", None)
+        if callable(bind_workspace):
+            bind_workspace(str(environment.workspace_grant["id"]))
+        for message in scenario.initial_messages:
+            environment.store.append(session_id, dict(message))
+        adapter = InMemoryTelemetryAdapter()
+        recorder = TelemetryRecorder(adapter)
+        self._compact_if_needed(
+            environment=environment,
+            session_id=session_id,
+            run_id=run_id,
+            variant=variant,
+            recorder=recorder,
+        )
+        emitted: list[dict[str, Any]] = []
+
+        async def emit(event: dict[str, Any]) -> None:
+            emitted.append(event)
+
+        infrastructure_error: str | None = None
+        try:
+            raw_result = asyncio.run(
+                run_turn(
+                    text=scenario.prompt,
+                    sid=session_id,
+                    store=environment.store,
+                    provider=provider,
+                    persona=None,
+                    skills=None,
+                    inbox=environment.inbox,
+                    openai_tools=tools,
+                    execute_kwargs={
+                        "store": environment.store,
+                        "gmail": environment.connectors.gmail,
+                        "drive": environment.connectors.drive,
+                        "calendar": environment.connectors.calendar,
+                        "http": environment.connectors.http,
+                        "apollo_key": None,
+                        "tavily_key": None,
+                        "mcp": environment.connectors.mcp,
+                        "people": environment.people,
+                        "workspace_runtime": environment.workspace_runtime,
+                        "actor": "assistant",
+                    },
+                    emit=emit,
+                    wait_permission=None,
+                    system_prompt_fn=_prompt(variant),
+                    identity=identity,
+                    telemetry=recorder,
+                )
+            )
+        except Exception as exc:  # run_turn normally contains failures itself
+            raw_result = {"status": "error", "text": ""}
+            infrastructure_error = f"{type(exc).__name__}: {exc}"
+        messages = environment.store.load(session_id)
+        events = environment.store.load_events(session_id)
+        terminal_state = _terminal_state(events, raw_result)
+        budget_error = getattr(provider, "budget_error", None)
+        tool_catalog_error = getattr(provider, "tool_catalog_error", None)
+        if (
+            raw_result.get("status") == "error"
+            and not budget_error
+            and not tool_catalog_error
+            and infrastructure_error is None
+        ):
+            infrastructure_error = "agent run ended with infrastructure error"
+        tool_sequence = tuple(
+            str(event["name"])
+            for event in events
+            if event.get("type") == "tool_started"
+        )
+        effects, effect_checks = self._persisted_effects(environment, scenario)
+        invariants = [
+            InvariantResult(
+                name="tool_sequence",
+                passed=tool_sequence == scenario.expected_tool_sequence,
+                detail=(
+                    f"expected {scenario.expected_tool_sequence!r}; got {tool_sequence!r}"
+                ),
+            ),
+            InvariantResult(
+                name="terminal_state",
+                passed=terminal_state == scenario.expected_terminal_state,
+                detail=(
+                    f"expected {scenario.expected_terminal_state!r}; got "
+                    f"{terminal_state!r}"
+                ),
+            ),
+            InvariantResult(
+                name="forbidden_tools",
+                passed=not set(tool_sequence).intersection(scenario.forbidden_tools),
+                detail=f"forbidden={scenario.forbidden_tools!r}; got={tool_sequence!r}",
+            ),
+            *effect_checks,
+        ]
+        if budget_error:
+            invariants.append(
+                InvariantResult(
+                    name="run_budget",
+                    passed=False,
+                    detail=str(budget_error),
+                )
+            )
+        invariants.append(
+            InvariantResult(
+                name="tool_catalog",
+                passed=not tool_catalog_error,
+                detail=(
+                    "all provider tool calls were in the active catalog"
+                    if not tool_catalog_error
+                    else str(tool_catalog_error)
+                ),
+            )
+        )
+        telemetry = tuple(record_to_dict(record) for record in adapter.records)
+        context_ok = bool(telemetry) and all(
+            record["context"] == {"session_id": session_id, "run_id": run_id}
+            for record in telemetry
+        )
+        invariants.append(
+            InvariantResult(
+                name="telemetry_parentage",
+                passed=context_ok,
+                detail="all closed telemetry records must match the native session/run",
+            )
+        )
+        provider_sensitive_keys = sorted(
+            {
+                key
+                for sample in getattr(provider, "environment_samples", ())
+                for key in sample
+            }
+        )
+        tool_sensitive_keys = sorted(
+            {
+                str(key)
+                for event in events
+                if event.get("type") == "tool_finished"
+                and event.get("name") == "mcp__eval__environment_probe"
+                for key in (event.get("result") or {}).get("sensitive_keys", [])
+            }
+        )
+        invariants.append(
+            InvariantResult(
+                name="credential_environment",
+                passed=not provider_sensitive_keys and not tool_sensitive_keys,
+                detail=(
+                    f"provider keys={provider_sensitive_keys!r}; "
+                    f"tool keys={tool_sensitive_keys!r}"
+                ),
+            )
+        )
+        provider_transcript_issues = list(
+            getattr(provider, "transcript_issues", ())
+        )
+        invariants.append(
+            InvariantResult(
+                name="transcript_integrity",
+                passed=not provider_transcript_issues,
+                detail=(
+                    "valid assistant/tool transcript"
+                    if not provider_transcript_issues
+                    else "; ".join(provider_transcript_issues)
+                ),
+            )
+        )
+        environment_exact = dict(os.environ) == environment.credential_environment
+        invariants.append(
+            InvariantResult(
+                name="minimal_environment",
+                passed=environment_exact,
+                detail=(
+                    f"expected names={sorted(environment.credential_environment)!r}; "
+                    f"got names={sorted(os.environ)!r}"
+                ),
+            )
+        )
+        metrics = adapter.current_run_metrics(run_id=run_id, now_ns=time.monotonic_ns())
+        measurements = RunMeasurements(
+            input_tokens=metrics.input_tokens,
+            output_tokens=metrics.output_tokens,
+            total_tokens=metrics.total_tokens,
+            latency_ms=metrics.elapsed_ms,
+            estimated_cost_usd=metrics.estimated_cost_usd,
+            retry_count=metrics.retry_count,
+            compaction_count=metrics.compaction_count,
+        )
+        conversation_path = environment.store.conv_dir / f"{session_id}.jsonl"
+        events_path = environment.store.event_dir / f"{session_id}.jsonl"
+        telemetry_path = environment.root / "telemetry.jsonl"
+        result_path = environment.root / "result.json"
+        write_private_text(
+            telemetry_path,
+            "".join(json.dumps(record, sort_keys=True) + "\n" for record in telemetry),
+        )
+        artifacts = RunArtifacts(
+            root=str(environment.root.resolve()),
+            state_dir=str(environment.state_dir.resolve()),
+            workspace_dir=str(environment.workspace_dir.resolve()),
+            conversation_jsonl=str(conversation_path.resolve()),
+            events_jsonl=str(events_path.resolve()),
+            telemetry_jsonl=str(telemetry_path.resolve()),
+            result_json=str(result_path.resolve()),
+        )
+        result = EvalRunResult(
+            scenario_id=scenario.scenario_id,
+            variant_name=variant.name,
+            repetition=repetition,
+            pair_key=f"{scenario.scenario_id}:r{repetition}",
+            execution_mode=execution_mode,
+            provider=str(getattr(provider, "provider_id", variant.provider)),
+            model=str(getattr(provider, "model_id", variant.model)),
+            prompt_version=variant.prompt_version,
+            nondeterministic=nondeterministic,
+            session_id=session_id,
+            run_id=run_id,
+            terminal_state=terminal_state,
+            tool_sequence=tool_sequence,
+            provider_calls=sum(
+                record.get("record_type") == "span_started"
+                and (record.get("span") or {}).get("span_type") == "provider"
+                for record in telemetry
+            ),
+            invariants=tuple(invariants),
+            measurements=measurements,
+            variant=asdict(variant),
+            session_artifact={
+                "session": environment.store.index(session_id),
+                "messages": messages,
+                "events": events,
+            },
+            telemetry=telemetry,
+            persisted_effects=effects,
+            execution_environment={
+                "applied": dict(environment.credential_environment),
+                "provider_sensitive_keys": provider_sensitive_keys,
+                "tool_sensitive_keys": tool_sensitive_keys,
+                "process_isolated": process_isolated,
+                "child_pid": os.getpid(),
+                "workspace_grant": dict(environment.workspace_grant),
+            },
+            artifacts=artifacts,
+            infrastructure_error=infrastructure_error,
+            judge=judge,
+        )
+        write_private_text(
+            result_path,
+            json.dumps(
+                {"warning": ARTIFACT_WARNING, "result": asdict(result)},
+                indent=2,
+                sort_keys=True,
+                allow_nan=False,
+            )
+            + "\n",
+        )
+        environment.close()
+        return result
+
+    @staticmethod
+    def _compact_if_needed(
+        *,
+        environment: EvalEnvironment,
+        session_id: str,
+        run_id: str,
+        variant: EvalVariant,
+        recorder: TelemetryRecorder,
+    ) -> None:
+        policy = variant.compaction
+        messages = environment.store.load(session_id)
+        if not policy.enabled or len(messages) < policy.threshold_messages:
+            return
+        compacted = compact_transcript(
+            messages, retain_messages=policy.retain_messages
+        )
+        environment.store.replace_all(session_id, compacted)
+        span = recorder.start_span(
+            ToolSpan(tool_name="eval", operation="history.compact"),
+            TraceContext(session_id=session_id, run_id=run_id),
+        )
+        span.record(
+            CompactionEvent(
+                operation="history.compact",
+                reason=CompactionReason.POLICY,
+                input_tokens=None,
+                output_tokens=None,
+            )
+        )
+        span.finish()
+
+    @staticmethod
+    def _persisted_effects(
+        environment: EvalEnvironment,
+        scenario: EvalScenario,
+    ) -> tuple[dict[str, Any], list[InvariantResult]]:
+        with environment.people._lock:
+            person_ids = [
+                str(row["person_id"])
+                for row in environment.people._conn.execute(
+                    """
+                    SELECT person_id FROM people
+                    WHERE deleted_at IS NULL
+                    ORDER BY person_id
+                    """
+                ).fetchall()
+            ]
+        people = [
+            person
+            for person_id in person_ids
+            if (person := environment.people.get(person_id)) is not None
+        ]
+        people_by_apollo = {
+            str(person.get("apollo_id") or person["person_id"]): person
+            for person in people
+        }
+        checks: list[InvariantResult] = []
+        for expectation in scenario.expected_people:
+            person = people_by_apollo.get(expectation.apollo_id)
+            matches = person is not None and all(
+                person.get(field_name) == expected
+                for field_name, expected in expectation.fields
+            )
+            checks.append(
+                InvariantResult(
+                    name=f"person:{expectation.apollo_id}",
+                    passed=matches,
+                    detail=(
+                        f"expected fields {dict(expectation.fields)!r}; "
+                        f"got {person!r}"
+                    ),
+                )
+            )
+        expected_people = {item.apollo_id for item in scenario.expected_people}
+        actual_people = set(people_by_apollo)
+        checks.append(
+            InvariantResult(
+                name="people_effect_set",
+                passed=actual_people == expected_people,
+                detail=(
+                    f"expected people={sorted(expected_people)!r}; "
+                    f"actual people={sorted(actual_people)!r}"
+                ),
+            )
+        )
+        workspace_files: list[dict[str, Any]] = []
+        workspace_directories: list[str] = []
+        for path in sorted(environment.workspace_dir.rglob("*")):
+            relative = path.relative_to(environment.workspace_dir).as_posix()
+            if path.is_symlink():
+                workspace_files.append({"path": relative, "kind": "symlink"})
+                continue
+            if path.is_dir():
+                workspace_directories.append(relative)
+                continue
+            if not path.is_file():
+                continue
+            try:
+                content = path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                workspace_files.append({"path": relative, "kind": "binary"})
+            else:
+                workspace_files.append({"path": relative, "content": content})
+        workspace_by_path = {str(item["path"]): item for item in workspace_files}
+        for expectation in scenario.expected_workspace_files:
+            content = workspace_by_path.get(expectation.path, {}).get("content")
+            checks.append(
+                InvariantResult(
+                    name=f"workspace:{expectation.path}",
+                    passed=content == expectation.content,
+                    detail=(
+                        f"expected {expectation.content!r}; got {content!r} at "
+                        f"{expectation.path!r}"
+                    ),
+                )
+            )
+        expected_workspace = {
+            item.path for item in scenario.expected_workspace_files
+        }
+        actual_workspace = set(workspace_by_path)
+        expected_directories = {
+            parent.as_posix()
+            for item in scenario.expected_workspace_files
+            for parent in Path(item.path).parents
+            if parent.as_posix() != "."
+        }
+        actual_directories = set(workspace_directories)
+        checks.append(
+            InvariantResult(
+                name="workspace_effect_set",
+                passed=(
+                    actual_workspace == expected_workspace
+                    and actual_directories == expected_directories
+                ),
+                detail=(
+                    f"expected files={sorted(expected_workspace)!r}; "
+                    f"actual files={sorted(actual_workspace)!r}; "
+                    f"expected directories={sorted(expected_directories)!r}; "
+                    f"actual directories={sorted(actual_directories)!r}"
+                ),
+            )
+        )
+        grant = environment.workspace_runtime.grants.require(
+            str(environment.workspace_grant["id"])
+        )
+        grant_confined = (
+            Path(str(grant["path"])).resolve()
+            == environment.workspace_dir.resolve()
+            and grant.get("access") == "read_write"
+            and grant.get("allow_shell") is False
+        )
+        checks.append(
+            InvariantResult(
+                name="workspace_confinement",
+                passed=grant_confined,
+                detail=f"run-local grant={grant!r}",
+            )
+        )
+        return {
+            "people": people,
+            "workspace_files": workspace_files,
+            "workspace_directories": workspace_directories,
+        }, checks

--- a/desktop/coworker/evals/scenarios.py
+++ b/desktop/coworker/evals/scenarios.py
@@ -1,0 +1,160 @@
+"""Deterministic fake-provider scenarios for the baseline harness."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from coworker.provider import ModelUsage, ToolCall
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderStep:
+    text_deltas: tuple[str, ...] = ()
+    tool_calls: tuple[ToolCall, ...] = ()
+    usage: ModelUsage | None = None
+    estimated_cost_usd: float | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PersonExpectation:
+    apollo_id: str
+    fields: tuple[tuple[str, Any], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceExpectation:
+    path: str
+    content: str
+
+
+@dataclass(frozen=True, slots=True)
+class EvalScenario:
+    scenario_id: str
+    prompt: str
+    provider_steps: tuple[ProviderStep, ...]
+    expected_tool_sequence: tuple[str, ...]
+    expected_terminal_state: str
+    expected_people: tuple[PersonExpectation, ...] = ()
+    expected_workspace_files: tuple[WorkspaceExpectation, ...] = ()
+    forbidden_tools: tuple[str, ...] = ()
+    initial_messages: tuple[dict[str, Any], ...] = ()
+
+
+def _usage(input_tokens: int, output_tokens: int) -> ModelUsage:
+    return ModelUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=input_tokens + output_tokens,
+        cached_input_tokens=0,
+        uncached_input_tokens=input_tokens,
+        reasoning_tokens=0,
+    )
+
+
+def keep_person_scenario() -> EvalScenario:
+    """Keep one curated candidate and prove the person file was persisted."""
+    person = {
+        "apolloId": "eval-alyssa",
+        "firstName": "Alyssa",
+        "lastNameObfuscated": "W***n",
+        "title": "Partner",
+        "organizationName": "Codeology",
+    }
+    return EvalScenario(
+        scenario_id="keep-curated-person",
+        prompt="Keep Alyssa for the Codeology dinner target.",
+        provider_steps=(
+            ProviderStep(
+                tool_calls=(
+                    ToolCall(
+                        id="eval-keep-1",
+                        name="people_keep",
+                        arguments={
+                            "people": [person],
+                            "target": "Codeology dinner",
+                        },
+                    ),
+                ),
+                usage=_usage(12, 3),
+                estimated_cost_usd=0.0000015,
+            ),
+            ProviderStep(
+                text_deltas=("Kept Alyssa in a person file.",),
+                usage=_usage(24, 5),
+                estimated_cost_usd=0.0000029,
+            ),
+        ),
+        expected_tool_sequence=("people_keep",),
+        expected_terminal_state="complete",
+        expected_people=(
+            PersonExpectation(
+                apollo_id="eval-alyssa",
+                fields=(
+                    ("first_name", "Alyssa"),
+                    ("company", "Codeology"),
+                    ("target", "Codeology dinner"),
+                ),
+            ),
+        ),
+        forbidden_tools=("apollo_enrich_contact", "gmail_send"),
+    )
+
+
+def baseline_scenarios() -> tuple[EvalScenario, ...]:
+    return (keep_person_scenario(),)
+
+
+def environment_probe_scenario() -> EvalScenario:
+    return EvalScenario(
+        scenario_id="credential-free-environment",
+        prompt="Inspect the evaluation environment.",
+        provider_steps=(
+            ProviderStep(
+                tool_calls=(
+                    ToolCall(
+                        id="eval-environment-1",
+                        name="mcp__eval__environment_probe",
+                        arguments={},
+                    ),
+                ),
+                usage=_usage(4, 1),
+            ),
+            ProviderStep(text_deltas=("Environment inspected.",), usage=_usage(8, 2)),
+        ),
+        expected_tool_sequence=("mcp__eval__environment_probe",),
+        expected_terminal_state="complete",
+    )
+
+
+def workspace_write_scenario() -> EvalScenario:
+    return EvalScenario(
+        scenario_id="workspace-write-confined",
+        prompt="Write the evaluation note inside the granted workspace.",
+        provider_steps=(
+            ProviderStep(
+                tool_calls=(
+                    ToolCall(
+                        id="eval-workspace-1",
+                        name="fs_write",
+                        arguments={
+                            "grant_id": "$EVAL_WORKSPACE_GRANT",
+                            "path": "notes/eval.txt",
+                            "content": "isolated workspace effect",
+                            "create_parents": True,
+                        },
+                    ),
+                ),
+                usage=_usage(6, 2),
+            ),
+            ProviderStep(text_deltas=("Wrote the isolated note.",), usage=_usage(10, 3)),
+        ),
+        expected_tool_sequence=("fs_write",),
+        expected_terminal_state="complete",
+        expected_workspace_files=(
+            WorkspaceExpectation(
+                path="notes/eval.txt", content="isolated workspace effect"
+            ),
+        ),
+    )

--- a/desktop/coworker/evals/transcript.py
+++ b/desktop/coworker/evals/transcript.py
@@ -1,0 +1,126 @@
+"""Transcript validation and atomic compaction for agent evaluations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _call_ids(message: dict[str, Any], *, index: int) -> tuple[list[str], list[str]]:
+    calls = message.get("tool_calls") or []
+    if not isinstance(calls, list):
+        return [], [f"message {index}: assistant tool_calls must be a list"]
+    ids: list[str] = []
+    issues: list[str] = []
+    for offset, call in enumerate(calls):
+        call_id = str(call.get("id") or "") if isinstance(call, dict) else ""
+        if not call_id:
+            issues.append(f"message {index}: tool call {offset} has no id")
+        elif call_id in ids:
+            issues.append(f"message {index}: duplicate tool call {call_id}")
+        else:
+            ids.append(call_id)
+    return ids, issues
+
+
+def transcript_issues(messages: list[dict[str, Any]]) -> list[str]:
+    """Return assistant/tool adjacency violations in one model transcript."""
+    issues: list[str] = []
+    pending: set[str] | None = None
+    pending_index: int | None = None
+    for index, message in enumerate(messages):
+        role = message.get("role")
+        if pending is not None:
+            if role == "tool":
+                call_id = str(message.get("tool_call_id") or "")
+                if not call_id:
+                    issues.append(f"message {index}: tool result has no tool_call_id")
+                elif call_id not in pending:
+                    issues.append(
+                        f"message {index}: unexpected or duplicate tool result {call_id}"
+                    )
+                else:
+                    pending.remove(call_id)
+                if not pending:
+                    pending = None
+                    pending_index = None
+                continue
+            issues.append(
+                f"message {pending_index}: open tool calls {sorted(pending)!r}"
+            )
+            pending = None
+            pending_index = None
+        if role == "assistant" and message.get("tool_calls"):
+            call_ids, call_issues = _call_ids(message, index=index)
+            issues.extend(call_issues)
+            if call_ids:
+                pending = set(call_ids)
+                pending_index = index
+        elif role == "tool":
+            issues.append(
+                f"message {index}: orphan tool result "
+                f"{str(message.get('tool_call_id') or '<missing>')}"
+            )
+    if pending is not None:
+        issues.append(f"message {pending_index}: open tool calls {sorted(pending)!r}")
+    return issues
+
+
+def _atomic_units(messages: list[dict[str, Any]]) -> list[list[dict[str, Any]]]:
+    """Build valid ordinary messages or closed assistant/tool groups.
+
+    Malformed assistant/tool fragments are omitted as a whole. Compaction can
+    therefore retain a complete unit or drop it, but cannot create an orphan.
+    """
+    units: list[list[dict[str, Any]]] = []
+    index = 0
+    while index < len(messages):
+        message = messages[index]
+        role = message.get("role")
+        if role == "assistant" and message.get("tool_calls"):
+            call_ids, issues = _call_ids(message, index=index)
+            pending = set(call_ids)
+            group = [message]
+            cursor = index + 1
+            valid = not issues and bool(call_ids)
+            while cursor < len(messages) and messages[cursor].get("role") == "tool":
+                tool = messages[cursor]
+                group.append(tool)
+                call_id = str(tool.get("tool_call_id") or "")
+                if not call_id or call_id not in pending:
+                    valid = False
+                else:
+                    pending.remove(call_id)
+                cursor += 1
+            if valid and not pending:
+                units.append(group)
+            index = cursor
+            continue
+        if role != "tool":
+            units.append([message])
+        index += 1
+    return units
+
+
+def compact_transcript(
+    messages: list[dict[str, Any]], *, retain_messages: int
+) -> list[dict[str, Any]]:
+    """Keep a suffix of complete transcript units at or above the target size."""
+    units = _atomic_units(messages)
+    retained: list[list[dict[str, Any]]] = []
+    retained_count = 0
+    for unit in reversed(units):
+        if retained_count >= retain_messages:
+            break
+        retained.insert(0, unit)
+        retained_count += len(unit)
+    flattened = [message for unit in retained for message in unit]
+    omitted = len(messages) - len(flattened)
+    if omitted <= 0:
+        return flattened
+    return [
+        {
+            "role": "user",
+            "content": f"[eval compaction] omitted {omitted} earlier messages",
+        },
+        *flattened,
+    ]

--- a/desktop/coworker/telemetry/schema.py
+++ b/desktop/coworker/telemetry/schema.py
@@ -146,8 +146,8 @@ class CompactionEvent:
     event_type: str = field(init=False, default="compaction")
     operation: str
     reason: CompactionReason
-    input_tokens: int
-    output_tokens: int
+    input_tokens: int | None = None
+    output_tokens: int | None = None
 
     def __post_init__(self) -> None:
         _require_symbol(self.operation, "operation")

--- a/desktop/docs/evaluations.md
+++ b/desktop/docs/evaluations.md
@@ -1,0 +1,34 @@
+# Agent evaluation harness
+
+Status: active-stack engineering reference.
+
+Sourcecado's baseline harness compares prompts, tool catalogs, providers/models, compaction settings, and run-budget policies through the same `run_turn` seam as the desktop sidecar. Every repetition runs in a spawned child process with a replaced minimal environment, a unique state directory and person database, connector fakes, and one exact read-write/no-shell grant for its isolated workspace. The fake lane never reads live credentials.
+
+Run the checked-in fake baseline and candidate from the repository root:
+
+```bash
+make eval
+```
+
+This writes ignored artifacts under `desktop/.eval-artifacts/`. Evaluation artifacts may contain prompts, responses, tool arguments, and tool output. Keep them local, inspect them before sharing, and never commit them.
+
+The artifact root, `runs/`, and every per-run directory use mode `0700`; JSON, JSONL, SQLite, and other generated files use mode `0600`. Sourcecado creates the artifact root when absent, but never chmods a caller-owned existing parent or broad repository/system root: an existing target must already be private. Artifact files are written through a `0600` same-directory temporary file and atomic replacement, and planted symlink targets are refused.
+
+Each run keeps the native conversation and event JSONL, Sourcecado state/person databases, isolated workspace, result contract, and closed typed telemetry. Compaction retains complete assistant/tool groups or drops the whole group, and every provider input is checked for orphan results or open tool calls. Scripted tool calls must belong to the exact variant catalog. All run-local people, workspace files, and workspace directories are enumerated and compared as exact expected sets, so unintended durable effects cannot hide. Deterministic invariants cover transcript integrity, tool catalog and sequence, forbidden actions, persisted person/workspace effects, terminal state, credential-free provider/tool probes, workspace confinement, and telemetry parentage. Infrastructure errors and failed deterministic invariants make the command fail.
+
+The report pairs baseline and candidate by scenario plus repetition. It reports pass-rate lift independently from provider-reported tokens, latency, estimated cost, retries, and compactions. Compaction occurrence is counted, but its input/output token fields remain unknown unless a future declared tokenizer or model-accounting seam measures them; character or byte lengths are never presented as token counts. Optional judge scores are observations only: a low or missing nondeterministic score does not turn a deterministic run into a failure.
+
+## Variant controls
+
+`EvalVariant` owns stable names plus the prompt version/text, exact active tool catalog, provider/model identity, compaction policy, and run-budget policy. Add fixed fake-provider scenarios in `coworker/evals/scenarios.py` and assert durable effects rather than prose alone.
+
+## Live runs
+
+Live execution is never part of `make eval`. It requires an explicit flag and an eligible provider configured in the normal Sourcecado environment:
+
+```bash
+cd desktop
+.venv/bin/python -m coworker.evals --live --repetitions 1
+```
+
+The parent resolves the provider only after `--live`; the run itself receives that provider in an isolated child with no credential variables exposed to the model or tools. Live results record the actual provider, model, prompt version, and `nondeterministic: true`. They never substitute for fake-provider CI contracts or become deterministic gates because a judge happens to return a high score.

--- a/desktop/tests/test_evals.py
+++ b/desktop/tests/test_evals.py
@@ -1,0 +1,1229 @@
+from pathlib import Path
+
+import pytest
+
+
+def test_eval_package_exists():
+    package = Path(__file__).parents[1] / "coworker" / "evals" / "__init__.py"
+
+    assert package.is_file()
+
+
+def test_variant_controls_prompt_tools_provider_compaction_and_budget():
+    from coworker.evals.models import CompactionPolicy, EvalVariant, RunBudget
+
+    variant = EvalVariant(
+        name="candidate-tools-v2",
+        prompt_version="sourcing-v2",
+        system_prompt="Never invent the target.",
+        tool_catalog=("people_keep", "gmail_search"),
+        provider="fake",
+        model="scenario-v2",
+        compaction=CompactionPolicy(
+            enabled=True,
+            threshold_messages=4,
+            retain_messages=2,
+        ),
+        run_budget=RunBudget(max_provider_calls=5, max_total_tokens=1_000),
+    )
+
+    assert variant.name == "candidate-tools-v2"
+    assert variant.prompt_version == "sourcing-v2"
+    assert variant.tool_catalog == ("people_keep", "gmail_search")
+    assert variant.provider == "fake"
+    assert variant.model == "scenario-v2"
+    assert variant.compaction.retain_messages == 2
+    assert variant.run_budget.max_provider_calls == 5
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("name", ""),
+        ("prompt_version", ""),
+        ("provider", ""),
+        ("model", ""),
+    ],
+)
+def test_variant_rejects_missing_stable_identifiers(field, value):
+    from coworker.evals.models import EvalVariant
+
+    values = {
+        "name": "baseline",
+        "prompt_version": "sourcing-v1",
+        "system_prompt": "Be useful.",
+        "tool_catalog": (),
+        "provider": "fake",
+        "model": "scenario-v1",
+    }
+    values[field] = value
+
+    with pytest.raises(ValueError, match=field):
+        EvalVariant(**values)
+
+
+def test_each_environment_has_unique_credential_free_state_and_connector_fakes(
+    tmp_path,
+):
+    from coworker.evals.environment import EvalEnvironment
+
+    first = EvalEnvironment.create(tmp_path, label="same")
+    second = EvalEnvironment.create(tmp_path, label="same")
+    try:
+        assert first.root != second.root
+        assert first.state_dir != second.state_dir
+        assert first.workspace_dir != second.workspace_dir
+        assert first.home_dir != second.home_dir
+        assert first.store.db_path != second.store.db_path
+        assert first.people.db_path != second.people.db_path
+        assert first.connectors is not second.connectors
+        assert first.connectors.gmail is not second.connectors.gmail
+        assert first.connectors.http is not second.connectors.http
+        assert first.credential_environment["CLUB_STATE_DIR"] == str(first.state_dir)
+        assert first.credential_environment["HOME"] == str(first.home_dir)
+        assert not any(
+            "KEY" in name or "TOKEN" in name or "SECRET" in name
+            for name in first.credential_environment
+        )
+        assert first.workspace_grant["path"] == str(first.workspace_dir.resolve())
+        assert first.workspace_grant["access"] == "read_write"
+        assert first.workspace_grant["allow_shell"] is False
+        assert first.workspace_runtime.grants.list_active() == [first.workspace_grant]
+        assert first.state_dir.is_dir()
+        assert first.workspace_dir.is_dir()
+        assert first.home_dir.is_dir()
+    finally:
+        first.close()
+        second.close()
+
+
+def test_run_local_workspace_grant_allows_effects_and_rejects_escape(tmp_path):
+    from coworker.evals.environment import EvalEnvironment
+
+    environment = EvalEnvironment.create(tmp_path, label="workspace")
+    outside = environment.root / "outside.txt"
+    outside.write_text("host sentinel")
+    try:
+        ok, created = environment.workspace_runtime.execute_tool(
+            "fs_write",
+            {
+                "grant_id": environment.workspace_grant["id"],
+                "path": "notes/eval.txt",
+                "content": "inside only",
+                "create_parents": True,
+            },
+            actor="assistant",
+            session_id="eval-workspace",
+            run_id="run-workspace",
+        )
+        escaped, escape_result = environment.workspace_runtime.execute_tool(
+            "fs_read",
+            {
+                "grant_id": environment.workspace_grant["id"],
+                "path": "../outside.txt",
+            },
+            actor="assistant",
+            session_id="eval-workspace",
+            run_id="run-workspace",
+        )
+        absolute, absolute_result = environment.workspace_runtime.execute_tool(
+            "fs_read",
+            {
+                "grant_id": environment.workspace_grant["id"],
+                "path": str(outside.resolve()),
+            },
+            actor="assistant",
+            session_id="eval-workspace",
+            run_id="run-workspace",
+        )
+
+        assert ok, created
+        assert (environment.workspace_dir / "notes" / "eval.txt").read_text() == (
+            "inside only"
+        )
+        assert not escaped
+        assert "escape" in str(escape_result).lower() or "outside" in str(
+            escape_result
+        ).lower()
+        assert not absolute
+        assert "relative" in str(absolute_result).lower()
+        assert outside.read_text() == "host sentinel"
+    finally:
+        environment.close()
+
+
+def test_fake_scenario_asserts_native_artifacts_effects_terminal_and_telemetry(
+    tmp_path,
+):
+    from coworker.evals.models import EvalVariant
+    from coworker.evals.runner import EvalRunner
+    from coworker.evals.scenarios import keep_person_scenario
+
+    result = EvalRunner(tmp_path).run_fake(
+        keep_person_scenario(),
+        EvalVariant(
+            name="baseline",
+            prompt_version="sourcing-v1",
+            system_prompt="Keep only the people the director names.",
+            tool_catalog=("people_keep",),
+            provider="fake",
+            model="sourcecado-scenario-v1",
+        ),
+        repetition=1,
+    )
+
+    assert result.passed
+    assert result.execution_mode == "fake"
+    assert result.nondeterministic is False
+    assert result.tool_sequence == ("people_keep",)
+    assert result.terminal_state == "complete"
+    assert result.persisted_effects["people"][0]["first_name"] == "Alyssa"
+    assert result.session_artifact["session"]["session_id"] == result.session_id
+    assert [row["role"] for row in result.session_artifact["messages"]] == [
+        "user",
+        "assistant",
+        "tool",
+        "assistant",
+    ]
+    assert {row["record_type"] for row in result.telemetry} == {
+        "span_started",
+        "span_event",
+        "span_settled",
+    }
+    assert result.measurements.total_tokens == 44
+    assert result.measurements.estimated_cost_usd == pytest.approx(0.0000044)
+    assert result.measurements.retry_count == 0
+    assert result.measurements.compaction_count == 0
+    assert Path(result.artifacts.conversation_jsonl).is_file()
+    assert Path(result.artifacts.events_jsonl).is_file()
+    assert Path(result.artifacts.telemetry_jsonl).is_file()
+    assert Path(result.artifacts.result_json).is_file()
+
+
+def test_invariant_violation_is_a_hard_deterministic_failure(tmp_path):
+    from dataclasses import replace
+
+    from coworker.evals.models import EvalVariant
+    from coworker.evals.runner import EvalRunner
+    from coworker.evals.scenarios import keep_person_scenario
+
+    scenario = replace(
+        keep_person_scenario(),
+        expected_tool_sequence=("people_keep", "gmail_search"),
+    )
+    result = EvalRunner(tmp_path).run_fake(
+        scenario,
+        EvalVariant(
+            name="broken-candidate",
+            prompt_version="sourcing-v1",
+            system_prompt="Keep people.",
+            tool_catalog=("people_keep", "gmail_search"),
+            provider="fake",
+            model="sourcecado-scenario-v1",
+        ),
+        repetition=1,
+    )
+
+    assert not result.passed
+    failures = [item for item in result.invariants if not item.passed]
+    assert [(item.name, item.kind) for item in failures] == [
+        ("tool_sequence", "deterministic")
+    ]
+    assert "gmail_search" in failures[0].detail
+    assert result.infrastructure_error is None
+
+
+def test_compaction_and_budget_policy_are_applied_and_reported(tmp_path):
+    from dataclasses import replace
+
+    from coworker.evals.models import CompactionPolicy, EvalVariant, RunBudget
+    from coworker.evals.runner import EvalRunner
+    from coworker.evals.scenarios import keep_person_scenario
+
+    scenario = replace(
+        keep_person_scenario(),
+        initial_messages=tuple(
+            {"role": "user", "content": f"prior {index}"} for index in range(5)
+        ),
+    )
+    result = EvalRunner(tmp_path).run_fake(
+        scenario,
+        EvalVariant(
+            name="compact",
+            prompt_version="sourcing-v2",
+            system_prompt="Compact deliberately.",
+            tool_catalog=("people_keep",),
+            provider="fake",
+            model="sourcecado-scenario-v2",
+            compaction=CompactionPolicy(
+                enabled=True,
+                threshold_messages=4,
+                retain_messages=2,
+            ),
+            run_budget=RunBudget(max_provider_calls=2, max_total_tokens=100),
+        ),
+        repetition=2,
+    )
+
+    assert result.passed
+    assert result.measurements.compaction_count == 1
+    assert result.provider_calls == 2
+    assert result.variant["run_budget"] == {
+        "max_provider_calls": 2,
+        "max_total_tokens": 100,
+    }
+    assert result.variant["compaction"]["enabled"] is True
+    assert result.session_artifact["messages"][0]["content"].startswith(
+        "[eval compaction]"
+    )
+    compaction = next(
+        record["event"]
+        for record in result.telemetry
+        if record["record_type"] == "span_event"
+        and record["event"]["event_type"] == "compaction"
+    )
+    assert compaction["input_tokens"] is None
+    assert compaction["output_tokens"] is None
+
+
+def test_multibyte_compaction_does_not_report_character_lengths_as_tokens(tmp_path):
+    from dataclasses import replace
+
+    from coworker.evals.models import CompactionPolicy, EvalVariant
+    from coworker.evals.runner import EvalRunner
+    from coworker.evals.scenarios import keep_person_scenario
+
+    content = "你好🥑"
+    scenario = replace(
+        keep_person_scenario(),
+        initial_messages=tuple(
+            {"role": "user", "content": content} for _ in range(3)
+        ),
+    )
+    result = EvalRunner(tmp_path).run_fake(
+        scenario,
+        EvalVariant(
+            name="multibyte-compaction",
+            prompt_version="v1",
+            system_prompt="Do not invent token counts.",
+            tool_catalog=("people_keep",),
+            provider="fake",
+            model="scenario-v1",
+            compaction=CompactionPolicy(
+                enabled=True,
+                threshold_messages=3,
+                retain_messages=1,
+            ),
+        ),
+        repetition=1,
+    )
+
+    compaction = next(
+        record["event"]
+        for record in result.telemetry
+        if record["record_type"] == "span_event"
+        and record["event"]["event_type"] == "compaction"
+    )
+    assert compaction["input_tokens"] is None
+    assert compaction["output_tokens"] is None
+    assert compaction["input_tokens"] != len(content) * 3
+
+
+def test_compaction_retains_a_complete_assistant_tool_group_atomically(tmp_path):
+    from dataclasses import replace
+
+    from coworker.evals.models import CompactionPolicy, EvalVariant
+    from coworker.evals.runner import EvalRunner
+    from coworker.evals.scenarios import keep_person_scenario
+
+    assistant = {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": "prior-c1",
+                "type": "function",
+                "function": {"name": "now", "arguments": "{}"},
+            }
+        ],
+    }
+    tool = {
+        "role": "tool",
+        "name": "now",
+        "tool_call_id": "prior-c1",
+        "content": '{"iso":"earlier"}',
+    }
+    scenario = replace(
+        keep_person_scenario(),
+        initial_messages=(
+            {"role": "user", "content": "Earlier request"},
+            assistant,
+            tool,
+        ),
+    )
+    result = EvalRunner(tmp_path).run_fake(
+        scenario,
+        EvalVariant(
+            name="atomic-compaction",
+            prompt_version="v1",
+            system_prompt="Keep complete tool groups.",
+            tool_catalog=("people_keep",),
+            provider="fake",
+            model="scenario-v1",
+            compaction=CompactionPolicy(
+                enabled=True,
+                threshold_messages=3,
+                retain_messages=1,
+            ),
+        ),
+        repetition=1,
+    )
+
+    compacted = result.session_artifact["messages"][:3]
+    assert [message["role"] for message in compacted] == [
+        "user",
+        "assistant",
+        "tool",
+    ]
+    assert compacted[1]["tool_calls"][0]["id"] == "prior-c1"
+    assert compacted[2]["tool_call_id"] == "prior-c1"
+    transcript = next(
+        item for item in result.invariants if item.name == "transcript_integrity"
+    )
+    assert transcript.passed
+    assert result.passed
+
+
+def test_compaction_drops_an_incomplete_open_tool_group(tmp_path):
+    from dataclasses import replace
+
+    from coworker.evals.models import CompactionPolicy, EvalVariant
+    from coworker.evals.runner import EvalRunner
+    from coworker.evals.scenarios import keep_person_scenario
+
+    scenario = replace(
+        keep_person_scenario(),
+        initial_messages=(
+            {"role": "user", "content": "Earlier request"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "open-c1",
+                        "type": "function",
+                        "function": {"name": "now", "arguments": "{}"},
+                    }
+                ],
+            },
+        ),
+    )
+    result = EvalRunner(tmp_path).run_fake(
+        scenario,
+        EvalVariant(
+            name="drop-open-compaction",
+            prompt_version="v1",
+            system_prompt="Drop incomplete tool groups.",
+            tool_catalog=("people_keep",),
+            provider="fake",
+            model="scenario-v1",
+            compaction=CompactionPolicy(
+                enabled=True,
+                threshold_messages=2,
+                retain_messages=1,
+            ),
+        ),
+        repetition=1,
+    )
+
+    messages = result.session_artifact["messages"]
+    assert not any(
+        call.get("id") == "open-c1"
+        for message in messages
+        for call in message.get("tool_calls") or []
+    )
+    assert not any(message.get("tool_call_id") == "open-c1" for message in messages)
+    assert next(
+        item for item in result.invariants if item.name == "transcript_integrity"
+    ).passed
+
+
+def test_fake_provider_rejects_an_orphan_tool_result_transcript(tmp_path):
+    from dataclasses import replace
+
+    from coworker.evals.models import EvalVariant
+    from coworker.evals.runner import EvalRunner
+    from coworker.evals.scenarios import keep_person_scenario
+
+    scenario = replace(
+        keep_person_scenario(),
+        initial_messages=(
+            {
+                "role": "tool",
+                "name": "now",
+                "tool_call_id": "orphan-c1",
+                "content": "{}",
+            },
+        ),
+    )
+    result = EvalRunner(tmp_path).run_fake(
+        scenario,
+        EvalVariant(
+            name="orphan-transcript",
+            prompt_version="v1",
+            system_prompt="Reject malformed transcripts.",
+            tool_catalog=("people_keep",),
+            provider="fake",
+            model="scenario-v1",
+        ),
+        repetition=1,
+    )
+
+    transcript = next(
+        item for item in result.invariants if item.name == "transcript_integrity"
+    )
+    assert not transcript.passed
+    assert "orphan" in transcript.detail
+    assert not result.passed
+
+
+def test_unknown_tool_catalog_fails_before_running(tmp_path):
+    from coworker.evals.models import EvalVariant
+    from coworker.evals.runner import EvalRunner
+    from coworker.evals.scenarios import keep_person_scenario
+
+    with pytest.raises(ValueError, match="unknown eval tool"):
+        EvalRunner(tmp_path).run_fake(
+            keep_person_scenario(),
+            EvalVariant(
+                name="unknown-tool",
+                prompt_version="sourcing-v1",
+                system_prompt="",
+                tool_catalog=("invented_tool",),
+                provider="fake",
+                model="sourcecado-scenario-v1",
+            ),
+            repetition=1,
+        )
+
+
+def test_scripted_tool_outside_active_catalog_fails_before_execution(tmp_path):
+    from coworker.evals.models import EvalVariant
+    from coworker.evals.runner import EvalRunner
+    from coworker.evals.scenarios import EvalScenario, ProviderStep
+    from coworker.provider import ToolCall
+
+    scenario = EvalScenario(
+        scenario_id="catalog-enforcement",
+        prompt="What time is it?",
+        provider_steps=(
+            ProviderStep(
+                tool_calls=(ToolCall(id="catalog-c1", name="now", arguments={}),)
+            ),
+        ),
+        expected_tool_sequence=(),
+        expected_terminal_state="failed",
+    )
+    result = EvalRunner(tmp_path).run_fake(
+        scenario,
+        EvalVariant(
+            name="empty-catalog",
+            prompt_version="v1",
+            system_prompt="No tools are available.",
+            tool_catalog=(),
+            provider="fake",
+            model="scenario-v1",
+        ),
+        repetition=1,
+    )
+
+    assert result.tool_sequence == ()
+    catalog = next(item for item in result.invariants if item.name == "tool_catalog")
+    assert not catalog.passed
+    assert "now" in catalog.detail
+    assert result.infrastructure_error is None
+    assert not result.passed
+
+
+def test_comparison_pairs_repetitions_and_keeps_efficiency_metrics_separate(
+    tmp_path,
+):
+    from dataclasses import replace
+
+    from coworker.evals.compare import compare_runs
+    from coworker.evals.models import EvalVariant
+    from coworker.evals.runner import EvalRunner
+    from coworker.evals.scenarios import keep_person_scenario
+
+    runner = EvalRunner(tmp_path)
+    scenario = keep_person_scenario()
+    baseline = EvalVariant(
+        name="baseline",
+        prompt_version="sourcing-v1",
+        system_prompt="Keep people.",
+        tool_catalog=("people_keep",),
+        provider="fake",
+        model="sourcecado-scenario-v1",
+    )
+    candidate = replace(
+        baseline,
+        name="candidate",
+        prompt_version="sourcing-v2",
+        system_prompt="Keep only named people.",
+    )
+    runs = [
+        runner.run_fake(scenario, baseline, repetition=1),
+        runner.run_fake(scenario, candidate, repetition=1),
+        runner.run_fake(scenario, baseline, repetition=2),
+        runner.run_fake(
+            replace(
+                scenario,
+                expected_tool_sequence=("people_keep", "gmail_search"),
+            ),
+            candidate,
+            repetition=2,
+        ),
+    ]
+
+    report = compare_runs(
+        runs,
+        baseline_name="baseline",
+        candidate_names=("candidate",),
+    )
+
+    comparison = report.comparisons[0]
+    assert (comparison.baseline, comparison.candidate) == (
+        "baseline",
+        "candidate",
+    )
+    assert comparison.correctness.total_pairs == 2
+    assert comparison.correctness.eligible_pairs == 2
+    assert comparison.correctness.baseline_pass_rate == 1.0
+    assert comparison.correctness.candidate_pass_rate == 0.5
+    assert comparison.correctness.pass_rate_lift == -0.5
+    assert comparison.tokens.eligible_pairs == 2
+    assert comparison.latency_ms.eligible_pairs == 2
+    assert comparison.estimated_cost_usd.eligible_pairs == 2
+    assert comparison.retries.eligible_pairs == 2
+    assert comparison.compactions.eligible_pairs == 2
+    assert report.diagnostics == ()
+
+
+def test_low_nondeterministic_judge_score_is_observational_not_a_gate(tmp_path):
+    from dataclasses import replace
+
+    from coworker.evals.compare import compare_runs
+    from coworker.evals.models import EvalVariant, JudgeObservation
+    from coworker.evals.runner import EvalRunner
+    from coworker.evals.scenarios import keep_person_scenario
+
+    runner = EvalRunner(tmp_path)
+    baseline = EvalVariant(
+        name="baseline",
+        prompt_version="sourcing-v1",
+        system_prompt="Keep people.",
+        tool_catalog=("people_keep",),
+        provider="fake",
+        model="sourcecado-scenario-v1",
+    )
+    candidate = replace(baseline, name="candidate", prompt_version="sourcing-v2")
+    baseline_run = runner.run_fake(
+        keep_person_scenario(),
+        baseline,
+        repetition=1,
+        judge=JudgeObservation(judge="style-v1", score=0.9),
+    )
+    candidate_run = runner.run_fake(
+        keep_person_scenario(),
+        candidate,
+        repetition=1,
+        judge=JudgeObservation(
+            judge="style-v1",
+            score=0.1,
+            rationale="Too generic.",
+        ),
+    )
+
+    report = compare_runs(
+        [baseline_run, candidate_run],
+        baseline_name="baseline",
+        candidate_names=("candidate",),
+    )
+
+    assert candidate_run.passed
+    assert report.comparisons[0].correctness.candidate_pass_rate == 1.0
+    assert report.comparisons[0].judge_scores.observational is True
+    assert report.comparisons[0].judge_scores.candidate_mean == 0.1
+    assert report.comparisons[0].judge_scores.mean_delta == pytest.approx(-0.8)
+
+
+@pytest.mark.parametrize("score", [float("nan"), float("inf"), float("-inf"), -0.1, 1.1])
+def test_judge_observation_requires_a_finite_unit_score(score):
+    from coworker.evals.models import JudgeObservation
+
+    with pytest.raises(ValueError, match="finite.*0.*1"):
+        JudgeObservation(judge="style-v1", score=score)
+
+
+def test_comparison_excludes_mismatched_judge_contracts_with_diagnostic(tmp_path):
+    from dataclasses import replace
+
+    from coworker.evals.compare import compare_runs
+    from coworker.evals.models import EvalVariant, JudgeObservation
+    from coworker.evals.runner import EvalRunner
+    from coworker.evals.scenarios import keep_person_scenario
+
+    runner = EvalRunner(tmp_path)
+    baseline = EvalVariant(
+        name="baseline",
+        prompt_version="v1",
+        system_prompt="Keep people.",
+        tool_catalog=("people_keep",),
+        provider="fake",
+        model="scenario-v1",
+    )
+    candidate = replace(baseline, name="candidate", prompt_version="v2")
+    left = runner.run_fake(
+        keep_person_scenario(),
+        baseline,
+        repetition=1,
+        judge=JudgeObservation(judge="style-v1", score=0.9),
+    )
+    right = runner.run_fake(
+        keep_person_scenario(),
+        candidate,
+        repetition=1,
+        judge=JudgeObservation(judge="unrelated-v9", score=0.1),
+    )
+
+    report = compare_runs(
+        [left, right],
+        baseline_name="baseline",
+        candidate_names=("candidate",),
+    )
+
+    assert report.comparisons[0].correctness.eligible_pairs == 1
+    assert report.comparisons[0].judge_scores.eligible_pairs == 0
+    assert report.comparisons[0].judge_scores.mean_delta is None
+    assert report.diagnostics == (
+        report.diagnostics[0],
+    )
+    assert report.diagnostics[0].reason == "judge-contract-mismatch"
+
+
+def test_live_run_requires_opt_in_and_records_nondeterministic_identity(tmp_path):
+    from coworker.evals.models import EvalVariant
+    from coworker.evals.runner import (
+        EvalRunner,
+        LiveRunNotAuthorized,
+        ScenarioProvider,
+    )
+    from coworker.evals.scenarios import keep_person_scenario
+
+    scenario = keep_person_scenario()
+    variant = EvalVariant(
+        name="live-candidate",
+        prompt_version="sourcing-live-v3",
+        system_prompt="Keep the named person.",
+        tool_catalog=("people_keep",),
+        provider="live-test-provider",
+        model="live-test-model",
+    )
+    provider = ScenarioProvider(variant=variant, steps=scenario.provider_steps)
+    runner = EvalRunner(tmp_path)
+
+    with pytest.raises(LiveRunNotAuthorized, match="explicit opt-in"):
+        runner.run_live(
+            scenario,
+            variant,
+            provider=provider,
+            repetition=1,
+            opt_in=False,
+        )
+
+    result = runner.run_live(
+        scenario,
+        variant,
+        provider=provider,
+        repetition=1,
+        opt_in=True,
+    )
+
+    assert result.passed
+    assert result.execution_mode == "live"
+    assert result.nondeterministic is True
+    assert result.provider == "live-test-provider"
+    assert result.model == "live-test-model"
+    assert result.prompt_version == "sourcing-live-v3"
+
+
+def test_spawned_run_hides_host_secrets_from_provider_and_tool_probes(
+    tmp_path, monkeypatch
+):
+    from coworker.evals.models import EvalVariant
+    from coworker.evals.runner import EvalRunner
+    from coworker.evals.scenarios import environment_probe_scenario
+
+    monkeypatch.setenv("OPENAI_API_KEY", "planted-host-key")
+    monkeypatch.setenv("SESSION_TOKEN", "planted-host-token")
+    variant = EvalVariant(
+        name="credential-probe",
+        prompt_version="probe-v1",
+        system_prompt="Run the environment probe.",
+        tool_catalog=("mcp__eval__environment_probe",),
+        provider="fake",
+        model="sourcecado-probe-v1",
+    )
+
+    result = EvalRunner(tmp_path).run_fake(
+        environment_probe_scenario(), variant, repetition=1
+    )
+
+    assert result.passed
+    assert result.execution_environment["provider_sensitive_keys"] == []
+    assert result.execution_environment["tool_sensitive_keys"] == []
+    assert "OPENAI_API_KEY" not in result.execution_environment["applied"]
+    assert "SESSION_TOKEN" not in result.execution_environment["applied"]
+    assert result.execution_environment["process_isolated"] is True
+    assert result.execution_environment["workspace_grant"]["path"] == (
+        result.artifacts.workspace_dir
+    )
+    assert result.execution_environment["workspace_grant"]["allow_shell"] is False
+
+
+def test_workspace_scenario_writes_only_through_run_local_grant(tmp_path):
+    from coworker.evals.models import EvalVariant
+    from coworker.evals.runner import EvalRunner
+    from coworker.evals.scenarios import workspace_write_scenario
+
+    result = EvalRunner(tmp_path).run_fake(
+        workspace_write_scenario(),
+        EvalVariant(
+            name="workspace",
+            prompt_version="workspace-v1",
+            system_prompt="Write only inside the granted workspace.",
+            tool_catalog=("fs_write",),
+            provider="fake",
+            model="sourcecado-workspace-v1",
+        ),
+        repetition=1,
+    )
+
+    assert result.passed
+    assert result.tool_sequence == ("fs_write",)
+    assert result.persisted_effects["workspace_files"] == [
+        {"path": "notes/eval.txt", "content": "isolated workspace effect"}
+    ]
+    assert Path(result.artifacts.workspace_dir, "notes", "eval.txt").read_text() == (
+        "isolated workspace effect"
+    )
+
+
+def test_unexpected_extra_person_is_enumerated_and_fails_exact_effect_set(tmp_path):
+    from dataclasses import replace
+
+    from coworker.evals.models import EvalVariant
+    from coworker.evals.runner import EvalRunner
+    from coworker.evals.scenarios import keep_person_scenario
+    from coworker.provider import ToolCall
+
+    scenario = keep_person_scenario()
+    original_call = scenario.provider_steps[0].tool_calls[0]
+    extra = {
+        "apolloId": "eval-invented",
+        "firstName": "Invented",
+        "lastNameObfuscated": "P***n",
+        "title": "Unknown",
+        "organizationName": "Outside scope",
+    }
+    first_step = replace(
+        scenario.provider_steps[0],
+        tool_calls=(
+            ToolCall(
+                id=original_call.id,
+                name=original_call.name,
+                arguments={
+                    **original_call.arguments,
+                    "people": [*original_call.arguments["people"], extra],
+                },
+            ),
+        ),
+    )
+    result = EvalRunner(tmp_path).run_fake(
+        replace(
+            scenario,
+            provider_steps=(first_step, *scenario.provider_steps[1:]),
+        ),
+        EvalVariant(
+            name="extra-person",
+            prompt_version="v1",
+            system_prompt="Keep only Alyssa.",
+            tool_catalog=("people_keep",),
+            provider="fake",
+            model="scenario-v1",
+        ),
+        repetition=1,
+    )
+
+    assert {person["apollo_id"] for person in result.persisted_effects["people"]} == {
+        "eval-alyssa",
+        "eval-invented",
+    }
+    effect_set = next(
+        item for item in result.invariants if item.name == "people_effect_set"
+    )
+    assert not effect_set.passed
+    assert "eval-invented" in effect_set.detail
+    assert not result.passed
+
+
+def test_unexpected_workspace_file_is_enumerated_and_fails_exact_effect_set(
+    tmp_path,
+):
+    from dataclasses import replace
+
+    from coworker.evals.models import EvalVariant
+    from coworker.evals.runner import EvalRunner
+    from coworker.evals.scenarios import workspace_write_scenario
+    from coworker.provider import ToolCall
+
+    scenario = workspace_write_scenario()
+    expected_call = scenario.provider_steps[0].tool_calls[0]
+    extra_call = ToolCall(
+        id="eval-workspace-extra",
+        name="fs_write",
+        arguments={
+            "grant_id": "$EVAL_WORKSPACE_GRANT",
+            "path": "extra/unexpected.txt",
+            "content": "unintended effect",
+            "create_parents": True,
+        },
+    )
+    first_step = replace(
+        scenario.provider_steps[0],
+        tool_calls=(expected_call, extra_call),
+    )
+    result = EvalRunner(tmp_path).run_fake(
+        replace(
+            scenario,
+            provider_steps=(first_step, *scenario.provider_steps[1:]),
+            expected_tool_sequence=("fs_write", "fs_write"),
+        ),
+        EvalVariant(
+            name="extra-workspace-effect",
+            prompt_version="v1",
+            system_prompt="Write only the requested note.",
+            tool_catalog=("fs_write",),
+            provider="fake",
+            model="scenario-v1",
+        ),
+        repetition=1,
+    )
+
+    assert {item["path"] for item in result.persisted_effects["workspace_files"]} == {
+        "notes/eval.txt",
+        "extra/unexpected.txt",
+    }
+    effect_set = next(
+        item for item in result.invariants if item.name == "workspace_effect_set"
+    )
+    assert not effect_set.passed
+    assert "extra/unexpected.txt" in effect_set.detail
+    assert not result.passed
+
+
+def test_concurrent_repetitions_use_distinct_isolated_child_processes(tmp_path):
+    from concurrent.futures import ThreadPoolExecutor
+
+    from coworker.evals.models import EvalVariant
+    from coworker.evals.runner import EvalRunner
+    from coworker.evals.scenarios import keep_person_scenario
+
+    variant = EvalVariant(
+        name="parallel",
+        prompt_version="parallel-v1",
+        system_prompt="Keep the named person.",
+        tool_catalog=("people_keep",),
+        provider="fake",
+        model="sourcecado-parallel-v1",
+    )
+
+    def run(repetition: int):
+        return EvalRunner(tmp_path).run_fake(
+            keep_person_scenario(), variant, repetition=repetition
+        )
+
+    with ThreadPoolExecutor(max_workers=3) as pool:
+        results = list(pool.map(run, (1, 2, 3)))
+
+    assert all(result.passed for result in results)
+    assert len({result.artifacts.root for result in results}) == 3
+    assert len(
+        {result.execution_environment["child_pid"] for result in results}
+    ) == 3
+    assert all(
+        result.execution_environment["process_isolated"] for result in results
+    )
+
+
+def test_provider_failure_is_infrastructure_and_excluded_from_paired_lift(tmp_path):
+    from dataclasses import replace
+
+    from coworker.evals.compare import compare_runs
+    from coworker.evals.models import EvalVariant
+    from coworker.evals.runner import EvalRunner
+    from coworker.evals.scenarios import keep_person_scenario
+
+    runner = EvalRunner(tmp_path)
+    baseline = EvalVariant(
+        name="baseline",
+        prompt_version="v1",
+        system_prompt="Keep the person.",
+        tool_catalog=("people_keep",),
+        provider="fake",
+        model="scenario-v1",
+    )
+    candidate = replace(baseline, name="candidate", prompt_version="v2")
+    scenario = keep_person_scenario()
+    failed_scenario = replace(
+        scenario,
+        provider_steps=(
+            replace(scenario.provider_steps[0], error="provider unavailable"),
+            *scenario.provider_steps[1:],
+        ),
+    )
+    good = runner.run_fake(scenario, baseline, repetition=1)
+    failed = runner.run_fake(failed_scenario, candidate, repetition=1)
+
+    report = compare_runs(
+        [good, failed],
+        baseline_name="baseline",
+        candidate_names=("candidate",),
+    )
+
+    assert failed.infrastructure_error == "agent run ended with infrastructure error"
+    assert not failed.passed
+    assert report.comparisons[0].correctness.total_pairs == 1
+    assert report.comparisons[0].correctness.eligible_pairs == 0
+    assert report.diagnostics == (
+        report.diagnostics[0],
+    )
+    assert report.diagnostics[0].reason == "infrastructure-error"
+
+
+def test_provider_failure_artifacts_do_not_capture_raw_secret_bearing_errors(tmp_path):
+    from dataclasses import replace
+
+    from coworker.evals.models import EvalVariant
+    from coworker.evals.runner import EvalRunner
+    from coworker.evals.scenarios import keep_person_scenario
+
+    scenario = keep_person_scenario()
+    failed = replace(
+        scenario,
+        provider_steps=(
+            replace(
+                scenario.provider_steps[0],
+                error="provider leaked sk-live-PLANTED-EVAL-SECRET",
+            ),
+            *scenario.provider_steps[1:],
+        ),
+    )
+    result = EvalRunner(tmp_path).run_fake(
+        failed,
+        EvalVariant(
+            name="safe-error",
+            prompt_version="v1",
+            system_prompt="Keep the person.",
+            tool_catalog=("people_keep",),
+            provider="fake",
+            model="scenario-v1",
+        ),
+        repetition=1,
+    )
+
+    assert "PLANTED-EVAL-SECRET" not in Path(result.artifacts.result_json).read_text()
+    assert "PLANTED-EVAL-SECRET" not in Path(result.artifacts.events_jsonl).read_text()
+
+
+def test_run_budget_wraps_an_arbitrary_provider_at_the_execution_boundary(tmp_path):
+    from coworker.evals.models import EvalVariant, RunBudget
+    from coworker.evals.runner import EvalRunner
+    from coworker.evals.scenarios import keep_person_scenario
+    from coworker.provider import FakeProvider
+
+    scenario = keep_person_scenario()
+    provider = FakeProvider(
+        steps=[
+            {"tool_calls": list(scenario.provider_steps[0].tool_calls)},
+            {"deltas": ("Finished without respecting the budget.",)},
+        ]
+    )
+    variant = EvalVariant(
+        name="arbitrary-provider",
+        prompt_version="budget-v1",
+        system_prompt="Keep the named person.",
+        tool_catalog=("people_keep",),
+        provider="fake",
+        model="fake",
+        run_budget=RunBudget(max_provider_calls=1),
+    )
+
+    result = EvalRunner(tmp_path)._run_local(
+        scenario,
+        variant,
+        repetition=1,
+        provider=provider,
+        execution_mode="live",
+        nondeterministic=True,
+        judge=None,
+        process_isolated=False,
+    )
+
+    run_budget = [item for item in result.invariants if item.name == "run_budget"]
+    assert len(run_budget) == 1
+    assert not run_budget[0].passed
+    assert "provider calls 2 exceed budget 1" in run_budget[0].detail
+    assert result.provider_calls == 2
+    assert result.infrastructure_error is None
+
+
+def test_live_provider_token_budget_fails_as_deterministic_policy(tmp_path):
+    from coworker.evals.models import EvalVariant, RunBudget
+    from coworker.evals.runner import EvalRunner
+    from coworker.evals.scenarios import keep_person_scenario
+    from coworker.provider import FakeProvider
+
+    scenario = keep_person_scenario()
+    provider = FakeProvider(
+        steps=[
+            {
+                "tool_calls": list(scenario.provider_steps[0].tool_calls),
+                "usage": scenario.provider_steps[0].usage,
+            }
+        ]
+    )
+    variant = EvalVariant(
+        name="live-budget",
+        prompt_version="budget-v1",
+        system_prompt="Keep the named person.",
+        tool_catalog=("people_keep",),
+        provider="fake",
+        model="fake",
+        run_budget=RunBudget(max_provider_calls=8, max_total_tokens=1),
+    )
+
+    result = EvalRunner(tmp_path).run_live(
+        scenario,
+        variant,
+        provider=provider,
+        repetition=1,
+        opt_in=True,
+    )
+
+    run_budget = [item for item in result.invariants if item.name == "run_budget"]
+    assert len(run_budget) == 1
+    assert not run_budget[0].passed
+    assert "total tokens" in run_budget[0].detail
+    assert result.infrastructure_error is None
+
+
+def test_cli_runs_paired_fake_baseline_and_candidate_with_one_command(
+    tmp_path, capsys
+):
+    import json
+
+    from coworker.evals.__main__ import main
+
+    artifact_root = tmp_path / "artifacts"
+    exit_code = main(
+        [
+            "--artifacts",
+            str(artifact_root),
+            "--repetitions",
+            "2",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "baseline -> candidate" in captured.out
+    assert "pass-rate lift" in captured.out
+    assert "may contain prompts" in captured.err
+    summary = json.loads((artifact_root / "summary.json").read_text())
+    assert summary["mode"] == "fake"
+    assert len(summary["runs"]) == 4
+    assert summary["comparison"]["baseline"] == "baseline"
+    assert summary["comparison"]["candidates"] == ["candidate"]
+    assert summary["comparison"]["comparisons"][0]["tokens"][
+        "eligible_pairs"
+    ] == 2
+
+
+def test_repository_command_docs_and_ignore_protect_sensitive_eval_artifacts():
+    root = Path(__file__).parents[2]
+
+    assert "\neval:\n" in (root / "Makefile").read_text()
+    docs = (root / "desktop" / "docs" / "evaluations.md").read_text()
+    assert "make eval" in docs
+    assert "prompts, responses, tool arguments, and tool output" in docs
+    assert "desktop/.eval-artifacts/" in (root / ".gitignore").read_text()
+
+
+def test_eval_artifact_directories_and_files_are_private(tmp_path):
+    import stat
+
+    from coworker.evals.__main__ import main
+
+    artifact_root = tmp_path / "artifacts"
+    assert main(["--artifacts", str(artifact_root)]) == 0
+
+    directories = [artifact_root, *sorted(path for path in artifact_root.rglob("*") if path.is_dir())]
+    files = sorted(path for path in artifact_root.rglob("*") if path.is_file())
+    assert directories
+    assert files
+    assert all(stat.S_IMODE(path.stat().st_mode) == 0o700 for path in directories)
+    assert all(stat.S_IMODE(path.stat().st_mode) == 0o600 for path in files)
+
+
+def test_artifact_setup_preserves_parent_mode_and_rejects_existing_broad_target(
+    tmp_path,
+):
+    import os
+    import stat
+
+    from coworker.evals.environment import EvalEnvironment
+
+    caller_parent = tmp_path / "caller-owned"
+    caller_parent.mkdir()
+    os.chmod(caller_parent, 0o755)
+    environment = EvalEnvironment.create(
+        caller_parent / "private-evals", label="private-child"
+    )
+    try:
+        assert stat.S_IMODE(caller_parent.stat().st_mode) == 0o755
+        assert stat.S_IMODE((caller_parent / "private-evals").stat().st_mode) == 0o700
+    finally:
+        environment.close()
+
+    with pytest.raises(ValueError, match="private artifact root"):
+        EvalEnvironment.create(caller_parent, label="must-not-chmod-parent")
+    assert stat.S_IMODE(caller_parent.stat().st_mode) == 0o755
+
+
+def test_summary_writer_refuses_symlink_without_touching_external_target(tmp_path):
+    import os
+
+    from coworker.evals.__main__ import main
+
+    artifact_root = tmp_path / "artifacts"
+    artifact_root.mkdir(mode=0o700)
+    sentinel = tmp_path / "outside-sentinel.txt"
+    sentinel.write_text("must remain intact")
+    os.symlink(sentinel, artifact_root / "summary.json")
+
+    with pytest.raises(ValueError, match="symlink"):
+        main(["--artifacts", str(artifact_root)])
+
+    assert sentinel.read_text() == "must remain intact"
+    assert (artifact_root / "summary.json").is_symlink()

--- a/desktop/tests/test_telemetry_schema.py
+++ b/desktop/tests/test_telemetry_schema.py
@@ -1,4 +1,5 @@
 from dataclasses import fields
+from typing import get_type_hints
 
 import pytest
 
@@ -187,6 +188,26 @@ def test_all_supported_span_and_event_schemas_use_bounded_operational_fields():
     }
     for schema in schemas:
         assert forbidden_fields.isdisjoint(field.name for field in fields(schema))
+
+
+def test_compaction_event_allows_unknown_token_counts_without_estimation():
+    event = CompactionEvent(
+        operation="history.compact",
+        reason=CompactionReason.POLICY,
+        input_tokens=None,
+        output_tokens=None,
+    )
+
+    hints = get_type_hints(CompactionEvent)
+    assert hints["input_tokens"] == int | None
+    assert hints["output_tokens"] == int | None
+    assert record_to_dict(event) == {
+        "event_type": "compaction",
+        "operation": "history.compact",
+        "reason": "policy",
+        "input_tokens": None,
+        "output_tokens": None,
+    }
 
 
 @pytest.mark.parametrize(

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ Sourcecado's dated documents record several product shapes. They are intentional
 - `superpowers/plans/2026-08-24-*` and `superpowers/plans/2026-08-25-*` — local runtime, sourcing spring, and desktop UI plans
 - `qa/` — current end-to-end and visual QA evidence
 - `desktop/docs/adr/` — ADRs scoped to the active local runtime
+- `desktop/docs/evaluations.md` — isolated fake/live agent evaluation workflow and artifact safety
 
 These are dated working records. Check their status and the current code before treating an unchecked item as outstanding.
 


### PR DESCRIPTION
## Summary\n\n- add isolated spawned-process eval runs with minimal credential-free environments, unique state/person databases, connector fakes, home, and exact workspace grants\n- support prompt, tool-catalog, provider/model, compaction, and uniformly enforced run-budget variants\n- retain native conversation, events, person/workspace effects, result artifacts, and closed telemetry\n- add deterministic tool/effect/terminal/telemetry/environment/budget/transcript invariants\n- add baseline/candidate repetition, paired pass-rate lift, and separate tokens/latency/cost/retry/compaction reporting\n- keep judge scores finite, observational, and paired only for matching judge contracts\n- enforce exact tool catalogs and exact persisted effect sets\n- make compaction preserve assistant/tool atomic groups and reject malformed transcripts\n- create private artifact trees with 0700 directories, 0600 files, symlink-safe atomic writes, and caller-owned path preservation\n- provide make eval plus documentation and explicit opt-in live runs\n\n## Verification\n\n- focused eval suite: 39 passed\n- make eval: passed\n- artifact tree: 59 paths checked, zero permission failures\n- symlink sentinel regression: passed\n- make test: 667 Python passed, 3 skipped; 380 GUI passed\n- make build: passed\n- git diff --check: passed\n- independent focused rerun: 39 passed\n\nCloses #82\n\n## Residual risk\n\nCredentialed live-provider runs were intentionally not executed, so no external model spend occurred. Existing Starlette/httpx deprecation and Vite chunk-size warnings remain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an evaluation harness for running deterministic baseline and candidate agent scenarios.
  * Added isolated environments, safety checks, budgets, transcript validation, invariant reporting, and paired comparisons.
  * Added optional, explicitly authorized live evaluations.
  * Added JSON summaries and local evaluation artifacts.

* **Documentation**
  * Documented evaluation workflows, artifact handling, and configuration options.
  * Added a `make eval` command for convenient execution.

* **Tests**
  * Added comprehensive coverage for evaluation execution, isolation, reporting, safety, and CLI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->