### PR TITLE
feat(desktop): open person files in bound chats

### DIFF
--- a/desktop/coworker/ledger.py
+++ b/desktop/coworker/ledger.py
@@ -280,9 +280,16 @@ def record_tool_on_person(
     if name == "people_keep" and ok:
         kept = result.get("kept") or []
         if len(kept) == 1:
-            person_id = kept[0].get("person_id") if isinstance(kept[0], dict) else None
+            item = kept[0] if isinstance(kept[0], dict) else {}
+            person_id = item.get("person_id")
             if person_id:
-                people.bind_session(session_id, str(person_id))
+                sourcing_chat = item.get("sourcing_chat")
+                if isinstance(sourcing_chat, dict) and sourcing_chat.get("session_id"):
+                    return
+                try:
+                    people.bind_session(session_id, str(person_id))
+                except ValueError:
+                    return
         return
     if not ok and str(result.get("error") or "") == "denied by user":
         return

--- a/desktop/coworker/ledger.py
+++ b/desktop/coworker/ledger.py
@@ -276,20 +276,13 @@ def record_tool_on_person(
     *,
     ok: bool,
 ) -> None:
-    """Bind a one-person keep to this session, then file connector events on the bound person."""
+    """Bind a first one-person keep to this session, then file connector events on the bound person."""
     if name == "people_keep" and ok:
         kept = result.get("kept") or []
         if len(kept) == 1:
-            item = kept[0] if isinstance(kept[0], dict) else {}
-            person_id = item.get("person_id")
-            if person_id:
-                sourcing_chat = item.get("sourcing_chat")
-                if isinstance(sourcing_chat, dict) and sourcing_chat.get("session_id"):
-                    return
-                try:
-                    people.bind_session(session_id, str(person_id))
-                except ValueError:
-                    return
+            person_id = kept[0].get("person_id") if isinstance(kept[0], dict) else None
+            if person_id and people.session_for_person(str(person_id)) is None:
+                people.bind_session(session_id, str(person_id))
         return
     if not ok and str(result.get("error") or "") == "denied by user":
         return

--- a/desktop/coworker/people.py
+++ b/desktop/coworker/people.py
@@ -640,22 +640,48 @@ class PersonStore:
             ).fetchall()
         return [self._event_dict(row) for row in rows]
 
-    def bind_session(self, session_id: str, person_id: str) -> None:
+    def bind_session(
+        self,
+        session_id: str,
+        person_id: str,
+        *,
+        expected_person_version: int | None = None,
+    ) -> None:
         sid = (session_id or "").strip()
         if not sid or not _SID_RE.fullmatch(sid) or ".." in sid:
             raise ValueError("invalid session id")
         with self._lock:
             exists = self._conn.execute(
-                "SELECT 1 FROM people WHERE person_id = ?",
+                "SELECT version FROM people WHERE person_id = ? AND deleted_at IS NULL",
                 (person_id,),
             ).fetchone()
             if exists is None:
                 raise ValueError("unknown person")
+            current_version = int(exists["version"])
+            if (
+                expected_person_version is not None
+                and current_version != expected_person_version
+            ):
+                raise ValueError(
+                    "stale record version: "
+                    f"expected {expected_person_version}, current {current_version}"
+                )
+            bound = self._conn.execute(
+                "SELECT person_id FROM session_people WHERE session_id = ?",
+                (sid,),
+            ).fetchone()
+            if bound is not None:
+                if str(bound["person_id"]) != person_id:
+                    raise ValueError("session is already bound to another person")
+                return
+            person_session = self._conn.execute(
+                "SELECT session_id FROM session_people WHERE person_id = ?",
+                (person_id,),
+            ).fetchone()
+            if person_session is not None:
+                raise ValueError("person already has a bound sourcing session")
             self._conn.execute(
-                """
-                INSERT INTO session_people (session_id, person_id) VALUES (?, ?)
-                ON CONFLICT(session_id) DO UPDATE SET person_id = excluded.person_id
-                """,
+                "INSERT INTO session_people (session_id, person_id) VALUES (?, ?)",
                 (sid, person_id),
             )
             self._conn.commit()
@@ -669,6 +695,18 @@ class PersonStore:
         if row is None:
             return None
         return str(row["person_id"])
+
+    def session_for_person(self, person_id: str) -> str | None:
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT session_id FROM session_people WHERE person_id = ?",
+                (person_id,),
+            ).fetchall()
+        if not rows:
+            return None
+        if len(rows) > 1:
+            raise ValueError("person has multiple bound sourcing sessions")
+        return str(rows[0]["session_id"])
 
     def set_handoff(
         self,

--- a/desktop/coworker/server.py
+++ b/desktop/coworker/server.py
@@ -164,9 +164,14 @@ def system_prompt_assembly(
             brief = build_brief(person, events)
             recent = events[-_PERSON_FILE_EVENT_CAP:]
             learned_lines = [
-                str(event.get("summary") or "")
+                (
+                    f"[{event.get('source')}:{event.get('event_id')}] "
+                    f"{event.get('summary')}"
+                )
                 for event in recent
                 if event.get("summary")
+                and event.get("source")
+                and event.get("event_id")
             ]
             person_context = (
                 "Person file:\n"

--- a/desktop/coworker/server.py
+++ b/desktop/coworker/server.py
@@ -1536,12 +1536,116 @@ def create_app(
         if person is None:
             return JSONResponse({"error": "not found"}, status_code=404)
         timeline = [_public_event(event) for event in app.state.people.timeline(person_id)]
+        try:
+            session_id = app.state.people.session_for_person(person_id)
+        except ValueError:
+            return JSONResponse(
+                {
+                    "error": "person has multiple bound sourcing sessions",
+                    "code": "person_chat_conflict",
+                },
+                status_code=409,
+            )
         return {
             "person": person,
             "brief": build_brief(person, timeline),
             "timeline": timeline,
             "versions": app.state.people.versions(person_id),
+            "sourcing_chat": (
+                {"session_id": session_id, "person_id": person_id}
+                if session_id is not None
+                else None
+            ),
         }
+
+    @app.post("/v1/people/{person_id}/sourcing-chat")
+    async def people_sourcing_chat(person_id: str, request: Request):
+        person = app.state.people.get(person_id)
+        if person is None:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        payload = await request.json()
+        expected_version = payload.get("expected_person_version")
+        if not isinstance(expected_version, int) or isinstance(expected_version, bool):
+            return JSONResponse(
+                {"error": "expected_person_version is required"}, status_code=400
+            )
+        if int(person["version"]) != expected_version:
+            return JSONResponse({"error": "stale person version"}, status_code=409)
+        requested_session_id = str(payload.get("session_id") or "").strip()
+        if requested_session_id:
+            owner = app.state.people.person_for_session(requested_session_id)
+            if owner != person_id:
+                return JSONResponse(
+                    {
+                        "error": (
+                            "session is already bound to another person"
+                            if owner is not None
+                            else "session is not bound to this person"
+                        )
+                    },
+                    status_code=409,
+                )
+        brief = build_brief(person, app.state.people.timeline(person_id))
+        label = str(brief["who"] or "Person")
+        try:
+            existing_session_id = app.state.people.session_for_person(person_id)
+        except ValueError:
+            return JSONResponse(
+                {
+                    "error": "person has multiple bound sourcing sessions",
+                    "code": "person_chat_conflict",
+                },
+                status_code=409,
+            )
+        if existing_session_id is not None:
+            existing = app.state.store.index(existing_session_id)
+            if existing is None:
+                return JSONResponse(
+                    {"error": "bound sourcing session is unavailable"},
+                    status_code=409,
+                )
+            app.state.store.set_open_session(existing_session_id)
+            return {
+                "created": False,
+                "session": {
+                    "id": existing_session_id,
+                    "title": existing["title"],
+                    "n_msgs": existing["n_msgs"],
+                },
+                "active_person": {
+                    "person_id": person_id,
+                    "version": int(person["version"]),
+                    "label": label,
+                },
+            }
+        row = app.state.store.create_session()
+        session_id = str(row["session_id"])
+        try:
+            app.state.people.bind_session(
+                session_id,
+                person_id,
+                expected_person_version=expected_version,
+            )
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=409)
+        titled = app.state.store.rename_session(session_id, f"Sourcing · {label}")
+        app.state.store.set_open_session(session_id)
+        return JSONResponse(
+            {
+                "created": True,
+                "session": {
+                    "id": session_id,
+                    "title": titled["title"] if titled is not None else None,
+                    "n_msgs": 0,
+                },
+                "active_person": {
+                    "person_id": person_id,
+                    "version": int(person["version"]),
+                    "label": label,
+                },
+            },
+            status_code=201,
+        )
 
     @app.post("/v1/people/{person_id}/revert")
     async def people_revert(person_id: str, request: Request):
@@ -1583,16 +1687,49 @@ def create_app(
         return {"id": row["session_id"], "title": row["title"], "n_msgs": row["n_msgs"]}
 
     @app.get("/v1/sessions/{sid}")
-    async def sessions_get(sid: str):
+    async def sessions_get(sid: str, request: Request):
         store = app.state.store
         row = store.index(sid)
         if row is None:
             return JSONResponse({"error": "not found"}, status_code=404)
+        bound_person_id = app.state.people.person_for_session(sid)
+        expected_person_id = str(
+            request.query_params.get("expected_person_id") or ""
+        ).strip()
+        if expected_person_id and bound_person_id != expected_person_id:
+            return JSONResponse(
+                {
+                    "error": "conversation is bound to a different person",
+                    "code": "person_binding_mismatch",
+                },
+                status_code=409,
+            )
+        bound_person = (
+            app.state.people.get(bound_person_id) if bound_person_id is not None else None
+        )
+        if bound_person_id is not None and bound_person is None:
+            return JSONResponse(
+                {
+                    "error": "bound person file is unavailable",
+                    "code": "bound_person_unavailable",
+                },
+                status_code=409,
+            )
         # A restored thread must not show a live-looking card for an
         # already-expired approval: reap and persist receipts first.
         await _reap_and_publish_expired()
         if not sid.startswith("sched-"):
             store.set_open_session(sid)
+        active_person = None
+        if bound_person is not None:
+            bound_brief = build_brief(
+                bound_person, app.state.people.timeline(bound_person_id)
+            )
+            active_person = {
+                "person_id": bound_person_id,
+                "version": int(bound_person["version"]),
+                "label": str(bound_brief["who"] or "Person"),
+            }
         return {
             "id": sid,
             "title": row["title"],
@@ -1600,6 +1737,7 @@ def create_app(
             "events": store.load_events(sid),
             "queue": store.list_queue(sid),
             "queue_paused": store.queue_paused(sid),
+            "active_person": active_person,
         }
 
     @app.get("/v1/sessions/{sid}/telemetry/current")
@@ -2471,6 +2609,20 @@ def create_app(
                     continue
                 if not sid:
                     sid = store.create_session()["session_id"]
+                bound_person_id = app.state.people.person_for_session(sid)
+                if (
+                    bound_person_id is not None
+                    and app.state.people.get(bound_person_id) is None
+                ):
+                    await _send(
+                        {
+                            "type": "error",
+                            "message": (
+                                "This conversation's bound person file is unavailable."
+                            ),
+                        }
+                    )
+                    continue
                 store.set_open_session(sid)
                 queue_busy = not store.queue_paused(sid) and any(
                     item["state"] in ("waiting", "retrying", "reconnecting")

--- a/desktop/coworker/tools.py
+++ b/desktop/coworker/tools.py
@@ -695,6 +695,10 @@ def execute(
                 company=row.get("organizationName"),
                 target=target,
             )
+            try:
+                sourcing_session = people.session_for_person(person["person_id"])
+            except ValueError:
+                sourcing_session = None
             kept.append(
                 {
                     "person_id": person["person_id"],
@@ -703,6 +707,11 @@ def execute(
                     "last_name": person["last_name"],
                     "title": person["title"],
                     "company": person["company"],
+                    "sourcing_chat": (
+                        {"session_id": sourcing_session}
+                        if sourcing_session is not None
+                        else None
+                    ),
                 }
             )
         return True, {"kept": kept}

--- a/desktop/coworker/turn.py
+++ b/desktop/coworker/turn.py
@@ -729,6 +729,20 @@ async def run_turn(
             )
         return {"status": "stopped", "text": text_so_far}
 
+    people = execute_kwargs.get("people")
+    if people is not None:
+        bound_person_id = people.person_for_session(sid)
+        if bound_person_id is not None and people.get(bound_person_id) is None:
+            turn_span.fail(ErrorKind.POLICY)
+            await _terminal(
+                {
+                    "type": "error",
+                    "state": "failed",
+                    "message": "This conversation's bound person file is unavailable.",
+                }
+            )
+            return {"status": "error", "text": ""}
+
     await _emit({"type": "turn_start", "state": "running"})
     if provider is None:
         turn_span.fail(ErrorKind.PROVIDER)

--- a/desktop/surfaces/gui/src/PersonFile.tsx
+++ b/desktop/surfaces/gui/src/PersonFile.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useState } from "react";
 
-import { getPerson, revertPerson, setPersonSequence, type PersonFile } from "./api";
+import {
+  getPerson,
+  openPersonSourcingChat,
+  revertPerson,
+  setPersonSequence,
+  type PersonFile,
+} from "./api";
 
 const STATES = [
   { id: "open", label: "Open" },
@@ -14,6 +20,8 @@ export function PersonFileView({ personId }: { personId: string }) {
   const [attempt, setAttempt] = useState(0);
   const [moving, setMoving] = useState<string | null>(null);
   const [moveFailed, setMoveFailed] = useState(false);
+  const [openingChat, setOpeningChat] = useState(false);
+  const [chatFailed, setChatFailed] = useState(false);
 
   useEffect(() => {
     let active = true;
@@ -52,6 +60,28 @@ export function PersonFileView({ personId }: { personId: string }) {
     }
   }
 
+  async function openSourcingChat() {
+    if (openingChat || !file) return;
+    const version = file.person.version;
+    if (typeof version !== "number" || !Number.isInteger(version)) {
+      setChatFailed(true);
+      return;
+    }
+    setOpeningChat(true);
+    setChatFailed(false);
+    try {
+      const result = await openPersonSourcingChat(personId, version);
+      if (result.active_person.person_id !== personId) {
+        throw new Error("person binding mismatch");
+      }
+      window.location.hash = `#/chat/${encodeURIComponent(result.session.id)}/person/${encodeURIComponent(personId)}`;
+    } catch {
+      setChatFailed(true);
+    } finally {
+      setOpeningChat(false);
+    }
+  }
+
   if (failed) {
     return (
       <main className="route-page person-page">
@@ -83,6 +113,24 @@ export function PersonFileView({ personId }: { personId: string }) {
         <p className="eyebrow">Person file</p>
         <h1>{file.brief.who || "Person"}</h1>
         {file.brief.why ? <p>{file.brief.why}</p> : null}
+        <div className="person-chat-action">
+          <button
+            type="button"
+            disabled={openingChat}
+            onClick={() => void openSourcingChat()}
+          >
+            {openingChat
+              ? "Opening sourcing chat…"
+              : file.sourcing_chat
+                ? "Open sourcing chat"
+                : "Create sourcing chat"}
+          </button>
+          {chatFailed ? (
+            <p role="alert">
+              Couldn’t open this person’s sourcing chat. Refresh the person file and try again.
+            </p>
+          ) : null}
+        </div>
       </header>
 
       <section className="person-sequence" aria-labelledby="person-sequence-heading">

--- a/desktop/surfaces/gui/src/api.ts
+++ b/desktop/surfaces/gui/src/api.ts
@@ -113,6 +113,7 @@ export type Conversation = {
   title: string | null;
   messages: StoredMessage[];
   events: ChatEvent[];
+  active_person?: ActivePerson | null;
   queue?: QueueItem[];
   queue_paused?: boolean;
 };
@@ -222,15 +223,44 @@ export async function createSession(): Promise<{ id: string; title: string | nul
   return res.json();
 }
 
-export async function getSession(id: string): Promise<Conversation> {
-  const res = await get(`/v1/sessions/${encodeURIComponent(id)}`);
+export async function getSession(
+  id: string,
+  expectedPersonId?: string,
+): Promise<Conversation> {
+  const expected = expectedPersonId
+    ? `?expected_person_id=${encodeURIComponent(expectedPersonId)}`
+    : "";
+  const res = await get(`/v1/sessions/${encodeURIComponent(id)}${expected}`);
   if (!res.ok) throw new Error(`session ${res.status}`);
   const body = await res.json();
+  const activePerson = body.active_person as Record<string, unknown> | null | undefined;
+  if (
+    activePerson !== null &&
+    activePerson !== undefined &&
+    (typeof activePerson.person_id !== "string" ||
+      !activePerson.person_id ||
+      typeof activePerson.version !== "number" ||
+      !Number.isInteger(activePerson.version) ||
+      activePerson.version < 1 ||
+      typeof activePerson.label !== "string" ||
+      !activePerson.label)
+  ) {
+    throw new Error("session person binding malformed");
+  }
   return {
     id: body.id,
     title: body.title,
     messages: body.messages,
     events: Array.isArray(body.events) ? body.events.map(parseChatEvent) : [],
+    ...(activePerson
+      ? {
+          active_person: {
+            person_id: activePerson.person_id as string,
+            version: activePerson.version as number,
+            label: activePerson.label as string,
+          },
+        }
+      : {}),
     ...(Array.isArray(body.queue) ? { queue: body.queue } : {}),
     ...(typeof body.queue_paused === "boolean"
       ? { queue_paused: body.queue_paused }
@@ -346,6 +376,19 @@ export type PersonFile = {
     payload: Record<string, unknown>;
   }>;
   versions?: Array<{ version: number; created_at: string }>;
+  sourcing_chat: { session_id: string; person_id: string } | null;
+};
+
+export type ActivePerson = {
+  person_id: string;
+  version: number;
+  label: string;
+};
+
+export type PersonSourcingChatResult = {
+  created: boolean;
+  session: { id: string; title: string | null; n_msgs: number };
+  active_person: ActivePerson;
 };
 
 export async function getBoard(): Promise<Board> {
@@ -358,6 +401,60 @@ export async function getPerson(id: string): Promise<PersonFile> {
   const res = await get(`/v1/people/${encodeURIComponent(id)}`);
   if (!res.ok) throw new Error(`person ${res.status}`);
   return res.json();
+}
+
+export async function openPersonSourcingChat(
+  id: string,
+  expectedPersonVersion: number,
+): Promise<PersonSourcingChatResult> {
+  const res = await fetch(
+    `${httpBase()}/v1/people/${encodeURIComponent(id)}/sourcing-chat`,
+    {
+      method: "POST",
+      headers: {
+        "X-Club-Token": apiToken(),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ expected_person_version: expectedPersonVersion }),
+    },
+  );
+  const raw = (await res.json()) as Record<string, unknown>;
+  if (!res.ok) throw new Error(`person sourcing chat ${res.status}`);
+  const session = raw.session as Record<string, unknown> | undefined;
+  const activePerson = raw.active_person as Record<string, unknown> | undefined;
+  if (
+    typeof raw.created !== "boolean" ||
+    !session ||
+    typeof session.id !== "string" ||
+    !session.id ||
+    (session.title !== null && typeof session.title !== "string") ||
+    typeof session.n_msgs !== "number" ||
+    !Number.isInteger(session.n_msgs) ||
+    session.n_msgs < 0 ||
+    !activePerson ||
+    typeof activePerson.person_id !== "string" ||
+    !activePerson.person_id ||
+    typeof activePerson.version !== "number" ||
+    !Number.isInteger(activePerson.version) ||
+    activePerson.version < 1 ||
+    typeof activePerson.label !== "string" ||
+    !activePerson.label
+  ) {
+    throw new Error("person sourcing chat payload malformed");
+  }
+  return {
+    created: raw.created,
+    session: {
+      id: session.id,
+      title: session.title as string | null,
+      n_msgs: session.n_msgs,
+    },
+    active_person: {
+      person_id: activePerson.person_id,
+      version: activePerson.version,
+      label: activePerson.label,
+    },
+  };
 }
 
 export async function setPersonSequence(

--- a/desktop/surfaces/gui/src/app/AppShell.tsx
+++ b/desktop/surfaces/gui/src/app/AppShell.tsx
@@ -175,9 +175,11 @@ export function AppShell() {
       if (restored) {
         cachedRestoreHashRef.current = restored;
         window.location.hash = restored;
+        setRoute(parseHash(restored));
       } else if (cachedListing.sessions.length > 0) {
         cachedRestoreHashRef.current = "#/chat";
         window.location.hash = "#/chat";
+        setRoute({ kind: "chat" });
       }
     }
     getSessions()
@@ -194,10 +196,12 @@ export function AppShell() {
             (listing.open_id ? `#/chat/${encodeURIComponent(listing.open_id)}` : "");
           if (restored) {
             window.location.hash = restored;
+            setRoute(parseHash(restored));
           } else if (listing.sessions.length > 0) {
             // Sessions exist but neither open_id nor last_destination named one:
             // escape the root "Restoring workspace" skeleton instead of hanging on it.
             window.location.hash = "#/chat";
+            setRoute({ kind: "chat" });
           }
         }
         cachedRestoreHashRef.current = null;
@@ -243,13 +247,14 @@ export function AppShell() {
     outlet = <SettingsPage />;
   } else if (
     route.sessionId &&
+    !route.personId &&
     !route.sessionId.startsWith("sched-") &&
     sessions !== null &&
     !sessions.some((session) => session.session_id === route.sessionId)
   ) {
     outlet = <UnavailableThreadPage recentSessionId={openSessionId} />;
   } else {
-    outlet = <ChatPage sessionId={route.sessionId} />;
+    outlet = <ChatPage sessionId={route.sessionId} personId={route.personId} />;
   }
   return (
     <div className="app-shell">

--- a/desktop/surfaces/gui/src/app/route.ts
+++ b/desktop/surfaces/gui/src/app/route.ts
@@ -5,7 +5,7 @@ export type AppRoute =
   | { kind: "scheduled" }
   | { kind: "settings" }
   | { kind: "skills" }
-  | { kind: "chat"; sessionId?: string };
+  | { kind: "chat"; sessionId?: string; personId?: string };
 
 export function parseHash(hash: string): AppRoute {
   if (hash === "#/board") return { kind: "board" };
@@ -33,6 +33,20 @@ export function parseHash(hash: string): AppRoute {
   if (hash === "#/scheduled") return { kind: "scheduled" };
   if (hash === "#/settings") return { kind: "settings" };
   if (hash === "#/skills") return { kind: "skills" };
+  if (hash.startsWith("#/chat/") && hash.includes("/person/")) {
+    const [sessionId, personId] = hash.slice("#/chat/".length).split("/person/", 2);
+    if (sessionId && personId) {
+      try {
+        return {
+          kind: "chat",
+          sessionId: decodeURIComponent(sessionId),
+          personId: decodeURIComponent(personId),
+        };
+      } catch {
+        return { kind: "chat" };
+      }
+    }
+  }
   if (hash.startsWith("#/chat/") && hash.length > "#/chat/".length) {
     try {
       return {

--- a/desktop/surfaces/gui/src/chat/ThreadHeader.tsx
+++ b/desktop/surfaces/gui/src/chat/ThreadHeader.tsx
@@ -1,12 +1,14 @@
-import type { CurrentRunMetrics } from "../api";
+import type { ActivePerson, CurrentRunMetrics } from "../api";
 import { RunMetrics } from "./RunMetrics";
 
 export function ThreadHeader({
   title,
+  activePerson,
   personaName,
   runMetrics,
 }: {
   readonly title: string | null;
+  readonly activePerson?: ActivePerson | null;
   readonly personaName?: string | null;
   readonly runMetrics?: CurrentRunMetrics | null;
 }) {
@@ -15,6 +17,15 @@ export function ThreadHeader({
       <div>
         <p className="eyebrow">Sourcing workspace</p>
         <h1>{title?.trim() || "New sourcing conversation"}</h1>
+        {activePerson ? (
+          <a
+            className="sourcecado-active-person"
+            href={`#/people/${encodeURIComponent(activePerson.person_id)}`}
+            aria-label={`Active person: ${activePerson.label}`}
+          >
+            {activePerson.label}
+          </a>
+        ) : null}
         {runMetrics ? <RunMetrics metrics={runMetrics} /> : null}
       </div>
       {personaName ? (

--- a/desktop/surfaces/gui/src/chat/ThreadView.tsx
+++ b/desktop/surfaces/gui/src/chat/ThreadView.tsx
@@ -6,11 +6,12 @@ import { ComposerDraftProvider } from "./ComposerDraftContext";
 import { Queue } from "./Queue";
 import { ThreadHeader } from "./ThreadHeader";
 import { UserMessage } from "./UserMessage";
-import type { CurrentRunMetrics, QueueItem } from "../api";
+import type { ActivePerson, CurrentRunMetrics, QueueItem } from "../api";
 import { Inspector } from "./Inspector";
 
 type ThreadViewProps = {
   readonly title: string | null;
+  readonly activePerson?: ActivePerson | null;
   readonly personaName?: string | null;
   readonly runMetrics?: CurrentRunMetrics | null;
   readonly loading: boolean;
@@ -53,6 +54,7 @@ function Starter({
 
 export function ThreadView({
   title,
+  activePerson,
   personaName,
   runMetrics,
   loading,
@@ -80,6 +82,7 @@ export function ThreadView({
     <ThreadPrimitive.Root className="sourcecado-thread">
       <ThreadHeader
         title={title}
+        activePerson={activePerson}
         personaName={personaName}
         runMetrics={runMetrics}
       />

--- a/desktop/surfaces/gui/src/routes/ChatPage.tsx
+++ b/desktop/surfaces/gui/src/routes/ChatPage.tsx
@@ -11,6 +11,7 @@ import {
   getSessions,
   hasToken,
   openChat,
+  type ActivePerson,
   type CommandDelivery,
   type ConnectionStatus,
   type CurrentRunMetrics,
@@ -64,7 +65,13 @@ function writeDraft(threadId: string, draft: string): void {
   }
 }
 
-export function ChatPage({ sessionId: requestedSessionId }: { sessionId?: string }) {
+export function ChatPage({
+  sessionId: requestedSessionId,
+  personId,
+}: {
+  sessionId?: string;
+  personId?: string;
+}) {
   const initialThreadId = requestedSessionId ?? "";
   const storeRef = useRef(
     new SourcecadoChatStore(
@@ -77,6 +84,7 @@ export function ChatPage({ sessionId: requestedSessionId }: { sessionId?: string
   const loadVersionRef = useRef(0);
   const loadedThreadsRef = useRef(new Set<string>());
   const threadTitlesRef = useRef(new Map<string, string | null>());
+  const threadPeopleRef = useRef(new Map<string, ActivePerson | null>());
   const threadQueuesRef = useRef(
     new Map<string, { items: readonly QueueItem[]; paused: boolean }>(),
   );
@@ -93,6 +101,7 @@ export function ChatPage({ sessionId: requestedSessionId }: { sessionId?: string
   const [loadAttempt, setLoadAttempt] = useState(0);
   const [announcement, setAnnouncement] = useState("");
   const [personaName, setPersonaName] = useState<string | null>(null);
+  const [activePerson, setActivePerson] = useState<ActivePerson | null>(null);
   const [runMetrics, setRunMetrics] = useState<CurrentRunMetrics | null>(null);
   const [, setRevision] = useState(0);
 
@@ -145,6 +154,7 @@ export function ChatPage({ sessionId: requestedSessionId }: { sessionId?: string
     let active = true;
     setLoadError(false);
     setTitle(null);
+    setActivePerson(null);
 
     async function loadThread() {
       if (!hasToken()) throw new Error("missing launch token");
@@ -159,19 +169,29 @@ export function ChatPage({ sessionId: requestedSessionId }: { sessionId?: string
         return;
       }
       if (loadedThreadsRef.current.has(threadId)) {
-        setTitle(threadTitlesRef.current.get(threadId) ?? null);
-        setLoading(false);
-        refresh();
-        return;
+        const cachedPerson = threadPeopleRef.current.get(threadId) ?? null;
+        if (!personId || cachedPerson?.person_id === personId) {
+          setTitle(threadTitlesRef.current.get(threadId) ?? null);
+          setActivePerson(cachedPerson);
+          setLoading(false);
+          refresh();
+          return;
+        }
       }
       setLoading(true);
-      const conversation = await getSession(threadId);
+      const conversation = personId
+        ? await getSession(threadId, personId)
+        : await getSession(threadId);
       if (
         !active ||
         loadVersion !== loadVersionRef.current ||
         activeThreadRef.current !== threadId
       ) {
         return;
+      }
+      const loadedPerson = conversation.active_person ?? null;
+      if (personId && loadedPerson?.person_id !== personId) {
+        throw new Error("conversation person binding mismatch");
       }
       storeRef.current.replaceThread(threadId, restoreConversation(conversation));
       threadQueuesRef.current.set(threadId, {
@@ -180,8 +200,17 @@ export function ChatPage({ sessionId: requestedSessionId }: { sessionId?: string
       });
       loadedThreadsRef.current.add(threadId);
       threadTitlesRef.current.set(threadId, conversation.title);
+      threadPeopleRef.current.set(threadId, loadedPerson);
       nextLegacyIndexRef.current.set(threadId, conversation.messages.length);
       setTitle(conversation.title);
+      setActivePerson(loadedPerson);
+      if (
+        !personId &&
+        loadedPerson &&
+        window.location.hash === `#/chat/${encodeURIComponent(threadId)}`
+      ) {
+        window.location.hash = `#/chat/${encodeURIComponent(threadId)}/person/${encodeURIComponent(loadedPerson.person_id)}`;
+      }
       setLoading(false);
       setLoadError(false);
       refresh();
@@ -195,7 +224,7 @@ export function ChatPage({ sessionId: requestedSessionId }: { sessionId?: string
     return () => {
       active = false;
     };
-  }, [loadAttempt, refresh, requestedSessionId]);
+  }, [loadAttempt, personId, refresh, requestedSessionId]);
 
   useEffect(() => {
     if (!hasToken()) return;
@@ -461,6 +490,7 @@ export function ChatPage({ sessionId: requestedSessionId }: { sessionId?: string
       >
         <ThreadView
           title={title}
+          activePerson={activePerson}
           personaName={personaName}
           runMetrics={runMetrics}
           loading={loading}

--- a/desktop/surfaces/gui/src/styles.css
+++ b/desktop/surfaces/gui/src/styles.css
@@ -95,7 +95,8 @@
 
 .board-row:focus-visible,
 .person-back-link:focus-visible,
-.person-sequence-action:focus-visible {
+.person-sequence-action:focus-visible,
+.person-chat-action button:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
 }
@@ -127,6 +128,36 @@
   color: var(--accent-deep);
   font-weight: 600;
   text-decoration: none;
+}
+
+.person-chat-action {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.person-chat-action button {
+  min-height: 44px;
+  padding: 0 15px;
+  border: 1px solid var(--accent);
+  border-radius: 8px;
+  background: var(--accent);
+  color: var(--surface);
+  font: inherit;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.person-chat-action button:disabled {
+  cursor: wait;
+  opacity: .65;
+}
+
+.person-chat-action [role="alert"] {
+  margin: 0;
+  color: var(--error);
+  line-height: 1.45;
 }
 
 .person-sequence,
@@ -252,5 +283,9 @@
   .person-sequence-action {
     width: 100%;
   }
-}
 
+  .person-chat-action {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}

--- a/desktop/surfaces/gui/src/styles/chat.css
+++ b/desktop/surfaces/gui/src/styles/chat.css
@@ -272,6 +272,19 @@
   white-space: nowrap;
 }
 
+.sourcecado-active-person {
+  display: inline-flex;
+  max-width: 100%;
+  margin-top: 5px;
+  overflow: hidden;
+  color: var(--accent-deep);
+  font-size: 12px;
+  font-weight: 600;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .sourcecado-run-metrics {
   display: flex;
   flex-wrap: wrap;

--- a/desktop/surfaces/gui/tests/boardPerson.test.tsx
+++ b/desktop/surfaces/gui/tests/boardPerson.test.tsx
@@ -7,6 +7,7 @@ import { PersonFileView } from "../src/PersonFile";
 const api = vi.hoisted(() => ({
   getBoard: vi.fn(),
   getPerson: vi.fn(),
+  openPersonSourcingChat: vi.fn(),
   revertPerson: vi.fn(),
   setPersonSequence: vi.fn(),
 }));
@@ -14,6 +15,7 @@ const api = vi.hoisted(() => ({
 vi.mock("../src/api", () => ({
   getBoard: api.getBoard,
   getPerson: api.getPerson,
+  openPersonSourcingChat: api.openPersonSourcingChat,
   revertPerson: api.revertPerson,
   setPersonSequence: api.setPersonSequence,
 }));
@@ -59,6 +61,12 @@ describe("Board and person-file routes", () => {
         { version: 1, created_at: "2026-08-26T10:00:00Z" },
         { version: 2, created_at: "2026-08-26T11:00:00Z" },
       ],
+      sourcing_chat: null,
+    });
+    api.openPersonSourcingChat.mockResolvedValue({
+      created: true,
+      session: { id: "thread one", title: "Sourcing · Alyssa Lee", n_msgs: 0 },
+      active_person: { person_id: "person one", version: 2, label: "Alyssa Lee" },
     });
     api.setPersonSequence.mockResolvedValue({
       person: { person_id: "person one", sequence_state: "in_conversation" },
@@ -111,6 +119,68 @@ describe("Board and person-file routes", () => {
         expectedVersion: 2,
         rationaleSummary: "Restore version 1 from person history.",
       }),
+    );
+  });
+
+  it("creates the person's sourcing chat and navigates with both identities", async () => {
+    window.location.hash = "#/people/person%20one";
+    render(<PersonFileView personId="person one" />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Create sourcing chat" }),
+    );
+
+    await waitFor(() =>
+      expect(api.openPersonSourcingChat).toHaveBeenCalledWith("person one", 2),
+    );
+    await waitFor(() =>
+      expect(window.location.hash).toBe(
+        "#/chat/thread%20one/person/person%20one",
+      ),
+    );
+  });
+
+  it("offers the same single action as Open when the person is already bound", async () => {
+    api.getPerson.mockResolvedValueOnce({
+      ...(await api.getPerson()),
+      sourcing_chat: { session_id: "thread one", person_id: "person one" },
+    });
+    render(<PersonFileView personId="person one" />);
+
+    expect(
+      await screen.findByRole("button", { name: "Open sourcing chat" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Create sourcing chat" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps a stale person-chat failure visible without navigating", async () => {
+    window.location.hash = "#/people/person%20one";
+    api.openPersonSourcingChat.mockRejectedValueOnce(new Error("stale version"));
+    render(<PersonFileView personId="person one" />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Create sourcing chat" }),
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Refresh the person file",
+    );
+    expect(window.location.hash).toBe("#/people/person%20one");
+  });
+
+  it("shows missing person recovery without offering a chat action", async () => {
+    api.getPerson.mockRejectedValueOnce(new Error("not found"));
+    render(<PersonFileView personId="missing-person" />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Couldn’t load this person file",
+    );
+    expect(
+      screen.queryByRole("button", { name: /sourcing chat/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Back to Board" })).toHaveAttribute(
+      "href",
+      "#/board",
     );
   });
 });

--- a/desktop/surfaces/gui/tests/boardPersonStyles.test.ts
+++ b/desktop/surfaces/gui/tests/boardPersonStyles.test.ts
@@ -14,5 +14,8 @@ describe("Board and person-file styles", () => {
     expect(styles).toMatch(
       /@media \(max-width: 767px\)[\s\S]*?\.board-grid,\s*\.person-summary-grid\s*\{[^}]*grid-template-columns:\s*1fr;/,
     );
+    expect(styles).toMatch(
+      /\.person-chat-action button\s*\{[^}]*min-height:\s*44px;/,
+    );
   });
 });

--- a/desktop/surfaces/gui/tests/chatPage.test.tsx
+++ b/desktop/surfaces/gui/tests/chatPage.test.tsx
@@ -164,6 +164,69 @@ describe("ChatPage Warm Operator thread", () => {
     expect(container).not.toHaveTextContent("private error");
   });
 
+  it("shows the route-verified active person without replacing the chat title", async () => {
+    api.getSession.mockResolvedValue({
+      id: "thread-alpha",
+      title: "Sourcing · Alyssa",
+      messages: [],
+      events: [],
+      active_person: {
+        person_id: "person one",
+        version: 2,
+        label: "Alyssa Lee, Partner at Codeology",
+      },
+    });
+
+    render(<ChatPage sessionId="thread-alpha" personId="person one" />);
+
+    expect(
+      await screen.findByRole("heading", { name: "Sourcing · Alyssa" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: "Active person: Alyssa Lee, Partner at Codeology",
+      }),
+    ).toHaveAttribute("href", "#/people/person%20one");
+    expect(api.getSession).toHaveBeenCalledWith("thread-alpha", "person one");
+  });
+
+  it("canonicalizes a plain bound thread route to include its person", async () => {
+    window.location.hash = "#/chat/thread-alpha";
+    api.getSession.mockResolvedValue({
+      id: "thread-alpha",
+      title: "Sourcing · Alyssa",
+      messages: [],
+      events: [],
+      active_person: {
+        person_id: "person one",
+        version: 2,
+        label: "Alyssa Lee",
+      },
+    });
+
+    render(<ChatPage sessionId="thread-alpha" />);
+
+    await waitFor(() =>
+      expect(window.location.hash).toBe(
+        "#/chat/thread-alpha/person/person%20one",
+      ),
+    );
+  });
+
+  it("shows a load failure when the route names a different person", async () => {
+    api.getSession.mockRejectedValueOnce(new Error("binding mismatch"));
+
+    render(<ChatPage sessionId="thread-alpha" personId="person two" />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "couldn’t load this conversation",
+    );
+    expect(
+      screen.queryByRole("link", { name: /Active person:/ }),
+    ).not.toBeInTheDocument();
+    expect(api.getSession).toHaveBeenCalledWith("thread-alpha", "person two");
+  });
+
   it("does not carry measurements across threads while the next run loads", async () => {
     const betaMetrics = deferred<{
       version: 1;

--- a/desktop/surfaces/gui/tests/chatStyles.test.ts
+++ b/desktop/surfaces/gui/tests/chatStyles.test.ts
@@ -60,6 +60,12 @@ describe("Warm Operator thread styles", () => {
     );
   });
 
+  it("keeps the bound person visible as a compact header link", () => {
+    expect(styles).toMatch(
+      /\.sourcecado-active-person\s*\{[^}]*display:\s*inline-flex;[^}]*color:\s*var\(--accent-deep\);/,
+    );
+  });
+
   it("distinguishes pending approval cards from collapsed audit receipts", () => {
     expect(styles).toMatch(
       /\.sourcecado-approval-card\s*\{[^}]*border:\s*1px solid var\(--warn\);/,

--- a/desktop/surfaces/gui/tests/personChatApi.test.ts
+++ b/desktop/surfaces/gui/tests/personChatApi.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getSession, openPersonSourcingChat } from "../src/api";
+
+describe("person sourcing chat API boundary", () => {
+  beforeEach(() => {
+    window.__CLUB_HTTP__ = "http://sidecar.test";
+    window.__CLUB_API_TOKEN__ = "review-token";
+  });
+
+  it("sends the viewed version and rebuilds only stable binding fields", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        created: true,
+        session: { id: "thread one", title: "Sourcing · Ada", n_msgs: 0 },
+        active_person: {
+          person_id: "person one",
+          version: 2,
+          label: "Ada, Founder at Analytic",
+          private_evidence: "PLANTED",
+        },
+        raw_prompt: "PLANTED",
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(openPersonSourcingChat("person one", 2)).resolves.toEqual({
+      created: true,
+      session: { id: "thread one", title: "Sourcing · Ada", n_msgs: 0 },
+      active_person: {
+        person_id: "person one",
+        version: 2,
+        label: "Ada, Founder at Analytic",
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://sidecar.test/v1/people/person%20one/sourcing-chat",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ expected_person_version: 2 }),
+      }),
+    );
+  });
+
+  it("verifies the route person while loading a bound session", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        id: "thread one",
+        title: "Sourcing · Ada",
+        messages: [],
+        events: [],
+        active_person: {
+          person_id: "person one",
+          version: 2,
+          label: "Ada",
+          private_evidence: "PLANTED",
+        },
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const conversation = await getSession("thread one", "person one");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://sidecar.test/v1/sessions/thread%20one?expected_person_id=person%20one",
+      expect.any(Object),
+    );
+    expect(conversation.active_person).toEqual({
+      person_id: "person one",
+      version: 2,
+      label: "Ada",
+    });
+    expect(JSON.stringify(conversation)).not.toContain("PLANTED");
+  });
+});

--- a/desktop/surfaces/gui/tests/route.test.ts
+++ b/desktop/surfaces/gui/tests/route.test.ts
@@ -14,4 +14,12 @@ describe("app route parser", () => {
   it("falls back safely when a person id is malformed", () => {
     expect(parseHash("#/people/%E0%A4%A")).toEqual({ kind: "board" });
   });
+
+  it("parses a person-bound chat route with both stable identities", () => {
+    expect(parseHash("#/chat/thread%20one/person/person%20one")).toEqual({
+      kind: "chat",
+      sessionId: "thread one",
+      personId: "person one",
+    });
+  });
 });

--- a/desktop/surfaces/gui/tests/shell.test.tsx
+++ b/desktop/surfaces/gui/tests/shell.test.tsx
@@ -31,6 +31,7 @@ const api = vi.hoisted(() => ({
   getSkills: vi.fn(),
   hasToken: vi.fn(),
   openChat: vi.fn(),
+  openPersonSourcingChat: vi.fn(),
   pinSession: vi.fn(),
   renameSession: vi.fn(),
   setLastDestination: vi.fn(),
@@ -60,6 +61,7 @@ vi.mock("../src/api", () => ({
   getSkills: api.getSkills,
   hasToken: api.hasToken,
   openChat: api.openChat,
+  openPersonSourcingChat: api.openPersonSourcingChat,
   pinSession: api.pinSession,
   renameSession: api.renameSession,
   resolveInbox: vi.fn(),
@@ -102,6 +104,11 @@ describe("App shell routing", () => {
     api.getSkills.mockResolvedValue({ skills: [] });
     api.hasToken.mockReturnValue(true);
     api.openChat.mockReturnValue({ send: vi.fn(), approve: vi.fn(), close: vi.fn() });
+    api.openPersonSourcingChat.mockResolvedValue({
+      created: true,
+      session: { id: "thread-person", title: "Sourcing · Alyssa", n_msgs: 0 },
+      active_person: { person_id: "person-1", version: 1, label: "Alyssa" },
+    });
     api.pinSession.mockResolvedValue({ id: "alpha", title: "Alpha", pinned: true });
     api.renameSession.mockResolvedValue({ id: "alpha", title: "Renamed Alpha" });
     api.setLastDestination.mockResolvedValue({ destination: "#/skills" });
@@ -135,6 +142,36 @@ describe("App shell routing", () => {
     expect(api.getPerson).toHaveBeenCalledWith("person one");
     expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
     expect(screen.getByRole("link", { name: "Board" })).toHaveAttribute("aria-current", "page");
+  });
+
+  it("opens a newly created person chat before the cached session list refreshes", async () => {
+    window.location.hash = "#/people/person-1";
+    api.getPerson.mockResolvedValue({
+      person: { person_id: "person-1", sequence_state: "open", version: 1 },
+      brief: { who: "Alyssa", why: "Strong fit", learned: [], missing: [], sources: [] },
+      timeline: [],
+      sourcing_chat: null,
+    });
+    api.getSessions.mockResolvedValue({ sessions: [], open_id: null, last_destination: null });
+    api.getSession.mockResolvedValue({
+      id: "thread-person",
+      title: "Sourcing · Alyssa",
+      messages: [],
+      events: [],
+      active_person: { person_id: "person-1", version: 1, label: "Alyssa" },
+    });
+    render(<App />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Create sourcing chat" }),
+    );
+
+    await waitFor(() =>
+      expect(api.getSession).toHaveBeenCalledWith("thread-person", "person-1"),
+    );
+    expect(
+      screen.getByRole("link", { name: "Active person: Alyssa" }),
+    ).toBeInTheDocument();
   });
 
   it("renders a direct Scheduled hash route", async () => {
@@ -177,6 +214,44 @@ describe("App shell routing", () => {
     render(<App />);
 
     await waitFor(() => expect(api.getSession).toHaveBeenCalledWith("thread-alpha"));
+  });
+
+  it("keeps the person identity on the canonical bound-chat route", async () => {
+    window.location.hash = "#/chat/thread-alpha/person/person%20one";
+    api.getSessions.mockResolvedValue({
+      sessions: [
+        {
+          session_id: "thread-alpha",
+          title: "Sourcing · Alyssa",
+          n_msgs: 0,
+          pinned: false,
+          opened_at: "2026-08-27T10:00:00Z",
+          updated_at: "2026-08-27T10:00:00Z",
+        },
+      ],
+      open_id: "thread-alpha",
+      last_destination: "#/chat/thread-alpha/person/person%20one",
+    });
+    api.getSession.mockResolvedValue({
+      id: "thread-alpha",
+      title: "Sourcing · Alyssa",
+      messages: [],
+      events: [],
+      active_person: {
+        person_id: "person one",
+        version: 2,
+        label: "Alyssa Lee",
+      },
+    });
+
+    render(<App />);
+
+    await waitFor(() =>
+      expect(api.getSession).toHaveBeenCalledWith("thread-alpha", "person one"),
+    );
+    expect(
+      screen.getByRole("link", { name: "Active person: Alyssa Lee" }),
+    ).toHaveAttribute("href", "#/people/person%20one");
   });
 
   it("does not persist a scheduled transcript over the last normal destination", async () => {
@@ -276,6 +351,40 @@ describe("App shell routing", () => {
 
     expect(await screen.findByRole("heading", { level: 1, name: "Settings" })).toBeInTheDocument();
     expect(window.location.hash).toBe("#/settings");
+  });
+
+  it("restores the same canonical person-bound chat after restart", async () => {
+    window.location.hash = "";
+    api.getSessions.mockResolvedValue({
+      sessions: [
+        {
+          session_id: "thread-alpha",
+          title: "Sourcing · Alyssa",
+          n_msgs: 0,
+          pinned: false,
+          opened_at: "2026-08-27T10:00:00Z",
+          updated_at: "2026-08-27T10:00:00Z",
+        },
+      ],
+      open_id: "thread-alpha",
+      last_destination: "#/chat/thread-alpha/person/person%20one",
+    });
+    api.getSession.mockResolvedValue({
+      id: "thread-alpha",
+      title: "Sourcing · Alyssa",
+      messages: [],
+      events: [],
+      active_person: { person_id: "person one", version: 2, label: "Alyssa Lee" },
+    });
+
+    render(<App />);
+
+    await waitFor(() =>
+      expect(api.getSession).toHaveBeenCalledWith("thread-alpha", "person one"),
+    );
+    expect(window.location.hash).toBe(
+      "#/chat/thread-alpha/person/person%20one",
+    );
   });
 
   it("does not persist a cached destination before fresh session state resolves", async () => {

--- a/desktop/tests/test_bound_turn.py
+++ b/desktop/tests/test_bound_turn.py
@@ -77,6 +77,60 @@ def test_keep_one_person_binds_that_session_only(tmp_path):
     assert people.person_for_session("sess-b") is None
 
 
+def test_keep_existing_person_from_another_thread_preserves_chat_and_turn(tmp_path):
+    people = PersonStore(tmp_path)
+    person = people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+        target="initial target",
+    )
+    people.bind_session("sess-ada", person["person_id"])
+    provider = FakeProvider(
+        steps=[
+            {
+                "tool_calls": [
+                    ToolCall(
+                        id="keep_existing",
+                        name="people_keep",
+                        arguments={
+                            "people": [_ada()],
+                            "target": "updated target",
+                        },
+                    )
+                ]
+            },
+            {"deltas": ("Kept Ada in her existing sourcing chat.",)},
+        ]
+    )
+
+    result = _run(
+        tmp_path=tmp_path,
+        sid="sess-other",
+        text="keep Ada here too",
+        provider=provider,
+        people=people,
+    )
+
+    assert result == {
+        "status": "ok",
+        "text": "Kept Ada in her existing sourcing chat.",
+    }
+    assert people.person_for_session("sess-ada") == person["person_id"]
+    assert people.person_for_session("sess-other") is None
+    assert people.get(person["person_id"])["target"] == "updated target"
+    tool_receipt = next(
+        message
+        for message in ConversationStore(tmp_path).load("sess-other")
+        if message.get("role") == "tool"
+    )
+    assert '"sourcing_chat": {"session_id": "sess-ada"}' in tool_receipt[
+        "content"
+    ]
+
+
 def test_deleted_bound_person_stops_turn_before_model_request(tmp_path):
     people = PersonStore(tmp_path)
     person = people.keep_from_apollo(

--- a/desktop/tests/test_bound_turn.py
+++ b/desktop/tests/test_bound_turn.py
@@ -77,6 +77,37 @@ def test_keep_one_person_binds_that_session_only(tmp_path):
     assert people.person_for_session("sess-b") is None
 
 
+def test_deleted_bound_person_stops_turn_before_model_request(tmp_path):
+    people = PersonStore(tmp_path)
+    person = people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+    )
+    people.bind_session("sess-ada", person["person_id"])
+    people.delete(
+        person["person_id"],
+        expected_version=person["version"],
+        actor="director",
+        rationale_summary="Remove stale person file.",
+    )
+    provider = FakeProvider(deltas=("must not run",))
+
+    result = _run(
+        tmp_path=tmp_path,
+        sid="sess-ada",
+        text="continue",
+        provider=provider,
+        people=people,
+    )
+
+    assert result == {"status": "error", "text": ""}
+    assert provider.calls == []
+    assert ConversationStore(tmp_path).load("sess-ada") == []
+
+
 def _ada() -> dict:
     return {
         "apolloId": "ada",

--- a/desktop/tests/test_bound_turn.py
+++ b/desktop/tests/test_bound_turn.py
@@ -119,6 +119,7 @@ def test_keep_existing_person_from_another_thread_preserves_chat_and_turn(tmp_pa
         "text": "Kept Ada in her existing sourcing chat.",
     }
     assert people.person_for_session("sess-ada") == person["person_id"]
+    assert people.session_for_person(person["person_id"]) == "sess-ada"
     assert people.person_for_session("sess-other") is None
     assert people.get(person["person_id"])["target"] == "updated target"
     tool_receipt = next(

--- a/desktop/tests/test_people.py
+++ b/desktop/tests/test_people.py
@@ -213,19 +213,48 @@ def test_hubspot_is_not_a_source(tmp_path):
     assert store.timeline(person["person_id"]) == []
 
 
-def test_session_can_be_rebound_to_a_different_person(tmp_path):
+def test_session_binding_is_idempotent_and_cannot_be_rebound(tmp_path):
     store = PersonStore(tmp_path)
     ada = _ada(store)
     alonzo = _alonzo(store)
     store.bind_session("chat-1", ada["person_id"])
     assert store.person_for_session("chat-1") == ada["person_id"]
-    store.bind_session("chat-1", alonzo["person_id"])
-    assert store.person_for_session("chat-1") == alonzo["person_id"]
+    store.bind_session("chat-1", ada["person_id"])
+    with pytest.raises(ValueError, match="already bound"):
+        store.bind_session("chat-1", alonzo["person_id"])
+    assert store.person_for_session("chat-1") == ada["person_id"]
     assert store.person_for_session("chat-2") is None
     with pytest.raises(ValueError, match="unknown person"):
         store.bind_session("chat-1", "per_" + "0" * 32)
     restarted = PersonStore(tmp_path)
-    assert restarted.person_for_session("chat-1") == alonzo["person_id"]
+    assert restarted.person_for_session("chat-1") == ada["person_id"]
+
+
+def test_session_binding_rejects_a_stale_person_version(tmp_path):
+    store = PersonStore(tmp_path)
+    ada = _ada(store)
+
+    with pytest.raises(ValueError, match="stale record version"):
+        store.bind_session(
+            "chat-1",
+            ada["person_id"],
+            expected_person_version=ada["version"] + 1,
+        )
+
+    assert store.person_for_session("chat-1") is None
+
+
+def test_person_has_one_durable_bound_sourcing_session(tmp_path):
+    store = PersonStore(tmp_path)
+    ada = _ada(store)
+    store.bind_session("chat-1", ada["person_id"])
+
+    with pytest.raises(ValueError, match="already has a bound sourcing session"):
+        store.bind_session("chat-2", ada["person_id"])
+
+    assert store.session_for_person(ada["person_id"]) == "chat-1"
+    restarted = PersonStore(tmp_path)
+    assert restarted.session_for_person(ada["person_id"]) == "chat-1"
 
 
 def test_handoff_four_fields_survive_get(tmp_path):

--- a/desktop/tests/test_people_api.py
+++ b/desktop/tests/test_people_api.py
@@ -49,6 +49,431 @@ def test_get_unknown_person_is_404(tmp_path):
     assert res.status_code == 404
 
 
+def test_create_person_sourcing_chat_persists_binding_before_any_turn(tmp_path):
+    app = _app(tmp_path)
+    person = app.state.people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+    )
+
+    response = TestClient(app).post(
+        f"/v1/people/{person['person_id']}/sourcing-chat",
+        headers={TOKEN_HEADER: TOKEN},
+        json={"expected_person_version": person["version"]},
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    session_id = body["session"]["id"]
+    assert body["created"] is True
+    assert body["active_person"] == {
+        "person_id": person["person_id"],
+        "version": person["version"],
+        "label": "Ada L, Founder at Analytic",
+    }
+    assert app.state.people.person_for_session(session_id) == person["person_id"]
+    assert app.state.store.index(session_id) is not None
+    assert app.state.store.load(session_id) == []
+    assert app.state.store.load_events(session_id) == []
+
+
+def test_reopen_person_sourcing_chat_returns_same_session_after_restart(tmp_path):
+    app = _app(tmp_path)
+    person = app.state.people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+    )
+    first = TestClient(app).post(
+        f"/v1/people/{person['person_id']}/sourcing-chat",
+        headers={TOKEN_HEADER: TOKEN},
+        json={"expected_person_version": person["version"]},
+    )
+    session_id = first.json()["session"]["id"]
+
+    restarted = _app(tmp_path)
+    reopened = TestClient(restarted).post(
+        f"/v1/people/{person['person_id']}/sourcing-chat",
+        headers={TOKEN_HEADER: TOKEN},
+        json={"expected_person_version": person["version"]},
+    )
+
+    assert reopened.status_code == 200
+    assert reopened.json()["created"] is False
+    assert reopened.json()["session"]["id"] == session_id
+    assert restarted.state.people.person_for_session(session_id) == person["person_id"]
+
+
+def test_person_file_reports_whether_bound_sourcing_chat_exists(tmp_path):
+    app = _app(tmp_path)
+    person = app.state.people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+    )
+    client = TestClient(app)
+
+    before = client.get(
+        f"/v1/people/{person['person_id']}", headers={TOKEN_HEADER: TOKEN}
+    )
+    assert before.json()["sourcing_chat"] is None
+
+    created = client.post(
+        f"/v1/people/{person['person_id']}/sourcing-chat",
+        headers={TOKEN_HEADER: TOKEN},
+        json={"expected_person_version": person["version"]},
+    ).json()
+    after = client.get(
+        f"/v1/people/{person['person_id']}", headers={TOKEN_HEADER: TOKEN}
+    )
+
+    assert after.json()["sourcing_chat"] == {
+        "session_id": created["session"]["id"],
+        "person_id": person["person_id"],
+    }
+
+
+def test_create_sourcing_chat_for_missing_person_is_404(tmp_path):
+    response = TestClient(_app(tmp_path), raise_server_exceptions=False).post(
+        f"/v1/people/per_{'0' * 32}/sourcing-chat",
+        headers={TOKEN_HEADER: TOKEN},
+        json={"expected_person_version": 1},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"error": "not found"}
+
+
+def test_stale_person_version_does_not_create_or_bind_a_chat(tmp_path):
+    app = _app(tmp_path)
+    person = app.state.people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+    )
+    app.state.people.set_sequence(person["person_id"], "open", actor="director")
+    sessions_before = app.state.store.list_sessions()
+
+    response = TestClient(app).post(
+        f"/v1/people/{person['person_id']}/sourcing-chat",
+        headers={TOKEN_HEADER: TOKEN},
+        json={"expected_person_version": person["version"]},
+    )
+
+    assert response.status_code == 409
+    assert "stale" in response.json()["error"]
+    assert app.state.people.session_for_person(person["person_id"]) is None
+    assert app.state.store.list_sessions() == sessions_before
+
+
+def test_cross_person_session_reuse_fails_without_rebinding(tmp_path):
+    app = _app(tmp_path)
+    ada = app.state.people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+    )
+    alonzo = app.state.people.keep_from_apollo(
+        apollo_id="alonzo",
+        first_name="Alonzo",
+        last_name_obfuscated="C",
+        title="Professor",
+        company="Princeton",
+    )
+    client = TestClient(app)
+    ada_session = client.post(
+        f"/v1/people/{ada['person_id']}/sourcing-chat",
+        headers={TOKEN_HEADER: TOKEN},
+        json={"expected_person_version": ada["version"]},
+    ).json()["session"]["id"]
+
+    response = client.post(
+        f"/v1/people/{alonzo['person_id']}/sourcing-chat",
+        headers={TOKEN_HEADER: TOKEN},
+        json={
+            "expected_person_version": alonzo["version"],
+            "session_id": ada_session,
+        },
+    )
+
+    assert response.status_code == 409
+    assert "already bound" in response.json()["error"]
+    assert app.state.people.person_for_session(ada_session) == ada["person_id"]
+    assert app.state.people.session_for_person(alonzo["person_id"]) is None
+
+
+def test_bound_session_restore_returns_current_active_person(tmp_path):
+    app = _app(tmp_path)
+    person = app.state.people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+    )
+    client = TestClient(app)
+    session_id = client.post(
+        f"/v1/people/{person['person_id']}/sourcing-chat",
+        headers={TOKEN_HEADER: TOKEN},
+        json={"expected_person_version": person["version"]},
+    ).json()["session"]["id"]
+
+    restored = client.get(
+        f"/v1/sessions/{session_id}", headers={TOKEN_HEADER: TOKEN}
+    )
+
+    assert restored.status_code == 200
+    assert restored.json()["active_person"] == {
+        "person_id": person["person_id"],
+        "version": person["version"],
+        "label": "Ada L, Founder at Analytic",
+    }
+
+
+def test_deleted_bound_person_makes_session_restore_fail_visibly(tmp_path):
+    app = _app(tmp_path)
+    person = app.state.people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+    )
+    client = TestClient(app)
+    session_id = client.post(
+        f"/v1/people/{person['person_id']}/sourcing-chat",
+        headers={TOKEN_HEADER: TOKEN},
+        json={"expected_person_version": person["version"]},
+    ).json()["session"]["id"]
+    app.state.people.delete(
+        person["person_id"],
+        expected_version=person["version"],
+        actor="director",
+        rationale_summary="Remove stale person file.",
+    )
+
+    restored = client.get(
+        f"/v1/sessions/{session_id}", headers={TOKEN_HEADER: TOKEN}
+    )
+
+    assert restored.status_code == 409
+    assert restored.json() == {
+        "error": "bound person file is unavailable",
+        "code": "bound_person_unavailable",
+    }
+
+
+def test_deleted_bound_person_blocks_model_turn_before_provider_call(tmp_path):
+    app = _app(tmp_path)
+    person = app.state.people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+    )
+    client = TestClient(app)
+    session_id = client.post(
+        f"/v1/people/{person['person_id']}/sourcing-chat",
+        headers={TOKEN_HEADER: TOKEN},
+        json={"expected_person_version": person["version"]},
+    ).json()["session"]["id"]
+    app.state.people.delete(
+        person["person_id"],
+        expected_version=person["version"],
+        actor="director",
+        rationale_summary="Remove stale person file.",
+    )
+
+    with client.websocket_connect("/ws/chat", subprotocols=["club", TOKEN]) as ws:
+        ws.send_json(
+            {"type": "chat", "text": "do not run", "session_id": session_id}
+        )
+        event = ws.receive_json()
+
+    assert event == {
+        "type": "error",
+        "message": "This conversation's bound person file is unavailable.",
+    }
+    assert app.state.provider.calls == []
+    assert app.state.store.load(session_id) == []
+
+
+def test_session_route_rejects_a_different_expected_person(tmp_path):
+    app = _app(tmp_path)
+    ada = app.state.people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+    )
+    alonzo = app.state.people.keep_from_apollo(
+        apollo_id="alonzo",
+        first_name="Alonzo",
+        last_name_obfuscated="C",
+        title="Professor",
+        company="Princeton",
+    )
+    client = TestClient(app)
+    session_id = client.post(
+        f"/v1/people/{ada['person_id']}/sourcing-chat",
+        headers={TOKEN_HEADER: TOKEN},
+        json={"expected_person_version": ada["version"]},
+    ).json()["session"]["id"]
+
+    response = client.get(
+        f"/v1/sessions/{session_id}",
+        headers={TOKEN_HEADER: TOKEN},
+        params={"expected_person_id": alonzo["person_id"]},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "error": "conversation is bound to a different person",
+        "code": "person_binding_mismatch",
+    }
+    assert app.state.people.person_for_session(session_id) == ada["person_id"]
+
+
+def test_reverting_person_data_preserves_the_same_bound_session(tmp_path):
+    app = _app(tmp_path)
+    person = app.state.people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+    )
+    version_two = app.state.people.set_sequence(
+        person["person_id"], "open", actor="director"
+    )
+    client = TestClient(app)
+    session_id = client.post(
+        f"/v1/people/{person['person_id']}/sourcing-chat",
+        headers={TOKEN_HEADER: TOKEN},
+        json={"expected_person_version": version_two["version"]},
+    ).json()["session"]["id"]
+    reverted = app.state.people.revert(
+        person["person_id"],
+        to_version=person["version"],
+        expected_version=version_two["version"],
+        actor="director",
+        rationale_summary="Restore the earlier person file.",
+    )
+
+    restored = client.get(
+        f"/v1/sessions/{session_id}",
+        headers={TOKEN_HEADER: TOKEN},
+        params={"expected_person_id": person["person_id"]},
+    )
+    reopened = client.post(
+        f"/v1/people/{person['person_id']}/sourcing-chat",
+        headers={TOKEN_HEADER: TOKEN},
+        json={"expected_person_version": reverted["version"]},
+    )
+
+    assert restored.status_code == 200
+    assert restored.json()["active_person"]["person_id"] == person["person_id"]
+    assert restored.json()["active_person"]["version"] == reverted["version"]
+    assert reopened.json()["session"]["id"] == session_id
+    assert reopened.json()["created"] is False
+
+
+def test_explicit_bound_chat_prompt_uses_only_its_person_evidence(tmp_path):
+    app = _app(tmp_path)
+    ada = app.state.people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+        target="research dinner",
+    )
+    alonzo = app.state.people.keep_from_apollo(
+        apollo_id="alonzo",
+        first_name="Alonzo",
+        last_name_obfuscated="C",
+        title="Professor",
+        company="Princeton",
+        target="different project",
+    )
+    app.state.people.append_event(
+        ada["person_id"],
+        source="gmail",
+        kind="mail",
+        summary="Ada asked about the research dinner.",
+    )
+    app.state.people.append_event(
+        alonzo["person_id"],
+        source="granola",
+        kind="meeting",
+        summary="PRIVATE ALONZO NOTES",
+    )
+    client = TestClient(app)
+    session_id = client.post(
+        f"/v1/people/{ada['person_id']}/sourcing-chat",
+        headers={TOKEN_HEADER: TOKEN},
+        json={"expected_person_version": ada["version"]},
+    ).json()["session"]["id"]
+
+    with client.websocket_connect("/ws/chat", subprotocols=["club", TOKEN]) as ws:
+        ws.send_json(
+            {"type": "chat", "text": "prepare me", "session_id": session_id}
+        )
+        while ws.receive_json()["type"] not in {"turn_end", "error"}:
+            pass
+
+    prompt = str(app.state.provider.calls[0][0]["content"])
+    assert "Ada" in prompt
+    assert "Ada asked about the research dinner." in prompt
+    assert "Alonzo" not in prompt
+    assert "PRIVATE ALONZO NOTES" not in prompt
+
+
+def test_legacy_multiple_person_chats_fail_visibly_instead_of_choosing_one(tmp_path):
+    app = _app(tmp_path)
+    person = app.state.people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+    )
+    app.state.store.create_session("legacy-one")
+    app.state.store.create_session("legacy-two")
+    with app.state.people._lock:
+        app.state.people._conn.executemany(
+            "INSERT INTO session_people (session_id, person_id) VALUES (?, ?)",
+            [
+                ("legacy-one", person["person_id"]),
+                ("legacy-two", person["person_id"]),
+            ],
+        )
+        app.state.people._conn.commit()
+
+    response = TestClient(app, raise_server_exceptions=False).get(
+        f"/v1/people/{person['person_id']}", headers={TOKEN_HEADER: TOKEN}
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "error": "person has multiple bound sourcing sessions",
+        "code": "person_chat_conflict",
+    }
+
+
 def test_get_person_does_not_leak_access_token(tmp_path):
     app = _app(tmp_path)
     person = app.state.people.keep_from_apollo(

--- a/desktop/tests/test_person_prompt.py
+++ b/desktop/tests/test_person_prompt.py
@@ -100,3 +100,27 @@ def test_prompt_does_not_include_access_token(tmp_path):
     prompt = system_prompt(conv, people=people, session_id="sess-ada")
     assert "ya29.secret" not in prompt
     assert "access_token" not in prompt
+
+
+def test_bound_prompt_keeps_recent_source_references_with_the_brief(tmp_path):
+    conv = ConversationStore(tmp_path)
+    people = PersonStore(tmp_path)
+    ada = people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+    )
+    people.bind_session("sess-ada", ada["person_id"])
+    evidence = people.append_event(
+        ada["person_id"],
+        source="gmail",
+        kind="mail",
+        summary="Ada confirmed the dinner timing.",
+    )
+
+    prompt = system_prompt(conv, people=people, session_id="sess-ada")
+
+    assert f"gmail:{evidence['event_id']}" in prompt
+    assert "Ada confirmed the dinner timing." in prompt


### PR DESCRIPTION
## Summary\n\n- add one labeled Create/Open sourcing chat action from each person file\n- persist immutable one-person session binding before the first model turn\n- restore the same chat across reopen and restart\n- include session and person identities in canonical routes and show the active person in the chat header\n- keep bound prompts capped with stable recent source references\n- fail visibly on missing, stale, deleted, reverted, cross-person, and legacy-conflict states\n- prevent stale session caches and failed creates from leaving orphan or misbound sessions\n\n## Verification\n\n- focused Python: 107 passed\n- focused GUI: 121 passed\n- make test: 687 Python passed, 3 skipped; 396 GUI passed\n- make build: passed\n- git diff --check: passed\n- rebased onto merged Sprint 1 main\n\nCloses #62\n\n## Residual risk\n\nLegacy people with multiple historical bindings now fail visibly and require manual reconciliation; none is selected silently. No credentialed live-provider smoke was run.