### PR TITLE
feat(desktop): derive effective tools from runtime policy

### DIFF
--- a/desktop/coworker/effective_tools.py
+++ b/desktop/coworker/effective_tools.py
@@ -1,0 +1,192 @@
+"""Validated per-run model-facing tool catalogs."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from coworker.persona import ManifestError, Persona
+from coworker.permissions import model_approval_class
+from coworker.workspace_runtime import WORKSPACE_TOOL_NAMES, WorkspaceRuntime
+
+
+class ToolCatalogError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class ToolAvailability:
+    gmail: bool = True
+    drive: bool = True
+    calendar: bool = True
+    apollo: bool = True
+    web: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class ToolCapability:
+    name: str
+    approval_class: str
+
+
+@dataclass(frozen=True, slots=True)
+class EffectiveToolCatalog:
+    schemas: tuple[dict[str, Any], ...]
+    capabilities: tuple[ToolCapability, ...]
+
+    @property
+    def names(self) -> tuple[str, ...]:
+        return tuple(item.name for item in self.capabilities)
+
+    def diagnostics(self) -> tuple[dict[str, str], ...]:
+        return tuple(
+            {"name": item.name, "approval_class": item.approval_class}
+            for item in self.capabilities
+        )
+
+
+_GMAIL = frozenset({"gmail_search", "gmail_read", "gmail_draft", "gmail_send"})
+_DRIVE = frozenset({"drive_search", "drive_list_folder", "drive_read"})
+_CALENDAR = frozenset(
+    {"calendar_list", "calendar_create", "calendar_update"}
+)
+_APOLLO = frozenset({"apollo_search_people", "apollo_enrich_contact"})
+_WEB = frozenset({"web_search"})
+_WORKSPACE_READ = frozenset(
+    {"fs_stat", "fs_list", "fs_find", "fs_search", "fs_read"}
+)
+_WORKSPACE_WRITE = frozenset(
+    {"fs_mkdir", "fs_write", "fs_patch", "fs_copy", "fs_move", "fs_trash"}
+)
+_WORKSPACE_SHELL = frozenset(
+    {"shell_exec", "shell_poll", "shell_write_stdin", "shell_kill"}
+)
+_BUDDY_BASE = frozenset(
+    {
+        "now",
+        "remember",
+        "memory_update",
+        "memory_forget",
+        "gmail_draft",
+        "request_directory",
+        *_WORKSPACE_READ,
+        *_WORKSPACE_WRITE,
+        *_WORKSPACE_SHELL,
+    }
+)
+
+
+def _schema_name(schema: object) -> str:
+    if not isinstance(schema, dict):
+        raise ToolCatalogError("registered tool schema must be an object")
+    function = schema.get("function")
+    if not isinstance(function, dict):
+        raise ToolCatalogError("registered tool schema requires function metadata")
+    name = str(function.get("name") or "")
+    if not name:
+        raise ToolCatalogError("registered tool schema requires a name")
+    return name
+
+
+def _registry(
+    schemas: Iterable[dict[str, Any]],
+) -> tuple[tuple[str, dict[str, Any]], ...]:
+    rows: list[tuple[str, dict[str, Any]]] = []
+    seen: set[str] = set()
+    for schema in schemas:
+        name = _schema_name(schema)
+        if name in seen:
+            raise ToolCatalogError(f"duplicate registered tool: {name}")
+        seen.add(name)
+        rows.append((name, schema))
+    return tuple(rows)
+
+
+def _workspace_names(runtime: WorkspaceRuntime | None) -> set[str]:
+    if runtime is None:
+        return set()
+    allowed = {"request_directory"}
+    grants = runtime.grants.list_active()
+    if not grants:
+        return allowed
+    allowed.update(_WORKSPACE_READ)
+    writable = [grant for grant in grants if grant.get("access") == "read_write"]
+    if writable:
+        allowed.update(_WORKSPACE_WRITE)
+    if any(grant.get("allow_shell") for grant in writable):
+        allowed.update(_WORKSPACE_SHELL)
+    return allowed
+
+
+def _availability_names(
+    registry_names: set[str],
+    availability: ToolAvailability,
+    workspace_runtime: WorkspaceRuntime | None,
+) -> set[str]:
+    allowed = set(registry_names)
+    for enabled, group in (
+        (availability.gmail, _GMAIL),
+        (availability.drive, _DRIVE),
+        (availability.calendar, _CALENDAR),
+        (availability.apollo, _APOLLO),
+        (availability.web, _WEB),
+    ):
+        if not enabled:
+            allowed.difference_update(group)
+    allowed.difference_update(WORKSPACE_TOOL_NAMES)
+    allowed.update(_workspace_names(workspace_runtime) & registry_names)
+    return allowed
+
+
+def effective_tool_catalog(
+    *,
+    persona: Persona,
+    registered_schemas: Iterable[dict[str, Any]],
+    workspace_runtime: WorkspaceRuntime | None,
+    availability: ToolAvailability,
+) -> EffectiveToolCatalog:
+    registry = _registry(registered_schemas)
+    registry_names = {name for name, _schema in registry}
+    unknown = [name for name in persona.tools if name not in registry_names]
+    if unknown:
+        raise ManifestError(f"unknown persona tool: {unknown[0]}")
+
+    if persona.id == "sourcing":
+        persona_base = set(registry_names)
+    elif persona.id == "buddy":
+        missing_policy_names = sorted(_BUDDY_BASE - registry_names)
+        if missing_policy_names:
+            raise ToolCatalogError(
+                "buddy policy references unknown tool: " + missing_policy_names[0]
+            )
+        persona_base = set(_BUDDY_BASE & registry_names)
+    else:
+        persona_base = set()
+    if persona.tools:
+        persona_base.intersection_update(persona.tools)
+
+    effective_names = persona_base & _availability_names(
+        registry_names, availability, workspace_runtime
+    )
+    schemas: list[dict[str, Any]] = []
+    capabilities: list[ToolCapability] = []
+    for name, raw_schema in registry:
+        if name not in effective_names:
+            continue
+        approval_class = model_approval_class(name)
+        if approval_class is None:
+            if name.startswith("mcp__"):
+                continue
+            raise ToolCatalogError(
+                f"registered tool {name} has no permission policy"
+            )
+        schema = deepcopy(raw_schema)
+        function = schema["function"]
+        description = str(function.get("description") or name).rstrip()
+        function["description"] = (
+            f"{description} Runtime approval: {approval_class}."
+        )
+        schemas.append(schema)
+        capabilities.append(ToolCapability(name, approval_class))
+    return EffectiveToolCatalog(tuple(schemas), tuple(capabilities))

--- a/desktop/coworker/permissions.py
+++ b/desktop/coworker/permissions.py
@@ -60,6 +60,21 @@ RETRY_SAFE = frozenset(
 )
 _MCP_WRITE = re.compile(r"write|create|delete|update", re.I)
 
+_WORKSPACE_AUTO = frozenset(
+    {
+        "fs_stat",
+        "fs_list",
+        "fs_find",
+        "fs_search",
+        "fs_read",
+        "request_directory",
+        "shell_poll",
+        "shell_kill",
+    }
+)
+_WORKSPACE_APPROVAL = frozenset({"fs_trash", "shell_write_stdin"})
+_WORKSPACE_CONDITIONAL = WORKSPACE_TOOL_NAMES - _WORKSPACE_AUTO - _WORKSPACE_APPROVAL
+
 
 @dataclass
 class Decision:
@@ -69,6 +84,32 @@ class Decision:
     risk_class: str | None = None
     execution_target: str | None = None
     command_fingerprint: str | None = None
+
+
+def model_approval_class(name: str) -> str | None:
+    """Content-free schema-level guidance derived from runtime policy.
+
+    ``conditional`` means the concrete arguments, grant, or target determine
+    whether the call is automatic or approval-gated.
+    """
+    if name in AUTO:
+        return "auto"
+    if name in ASK:
+        return "approval_required"
+    if name in _WORKSPACE_AUTO:
+        return "auto"
+    if name in _WORKSPACE_APPROVAL:
+        return "approval_required"
+    if name in _WORKSPACE_CONDITIONAL:
+        return "conditional"
+    if name.startswith("mcp__"):
+        decision = decide(name)
+        if decision.allowed:
+            return "auto"
+        if decision.needs_user:
+            return "approval_required"
+        return None
+    return None
 
 
 def decide(

--- a/desktop/coworker/personas/buddy.md
+++ b/desktop/coworker/personas/buddy.md
@@ -1,7 +1,6 @@
 ---
 id: buddy
 name: Club
-tools: [now, remember, memory_update, memory_forget, gmail_draft, fs_stat, fs_list, fs_find, fs_search, fs_read, fs_mkdir, fs_write, fs_patch, fs_copy, fs_move, fs_trash, request_directory, shell_exec, shell_poll, shell_write_stdin, shell_kill]
 ---
 
 You are Club, Fisher's local work buddy on this Mac. You are a generic personal coworker, not a sourcing agent and not a coding agent.

--- a/desktop/coworker/personas/sourcing.md
+++ b/desktop/coworker/personas/sourcing.md
@@ -1,7 +1,6 @@
 ---
 id: sourcing
 name: Sourcecado Sourcing Agent
-tools: [search_memory, add_memory_note, web_search, web_fetch, apollo_search_people, apollo_enrich_contact, fs_stat, fs_list, fs_find, fs_search, fs_read, fs_mkdir, fs_write, fs_patch, fs_copy, fs_move, fs_trash, request_directory, shell_exec, shell_poll, shell_write_stdin, shell_kill]
 ---
 
 ## Active prompt

--- a/desktop/coworker/server.py
+++ b/desktop/coworker/server.py
@@ -46,8 +46,14 @@ from coworker.connectors.google_oauth import (
     save_google,
 )
 from coworker.drive import drive_from_secrets
+from coworker.effective_tools import (
+    EffectiveToolCatalog,
+    ToolAvailability,
+    ToolCatalogError,
+    effective_tool_catalog,
+)
 from coworker.events import build_event, new_turn_identity, TurnIdentity
-from coworker.gmail import gmail_from_secrets
+from coworker.gmail import MissingGmail, gmail_from_secrets
 from coworker.inbox import Inbox
 from coworker.mcp import LiveMcp, write_default_mcp_json
 from coworker.mcp_oauth import McpOAuth
@@ -366,7 +372,25 @@ def create_app(
             oauth=app.state.mcp_oauth,
         )
     )
-    app.state.openai_tools = list(OPENAI_TOOLS) + app.state.mcp.schemas()
+
+    def _effective_tool_catalog(
+        persona: Persona | None = None,
+    ) -> EffectiveToolCatalog:
+        return effective_tool_catalog(
+            persona=persona or app.state.persona,
+            registered_schemas=(*OPENAI_TOOLS, *app.state.mcp.schemas()),
+            workspace_runtime=app.state.workspace_runtime,
+            availability=ToolAvailability(
+                gmail=not isinstance(app.state.gmail, MissingGmail),
+                drive=app.state.drive is not None,
+                calendar=app.state.calendar is not None,
+                apollo=bool(app.state.apollo_key),
+                web=bool(app.state.tavily_key),
+            ),
+        )
+
+    app.state.effective_tool_catalog = _effective_tool_catalog
+    _effective_tool_catalog()  # Fail startup on invalid persona/registry contracts.
 
     def _default_job_runner(job: dict[str, Any]) -> dict[str, Any]:
         import asyncio
@@ -385,7 +409,7 @@ def create_app(
                 persona=app.state.persona,
                 skills=app.state.skills,
                 inbox=app.state.inbox,
-                openai_tools=app.state.openai_tools,
+                openai_tools=list(_effective_tool_catalog().schemas),
                 execute_kwargs={
                     "store": app.state.store,
                     "gmail": app.state.gmail,
@@ -891,7 +915,11 @@ def create_app(
     @app.get("/v1/persona")
     def persona():
         p = app.state.persona
-        return {"id": p.id, "name": p.name, "tools": p.tools}
+        return {
+            "id": p.id,
+            "name": p.name,
+            "tools": list(_effective_tool_catalog().names),
+        }
 
     @app.get("/v1/skills")
     def skills():
@@ -956,7 +984,8 @@ def create_app(
         pid = str(payload.get("id") or "").strip()
         try:
             nxt = load_persona(pid)
-        except ManifestError as exc:
+            _effective_tool_catalog(nxt)
+        except (ManifestError, ToolCatalogError) as exc:
             return JSONResponse({"error": str(exc)}, status_code=400)
         app.state.store.set_setting("persona", nxt.id)
         app.state.persona = nxt
@@ -1400,7 +1429,6 @@ def create_app(
     @app.post("/v1/connectors/granola/disconnect")
     def granola_disconnect():
         app.state.secrets.delete("mcp-oauth:granola")
-        app.state.openai_tools = list(OPENAI_TOOLS) + app.state.mcp.schemas()
         return {"connected": False, "disconnected": ["granola"]}
 
     @app.get("/v1/mcp/oauth/callback")
@@ -1413,7 +1441,6 @@ def create_app(
             return HTMLResponse("<p>Granola connect failed: missing code.</p>", status_code=400)
         try:
             app.state.mcp_oauth.finish(code=code, state=state)
-            app.state.openai_tools = list(OPENAI_TOOLS) + app.state.mcp.schemas()
         except Exception as exc:
             return HTMLResponse(
                 f"<p>Granola connect failed: {html.escape(str(exc))}</p>", status_code=400
@@ -1653,6 +1680,7 @@ def create_app(
             "version": 1,
             "session_id": sid,
             **asdict(assembled.diagnostics),
+            "effective_tools": list(_effective_tool_catalog().diagnostics()),
         }
 
     @app.patch("/v1/sessions/{sid}")
@@ -2059,7 +2087,7 @@ def create_app(
                     persona=app.state.persona,
                     skills=app.state.skills,
                     inbox=app.state.inbox,
-                    openai_tools=app.state.openai_tools,
+                    openai_tools=list(_effective_tool_catalog().schemas),
                     execute_kwargs={
                         "store": store,
                         "gmail": app.state.gmail,

--- a/desktop/coworker/turn.py
+++ b/desktop/coworker/turn.py
@@ -646,6 +646,11 @@ async def run_turn(
         session_id=events.identity.session_id,
         run_id=events.identity.run_id,
     )
+    effective_tool_names = {
+        str((schema.get("function") or {}).get("name") or "")
+        for schema in openai_tools
+        if isinstance(schema, dict)
+    }
     turn_span = recorder.start_span(
         AgentTurnSpan(operation="agent.turn"), trace_context
     )
@@ -995,6 +1000,24 @@ async def run_turn(
                 approval_claimant: str | None = None
                 approval_scope = "once"
                 approval_fingerprint: str | None = None
+                if call.name not in effective_tool_names:
+                    result = {
+                        "error": f"tool {call.name} is not available in this run"
+                    }
+                    had_tool_failure = True
+                    await _emit(
+                        _tool_finished_event(
+                            call,
+                            ok=False,
+                            result=result,
+                            identity=events.identity,
+                        )
+                    )
+                    unavailable = _stamp(_tool_result_message(call, result))
+                    history.append(unavailable)
+                    _persist_message(unavailable)
+                    _record_person_file(sid, call, False, result, execute_kwargs)
+                    continue
                 workspace_runtime = execute_kwargs.get("workspace_runtime")
                 if workspace_runtime is not None and workspace_runtime.owns_tool(
                     call.name

--- a/desktop/docs/effective-tools.md
+++ b/desktop/docs/effective-tools.md
@@ -1,0 +1,20 @@
+# Effective model tool catalog
+
+Status: active-stack engineering reference.
+
+The schemas sent to a model for a Sourcecado run are the sole capability surface for that run. The catalog is rebuilt immediately before scheduled and interactive turns from:
+
+1. the registered Sourcecado and connected MCP schemas;
+2. the runtime-owned sourcing or buddy narrowing policy;
+3. any validated persona declaration, which may narrow but never broaden that policy;
+4. current connector availability;
+5. active Sourcecado workspace grants, including read/write and shell authority; and
+6. the schema-level approval class derived from the runtime permission policy.
+
+Persona prose and frontmatter do not grant tools. The built-in personas declare no tools. A custom declaration is treated only as an additional allowlist restriction, and an unknown or misspelled name fails composition clearly.
+
+Filesystem tools require an active workspace grant. Write tools additionally require a read-write grant. Shell tools require a read-write grant with shell authority. `request_directory` remains available so the operator can deliberately create the contract; it grants no filesystem or shell authority by itself.
+
+Each effective schema keeps its registered shape and receives a content-free approval annotation: `auto`, `approval_required`, or `conditional`. Provider calls outside the supplied catalog are persisted as failed tool results and never execute.
+
+Prompt diagnostics expose only ordered effective tool names and approval classes. They never include descriptions, parameter schemas, arguments, connector output, credentials, or prompt prose.

--- a/desktop/tests/test_chat.py
+++ b/desktop/tests/test_chat.py
@@ -648,6 +648,7 @@ def test_failed_tool_emits_structured_recovery_metadata_and_partial_terminal(
 
     monkeypatch.setattr("coworker.turn.execute", fake_execute)
     built = create_app(token=TOKEN, provider=fake, state=tmp_path)
+    built.state.drive = object()
     sid = built.state.store.open_session_id()
     with TestClient(built).websocket_connect(
         "/ws/chat", subprotocols=["club", TOKEN]
@@ -714,6 +715,7 @@ def test_safe_failed_step_retry_is_addressed_idempotent_and_reruns_only_failure(
 
     monkeypatch.setattr("coworker.turn.execute", flaky_execute)
     built = create_app(token=TOKEN, provider=fake, state=tmp_path)
+    built.state.drive = object()
     sid = built.state.store.open_session_id()
     with TestClient(built).websocket_connect(
         "/ws/chat", subprotocols=["club", TOKEN]
@@ -774,6 +776,7 @@ def test_unsafe_failed_step_retry_creates_fresh_approval_before_execution(
 
     monkeypatch.setattr("coworker.turn.execute", failing_execute)
     built = create_app(token=TOKEN, provider=fake, state=tmp_path)
+    built.state.gmail = FakeGmail()
     sid = built.state.store.open_session_id()
     with TestClient(built).websocket_connect(
         "/ws/chat", subprotocols=["club", TOKEN]
@@ -867,6 +870,7 @@ def test_unsafe_retry_http_allow_closes_recovery_and_replays_terminal_result(
     monkeypatch.setattr("coworker.turn.execute", retry_execute)
     monkeypatch.setattr("coworker.server.execute", retry_execute)
     built = create_app(token=TOKEN, provider=fake, state=tmp_path)
+    built.state.gmail = FakeGmail()
     client = TestClient(built)
     sid = built.state.store.open_session_id()
 
@@ -1025,6 +1029,7 @@ def test_unsafe_retry_http_deny_closes_recovery_without_executing(
     monkeypatch.setattr("coworker.turn.execute", failing_execute)
     monkeypatch.setattr("coworker.server.execute", failing_execute)
     built = create_app(token=TOKEN, provider=fake, state=tmp_path)
+    built.state.gmail = FakeGmail()
     client = TestClient(built)
     sid = built.state.store.open_session_id()
 
@@ -1267,6 +1272,7 @@ def test_repair_and_continue_without_source_are_durable_idempotent_choices(
         ),
     )
     built = create_app(token=TOKEN, provider=fake, state=tmp_path)
+    built.state.drive = object()
     sid = built.state.store.open_session_id()
     with TestClient(built).websocket_connect(
         "/ws/chat", subprotocols=["club", TOKEN]
@@ -1352,6 +1358,7 @@ def test_tool_result_normalizes_stable_source_and_artifact_provenance(
         ),
     )
     built = create_app(token=TOKEN, provider=fake, state=tmp_path)
+    built.state.drive = object()
     sid = built.state.store.open_session_id()
     with TestClient(built).websocket_connect(
         "/ws/chat", subprotocols=["club", TOKEN]

--- a/desktop/tests/test_effective_tools.py
+++ b/desktop/tests/test_effective_tools.py
@@ -1,0 +1,285 @@
+from pathlib import Path
+
+import json
+
+import pytest
+
+
+def test_effective_tool_catalog_module_exists():
+    module = Path(__file__).parents[1] / "coworker" / "effective_tools.py"
+
+    assert module.is_file()
+
+
+def test_sourcing_catalog_filters_unavailable_connectors_and_ungranted_workspace(
+    tmp_path,
+):
+    from coworker.effective_tools import ToolAvailability, effective_tool_catalog
+    from coworker.persona import Persona
+    from coworker.tools import OPENAI_TOOLS
+    from coworker.workspace_runtime import WorkspaceRuntime
+
+    runtime = WorkspaceRuntime(tmp_path / "state")
+    try:
+        catalog = effective_tool_catalog(
+            persona=Persona(id="sourcing", name="Sourcing", body="", tools=[]),
+            registered_schemas=OPENAI_TOOLS,
+            workspace_runtime=runtime,
+            availability=ToolAvailability(
+                gmail=False,
+                drive=False,
+                calendar=False,
+                apollo=False,
+                web=False,
+            ),
+        )
+    finally:
+        runtime.close()
+
+    assert {"now", "remember", "people_keep", "board_query"} <= set(catalog.names)
+    assert not set(catalog.names).intersection(
+        {
+            "gmail_search",
+            "gmail_draft",
+            "drive_read",
+            "calendar_list",
+            "apollo_search_people",
+            "apollo_enrich_contact",
+            "web_search",
+        }
+    )
+    assert "request_directory" in catalog.names
+    assert not any(name.startswith("fs_") for name in catalog.names)
+    assert not any(name.startswith("shell_") for name in catalog.names)
+
+
+def test_permission_classes_and_prompt_facing_schema_annotations_share_one_catalog(
+    tmp_path,
+):
+    from coworker.effective_tools import ToolAvailability, effective_tool_catalog
+    from coworker.persona import Persona
+    from coworker.tools import OPENAI_TOOLS
+    from coworker.workspace_runtime import WorkspaceRuntime
+
+    runtime = WorkspaceRuntime(tmp_path / "state")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    runtime.add_grant(
+        workspace,
+        label="Workspace",
+        access="read_write",
+        allow_shell=True,
+    )
+    try:
+        catalog = effective_tool_catalog(
+            persona=Persona(id="sourcing", name="Sourcing", body="", tools=[]),
+            registered_schemas=OPENAI_TOOLS,
+            workspace_runtime=runtime,
+            availability=ToolAvailability(),
+        )
+    finally:
+        runtime.close()
+
+    classes = {item.name: item.approval_class for item in catalog.capabilities}
+    assert classes["now"] == "auto"
+    assert classes["gmail_draft"] == "approval_required"
+    assert classes["fs_read"] == "auto"
+    assert classes["shell_exec"] == "conditional"
+    for schema in catalog.schemas:
+        name = schema["function"]["name"]
+        assert f"Runtime approval: {classes[name]}." in schema["function"][
+            "description"
+        ]
+
+
+def test_workspace_contract_controls_read_write_and_shell_subsets(tmp_path):
+    from coworker.effective_tools import ToolAvailability, effective_tool_catalog
+    from coworker.persona import Persona
+    from coworker.tools import OPENAI_TOOLS
+    from coworker.workspace_runtime import WorkspaceRuntime
+
+    persona = Persona(id="sourcing", name="Sourcing", body="", tools=[])
+    runtime = WorkspaceRuntime(tmp_path / "state")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    try:
+        without_grant = effective_tool_catalog(
+            persona=persona,
+            registered_schemas=OPENAI_TOOLS,
+            workspace_runtime=runtime,
+            availability=ToolAvailability(),
+        )
+        read_only = runtime.add_grant(
+            workspace, label="Read", access="read_only", allow_shell=False
+        )
+        with_read = effective_tool_catalog(
+            persona=persona,
+            registered_schemas=OPENAI_TOOLS,
+            workspace_runtime=runtime,
+            availability=ToolAvailability(),
+        )
+        runtime.update_grant(read_only["id"], access="read_write")
+        with_write = effective_tool_catalog(
+            persona=persona,
+            registered_schemas=OPENAI_TOOLS,
+            workspace_runtime=runtime,
+            availability=ToolAvailability(),
+        )
+        runtime.update_grant(read_only["id"], allow_shell=True)
+        with_shell = effective_tool_catalog(
+            persona=persona,
+            registered_schemas=OPENAI_TOOLS,
+            workspace_runtime=runtime,
+            availability=ToolAvailability(),
+        )
+    finally:
+        runtime.close()
+
+    assert "fs_read" not in without_grant.names
+    assert "fs_read" in with_read.names
+    assert "fs_write" not in with_read.names
+    assert "fs_write" in with_write.names
+    assert "shell_exec" not in with_write.names
+    assert {"shell_exec", "shell_poll", "shell_kill"} <= set(with_shell.names)
+
+
+def test_persona_declarations_can_narrow_but_never_broaden_runtime_policy(tmp_path):
+    from coworker.effective_tools import ToolAvailability, effective_tool_catalog
+    from coworker.persona import Persona
+    from coworker.tools import OPENAI_TOOLS
+    from coworker.workspace_runtime import WorkspaceRuntime
+
+    runtime = WorkspaceRuntime(tmp_path / "state")
+    try:
+        buddy = effective_tool_catalog(
+            persona=Persona(
+                id="buddy",
+                name="Buddy",
+                body="I claim Apollo and shell access.",
+                tools=["apollo_search_people"],
+            ),
+            registered_schemas=OPENAI_TOOLS,
+            workspace_runtime=runtime,
+            availability=ToolAvailability(),
+        )
+        narrowed = effective_tool_catalog(
+            persona=Persona(id="sourcing", name="Sourcing", body="", tools=["now"]),
+            registered_schemas=OPENAI_TOOLS,
+            workspace_runtime=runtime,
+            availability=ToolAvailability(),
+        )
+    finally:
+        runtime.close()
+
+    assert "apollo_search_people" not in buddy.names
+    assert narrowed.names == ("now",)
+
+
+def test_unknown_or_misspelled_persona_declaration_fails_clearly(tmp_path):
+    from coworker.effective_tools import ToolAvailability, effective_tool_catalog
+    from coworker.persona import ManifestError, Persona
+    from coworker.tools import OPENAI_TOOLS
+    from coworker.workspace_runtime import WorkspaceRuntime
+
+    runtime = WorkspaceRuntime(tmp_path / "state")
+    try:
+        with pytest.raises(ManifestError, match="unknown persona tool: gmail_sned"):
+            effective_tool_catalog(
+                persona=Persona(
+                    id="sourcing",
+                    name="Sourcing",
+                    body="",
+                    tools=["gmail_sned"],
+                ),
+                registered_schemas=OPENAI_TOOLS,
+                workspace_runtime=runtime,
+                availability=ToolAvailability(),
+            )
+    finally:
+        runtime.close()
+
+
+def test_registered_schema_without_permission_policy_fails_contract(tmp_path):
+    from coworker.effective_tools import (
+        ToolAvailability,
+        ToolCatalogError,
+        effective_tool_catalog,
+    )
+    from coworker.persona import Persona
+    from coworker.workspace_runtime import WorkspaceRuntime
+
+    runtime = WorkspaceRuntime(tmp_path / "state")
+    try:
+        with pytest.raises(ToolCatalogError, match="no permission policy"):
+            effective_tool_catalog(
+                persona=Persona(id="sourcing", name="Sourcing", body="", tools=[]),
+                registered_schemas=(
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "invented_tool",
+                            "description": "not registered in policy",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    },
+                ),
+                workspace_runtime=runtime,
+                availability=ToolAvailability(),
+            )
+    finally:
+        runtime.close()
+
+
+def test_buddy_subset_drift_fails_when_a_registered_tool_is_renamed(tmp_path):
+    from coworker.effective_tools import (
+        ToolAvailability,
+        ToolCatalogError,
+        effective_tool_catalog,
+    )
+    from coworker.persona import Persona
+    from coworker.tools import OPENAI_TOOLS
+    from coworker.workspace_runtime import WorkspaceRuntime
+
+    schemas_without_now = tuple(
+        schema
+        for schema in OPENAI_TOOLS
+        if schema["function"]["name"] != "now"
+    )
+    runtime = WorkspaceRuntime(tmp_path / "state")
+    try:
+        with pytest.raises(ToolCatalogError, match="buddy.*unknown tool: now"):
+            effective_tool_catalog(
+                persona=Persona(id="buddy", name="Buddy", body="", tools=[]),
+                registered_schemas=schemas_without_now,
+                workspace_runtime=runtime,
+                availability=ToolAvailability(),
+            )
+    finally:
+        runtime.close()
+
+
+def test_diagnostics_expose_only_names_and_approval_classes(tmp_path, monkeypatch):
+    from coworker.effective_tools import ToolAvailability, effective_tool_catalog
+    from coworker.persona import Persona
+    from coworker.tools import OPENAI_TOOLS
+    from coworker.workspace_runtime import WorkspaceRuntime
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-live-PLANTED-SECRET")
+    runtime = WorkspaceRuntime(tmp_path / "state")
+    try:
+        catalog = effective_tool_catalog(
+            persona=Persona(id="sourcing", name="Sourcing", body="", tools=[]),
+            registered_schemas=OPENAI_TOOLS,
+            workspace_runtime=runtime,
+            availability=ToolAvailability(),
+        )
+    finally:
+        runtime.close()
+
+    diagnostics = catalog.diagnostics()
+    assert diagnostics
+    assert set(diagnostics[0]) == {"name", "approval_class"}
+    encoded = json.dumps(diagnostics)
+    assert "parameters" not in encoded
+    assert "description" not in encoded
+    assert "PLANTED-SECRET" not in encoded

--- a/desktop/tests/test_effective_tools_api.py
+++ b/desktop/tests/test_effective_tools_api.py
@@ -1,0 +1,205 @@
+import asyncio
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from coworker.inbox import Inbox
+from coworker.persona import ManifestError, Persona, load_persona
+from coworker.provider import FakeProvider, ToolCall
+from coworker.server import TOKEN_HEADER, create_app
+from coworker.store import ConversationStore
+from coworker.turn import run_turn
+
+
+TOKEN = "effective-tools-token"
+
+
+class RecordingToolsProvider(FakeProvider):
+    def __init__(self):
+        super().__init__(deltas=("Ready.",))
+        self.tool_catalogs = []
+
+    async def astream(self, *, messages, tools=None, context_id=None):
+        self.tool_catalogs.append(list(tools or []))
+        async for chunk in super().astream(
+            messages=messages, tools=tools, context_id=context_id
+        ):
+            yield chunk
+
+
+def _names(catalog):
+    return tuple(item.name for item in catalog.capabilities)
+
+
+def test_composition_root_uses_fresh_connector_and_workspace_availability(
+    tmp_path, monkeypatch
+):
+    monkeypatch.delenv("APOLLO_API_KEY", raising=False)
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    app = create_app(token=TOKEN, provider=FakeProvider(), state=tmp_path)
+
+    initial = _names(app.state.effective_tool_catalog())
+    assert "gmail_search" not in initial
+    assert "drive_read" not in initial
+    assert "calendar_list" not in initial
+    assert "apollo_search_people" not in initial
+    assert "web_search" not in initial
+    assert "fs_read" not in initial
+    assert "shell_exec" not in initial
+    assert "request_directory" in initial
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    app.state.workspace_runtime.add_grant(
+        workspace,
+        label="Workspace",
+        access="read_write",
+        allow_shell=False,
+    )
+    with_workspace = _names(app.state.effective_tool_catalog())
+    assert "fs_read" in with_workspace
+    assert "fs_write" in with_workspace
+    assert "shell_exec" not in with_workspace
+
+
+def test_prompt_diagnostics_report_only_effective_names_and_classes(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-live-PLANTED-SECRET")
+    monkeypatch.delenv("APOLLO_API_KEY", raising=False)
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    app = create_app(token=TOKEN, provider=FakeProvider(), state=tmp_path)
+    sid = app.state.store.open_session_id()
+
+    response = TestClient(app).get(
+        f"/v1/sessions/{sid}/prompt/current",
+        headers={TOKEN_HEADER: TOKEN},
+    )
+
+    assert response.status_code == 200
+    tools = response.json()["effective_tools"]
+    assert tools
+    assert set(tools[0]) == {"name", "approval_class"}
+    encoded = json.dumps(tools)
+    assert "parameters" not in encoded
+    assert "description" not in encoded
+    assert "PLANTED-SECRET" not in encoded
+
+
+def test_each_turn_receives_the_same_effective_schemas_reported_by_diagnostics(
+    tmp_path, monkeypatch
+):
+    monkeypatch.delenv("APOLLO_API_KEY", raising=False)
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+    provider = RecordingToolsProvider()
+    app = create_app(token=TOKEN, provider=provider, state=tmp_path)
+    sid = app.state.store.open_session_id()
+    client = TestClient(app)
+
+    with client.websocket_connect("/ws/chat", subprotocols=["club", TOKEN]) as ws:
+        ws.send_json({"type": "chat", "text": "hello", "session_id": sid})
+        while ws.receive_json()["type"] not in {"turn_end", "error"}:
+            pass
+
+    effective = app.state.effective_tool_catalog()
+    sent_names = tuple(
+        schema["function"]["name"] for schema in provider.tool_catalogs[0]
+    )
+    assert sent_names == effective.names
+    assert all(
+        "Runtime approval:" in schema["function"]["description"]
+        for schema in provider.tool_catalogs[0]
+    )
+
+
+def test_switching_to_buddy_narrows_effective_tools_without_registry_broadening(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("APOLLO_API_KEY", "fake-apollo")
+    app = create_app(token=TOKEN, provider=FakeProvider(), state=tmp_path)
+    client = TestClient(app)
+    sourcing = _names(app.state.effective_tool_catalog())
+    assert "apollo_search_people" in sourcing
+    assert "board_query" in sourcing
+
+    response = client.post(
+        "/v1/settings/persona",
+        headers={TOKEN_HEADER: TOKEN},
+        json={"id": "buddy"},
+    )
+
+    assert response.status_code == 200
+    buddy = _names(app.state.effective_tool_catalog())
+    assert "apollo_search_people" not in buddy
+    assert "board_query" not in buddy
+    assert set(buddy) < set(sourcing)
+
+
+def test_provider_call_outside_supplied_catalog_never_executes(tmp_path):
+    store = ConversationStore(tmp_path)
+    store.create_session("catalog-guard")
+    provider = FakeProvider(
+        steps=[
+            {
+                "tool_calls": [
+                    ToolCall(
+                        id="not-available",
+                        name="remember",
+                        arguments={"content": "must not persist"},
+                    )
+                ]
+            },
+            {"deltas": ("Done.",)},
+        ]
+    )
+
+    result = asyncio.run(
+        run_turn(
+            text="remember this",
+            sid="catalog-guard",
+            store=store,
+            provider=provider,
+            persona=load_persona("sourcing"),
+            skills=None,
+            inbox=Inbox(store),
+            openai_tools=[],
+            execute_kwargs={"store": store},
+        )
+    )
+
+    assert result["status"] == "partial"
+    assert store.list_memories() == []
+    tool_result = next(
+        message for message in store.load("catalog-guard") if message["role"] == "tool"
+    )
+    assert "not available in this run" in tool_result["content"]
+
+
+def test_invalid_builtin_persona_declaration_fails_startup(tmp_path, monkeypatch):
+    import coworker.server as server
+
+    monkeypatch.setattr(
+        server,
+        "load_persona",
+        lambda _persona_id: Persona(
+            id="sourcing",
+            name="Sourcing",
+            body="",
+            tools=["gmail_sned"],
+        ),
+    )
+
+    with pytest.raises(ManifestError, match="unknown persona tool: gmail_sned"):
+        create_app(token=TOKEN, provider=FakeProvider(), state=tmp_path)
+
+
+def test_static_system_prompt_contains_no_manual_tool_inventory(tmp_path):
+    from coworker.server import system_prompt
+
+    prompt = system_prompt(ConversationStore(tmp_path))
+
+    assert "gmail_send" not in prompt
+    assert "fs_write" not in prompt
+    assert "apollo_search_people" not in prompt
+    assert "Use only the tools actually available in this run" in prompt

--- a/desktop/tests/test_inbox.py
+++ b/desktop/tests/test_inbox.py
@@ -358,7 +358,9 @@ def test_inbox_http_allow_during_ws_executes_once(tmp_path, monkeypatch):
             {"deltas": ("drafted",)},
         ]
     )
-    app = create_app(token=TOKEN, provider=fake, state=tmp_path)
+    app = create_app(
+        token=TOKEN, provider=fake, state=tmp_path, gmail=FakeGmail()
+    )
     client = TestClient(app)
     http_response = {}
 
@@ -457,7 +459,9 @@ def test_ws_allow_claim_makes_overlapping_http_wait_for_terminal_result(
             {"deltas": ("drafted",)},
         ]
     )
-    app = create_app(token=TOKEN, provider=fake, state=tmp_path)
+    app = create_app(
+        token=TOKEN, provider=fake, state=tmp_path, gmail=FakeGmail()
+    )
     client = TestClient(app)
     http_response = {}
 
@@ -699,7 +703,9 @@ def test_ws_approval_that_expires_while_waiting_stops_without_denial(
             {"deltas": ("drafted",)},
         ]
     )
-    app = create_app(token=TOKEN, provider=fake, state=tmp_path)
+    app = create_app(
+        token=TOKEN, provider=fake, state=tmp_path, gmail=FakeGmail()
+    )
     client = TestClient(app)
 
     with client.websocket_connect("/ws/chat", subprotocols=["club", TOKEN]) as ws:

--- a/desktop/tests/test_persona.py
+++ b/desktop/tests/test_persona.py
@@ -16,9 +16,14 @@ def test_buddy_body_is_generic_not_sourcing():
 def test_sourcing_manifest_routes_to_versioned_runtime_definition():
     persona = load_persona("sourcing")
     assert persona.id == "sourcing"
+    assert persona.tools == []
     assert "sourcing-director-v1" in persona.body
     assert "Person File" in persona.body
     assert "Sourcing Lead" not in persona.body
+
+
+def test_buddy_manifest_does_not_declare_capabilities():
+    assert load_persona("buddy").tools == []
 
 
 def test_system_prompt_uses_on_duty_body(tmp_path):

--- a/desktop/tests/test_resilience.py
+++ b/desktop/tests/test_resilience.py
@@ -7,6 +7,7 @@ import time
 from fastapi.testclient import TestClient
 
 from coworker.events import new_turn_identity
+from coworker.gmail import FakeGmail
 from coworker.inbox import Inbox
 from coworker.provider import FakeProvider, ToolCall
 from coworker.server import TOKEN_HEADER, create_app
@@ -307,7 +308,9 @@ def test_ws_allow_for_a_dead_turn_executes_server_side_instead_of_wedging(
             {"deltas": ("drafted",)},
         ]
     )
-    built = create_app(token=TOKEN, provider=fake, state=tmp_path)
+    built = create_app(
+        token=TOKEN, provider=fake, state=tmp_path, gmail=FakeGmail()
+    )
     # Bare TestClient: each ws context has its own portal, so leaving the first
     # context kills the turn's task outright — the dead-before-claim variant.
     client = TestClient(built)

--- a/desktop/tests/test_telemetry_api.py
+++ b/desktop/tests/test_telemetry_api.py
@@ -163,6 +163,7 @@ def test_manual_safe_retry_records_one_typed_retry_and_nested_tool_span(
 
     monkeypatch.setattr("coworker.turn.execute", flaky_execute)
     app = create_app(token=TOKEN, provider=provider, state=tmp_path)
+    app.state.drive = object()
     sid = app.state.store.open_session_id()
     with TestClient(app).websocket_connect(
         "/ws/chat", subprotocols=["club", TOKEN]

--- a/desktop/tests/test_telemetry_live.py
+++ b/desktop/tests/test_telemetry_live.py
@@ -31,6 +31,7 @@ from coworker.telemetry.schema import (
     record_to_dict,
 )
 from coworker.turn import RunControl, _telemetry_provider_name, run_turn
+from coworker.tools import OPENAI_TOOLS
 
 
 class ContractProvider:
@@ -88,7 +89,7 @@ def run_with_telemetry(tmp_path, provider, *, control=None, text="find private c
             persona=None,
             skills=None,
             inbox=Inbox(store),
-            openai_tools=[],
+            openai_tools=OPENAI_TOOLS,
             execute_kwargs={},
             identity=TurnIdentity(
                 session_id="session-1",
@@ -605,7 +606,7 @@ def test_task_cancellation_settles_the_active_tool_and_agent_spans(
                 persona=None,
                 skills=None,
                 inbox=Inbox(store),
-                openai_tools=[],
+                openai_tools=OPENAI_TOOLS,
                 execute_kwargs={},
                 identity=TurnIdentity(
                     session_id="session-1",

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Sourcecado's dated documents record several product shapes. They are intentional
 - `qa/` — current end-to-end and visual QA evidence
 - `desktop/docs/adr/` — ADRs scoped to the active local runtime
 - `desktop/docs/evaluations.md` — isolated fake/live agent evaluation workflow and artifact safety
+- `desktop/docs/effective-tools.md` — per-run schema, permission, persona, connector, and workspace capability boundary
 
 These are dated working records. Check their status and the current code before treating an unchecked item as outstanding.
 


### PR DESCRIPTION
## Summary\n\n- build a fresh effective tool catalog for every scheduled and interactive run\n- derive model-facing tools from registered schemas, persona policy, connector availability, workspace grants, and permission classes\n- attach auto, approval_required, or conditional guidance to exact schemas\n- remove persona frontmatter tool declarations as an authority source\n- let custom declarations narrow but never broaden, failing clearly on unknown names\n- enforce a runtime-owned narrower buddy subset with registry-drift tests\n- require workspace authority before exposing filesystem or shell tools\n- reject and persist out-of-catalog provider calls without execution\n- remove the cached duplicate app.state.openai_tools source\n- expose only effective tool names and approval classes in diagnostics\n\n## Verification\n\n- focused effective-tool integration: 128 passed\n- catalog and permission contract: 25 passed\n- make test: 746 Python passed, 3 skipped; 382 GUI passed\n- make build: passed\n- git diff --check: passed\n- rebased onto current main after approved prompt activation\n\nCloses #55\n\n## Residual consideration\n\nConnector and workspace availability is sampled at turn start and applies to the next run. Conditional guidance remains schema-level; concrete arguments and grants determine final runtime permission.