### PR TITLE
docs: propose bounded person and session context

### DIFF
--- a/desktop/coworker/context_projection.py
+++ b/desktop/coworker/context_projection.py
@@ -1,0 +1,241 @@
+"""Inactive proposal contract for bounded Sourcecado context projection.
+
+The active prompt runtime does not import this module. Category rules and store
+adapters remain subject to Fisher's issue #58 approval.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from enum import StrEnum
+from hashlib import sha256
+
+
+class ContextCategory(StrEnum):
+    OPERATOR_PREFERENCE = "operator_preference"
+    SEQUENCE_STATE = "sequence_state"
+    PERSON_EVIDENCE = "person_evidence"
+    SESSION_WORKING = "session_working"
+
+
+class ContextState(StrEnum):
+    CURRENT = "current"
+    STALE = "stale"
+    CONFLICTING = "conflicting"
+    MISSING = "missing"
+
+
+class ContextAuthority(StrEnum):
+    DIRECTOR = "director"
+    SOURCECADO_RECORD = "sourcecado_record"
+    CONNECTOR = "connector"
+    DERIVED = "derived"
+
+
+class ContextSensitivity(StrEnum):
+    STANDARD = "standard"
+    RESTRICTED = "restricted"
+
+
+@dataclass(frozen=True)
+class ContextSourceRef:
+    id: str
+    provider: str
+    locator: str
+    observed_at: str
+    modified_at: str | None
+    fresh_until: str | None = None
+
+
+@dataclass(frozen=True)
+class ProjectionItem:
+    id: str
+    category: ContextCategory
+    text: str
+    tokens: int
+    state: ContextState
+    authority: ContextAuthority
+    updated_at: str
+    source_refs: tuple[ContextSourceRef, ...]
+    claim_key: str | None = None
+    truncated: bool = False
+    person_id: str | None = None
+    session_id: str | None = None
+    sensitivity: ContextSensitivity = ContextSensitivity.STANDARD
+
+
+@dataclass(frozen=True)
+class CategoryBudget:
+    category: ContextCategory
+    max_tokens: int
+    max_item_tokens: int
+
+
+@dataclass(frozen=True)
+class ProjectionPolicy:
+    version: str
+    total_tokens: int
+    category_budgets: tuple[CategoryBudget, ...]
+
+
+@dataclass(frozen=True)
+class CategoryProjectionDiagnostics:
+    category: ContextCategory
+    selected_count: int
+    omitted_count: int
+    used_tokens: int
+    budget_tokens: int
+
+
+@dataclass(frozen=True)
+class ProjectionDiagnostics:
+    policy_version: str
+    selected_item_ids: tuple[str, ...]
+    total_tokens: int
+    categories: tuple[CategoryProjectionDiagnostics, ...]
+    binding_sha256: str
+    content_sha256: str
+
+
+DEFAULT_PROJECTION_POLICY = ProjectionPolicy(
+    version="context-projection-v1-proposal",
+    total_tokens=2_048,
+    category_budgets=(
+        CategoryBudget(ContextCategory.OPERATOR_PREFERENCE, 256, 64),
+        CategoryBudget(ContextCategory.SEQUENCE_STATE, 256, 256),
+        CategoryBudget(ContextCategory.PERSON_EVIDENCE, 1_024, 160),
+        CategoryBudget(ContextCategory.SESSION_WORKING, 512, 128),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class ProjectionIdentity:
+    persona_id: str
+    session_id: str
+    person_id: str | None
+    target: str | None
+    prompt_version: str
+    effective_tools_hash: str
+
+
+@dataclass(frozen=True)
+class PreparedContextProjection:
+    identity: ProjectionIdentity
+    items: tuple[ProjectionItem, ...]
+    diagnostics: ProjectionDiagnostics
+
+    def reuse_for(self, identity: ProjectionIdentity) -> "PreparedContextProjection":
+        if identity != self.identity:
+            raise ValueError("context projection binding mismatch")
+        return self
+
+
+def prepare_context_projection(
+    *,
+    identity: ProjectionIdentity,
+    items: tuple[ProjectionItem, ...],
+    policy: ProjectionPolicy = DEFAULT_PROJECTION_POLICY,
+) -> PreparedContextProjection:
+    for item in items:
+        if item.sensitivity is ContextSensitivity.RESTRICTED:
+            raise ValueError("restricted context item reached projection boundary")
+        if item.state is ContextState.CONFLICTING and len(item.source_refs) < 2:
+            raise ValueError(
+                "conflicting context needs at least two source references"
+            )
+        if item.state is not ContextState.MISSING and not item.source_refs:
+            raise ValueError(f"source reference is required for context item {item.id}")
+        if item.category is ContextCategory.OPERATOR_PREFERENCE:
+            scoped_correctly = item.person_id is None and item.session_id is None
+        elif item.category in {
+            ContextCategory.SEQUENCE_STATE,
+            ContextCategory.PERSON_EVIDENCE,
+        }:
+            scoped_correctly = (
+                identity.person_id is not None
+                and item.person_id == identity.person_id
+                and item.session_id is None
+            )
+        else:
+            scoped_correctly = (
+                item.session_id == identity.session_id
+                and item.person_id in {None, identity.person_id}
+            )
+        if not scoped_correctly:
+            raise ValueError(f"context item scope mismatch: {item.id}")
+    state_order = {
+        ContextState.CONFLICTING: 0,
+        ContextState.MISSING: 1,
+        ContextState.CURRENT: 2,
+        ContextState.STALE: 3,
+    }
+    authority_order = {
+        ContextAuthority.DIRECTOR: 0,
+        ContextAuthority.SOURCECADO_RECORD: 1,
+        ContextAuthority.CONNECTOR: 2,
+        ContextAuthority.DERIVED: 3,
+    }
+
+    def item_key(item: ProjectionItem) -> tuple[int, int, float, str]:
+        updated = datetime.fromisoformat(item.updated_at).timestamp()
+        return (
+            state_order[item.state],
+            authority_order[item.authority],
+            -updated,
+            item.id,
+        )
+
+    selected: list[ProjectionItem] = []
+    category_diagnostics: list[CategoryProjectionDiagnostics] = []
+    total_used = 0
+    for category_budget in policy.category_budgets:
+        used = 0
+        omitted = 0
+        candidates = sorted(
+            (item for item in items if item.category == category_budget.category),
+            key=item_key,
+        )
+        for item in candidates:
+            if item.tokens > category_budget.max_item_tokens:
+                omitted += 1
+                continue
+            if used + item.tokens > category_budget.max_tokens:
+                omitted += 1
+                continue
+            if total_used + item.tokens > policy.total_tokens:
+                omitted += 1
+                continue
+            selected.append(item)
+            used += item.tokens
+            total_used += item.tokens
+        category_diagnostics.append(
+            CategoryProjectionDiagnostics(
+                category=category_budget.category,
+                selected_count=len(candidates) - omitted,
+                omitted_count=omitted,
+                used_tokens=used,
+                budget_tokens=category_budget.max_tokens,
+            )
+        )
+    binding_json = json.dumps(asdict(identity), sort_keys=True, separators=(",", ":"))
+    content_json = json.dumps(
+        [asdict(item) for item in selected],
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    diagnostics = ProjectionDiagnostics(
+        policy_version=policy.version,
+        selected_item_ids=tuple(item.id for item in selected),
+        total_tokens=sum(item.tokens for item in selected),
+        categories=tuple(category_diagnostics),
+        binding_sha256=sha256(binding_json.encode("utf-8")).hexdigest(),
+        content_sha256=sha256(content_json.encode("utf-8")).hexdigest(),
+    )
+    return PreparedContextProjection(
+        identity=identity,
+        items=tuple(selected),
+        diagnostics=diagnostics,
+    )

--- a/desktop/tests/test_context_projection.py
+++ b/desktop/tests/test_context_projection.py
@@ -1,0 +1,463 @@
+import importlib.util
+from dataclasses import replace
+
+import pytest
+
+from coworker.context_projection import (
+    CategoryBudget,
+    ContextAuthority,
+    ContextCategory,
+    ContextSensitivity,
+    ContextSourceRef,
+    ContextState,
+    DEFAULT_PROJECTION_POLICY,
+    ProjectionIdentity,
+    ProjectionItem,
+    ProjectionPolicy,
+    prepare_context_projection,
+)
+
+def test_context_projection_proposal_module_exists():
+    assert importlib.util.find_spec("coworker.context_projection") is not None
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    [
+        ("persona_id", "buddy"),
+        ("session_id", "session-other"),
+        ("person_id", "person-other"),
+        ("target", "different target"),
+        ("prompt_version", "sourcing-director-v2"),
+        ("effective_tools_hash", "tools-other"),
+    ],
+)
+def test_prepared_projection_fails_closed_when_binding_changes(
+    field, replacement
+):
+    identity = ProjectionIdentity(
+        persona_id="sourcing",
+        session_id="session-ada",
+        person_id="person-ada",
+        target="research dinner",
+        prompt_version="sourcing-director-v1",
+        effective_tools_hash="tools-v1",
+    )
+    prepared = prepare_context_projection(identity=identity, items=())
+
+    assert prepared.reuse_for(identity) is prepared
+    with pytest.raises(ValueError, match="context projection binding mismatch"):
+        prepared.reuse_for(replace(identity, **{field: replacement}))
+
+
+def test_projection_order_is_category_state_authority_freshness_then_id():
+    identity = ProjectionIdentity(
+        persona_id="sourcing",
+        session_id="session-ada",
+        person_id="person-ada",
+        target="research dinner",
+        prompt_version="sourcing-director-v1",
+        effective_tools_hash="tools-v1",
+    )
+
+    def ref(source_id):
+        return ContextSourceRef(
+            id=source_id,
+            provider="sourcecado",
+            locator=f"sourcecado://{source_id}",
+            observed_at="2026-08-27T10:00:00+00:00",
+            modified_at="2026-08-27T10:00:00+00:00",
+            fresh_until="2026-11-25T10:00:00+00:00",
+        )
+
+    items = (
+        ProjectionItem(
+            id="session-next",
+            category=ContextCategory.SESSION_WORKING,
+            text="Next: review the draft.",
+            tokens=20,
+            state=ContextState.CURRENT,
+            authority=ContextAuthority.DIRECTOR,
+            updated_at="2026-08-27T10:05:00+00:00",
+            session_id="session-ada",
+            person_id="person-ada",
+            source_refs=(ref("message-9"),),
+        ),
+        ProjectionItem(
+            id="evidence-stale",
+            category=ContextCategory.PERSON_EVIDENCE,
+            text="Older role evidence.",
+            tokens=20,
+            state=ContextState.STALE,
+            authority=ContextAuthority.CONNECTOR,
+            updated_at="2026-07-01T10:00:00+00:00",
+            person_id="person-ada",
+            source_refs=(ref("apollo-old"),),
+        ),
+        ProjectionItem(
+            id="sequence",
+            category=ContextCategory.SEQUENCE_STATE,
+            text="Sequence: Open.",
+            tokens=20,
+            state=ContextState.CURRENT,
+            authority=ContextAuthority.SOURCECADO_RECORD,
+            updated_at="2026-08-27T10:00:00+00:00",
+            person_id="person-ada",
+            source_refs=(ref("person-v3"),),
+        ),
+        ProjectionItem(
+            id="evidence-conflict",
+            category=ContextCategory.PERSON_EVIDENCE,
+            text="Two live role claims disagree.",
+            tokens=20,
+            state=ContextState.CONFLICTING,
+            authority=ContextAuthority.CONNECTOR,
+            updated_at="2026-08-27T10:00:00+00:00",
+            person_id="person-ada",
+            claim_key="person.role",
+            truncated=True,
+            source_refs=(ref("apollo-new"), ref("gmail-signature")),
+        ),
+        ProjectionItem(
+            id="preference",
+            category=ContextCategory.OPERATOR_PREFERENCE,
+            text="Prefer concise drafts.",
+            tokens=20,
+            state=ContextState.CURRENT,
+            authority=ContextAuthority.DIRECTOR,
+            updated_at="2026-08-26T10:00:00+00:00",
+            source_refs=(ref("memory-1"),),
+        ),
+    )
+
+    prepared = prepare_context_projection(identity=identity, items=items)
+
+    assert tuple(item.id for item in prepared.items) == (
+        "preference",
+        "sequence",
+        "evidence-conflict",
+        "evidence-stale",
+        "session-next",
+    )
+    assert DEFAULT_PROJECTION_POLICY.total_tokens == 2_048
+    conflict = next(item for item in prepared.items if item.id == "evidence-conflict")
+    assert conflict.claim_key == "person.role"
+    assert conflict.truncated is True
+    assert conflict.source_refs[0].fresh_until == "2026-11-25T10:00:00+00:00"
+    assert {
+        budget.category: (budget.max_tokens, budget.max_item_tokens)
+        for budget in DEFAULT_PROJECTION_POLICY.category_budgets
+    } == {
+        ContextCategory.OPERATOR_PREFERENCE: (256, 64),
+        ContextCategory.SEQUENCE_STATE: (256, 256),
+        ContextCategory.PERSON_EVIDENCE: (1_024, 160),
+        ContextCategory.SESSION_WORKING: (512, 128),
+    }
+
+
+@pytest.mark.parametrize(
+    "item",
+    [
+        ProjectionItem(
+            id="other-person",
+            category=ContextCategory.PERSON_EVIDENCE,
+            text="Unrelated person evidence.",
+            tokens=20,
+            state=ContextState.CURRENT,
+            authority=ContextAuthority.CONNECTOR,
+            updated_at="2026-08-27T10:00:00+00:00",
+            person_id="person-other",
+            source_refs=(
+                ContextSourceRef(
+                    id="source-1",
+                    provider="gmail",
+                    locator="gmail://source-1",
+                    observed_at="2026-08-27T10:00:00+00:00",
+                    modified_at="2026-08-27T10:00:00+00:00",
+                ),
+            ),
+        ),
+        ProjectionItem(
+            id="other-session",
+            category=ContextCategory.SESSION_WORKING,
+            text="Another session's next step.",
+            tokens=20,
+            state=ContextState.CURRENT,
+            authority=ContextAuthority.DIRECTOR,
+            updated_at="2026-08-27T10:00:00+00:00",
+            person_id="person-ada",
+            session_id="session-other",
+            source_refs=(
+                ContextSourceRef(
+                    id="message-1",
+                    provider="sourcecado",
+                    locator="session://session-other/message-1",
+                    observed_at="2026-08-27T10:00:00+00:00",
+                    modified_at=None,
+                ),
+            ),
+        ),
+        ProjectionItem(
+            id="scoped-preference",
+            category=ContextCategory.OPERATOR_PREFERENCE,
+            text="This is not actually global.",
+            tokens=20,
+            state=ContextState.CURRENT,
+            authority=ContextAuthority.DIRECTOR,
+            updated_at="2026-08-27T10:00:00+00:00",
+            person_id="person-ada",
+            source_refs=(
+                ContextSourceRef(
+                    id="memory-1",
+                    provider="sourcecado",
+                    locator="memory://1",
+                    observed_at="2026-08-27T10:00:00+00:00",
+                    modified_at=None,
+                ),
+            ),
+        ),
+    ],
+)
+def test_projection_rejects_cross_scope_item_before_ranking(item):
+    identity = ProjectionIdentity(
+        persona_id="sourcing",
+        session_id="session-ada",
+        person_id="person-ada",
+        target="research dinner",
+        prompt_version="sourcing-director-v1",
+        effective_tools_hash="tools-v1",
+    )
+
+    with pytest.raises(ValueError, match="context item scope mismatch"):
+        prepare_context_projection(identity=identity, items=(item,))
+
+
+def test_projection_rejects_restricted_item_before_ranking():
+    identity = ProjectionIdentity(
+        persona_id="sourcing",
+        session_id="session-ada",
+        person_id="person-ada",
+        target="research dinner",
+        prompt_version="sourcing-director-v1",
+        effective_tools_hash="tools-v1",
+    )
+    restricted = ProjectionItem(
+        id="resume",
+        category=ContextCategory.PERSON_EVIDENCE,
+        text="Restricted resume excerpt.",
+        tokens=20,
+        state=ContextState.CURRENT,
+        authority=ContextAuthority.CONNECTOR,
+        updated_at="2026-08-27T10:00:00+00:00",
+        person_id="person-ada",
+        sensitivity=ContextSensitivity.RESTRICTED,
+        source_refs=(
+            ContextSourceRef(
+                id="resume-source",
+                provider="drive",
+                locator="drive://resume-source",
+                observed_at="2026-08-27T10:00:00+00:00",
+                modified_at="2026-08-27T10:00:00+00:00",
+            ),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="restricted context item"):
+        prepare_context_projection(identity=identity, items=(restricted,))
+
+
+def test_projection_truncates_whole_items_and_reports_content_free_diagnostics():
+    identity = ProjectionIdentity(
+        persona_id="sourcing",
+        session_id="session-ada",
+        person_id="person-ada",
+        target="research dinner",
+        prompt_version="sourcing-director-v1",
+        effective_tools_hash="tools-v1",
+    )
+    source = ContextSourceRef(
+        id="memory",
+        provider="sourcecado",
+        locator="memory://1",
+        observed_at="2026-08-27T10:00:00+00:00",
+        modified_at=None,
+    )
+    older = ProjectionItem(
+        id="older",
+        category=ContextCategory.OPERATOR_PREFERENCE,
+        text="PRIVATE OLDER PREFERENCE",
+        tokens=15,
+        state=ContextState.CURRENT,
+        authority=ContextAuthority.DIRECTOR,
+        updated_at="2026-08-26T10:00:00+00:00",
+        source_refs=(source,),
+    )
+    newer = replace(
+        older,
+        id="newer",
+        text="PRIVATE NEWER PREFERENCE",
+        updated_at="2026-08-27T10:00:00+00:00",
+    )
+    oversized = ProjectionItem(
+        id="oversized",
+        category=ContextCategory.PERSON_EVIDENCE,
+        text="PRIVATE OVERSIZED EVIDENCE",
+        tokens=21,
+        state=ContextState.CURRENT,
+        authority=ContextAuthority.CONNECTOR,
+        updated_at="2026-08-27T10:00:00+00:00",
+        person_id="person-ada",
+        source_refs=(source,),
+    )
+    policy = ProjectionPolicy(
+        version="context-projection-test",
+        total_tokens=40,
+        category_budgets=(
+            CategoryBudget(ContextCategory.OPERATOR_PREFERENCE, 20, 20),
+            CategoryBudget(ContextCategory.PERSON_EVIDENCE, 20, 20),
+        ),
+    )
+
+    first = prepare_context_projection(
+        identity=identity,
+        items=(older, oversized, newer),
+        policy=policy,
+    )
+    second = prepare_context_projection(
+        identity=identity,
+        items=(newer, older, oversized),
+        policy=policy,
+    )
+
+    assert tuple(item.id for item in first.items) == ("newer",)
+    assert first.items == second.items
+    assert first.diagnostics == second.diagnostics
+    assert first.diagnostics.policy_version == "context-projection-test"
+    assert first.diagnostics.selected_item_ids == ("newer",)
+    assert first.diagnostics.total_tokens == 15
+    assert {
+        row.category: (row.selected_count, row.omitted_count, row.used_tokens)
+        for row in first.diagnostics.categories
+    } == {
+        ContextCategory.OPERATOR_PREFERENCE: (1, 1, 15),
+        ContextCategory.PERSON_EVIDENCE: (0, 1, 0),
+    }
+    encoded = repr(first.diagnostics)
+    assert "PRIVATE" not in encoded
+
+
+@pytest.mark.parametrize(
+    ("state", "refs", "message"),
+    [
+        (ContextState.CURRENT, (), "source reference is required"),
+        (ContextState.STALE, (), "source reference is required"),
+        (
+            ContextState.CONFLICTING,
+            (
+                ContextSourceRef(
+                    id="only-one",
+                    provider="gmail",
+                    locator="gmail://only-one",
+                    observed_at="2026-08-27T10:00:00+00:00",
+                    modified_at=None,
+                ),
+            ),
+            "conflicting context needs at least two source references",
+        ),
+    ],
+)
+def test_evidence_state_requires_inspectable_source_references(state, refs, message):
+    identity = ProjectionIdentity(
+        persona_id="sourcing",
+        session_id="session-ada",
+        person_id="person-ada",
+        target="research dinner",
+        prompt_version="sourcing-director-v1",
+        effective_tools_hash="tools-v1",
+    )
+    item = ProjectionItem(
+        id="evidence",
+        category=ContextCategory.PERSON_EVIDENCE,
+        text="Claim or conflict.",
+        tokens=20,
+        state=state,
+        authority=ContextAuthority.CONNECTOR,
+        updated_at="2026-08-27T10:00:00+00:00",
+        person_id="person-ada",
+        source_refs=refs,
+    )
+
+    with pytest.raises(ValueError, match=message):
+        prepare_context_projection(identity=identity, items=(item,))
+
+
+def test_missing_state_is_explicit_without_inventing_a_source_reference():
+    identity = ProjectionIdentity(
+        persona_id="sourcing",
+        session_id="session-ada",
+        person_id="person-ada",
+        target="research dinner",
+        prompt_version="sourcing-director-v1",
+        effective_tools_hash="tools-v1",
+    )
+    missing = ProjectionItem(
+        id="gap-email",
+        category=ContextCategory.PERSON_EVIDENCE,
+        text="Missing: verified email address.",
+        tokens=12,
+        state=ContextState.MISSING,
+        authority=ContextAuthority.SOURCECADO_RECORD,
+        updated_at="2026-08-27T10:00:00+00:00",
+        person_id="person-ada",
+        source_refs=(),
+    )
+
+    prepared = prepare_context_projection(identity=identity, items=(missing,))
+
+    assert prepared.items == (missing,)
+
+
+def test_overall_token_budget_still_caps_custom_category_budgets():
+    identity = ProjectionIdentity(
+        persona_id="sourcing",
+        session_id="session-ada",
+        person_id=None,
+        target=None,
+        prompt_version="sourcing-director-v1",
+        effective_tools_hash="tools-v1",
+    )
+    preference = ProjectionItem(
+        id="preference",
+        category=ContextCategory.OPERATOR_PREFERENCE,
+        text="Prefer concise drafts.",
+        tokens=15,
+        state=ContextState.CURRENT,
+        authority=ContextAuthority.DIRECTOR,
+        updated_at="2026-08-27T10:00:00+00:00",
+        source_refs=(
+            ContextSourceRef(
+                id="memory-1",
+                provider="sourcecado",
+                locator="memory://1",
+                observed_at="2026-08-27T10:00:00+00:00",
+                modified_at=None,
+            ),
+        ),
+    )
+    policy = ProjectionPolicy(
+        version="overall-budget-test",
+        total_tokens=10,
+        category_budgets=(
+            CategoryBudget(ContextCategory.OPERATOR_PREFERENCE, 20, 20),
+        ),
+    )
+
+    prepared = prepare_context_projection(
+        identity=identity,
+        items=(preference,),
+        policy=policy,
+    )
+
+    assert prepared.items == ()
+    assert prepared.diagnostics.total_tokens == 0
+    assert prepared.diagnostics.categories[0].omitted_count == 1

--- a/docs/superpowers/plans/2026-08-27-context-projection-coauthoring.md
+++ b/docs/superpowers/plans/2026-08-27-context-projection-coauthoring.md
@@ -1,0 +1,310 @@
+# Bounded context projection v1 — Fisher approval packet
+
+Date: 2026-08-27
+Status: **UNAPPROVED PROPOSAL — not active model context**
+Issue: #58
+Stacked on: approved `sourcing-director-v1` activation / PR #95
+Proposed policy version after approval: `context-projection-v1`
+
+Nothing in this document or the inactive `coworker.context_projection` module is
+loaded by the prompt runtime. The active `saved_memory`, `skill_catalog`, and
+`person_file` sections remain unchanged until Fisher approves this complete
+category contract.
+
+## Current context inventory
+
+### Global saved memory
+
+`ConversationStore.memories` currently stores only `id`, free-form `content`, and
+`created_at`. It has no category, person, session, source reference, updated time,
+freshness, sensitivity, or conflict state.
+
+Every normal model request calls `list_memories()` in ascending id order, joins
+every row as `[#id] content`, then clips the combined string at 4,000 characters.
+This is a bounded full-store dump, not retrieval: it favors the oldest rows,
+can cut a row mid-content, and cannot distinguish an operator preference from a
+fact about one Person. `MEMORY.md` is still generated as a local index but is not
+the active prompt source after the `sourcing-director-v1` activation.
+
+### Person File
+
+`PersonStore` owns the durable Person, Target, Sequence state, outcome, timeline,
+Artifacts, Knowledge Gaps, Source References, versions, and the exact
+`session_people` binding. Restricted Source References are already omitted by
+default unless the existing PersonStore grant allows them.
+
+The active prompt reads only the bound Person, builds a Living Brief, and includes
+up to the twelve newest timeline summaries. It does not include stable Source
+References, timestamps, Person version, current Sequence state, outcome,
+attachment conflict state, or explicit freshness. It never queries another
+Person, which is the isolation invariant to preserve.
+
+### Session-local state
+
+The current session's entire persisted message history is sent to the provider
+separately from the system prompt. There is no bounded, typed working-state
+projection for the current request, director corrections, pending decisions,
+completed Artifacts, or immediate next step. Active desktop turns do not yet use
+the eval harness's compaction implementation.
+
+Queue records, approvals, run events, and tool receipts are durable but are not
+classified into session-local context.
+
+### Prompt and tool identity
+
+The active prompt is `sourcing-director-v1`. Static prompt order and budgets are
+deterministic. Dynamic prompt order is currently saved memory, skill catalog,
+then Person File. Content-free prompt diagnostics record the prompt version,
+ordered sections, sizes, and hash. Effective tools are assembled per app/session
+but do not yet participate in a prepared context identity.
+
+## Recommended category contract
+
+Exactly four categories may enter `context-projection-v1`. `legacy_unclassified`
+is a migration state, not a fifth context category.
+
+### 1. Global operator preference — `operator_preference`
+
+Durable, person-independent working preferences explicitly stated by the
+Sourcing Director: preferred draft tone or length, stable formatting choices,
+and recurring personal workflow defaults.
+
+Rules:
+
+- Must originate from an explicit director statement and carry a stable
+  Sourcecado memory Source Reference.
+- Must not contain Person facts, Target facts, connector evidence, Sequence
+  state, permissions, or product policy.
+- Has no `person_id` or `session_id`.
+- Does not become higher authority than Sourcecado policy; it remains untrusted
+  evidence under the approved prompt.
+- Does not expire by age. It becomes stale only when the director updates,
+  supersedes, or removes it.
+
+Examples that belong: “Prefer outreach drafts under 140 words.”
+Examples that do not: “Ada works at Analytic,” “send without asking,” or “this
+session is preparing Ada's draft.”
+
+### 2. Sequence state — `sequence_state`
+
+The canonical current operating state for the bound Person: Person id/version,
+Target, Sequence state (`Open`, `In conversation`, or `Done`), recorded Outreach
+Outcome, and the version-checked state needed to continue safely.
+
+Rules:
+
+- Comes only from the latest visible PersonStore record, never from a memory row
+  or connector claim.
+- Requires the exact bound `person_id`; an unbound session has no Sequence item.
+- Uses a stable Source Reference such as `person:<id>@version:<n>`.
+- The latest Person version is current; earlier versions are stale.
+- A connector disagreement is Person evidence, not permission to overwrite the
+  canonical Sequence state.
+
+### 3. Person evidence — `person_evidence`
+
+Visible, sourced claims and Knowledge Gaps attached to the bound Person: identity
+and company context, Apollo/Gmail/Drive/Calendar/web/Granola evidence, handoff
+facts, Artifacts, Source References, and Outreach Outcomes that help the current
+run.
+
+Rules:
+
+- Candidate collection begins from exactly one bound Person File. Unrelated
+  People are excluded before ranking, truncation, or summarization.
+- Every current or stale claim has at least one stable Source Reference.
+- Every conflict has at least two Source References and retains the competing
+  visible claims; projection never silently chooses a winner.
+- A missing item names a real required field or Knowledge Gap and may have no
+  source; it never invents a placeholder value.
+- Restricted records must already have been removed by the existing PersonStore
+  visibility contract. If a restricted item reaches projection anyway,
+  preparation fails closed. This proposal adds no grant hierarchy.
+- Raw connector payloads, credentials, authorization material, and hidden
+  reasoning never become projection text.
+
+### 4. Session-local working context — `session_working`
+
+Bounded state needed to continue this session: the current director request,
+director corrections and decisions, pending approval/task ids, relevant completed
+Artifact/tool receipt ids, immediate next step, and unresolved work.
+
+Rules:
+
+- Requires the exact `session_id`. When person-scoped, its `person_id` must also
+  match the projection binding.
+- Uses stable session message, event, approval, or run Source References.
+- Is not durable operator preference or Person evidence merely because it was
+  said in chat. Promotion requires the existing explicit memory or Board write.
+- Resolved transient items drop from the next projection rather than becoming
+  stale clutter.
+- The full transcript remains canonical history until compaction; this category
+  is the small mechanical working set, not a second transcript summary.
+
+## Source Reference and evidence-state contract
+
+Every Source Reference has:
+
+- stable `id`;
+- `provider` (`sourcecado`, `apollo`, `gmail`, `drive`, `calendar`, `web`, or
+  `granola`);
+- inspectable `locator` that contains no credential;
+- `observed_at`;
+- source `modified_at` when available;
+- `fresh_until` when the source or Sourcecado freshness policy supplies one.
+
+Every projected item has a stable item id, optional `claim_key`, category,
+bounded excerpt, token count, authority, `updated_at`, sensitivity, Source
+References, and exactly one evidence state:
+
+- `current` — latest visible, unsuperseded evidence and not past `fresh_until`.
+  Current means “best current evidence,” not guaranteed truth.
+- `stale` — explicitly superseded/deleted, from an earlier Person version, or
+  past its freshness window. It remains labeled; it never masquerades as current.
+- `conflicting` — two or more visible live sources disagree on one `claim_key`.
+  Preserve the competing claims and references together.
+- `missing` — a required field or named Knowledge Gap is absent. State the gap,
+  never a guessed value.
+
+Freshness defaults:
+
+- Director preferences: no time expiry; explicit supersession only.
+- Sequence state: version-based; latest Person version only.
+- Historical mail, meetings, sends, outcomes, and completed Artifacts: no time
+  expiry, but deleted/superseded sources become stale.
+- Mutable profile claims such as current role, title, company, or public contact
+  availability: stale after 90 days unless the source provides an earlier
+  `fresh_until` or newer evidence revalidates it.
+- Session working items: current while unresolved in this exact session; removed
+  after resolution.
+
+## Projection identity and reuse
+
+A prepared projection is bound to all six fields:
+
+1. persona id;
+2. session id;
+3. bound Person id, or explicit `null` for an unbound session;
+4. current Target, or explicit `null`;
+5. prompt version;
+6. SHA-256 of the ordered effective tool names and schemas.
+
+The projection content hash additionally covers the policy version, ordered item
+ids, item content hashes, states, and Source References. Reuse for a different
+persona, session, Person, Target, prompt version, or effective tool catalog raises
+a binding error before any model request.
+
+Diagnostics may record identity fields already present in the run, policy
+version, selected item ids, category token/count totals, omission counts, and
+binding/content hashes. Diagnostics never contain excerpts, source bodies,
+preferences, Person facts, or session text.
+
+## Token budget and deterministic selection
+
+`context-projection-v1` has a fixed **2,048-token** budget with no borrowing
+between categories:
+
+| Order | Category | Category cap | Per-item cap |
+|---:|---|---:|---:|
+| 1 | Global operator preference | 256 | 64 |
+| 2 | Sequence state | 256 | 256 |
+| 3 | Person evidence | 1,024 | 160 |
+| 4 | Session-local working context | 512 | 128 |
+
+At activation, token accounting uses one versioned, provider-independent,
+conservative counter: `ceil(len(rendered_utf8_bytes) / 3)`. It is an explicit
+budget unit, not a claim about provider billing tokens. The existing approved
+6,000-character combined memory/Person dynamic envelope remains a second hard
+cap; whichever cap is reached first wins. Skill catalog and static prompt budgets
+remain unchanged.
+
+Eligibility is checked before ranking. A scope or restricted-source violation
+fails the entire preparation rather than quietly leaking or hiding an adapter
+bug. Within each category, sort by:
+
+1. evidence state: `conflicting`, `missing`, `current`, `stale`;
+2. authority: director, Sourcecado record, direct connector, derived summary;
+3. `updated_at`, newest first;
+4. stable item id, ascending.
+
+The adapter clips each excerpt at a deterministic token/word boundary to the
+per-item cap and marks it truncated. The projector then selects whole items in
+rank order until the category cap or overall character cap is reached. It never
+cuts a Source Reference or half an item. Unused category budget stays unused so
+an oversized evidence category cannot unpredictably consume preferences or
+working state.
+
+## Safe migration default
+
+Add category/scope/source metadata to the memory store only during activation.
+Every existing memory row migrates to `legacy_unclassified` with
+`classification_status = needs_review`.
+
+Recommended migration rules:
+
+- Do not infer categories from free-form text.
+- Do not inject `legacy_unclassified` rows into normal model context.
+- Let the director classify a true global preference, move a Person fact through
+  the existing Board contract, keep session-only state in its session, or delete
+  obsolete content.
+- Preserve existing ids, timestamps, Markdown files, and audit history.
+- New `remember` writes become global preferences only when the director
+  explicitly asks for a person-independent preference to persist. Ambiguous
+  writes remain `needs_review`; Person facts route to the Person File.
+
+This temporarily withholds ambiguous legacy rows but prevents existing Person
+facts from silently becoming global after migration.
+
+## Compaction reuse contract
+
+Compaction consumes the same prepared projection; it does not build a second
+Person summary.
+
+1. Prepare and bind the projection from canonical stores before the model request.
+2. Compaction may replace only an older, complete transcript span with a bounded
+   session summary while preserving atomic tool-call groups.
+3. Reattach the unchanged prepared projection after the compaction summary and
+   revalidate all six identity fields.
+4. Person evidence, Sequence state, preferences, and Source References remain in
+   the projection rather than being rewritten by the summarizer.
+5. The compaction summary cannot promote text into memory, update a Person File,
+   change an evidence state, or manufacture a Source Reference.
+6. On the next model request, rebuild the projection if the Person version,
+   Target, prompt version, effective tools, or canonical source state changed.
+
+This follows the useful donor pattern of compacting only the outbound transcript
+view while leaving canonical history untouched, but the identity and category
+contract remains Sourcecado-owned.
+
+## One Fisher decision
+
+Recommended approval answer:
+
+> **Approve `context-projection-v1` as written: the four exact categories and
+> scope rules; current/stale/conflicting/missing evidence states; 90-day mutable
+> profile freshness default; stable Source References; fail-closed restricted and
+> cross-person handling; the 2,048-token no-borrow budget plus existing 6,000-char
+> cap; deterministic ranking/truncation; `legacy_unclassified` migration; exact
+> six-field identity; and reuse of the same projection through compaction.**
+
+Approval is all-or-revise for this packet because category, migration, budget,
+and compaction rules interact. No category behavior becomes active before this
+answer is recorded.
+
+## Exact activation step after approval
+
+1. Add the approved category/migration columns and migrate every current memory
+   row to `legacy_unclassified` without injecting it.
+2. Build store adapters that emit already-scoped `ProjectionItem` values from
+   global preferences, the exact bound PersonStore record/events/visible
+   attachments, and current session records.
+3. Add the conservative token counter, bounded excerpt renderer, conflict grouping,
+   and freshness classification with RED-first migration/cross-person/restart/
+   stale/conflict/oversize/missing tests.
+4. Replace active `saved_memory` plus `person_file` assembly with one
+   `context_projection` dynamic section while preserving the approved skill and
+   total prompt caps.
+5. Record content-free projection diagnostics on the run and pass the exact
+   prepared projection into active compaction.
+6. Add end-to-end tests proving another session/Person cannot reuse it and normal
+   model requests no longer receive the full memory store.


### PR DESCRIPTION
## Proposal\n\nThis PR prepares #58 context-projection-v1 without changing active model context.\n\nRecommended Fisher approval: approve the proposal as written.\n\nCategories and budgets:\n\n- global operator preference: 256 tokens, 64 per item\n- sequence state: 256 tokens\n- person evidence: 1,024 tokens, 160 per item\n- session-local working context: 512 tokens, 128 per item\n- total: 2,048 tokens with no borrowing, plus the existing 6,000-character combined envelope\n\nThe proposal defines stable source references, current/stale/conflicting/missing states, a 90-day mutable profile freshness default, fail-closed restricted/cross-person reuse, deterministic ranking/truncation, legacy_unclassified migration, exact projection identity, and reuse through compaction.\n\n## Safety\n\n- active model context remains unchanged\n- existing restricted-source and one-person binding rules remain authoritative\n- legacy unclassified memory stays out of prompts until reviewed\n- compaction cannot rewrite evidence or promote memory\n\n## Verification\n\n- projection contract: 18 passed\n- prompt/person boundary: 36 passed\n- make test-python: 747 passed, 3 skipped\n- git diff --check: passed\n\nRefs #58\n\n## Fisher approval requested\n\nApprove context-projection-v1 as written: four categories and scope rules; evidence states and source references; 90-day mutable freshness; 2,048-token no-borrow budget plus 6,000-character cap; deterministic ranking; legacy migration; exact binding identity; and reuse through compaction.