### PR TITLE
feat(desktop): curate Apollo candidates into person chats

### DIFF
--- a/desktop/coworker/apollo_curation.py
+++ b/desktop/coworker/apollo_curation.py
@@ -1,0 +1,88 @@
+"""Director-reviewed Apollo shortlist curation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from coworker.people import PersonStore
+
+
+def curate_apollo_candidates(
+    people: PersonStore,
+    rows: list[dict[str, Any]],
+    *,
+    target: str,
+) -> dict[str, Any]:
+    target = str(target or "").strip()
+    if not target:
+        raise ValueError("director-authored target is required")
+    kept: list[dict[str, Any]] = []
+    failed: list[dict[str, Any]] = []
+    duplicates: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    identities = {
+        str(row.get("apolloId") or "").strip()
+        for row in rows
+        if str(row.get("apolloId") or "").strip()
+    }
+    for index, row in enumerate(rows):
+        apollo_id = str(row.get("apolloId") or "").strip()
+        if not apollo_id:
+            failed.append(
+                {"row_index": index, "apollo_id": None, "code": "missing_apollo_id"}
+            )
+            continue
+        if apollo_id in seen:
+            duplicates.append({"row_index": index, "apollo_id": apollo_id})
+            continue
+        seen.add(apollo_id)
+        try:
+            existing = people.get_by_apollo_id(apollo_id)
+            person = people.keep_from_apollo(
+                apollo_id=apollo_id,
+                first_name=row.get("firstName"),
+                last_name_obfuscated=row.get("lastNameObfuscated"),
+                title=row.get("title"),
+                company=row.get("organizationName"),
+                target=target,
+            )
+        except Exception:
+            failed.append(
+                {
+                    "row_index": index,
+                    "apollo_id": apollo_id,
+                    "code": "invalid_candidate",
+                }
+            )
+            continue
+        try:
+            sourcing_session = people.session_for_person(person["person_id"])
+        except ValueError:
+            sourcing_session = None
+        kept.append(
+            {
+                "row_index": index,
+                "apollo_id": apollo_id,
+                "person_id": person["person_id"],
+                "version": int(person["version"]),
+                "operation": "updated" if existing is not None else "created",
+                "first_name": person["first_name"],
+                "last_name": person["last_name"],
+                "title": person["title"],
+                "company": person["company"],
+                "sourcing_chat": (
+                    {"session_id": sourcing_session}
+                    if sourcing_session is not None
+                    else None
+                ),
+            }
+        )
+    status = "success" if kept and not failed else "partial" if kept else "failed"
+    return {
+        "status": status,
+        "selected_row_count": len(rows),
+        "selected_identity_count": len(identities),
+        "kept": kept,
+        "failed": failed,
+        "duplicates": duplicates,
+    }

--- a/desktop/coworker/ledger.py
+++ b/desktop/coworker/ledger.py
@@ -279,7 +279,8 @@ def record_tool_on_person(
     """Bind a first one-person keep to this session, then file connector events on the bound person."""
     if name == "people_keep" and ok:
         kept = result.get("kept") or []
-        if len(kept) == 1:
+        selected_count = int(result.get("selected_row_count") or len(kept))
+        if selected_count == 1 and len(kept) == 1:
             person_id = kept[0].get("person_id") if isinstance(kept[0], dict) else None
             if person_id and people.session_for_person(str(person_id)) is None:
                 people.bind_session(session_id, str(person_id))

--- a/desktop/coworker/people.py
+++ b/desktop/coworker/people.py
@@ -312,7 +312,17 @@ class PersonStore:
             if existing is not None:
                 restoring = bool(existing["deleted_at"])
                 now = self._now()
-                next_version = int(existing["version"] or 1) + (1 if restoring else 0)
+                changed = restoring or any(
+                    incoming is not None and incoming != existing[field]
+                    for incoming, field in (
+                        (first_name, "first_name"),
+                        (last_name_obfuscated, "last_name"),
+                        (title, "title"),
+                        (company, "company"),
+                        (cleaned_target, "target"),
+                    )
+                )
+                next_version = int(existing["version"] or 1) + int(changed)
                 self._conn.execute(
                     """
                     UPDATE people SET

--- a/desktop/coworker/server.py
+++ b/desktop/coworker/server.py
@@ -28,6 +28,7 @@ from coworker.automation.scheduler import (
     next_monday_0900,
     now_iso,
 )
+from coworker.apollo_curation import curate_apollo_candidates
 from coworker.calendar import calendar_from_secrets
 from coworker.connectors.google_oauth import (
     CALENDAR_SCOPE,
@@ -1521,6 +1522,69 @@ def create_app(
     @app.get("/v1/board")
     def board_get():
         return app.state.people.list_board()
+
+    @app.post("/v1/apollo/curate")
+    async def apollo_curate(request: Request):
+        payload = await request.json()
+        session_id = str(payload.get("session_id") or "").strip()
+        if not valid_session_id(session_id) or app.state.store.index(session_id) is None:
+            return JSONResponse({"error": "session not found"}, status_code=404)
+        rows = payload.get("people")
+        if not isinstance(rows, list) or any(not isinstance(row, dict) for row in rows):
+            return JSONResponse({"error": "people must be a list of rows"}, status_code=400)
+        try:
+            result = curate_apollo_candidates(
+                app.state.people,
+                rows,
+                target=str(payload.get("target") or ""),
+            )
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+
+        binding_reason = (
+            "multiple_selection"
+            if result["selected_row_count"] > 1
+            else "unbound"
+        )
+        if (
+            payload.get("bind_original") is True
+            and result["selected_row_count"] == 1
+            and len(result["kept"]) == 1
+        ):
+            person_id = str(result["kept"][0]["person_id"])
+            try:
+                app.state.people.bind_session(session_id, person_id)
+            except ValueError:
+                binding_reason = "existing_person_chat"
+            else:
+                binding_reason = "single_selection"
+
+        kept = []
+        for item in result["kept"]:
+            person_session = app.state.people.session_for_person(item["person_id"])
+            kept.append(
+                {
+                    **item,
+                    "sourcing_chat": (
+                        {"session_id": person_session}
+                        if person_session is not None
+                        else None
+                    ),
+                }
+            )
+        bound_person_id = app.state.people.person_for_session(session_id)
+        if bound_person_id is not None and binding_reason in {
+            "multiple_selection",
+            "unbound",
+        }:
+            binding_reason = "already_bound"
+        result["kept"] = kept
+        result["original_session"] = {
+            "session_id": session_id,
+            "bound_person_id": bound_person_id,
+            "reason": binding_reason,
+        }
+        return result
 
     @app.post("/v1/people/{person_id}/sequence")
     async def people_sequence(person_id: str, request: Request):

--- a/desktop/coworker/tools.py
+++ b/desktop/coworker/tools.py
@@ -8,6 +8,7 @@ from typing import Any
 from zoneinfo import ZoneInfo
 
 from coworker.apollo import MISSING_KEY, enrich_contact, search_people
+from coworker.apollo_curation import curate_apollo_candidates
 from coworker.web import MISSING_KEY as TAVILY_MISSING, search_web
 from coworker.gmail import GmailError, MissingGmail
 from coworker.board_tools import BOARD_TOOL_NAMES, BOARD_TOOL_SCHEMAS, execute_board_tool
@@ -143,7 +144,7 @@ PEOPLE_KEEP_SCHEMA: dict[str, Any] = {
                     "description": "Why the director wants to write these people.",
                 },
             },
-            "required": ["people"],
+            "required": ["people", "target"],
             "additionalProperties": False,
         },
     },
@@ -682,39 +683,19 @@ def execute(
         rows = args.get("people") or []
         if not isinstance(rows, list):
             return False, {"error": "people must be a list"}
-        target = str(args.get("target") or "").strip() or None
-        kept: list[dict[str, Any]] = []
-        for row in rows:
-            if not isinstance(row, dict):
-                return False, {"error": "people rows must be objects"}
-            person = people.keep_from_apollo(
-                apollo_id=str(row.get("apolloId") or "") or None,
-                first_name=row.get("firstName"),
-                last_name_obfuscated=row.get("lastNameObfuscated"),
-                title=row.get("title"),
-                company=row.get("organizationName"),
-                target=target,
+        if not rows:
+            return True, {"kept": []}
+        if any(not isinstance(row, dict) for row in rows):
+            return False, {"error": "people rows must be objects"}
+        try:
+            result = curate_apollo_candidates(
+                people,
+                rows,
+                target=str(args.get("target") or ""),
             )
-            try:
-                sourcing_session = people.session_for_person(person["person_id"])
-            except ValueError:
-                sourcing_session = None
-            kept.append(
-                {
-                    "person_id": person["person_id"],
-                    "apollo_id": person["apollo_id"],
-                    "first_name": person["first_name"],
-                    "last_name": person["last_name"],
-                    "title": person["title"],
-                    "company": person["company"],
-                    "sourcing_chat": (
-                        {"session_id": sourcing_session}
-                        if sourcing_session is not None
-                        else None
-                    ),
-                }
-            )
-        return True, {"kept": kept}
+        except ValueError as exc:
+            return False, {"error": str(exc)}
+        return bool(result["kept"]), result
     if name == "web_search":
         if not tavily_key:
             return False, {"error": TAVILY_MISSING}

--- a/desktop/surfaces/gui/src/api.ts
+++ b/desktop/surfaces/gui/src/api.ts
@@ -391,6 +391,33 @@ export type PersonSourcingChatResult = {
   active_person: ActivePerson;
 };
 
+export type ApolloCurationKept = {
+  row_index: number;
+  apollo_id: string;
+  person_id: string;
+  version: number;
+  operation: "created" | "updated";
+  first_name: string | null;
+  last_name: string | null;
+  title: string | null;
+  company: string | null;
+  sourcing_chat: { session_id: string } | null;
+};
+
+export type ApolloCurationResult = {
+  status: "success" | "partial" | "failed";
+  selected_row_count: number;
+  selected_identity_count: number;
+  kept: ApolloCurationKept[];
+  failed: Array<{ row_index: number; apollo_id: string | null; code: string }>;
+  duplicates: Array<{ row_index: number; apollo_id: string }>;
+  original_session: {
+    session_id: string;
+    bound_person_id: string | null;
+    reason: string;
+  };
+};
+
 export async function getBoard(): Promise<Board> {
   const res = await get("/v1/board");
   if (!res.ok) throw new Error(`board ${res.status}`);
@@ -453,6 +480,114 @@ export async function openPersonSourcingChat(
       person_id: activePerson.person_id,
       version: activePerson.version,
       label: activePerson.label,
+    },
+  };
+}
+
+export async function curateApolloCandidates(input: {
+  sessionId: string;
+  target: string;
+  people: Array<Record<string, unknown>>;
+  bindOriginal: boolean;
+}): Promise<ApolloCurationResult> {
+  const res = await fetch(`${httpBase()}/v1/apollo/curate`, {
+    method: "POST",
+    headers: {
+      "X-Club-Token": apiToken(),
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      session_id: input.sessionId,
+      target: input.target,
+      people: input.people,
+      bind_original: input.bindOriginal,
+    }),
+  });
+  const raw = (await res.json()) as Record<string, unknown>;
+  if (!res.ok) throw new Error(`Apollo curation ${res.status}`);
+  const status = String(raw.status);
+  const keptRaw = Array.isArray(raw.kept) ? raw.kept : null;
+  const failedRaw = Array.isArray(raw.failed) ? raw.failed : null;
+  const duplicatesRaw = Array.isArray(raw.duplicates) ? raw.duplicates : null;
+  const originalRaw = record(raw.original_session);
+  if (
+    !["success", "partial", "failed"].includes(status) ||
+    !Number.isInteger(raw.selected_row_count) ||
+    !Number.isInteger(raw.selected_identity_count) ||
+    !keptRaw ||
+    !failedRaw ||
+    !duplicatesRaw ||
+    !originalRaw
+  ) {
+    throw new Error("Apollo curation payload malformed");
+  }
+  const nullableText = (value: unknown): string | null =>
+    typeof value === "string" && value ? value : null;
+  const kept = keptRaw.map((value) => {
+    const item = record(value);
+    const chat = item.sourcing_chat === null ? null : record(item.sourcing_chat);
+    if (
+      !Number.isInteger(item.row_index) ||
+      typeof item.apollo_id !== "string" ||
+      !item.apollo_id ||
+      typeof item.person_id !== "string" ||
+      !item.person_id ||
+      !Number.isInteger(item.version) ||
+      !["created", "updated"].includes(String(item.operation)) ||
+      (chat && (typeof chat.session_id !== "string" || !chat.session_id))
+    ) {
+      throw new Error("Apollo curation payload malformed");
+    }
+    return {
+      row_index: item.row_index as number,
+      apollo_id: item.apollo_id,
+      person_id: item.person_id,
+      version: item.version as number,
+      operation: item.operation as "created" | "updated",
+      first_name: nullableText(item.first_name),
+      last_name: nullableText(item.last_name),
+      title: nullableText(item.title),
+      company: nullableText(item.company),
+      sourcing_chat: chat ? { session_id: chat.session_id as string } : null,
+    };
+  });
+  const failed = failedRaw.map((value) => {
+    const item = record(value);
+    if (!Number.isInteger(item.row_index) || typeof item.code !== "string") {
+      throw new Error("Apollo curation payload malformed");
+    }
+    return {
+      row_index: item.row_index as number,
+      apollo_id: nullableText(item.apollo_id),
+      code: item.code,
+    };
+  });
+  const duplicates = duplicatesRaw.map((value) => {
+    const item = record(value);
+    if (!Number.isInteger(item.row_index) || typeof item.apollo_id !== "string") {
+      throw new Error("Apollo curation payload malformed");
+    }
+    return { row_index: item.row_index as number, apollo_id: item.apollo_id };
+  });
+  if (
+    typeof originalRaw.session_id !== "string" ||
+    (originalRaw.bound_person_id !== null &&
+      typeof originalRaw.bound_person_id !== "string") ||
+    typeof originalRaw.reason !== "string"
+  ) {
+    throw new Error("Apollo curation payload malformed");
+  }
+  return {
+    status: status as ApolloCurationResult["status"],
+    selected_row_count: raw.selected_row_count as number,
+    selected_identity_count: raw.selected_identity_count as number,
+    kept,
+    failed,
+    duplicates,
+    original_session: {
+      session_id: originalRaw.session_id,
+      bound_person_id: originalRaw.bound_person_id as string | null,
+      reason: originalRaw.reason,
     },
   };
 }

--- a/desktop/surfaces/gui/src/chat/Inspector.tsx
+++ b/desktop/surfaces/gui/src/chat/Inspector.tsx
@@ -25,12 +25,14 @@ export type InspectorTarget = {
 };
 
 type InspectorContextValue = {
+  readonly threadId: string;
   readonly selected: InspectorTarget | null;
   readonly select: (target: InspectorTarget, trigger: HTMLElement) => void;
   readonly close: () => void;
 };
 
 const InspectorContext = createContext<InspectorContextValue>({
+  threadId: "",
   selected: null,
   select: () => {},
   close: () => {},
@@ -82,6 +84,7 @@ export function InspectorProvider({
   return (
     <InspectorContext.Provider
       value={{
+        threadId,
         selected,
         select(target, trigger) {
           triggerRef.current = trigger;

--- a/desktop/surfaces/gui/src/generative/ApolloPeopleResult.tsx
+++ b/desktop/surfaces/gui/src/generative/ApolloPeopleResult.tsx
@@ -1,5 +1,10 @@
 import { useId, useState } from "react";
 
+import {
+  curateApolloCandidates,
+  openPersonSourcingChat,
+  type ApolloCurationResult,
+} from "../api";
 import { usePopulateComposer } from "../chat/ComposerDraftContext";
 import { useInspector } from "../chat/Inspector";
 import type { DomainRendererProps } from "../chat/toolRegistry";
@@ -12,6 +17,12 @@ type ApolloCandidate = {
   readonly hasEmail: boolean;
   readonly phoneStatus: string | null;
   readonly missing: readonly string[];
+  readonly raw: Record<string, unknown>;
+};
+
+type FailedCandidate = {
+  readonly candidate: ApolloCandidate;
+  readonly code: string;
 };
 
 function record(value: unknown): Record<string, unknown> | null {
@@ -44,6 +55,7 @@ function candidateOf(value: unknown, index: number): ApolloCandidate | null {
     hasEmail: raw.hasEmail === true,
     phoneStatus: text(raw.directPhoneStatus),
     missing,
+    raw,
   };
 }
 
@@ -74,8 +86,17 @@ export function ApolloPeopleResult({
   const titleId = useId();
   const listId = useId();
   const [visibleCount, setVisibleCount] = useState(5);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [target, setTarget] = useState("");
+  const [reviewing, setReviewing] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [curation, setCuration] = useState<ApolloCurationResult | null>(null);
+  const [curationFailed, setCurationFailed] = useState(false);
+  const [openingPersonId, setOpeningPersonId] = useState<string | null>(null);
+  const [chatActionFailed, setChatActionFailed] = useState(false);
+  const [failedCandidates, setFailedCandidates] = useState<FailedCandidate[]>([]);
   const populateComposer = usePopulateComposer();
-  const { select } = useInspector();
+  const { select, threadId } = useInspector();
   if (status === "error") return null;
   if (status === "loading") {
     return (
@@ -166,8 +187,116 @@ export function ApolloPeopleResult({
     ? raw.people
         .map(candidateOf)
         .filter((candidate): candidate is ApolloCandidate => candidate !== null)
+        .filter(
+          (candidate, index, candidates) =>
+            candidates.findIndex((item) => item.id === candidate.id) === index,
+        )
     : [];
   const query = queryLabel(args);
+  const selected = people.filter((candidate) => selectedIds.has(candidate.id));
+
+  function toggleCandidate(candidateId: string) {
+    setReviewing(false);
+    setSelectedIds((current) => {
+      const next = new Set(current);
+      if (next.has(candidateId)) next.delete(candidateId);
+      else next.add(candidateId);
+      return next;
+    });
+  }
+
+  async function keepSelected() {
+    if (!threadId || selected.length === 0 || !target.trim() || submitting) return;
+    setSubmitting(true);
+    setCurationFailed(false);
+    try {
+      const next = await curateApolloCandidates({
+        sessionId: threadId,
+        target: target.trim(),
+        people: selected.map((candidate) => candidate.raw),
+        bindOriginal: selected.length === 1,
+      });
+      setCuration(next);
+      setFailedCandidates(
+        next.failed.flatMap((failure) => {
+          const candidate =
+            selected.find((item) => item.id === failure.apollo_id) ??
+            selected[failure.row_index];
+          return candidate ? [{ candidate, code: failure.code }] : [];
+        }),
+      );
+      setReviewing(false);
+    } catch {
+      setCurationFailed(true);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function retryFailed() {
+    if (!threadId || failedCandidates.length === 0 || submitting) return;
+    const retrying = failedCandidates.map((failure) => failure.candidate);
+    setSubmitting(true);
+    setCurationFailed(false);
+    try {
+      const next = await curateApolloCandidates({
+        sessionId: threadId,
+        target: target.trim(),
+        people: retrying.map((candidate) => candidate.raw),
+        bindOriginal: false,
+      });
+      setCuration((current) => {
+        if (!current) return next;
+        const kept = [...current.kept];
+        for (const person of next.kept) {
+          const index = kept.findIndex((item) => item.apollo_id === person.apollo_id);
+          if (index === -1) kept.push(person);
+          else kept[index] = person;
+        }
+        return {
+          ...next,
+          kept,
+          original_session: current.original_session,
+        };
+      });
+      setFailedCandidates(
+        next.failed.flatMap((failure) => {
+          const candidate =
+            retrying.find((item) => item.id === failure.apollo_id) ??
+            retrying[failure.row_index];
+          return candidate ? [{ candidate, code: failure.code }] : [];
+        }),
+      );
+    } catch {
+      setCurationFailed(true);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function keptName(person: ApolloCurationResult["kept"][number]): string {
+    return [person.first_name, person.last_name].filter(Boolean).join(" ") || "Person";
+  }
+
+  async function openKeptChat(person: ApolloCurationResult["kept"][number]) {
+    if (openingPersonId) return;
+    const existingSession = person.sourcing_chat?.session_id;
+    if (existingSession) {
+      window.location.hash = `#/chat/${encodeURIComponent(existingSession)}/person/${encodeURIComponent(person.person_id)}`;
+      return;
+    }
+    setOpeningPersonId(person.person_id);
+    setChatActionFailed(false);
+    try {
+      const opened = await openPersonSourcingChat(person.person_id, person.version);
+      if (opened.active_person.person_id !== person.person_id) return;
+      window.location.hash = `#/chat/${encodeURIComponent(opened.session.id)}/person/${encodeURIComponent(person.person_id)}`;
+    } catch {
+      setChatActionFailed(true);
+    } finally {
+      setOpeningPersonId(null);
+    }
+  }
 
   if (people.length === 0) {
     return (
@@ -192,7 +321,7 @@ export function ApolloPeopleResult({
         <div>
           <h3 id={titleId}>Apollo shortlist</h3>
           <p>
-            <span>{people.length} candidates</span>
+            <span>{people.length} {people.length === 1 ? "candidate" : "candidates"}</span>
             {" · "}
             <span>{query}</span>
           </p>
@@ -222,6 +351,14 @@ export function ApolloPeopleResult({
       <ol id={listId} aria-label="Apollo candidates">
         {people.slice(0, visibleCount).map((candidate) => (
           <li key={candidate.id}>
+            <label className="sourcecado-apollo-select">
+              <input
+                type="checkbox"
+                checked={selectedIds.has(candidate.id)}
+                onChange={() => toggleCandidate(candidate.id)}
+              />
+              <span>Select {candidate.name}</span>
+            </label>
             <button
               type="button"
               className="sourcecado-apollo-candidate-name"
@@ -275,6 +412,101 @@ export function ApolloPeopleResult({
           Show {Math.min(5, people.length - visibleCount)} more candidates
         </button>
       ) : null}
+      <section className="sourcecado-apollo-curation" aria-label="Curate Apollo shortlist">
+        <label>
+          <span>Target for selected people</span>
+          <input
+            value={target}
+            onChange={(event) => {
+              setTarget(event.currentTarget.value);
+              setReviewing(false);
+            }}
+          />
+        </label>
+        <button
+          type="button"
+          disabled={selected.length === 0 || !target.trim()}
+          onClick={() => setReviewing(true)}
+        >
+          Review {selected.length} selected {selected.length === 1 ? "candidate" : "candidates"}
+        </button>
+        {reviewing ? (
+          <section
+            className="sourcecado-apollo-review"
+            aria-label="Review selected Apollo candidates"
+          >
+            <h4>Review before keeping</h4>
+            <p>{target.trim()}</p>
+            <ul>
+              {selected.map((candidate) => <li key={candidate.id}>{candidate.name}</li>)}
+            </ul>
+            <p>Keeping creates person files. It does not enrich or use Apollo credits.</p>
+            <button type="button" disabled={submitting} onClick={() => void keepSelected()}>
+              {submitting
+                ? "Keeping…"
+                : `Keep ${selected.length} ${selected.length === 1 ? "person" : "people"}`}
+            </button>
+          </section>
+        ) : null}
+        {curationFailed ? <p role="alert">Couldn’t keep the selected people. Try again.</p> : null}
+        {curation ? (
+          <section
+            className="sourcecado-apollo-curation-receipt"
+            aria-label="Apollo curation receipt"
+          >
+            <p role="status">
+              Kept {curation.kept.length} {curation.kept.length === 1 ? "person" : "people"}.
+            </p>
+            {curation.original_session.reason === "multiple_selection" ? (
+              <p>The original target conversation remains unbound. Continue in each person’s sourcing chat.</p>
+            ) : null}
+            <ul>
+              {curation.kept.map((person) => {
+                const name = keptName(person);
+                return (
+                  <li key={person.person_id}>
+                    <a
+                      href={`#/people/${encodeURIComponent(person.person_id)}`}
+                      aria-label={`Open person file for ${name}`}
+                    >
+                      {name}
+                    </a>
+                    <button
+                      type="button"
+                      disabled={openingPersonId !== null}
+                      aria-label={`${person.sourcing_chat ? "Open" : "Create"} sourcing chat for ${name}`}
+                      onClick={() => void openKeptChat(person)}
+                    >
+                      {openingPersonId === person.person_id
+                        ? "Opening…"
+                        : person.sourcing_chat
+                          ? "Open chat"
+                          : "Create chat"}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+            {chatActionFailed ? (
+              <p role="alert" aria-label="Sourcing chat unavailable">
+                Couldn’t open this person’s sourcing chat. Refresh the person file and try again.
+              </p>
+            ) : null}
+            {failedCandidates.length > 0 ? (
+              <div className="sourcecado-apollo-curation-failures">
+                {failedCandidates.map(({ candidate, code }) => (
+                  <p key={candidate.id}>
+                    {candidate.name} needs review ({code.replaceAll("_", " ")}).
+                  </p>
+                ))}
+                <button type="button" disabled={submitting} onClick={() => void retryFailed()}>
+                  Retry {failedCandidates.length} failed {failedCandidates.length === 1 ? "candidate" : "candidates"}
+                </button>
+              </div>
+            ) : null}
+          </section>
+        ) : null}
+      </section>
       <div className="sourcecado-apollo-credit-note">
         <p>Enrichment uses Apollo credits and requires approval.</p>
         <button

--- a/desktop/surfaces/gui/src/styles/chat.css
+++ b/desktop/surfaces/gui/src/styles/chat.css
@@ -997,6 +997,89 @@
   text-align: left;
 }
 
+.sourcecado-apollo-select {
+  display: flex;
+  min-height: 44px;
+  width: fit-content;
+  align-items: center;
+  gap: 7px;
+  color: var(--muted);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.sourcecado-apollo-select input {
+  width: 20px;
+  height: 20px;
+  margin: 0;
+  accent-color: var(--accent);
+}
+
+.sourcecado-apollo-curation {
+  display: grid;
+  gap: 10px;
+  margin-top: 10px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
+.sourcecado-apollo-curation > label {
+  display: grid;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.sourcecado-apollo-curation > label > input {
+  min-height: 40px;
+  padding: 0 11px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+}
+
+.sourcecado-apollo-review,
+.sourcecado-apollo-curation-receipt {
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--raised);
+}
+
+.sourcecado-apollo-review h4 {
+  margin: 0 0 7px;
+  font-size: 13px;
+}
+
+.sourcecado-apollo-review ul,
+.sourcecado-apollo-curation-receipt ul {
+  margin: 8px 0;
+  padding-left: 20px;
+}
+
+.sourcecado-apollo-curation-receipt li {
+  display: flex;
+  min-height: 40px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.sourcecado-apollo-curation-receipt a {
+  color: var(--accent-deep);
+  font-weight: 600;
+}
+
+.sourcecado-apollo-curation-failures {
+  margin-top: 9px;
+  padding-top: 9px;
+  border-top: 1px solid var(--error);
+  color: var(--error);
+}
+
 .sourcecado-apollo-credit-note {
   display: flex;
   flex-wrap: wrap;

--- a/desktop/surfaces/gui/tests/apolloCurationApi.test.ts
+++ b/desktop/surfaces/gui/tests/apolloCurationApi.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { curateApolloCandidates } from "../src/api";
+
+describe("Apollo curation API boundary", () => {
+  beforeEach(() => {
+    window.__CLUB_HTTP__ = "http://sidecar.test";
+    window.__CLUB_API_TOKEN__ = "review-token";
+  });
+
+  it("sends reviewed rows and keeps only person/chat receipt fields", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        status: "partial",
+        selected_row_count: 2,
+        selected_identity_count: 1,
+        kept: [
+          {
+            row_index: 0,
+            apollo_id: "person-tim",
+            person_id: "person-1",
+            version: 2,
+            operation: "created",
+            first_name: "Tim",
+            last_name: "Zh***g",
+            title: "CEO",
+            company: "Apollo.io",
+            sourcing_chat: null,
+            email: "PRIVATE@example.com",
+          },
+        ],
+        failed: [{ row_index: 1, apollo_id: null, code: "missing_apollo_id" }],
+        duplicates: [],
+        original_session: {
+          session_id: "thread-apollo",
+          bound_person_id: null,
+          reason: "multiple_selection",
+        },
+        raw_provider_payload: "PRIVATE",
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const people = [
+      { apolloId: "person-tim", firstName: "Tim" },
+      { firstName: "Missing identity" },
+    ];
+
+    const result = await curateApolloCandidates({
+      sessionId: "thread-apollo",
+      target: "Director-authored target",
+      people,
+      bindOriginal: false,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://sidecar.test/v1/apollo/curate",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          session_id: "thread-apollo",
+          target: "Director-authored target",
+          people,
+          bind_original: false,
+        }),
+      }),
+    );
+    expect(result.kept[0]).toEqual({
+      row_index: 0,
+      apollo_id: "person-tim",
+      person_id: "person-1",
+      version: 2,
+      operation: "created",
+      first_name: "Tim",
+      last_name: "Zh***g",
+      title: "CEO",
+      company: "Apollo.io",
+      sourcing_chat: null,
+    });
+    expect(JSON.stringify(result)).not.toContain("PRIVATE");
+  });
+});

--- a/desktop/surfaces/gui/tests/apolloPeopleResult.test.tsx
+++ b/desktop/surfaces/gui/tests/apolloPeopleResult.test.tsx
@@ -1,9 +1,19 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type { ToolCallMessagePart } from "@assistant-ui/react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ActivityGroup } from "../src/chat/ActivityGroup";
 import { Inspector, InspectorProvider } from "../src/chat/Inspector";
+
+const api = vi.hoisted(() => ({
+  curateApolloCandidates: vi.fn(),
+  openPersonSourcingChat: vi.fn(),
+}));
+
+vi.mock("../src/api", () => ({
+  curateApolloCandidates: api.curateApolloCandidates,
+  openPersonSourcingChat: api.openPersonSourcingChat,
+}));
 
 function apolloSearch(
   overrides: Partial<ToolCallMessagePart> = {},
@@ -78,6 +88,333 @@ function renderApollo(tool = apolloSearch()) {
 }
 
 describe("Apollo people result", () => {
+  beforeEach(() => {
+    api.curateApolloCandidates.mockReset();
+    api.curateApolloCandidates.mockResolvedValue({
+      status: "success",
+      selected_row_count: 2,
+      selected_identity_count: 2,
+      kept: [],
+      failed: [],
+      duplicates: [],
+      original_session: {
+        session_id: "thread-apollo",
+        bound_person_id: null,
+        reason: "multiple_selection",
+      },
+    });
+    api.openPersonSourcingChat.mockReset();
+  });
+
+  it("lets the director select several candidates and review before keeping", async () => {
+    renderApollo();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Searched Apollo · Completed" }),
+    );
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Tim Zh***g" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Maya" }));
+    fireEvent.change(
+      screen.getByRole("textbox", { name: "Target for selected people" }),
+      { target: { value: "Invite senior operators to the director's dinner." } },
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Review 2 selected candidates" }),
+    );
+
+    const review = screen.getByRole("region", {
+      name: "Review selected Apollo candidates",
+    });
+    expect(review).toHaveTextContent("Tim Zh***g");
+    expect(review).toHaveTextContent("Maya");
+    expect(review).toHaveTextContent(
+      "Invite senior operators to the director's dinner.",
+    );
+    expect(review).toHaveTextContent("does not enrich or use Apollo credits");
+    expect(api.curateApolloCandidates).not.toHaveBeenCalled();
+
+    fireEvent.click(within(review).getByRole("button", { name: "Keep 2 people" }));
+    await waitFor(() =>
+      expect(api.curateApolloCandidates).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionId: "thread-apollo",
+          target: "Invite senior operators to the director's dinner.",
+          bindOriginal: false,
+        }),
+      ),
+    );
+    expect(api.curateApolloCandidates.mock.calls[0]?.[0].people).toHaveLength(2);
+  });
+
+  it("binds the original conversation only for one reviewed candidate", async () => {
+    api.curateApolloCandidates.mockResolvedValueOnce({
+      status: "success",
+      selected_row_count: 1,
+      selected_identity_count: 1,
+      kept: [
+        {
+          row_index: 0,
+          apollo_id: "person-tim",
+          person_id: "person-tim-file",
+          version: 1,
+          operation: "created",
+          first_name: "Tim",
+          last_name: "Zh***g",
+          title: "CEO",
+          company: "Apollo.io",
+          sourcing_chat: { session_id: "thread-apollo" },
+        },
+      ],
+      failed: [],
+      duplicates: [],
+      original_session: {
+        session_id: "thread-apollo",
+        bound_person_id: "person-tim-file",
+        reason: "single_selection",
+      },
+    });
+    renderApollo();
+    fireEvent.click(screen.getByRole("button", { name: "Searched Apollo · Completed" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Tim Zh***g" }));
+    fireEvent.change(screen.getByRole("textbox", { name: "Target for selected people" }), {
+      target: { value: "Director-authored target" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Review 1 selected candidate" }));
+    fireEvent.click(screen.getByRole("button", { name: "Keep 1 person" }));
+
+    await waitFor(() =>
+      expect(api.curateApolloCandidates).toHaveBeenCalledWith(
+        expect.objectContaining({ bindOriginal: true }),
+      ),
+    );
+    expect(
+      await screen.findByRole("button", { name: "Open sourcing chat for Tim Zh***g" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/original target conversation remains unbound/i)).not.toBeInTheDocument();
+  });
+
+  it("deduplicates repeated Apollo identities before selection", () => {
+    renderApollo(
+      apolloSearch({
+        result: {
+          people: [
+            (apolloSearch().result as { people: unknown[] }).people[0],
+            {
+              ...(apolloSearch().result as { people: Record<string, unknown>[] }).people[0],
+              title: "Duplicate must not replace first",
+            },
+          ],
+        },
+      }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Searched Apollo · Completed" }));
+
+    expect(screen.getAllByRole("checkbox", { name: "Select Tim Zh***g" })).toHaveLength(1);
+    expect(screen.getByText("1 candidate")).toBeInTheDocument();
+    expect(screen.queryByText("Duplicate must not replace first")).not.toBeInTheDocument();
+  });
+
+  it("offers a direct person file and create-chat action for every kept row", async () => {
+    api.curateApolloCandidates.mockResolvedValueOnce({
+      status: "success",
+      selected_row_count: 2,
+      selected_identity_count: 2,
+      kept: [
+        {
+          row_index: 0,
+          apollo_id: "person-tim",
+          person_id: "person-tim-file",
+          version: 1,
+          operation: "created",
+          first_name: "Tim",
+          last_name: "Zh***g",
+          title: "CEO",
+          company: "Apollo.io",
+          sourcing_chat: null,
+        },
+        {
+          row_index: 1,
+          apollo_id: "person-partial",
+          person_id: "person-maya-file",
+          version: 1,
+          operation: "created",
+          first_name: "Maya",
+          last_name: null,
+          title: null,
+          company: "Apollo.io",
+          sourcing_chat: null,
+        },
+      ],
+      failed: [],
+      duplicates: [],
+      original_session: {
+        session_id: "thread-apollo",
+        bound_person_id: null,
+        reason: "multiple_selection",
+      },
+    });
+    api.openPersonSourcingChat.mockResolvedValueOnce({
+      created: true,
+      session: { id: "thread-tim", title: "Sourcing · Tim", n_msgs: 0 },
+      active_person: { person_id: "person-tim-file", version: 1, label: "Tim Zh***g" },
+    });
+    renderApollo();
+    fireEvent.click(screen.getByRole("button", { name: "Searched Apollo · Completed" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Tim Zh***g" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Maya" }));
+    fireEvent.change(screen.getByRole("textbox", { name: "Target for selected people" }), {
+      target: { value: "Director-authored target" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Review 2 selected candidates" }));
+    fireEvent.click(screen.getByRole("button", { name: "Keep 2 people" }));
+
+    expect(
+      await screen.findByRole("link", { name: "Open person file for Tim Zh***g" }),
+    ).toHaveAttribute("href", "#/people/person-tim-file");
+    expect(
+      screen.getByRole("link", { name: "Open person file for Maya" }),
+    ).toHaveAttribute("href", "#/people/person-maya-file");
+    fireEvent.click(
+      screen.getByRole("button", { name: "Create sourcing chat for Tim Zh***g" }),
+    );
+    await waitFor(() =>
+      expect(api.openPersonSourcingChat).toHaveBeenCalledWith("person-tim-file", 1),
+    );
+    expect(window.location.hash).toBe(
+      "#/chat/thread-tim/person/person-tim-file",
+    );
+  });
+
+  it("shows a visible error when a kept person's chat cannot be opened", async () => {
+    api.curateApolloCandidates.mockResolvedValueOnce({
+      status: "success",
+      selected_row_count: 1,
+      selected_identity_count: 1,
+      kept: [
+        {
+          row_index: 0,
+          apollo_id: "person-tim",
+          person_id: "person-tim-file",
+          version: 1,
+          operation: "created",
+          first_name: "Tim",
+          last_name: "Zh***g",
+          title: "CEO",
+          company: "Apollo.io",
+          sourcing_chat: null,
+        },
+      ],
+      failed: [],
+      duplicates: [],
+      original_session: {
+        session_id: "thread-apollo",
+        bound_person_id: null,
+        reason: "existing_person_chat",
+      },
+    });
+    api.openPersonSourcingChat.mockRejectedValueOnce(new Error("stale person version"));
+    renderApollo();
+    fireEvent.click(screen.getByRole("button", { name: "Searched Apollo · Completed" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Tim Zh***g" }));
+    fireEvent.change(screen.getByRole("textbox", { name: "Target for selected people" }), {
+      target: { value: "Director-authored target" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Review 1 selected candidate" }));
+    fireEvent.click(screen.getByRole("button", { name: "Keep 1 person" }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Create sourcing chat for Tim Zh***g" }),
+    );
+
+    expect(
+      await screen.findByRole("alert", { name: "Sourcing chat unavailable" }),
+    ).toHaveTextContent("Couldn’t open this person’s sourcing chat");
+  });
+
+  it("retries only failed rows while preserving successful receipts", async () => {
+    api.curateApolloCandidates
+      .mockResolvedValueOnce({
+        status: "partial",
+        selected_row_count: 2,
+        selected_identity_count: 2,
+        kept: [
+          {
+            row_index: 0,
+            apollo_id: "person-tim",
+            person_id: "person-tim-file",
+            version: 1,
+            operation: "created",
+            first_name: "Tim",
+            last_name: "Zh***g",
+            title: "CEO",
+            company: "Apollo.io",
+            sourcing_chat: null,
+          },
+        ],
+        failed: [
+          { row_index: 1, apollo_id: "person-partial", code: "invalid_candidate" },
+        ],
+        duplicates: [],
+        original_session: {
+          session_id: "thread-apollo",
+          bound_person_id: null,
+          reason: "multiple_selection",
+        },
+      })
+      .mockResolvedValueOnce({
+        status: "success",
+        selected_row_count: 1,
+        selected_identity_count: 1,
+        kept: [
+          {
+            row_index: 0,
+            apollo_id: "person-partial",
+            person_id: "person-maya-file",
+            version: 1,
+            operation: "created",
+            first_name: "Maya",
+            last_name: null,
+            title: null,
+            company: "Apollo.io",
+            sourcing_chat: null,
+          },
+        ],
+        failed: [],
+        duplicates: [],
+        original_session: {
+          session_id: "thread-apollo",
+          bound_person_id: null,
+          reason: "unbound",
+        },
+      });
+    renderApollo();
+    fireEvent.click(screen.getByRole("button", { name: "Searched Apollo · Completed" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Tim Zh***g" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Maya" }));
+    fireEvent.change(screen.getByRole("textbox", { name: "Target for selected people" }), {
+      target: { value: "Director-authored target" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Review 2 selected candidates" }));
+    fireEvent.click(screen.getByRole("button", { name: "Keep 2 people" }));
+
+    expect(
+      await screen.findByText("Maya needs review (invalid candidate)."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open person file for Tim Zh***g" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Retry 1 failed candidate" }));
+
+    await waitFor(() => expect(api.curateApolloCandidates).toHaveBeenCalledTimes(2));
+    const retry = api.curateApolloCandidates.mock.calls[1]?.[0];
+    expect(retry.people).toEqual([
+      expect.objectContaining({ apolloId: "person-partial" }),
+    ]);
+    expect(retry.bindOriginal).toBe(false);
+    expect(screen.getByRole("link", { name: "Open person file for Tim Zh***g" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("link", { name: "Open person file for Maya" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/needs review/)).not.toBeInTheDocument();
+  });
+
   it("keeps the original search query beside the result count", () => {
     renderApollo();
     fireEvent.click(

--- a/desktop/surfaces/gui/tests/apolloStyles.test.ts
+++ b/desktop/surfaces/gui/tests/apolloStyles.test.ts
@@ -18,6 +18,21 @@ describe("Apollo shortlist styles", () => {
     );
   });
 
+  it("keeps shortlist selection and review compact and keyboard visible", () => {
+    expect(styles).toMatch(
+      /\.sourcecado-apollo-curation\s*\{[^}]*display:\s*grid;/,
+    );
+    expect(styles).toMatch(
+      /\.sourcecado-apollo-select input\s*\{[^}]*width:\s*20px;[^}]*height:\s*20px;/,
+    );
+    expect(styles).toMatch(
+      /\.sourcecado-apollo-select\s*\{[^}]*min-height:\s*44px;/,
+    );
+    expect(styles).toMatch(
+      /\.sourcecado-apollo-curation-receipt li\s*\{[^}]*display:\s*flex;/,
+    );
+  });
+
   it("disables candidate skeleton animation when reduced motion is requested", () => {
     expect(styles).toMatch(
       /\.sourcecado-apollo-skeleton span\s*\{[^}]*animation:\s*shell-shimmer/,

--- a/desktop/tests/test_apollo_curation.py
+++ b/desktop/tests/test_apollo_curation.py
@@ -1,0 +1,294 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from coworker.apollo import FakeHttp
+from coworker.apollo_curation import curate_apollo_candidates
+from coworker.people import PersonStore
+from coworker.provider import FakeProvider
+from coworker.server import TOKEN_HEADER, create_app
+
+TOKEN = "test-token-apollo-curation"
+
+
+def _alyssa() -> dict:
+    return {
+        "apolloId": "abc123",
+        "firstName": "Alyssa",
+        "lastNameObfuscated": "W***n",
+        "title": "Partner",
+        "organizationName": "Codeology",
+        "hasEmail": True,
+    }
+
+
+def test_curate_one_candidate_creates_one_unenriched_person_with_target(tmp_path):
+    people = PersonStore(tmp_path)
+
+    result = curate_apollo_candidates(
+        people,
+        [_alyssa()],
+        target="Invite senior operators to the director's dinner.",
+    )
+
+    assert result["status"] == "success"
+    assert result["selected_identity_count"] == 1
+    assert result["failed"] == []
+    assert len(result["kept"]) == 1
+    kept = result["kept"][0]
+    assert kept["apollo_id"] == "abc123"
+    assert kept["operation"] == "created"
+    person = people.get(kept["person_id"])
+    assert person is not None
+    assert person["target"] == "Invite senior operators to the director's dinner."
+    assert person["email"] is None
+    assert person["sequence_state"] is None
+    assert "email" not in kept
+
+
+def test_duplicate_apollo_ids_are_kept_once_without_forking(tmp_path):
+    people = PersonStore(tmp_path)
+
+    result = curate_apollo_candidates(
+        people,
+        [
+            _alyssa(),
+            {**_alyssa(), "title": "Duplicate row must not run"},
+        ],
+        target="Director-authored target",
+    )
+
+    assert result["status"] == "success"
+    assert result["selected_identity_count"] == 1
+    assert len(result["kept"]) == 1
+    assert result["duplicates"] == [{"row_index": 1, "apollo_id": "abc123"}]
+    assert people.get_by_apollo_id("abc123")["title"] == "Partner"
+
+
+def test_partial_fields_and_failed_rows_preserve_success_with_selection_count(tmp_path):
+    people = PersonStore(tmp_path)
+
+    result = curate_apollo_candidates(
+        people,
+        [
+            {"apolloId": "partial-person", "firstName": "Maya"},
+            {"firstName": "Missing identity"},
+        ],
+        target="Director-authored target",
+    )
+
+    assert result["status"] == "partial"
+    assert result["selected_row_count"] == 2
+    assert result["selected_identity_count"] == 1
+    assert result["failed"] == [
+        {"row_index": 1, "apollo_id": None, "code": "missing_apollo_id"}
+    ]
+    assert len(result["kept"]) == 1
+    person = people.get(result["kept"][0]["person_id"])
+    assert person is not None
+    assert person["first_name"] == "Maya"
+    assert person["title"] is None
+    assert person["company"] is None
+    assert person["target"] == "Director-authored target"
+
+
+def test_repeated_identity_updates_same_person_once_and_survives_restart(tmp_path):
+    people = PersonStore(tmp_path)
+    first = curate_apollo_candidates(
+        people,
+        [_alyssa()],
+        target="Initial director target",
+    )["kept"][0]
+
+    restarted = PersonStore(tmp_path)
+    updated_row = {**_alyssa(), "title": "General Partner"}
+    second = curate_apollo_candidates(
+        restarted,
+        [updated_row],
+        target="Updated director target",
+    )["kept"][0]
+    third = curate_apollo_candidates(
+        restarted,
+        [updated_row],
+        target="Updated director target",
+    )["kept"][0]
+
+    assert second["person_id"] == first["person_id"]
+    assert second["operation"] == "updated"
+    assert second["version"] == first["version"] + 1
+    assert third["version"] == second["version"]
+    loaded = restarted.get_by_apollo_id("abc123")
+    assert loaded is not None
+    assert loaded["title"] == "General Partner"
+    assert loaded["target"] == "Updated director target"
+
+
+def test_row_failure_does_not_stop_later_rows_or_erase_earlier_success(tmp_path):
+    people = PersonStore(tmp_path)
+
+    result = curate_apollo_candidates(
+        people,
+        [
+            _alyssa(),
+            {"apolloId": "bad-row", "firstName": 42},
+            {"apolloId": "ada", "firstName": "Ada"},
+        ],
+        target="Director-authored target",
+    )
+
+    assert result["status"] == "partial"
+    assert [row["apollo_id"] for row in result["kept"]] == ["abc123", "ada"]
+    assert result["failed"] == [
+        {"row_index": 1, "apollo_id": "bad-row", "code": "invalid_candidate"}
+    ]
+    assert people.get_by_apollo_id("abc123") is not None
+    assert people.get_by_apollo_id("ada") is not None
+    assert people.get_by_apollo_id("bad-row") is None
+
+
+def test_curation_requires_the_director_authored_target(tmp_path):
+    people = PersonStore(tmp_path)
+
+    with pytest.raises(ValueError, match="target"):
+        curate_apollo_candidates(people, [_alyssa()], target="   ")
+
+    assert people.get_by_apollo_id("abc123") is None
+
+
+def test_multi_candidate_api_keeps_separate_unbound_people_without_credit_use(tmp_path):
+    http = FakeHttp()
+    app = create_app(
+        token=TOKEN,
+        provider=FakeProvider(),
+        state=tmp_path,
+        http=http,
+    )
+    session_id = app.state.store.open_session_id()
+    response = TestClient(app).post(
+        "/v1/apollo/curate",
+        headers={TOKEN_HEADER: TOKEN},
+        json={
+            "session_id": session_id,
+            "target": "Invite senior operators to the director's dinner.",
+            "people": [
+                _alyssa(),
+                {"apolloId": "partial-person", "firstName": "Maya"},
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "success"
+    assert body["original_session"] == {
+        "session_id": session_id,
+        "bound_person_id": None,
+        "reason": "multiple_selection",
+    }
+    assert len(body["kept"]) == 2
+    assert all(row["sourcing_chat"] is None for row in body["kept"])
+    assert app.state.people.person_for_session(session_id) is None
+    for row in body["kept"]:
+        person = app.state.people.get(row["person_id"])
+        assert person is not None
+        assert person["target"] == "Invite senior operators to the director's dinner."
+        assert person["email"] is None
+        assert person["sequence_state"] is None
+    assert http.calls == []
+
+
+def test_multi_candidate_api_preserves_and_reports_an_existing_chat_binding(tmp_path):
+    app = create_app(token=TOKEN, provider=FakeProvider(), state=tmp_path)
+    session_id = app.state.store.open_session_id()
+    owner = app.state.people.keep_from_apollo(
+        apollo_id="existing-owner",
+        first_name="Existing",
+        last_name_obfuscated=None,
+        title=None,
+        company=None,
+        target="Existing target",
+    )
+    app.state.people.bind_session(session_id, owner["person_id"])
+
+    response = TestClient(app).post(
+        "/v1/apollo/curate",
+        headers={TOKEN_HEADER: TOKEN},
+        json={
+            "session_id": session_id,
+            "target": "Director-authored target",
+            "people": [
+                _alyssa(),
+                {"apolloId": "partial-person", "firstName": "Maya"},
+            ],
+            "bind_original": False,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["original_session"] == {
+        "session_id": session_id,
+        "bound_person_id": owner["person_id"],
+        "reason": "already_bound",
+    }
+    assert app.state.people.person_for_session(session_id) == owner["person_id"]
+
+
+def test_single_candidate_api_binds_original_chat_to_that_person(tmp_path):
+    app = create_app(token=TOKEN, provider=FakeProvider(), state=tmp_path)
+    session_id = app.state.store.open_session_id()
+
+    response = TestClient(app).post(
+        "/v1/apollo/curate",
+        headers={TOKEN_HEADER: TOKEN},
+        json={
+            "session_id": session_id,
+            "target": "Director-authored target",
+            "people": [_alyssa()],
+            "bind_original": True,
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    kept = body["kept"][0]
+    assert body["original_session"] == {
+        "session_id": session_id,
+        "bound_person_id": kept["person_id"],
+        "reason": "single_selection",
+    }
+    assert kept["sourcing_chat"] == {"session_id": session_id}
+    assert app.state.people.person_for_session(session_id) == kept["person_id"]
+
+
+def test_retrying_only_failed_multi_rows_never_rebinds_or_updates_successes(tmp_path):
+    app = create_app(token=TOKEN, provider=FakeProvider(), state=tmp_path)
+    session_id = app.state.store.open_session_id()
+    client = TestClient(app)
+    first = client.post(
+        "/v1/apollo/curate",
+        headers={TOKEN_HEADER: TOKEN},
+        json={
+            "session_id": session_id,
+            "target": "Director-authored target",
+            "people": [_alyssa(), {"firstName": "Missing identity"}],
+            "bind_original": False,
+        },
+    ).json()
+    successful = first["kept"][0]
+
+    retried = client.post(
+        "/v1/apollo/curate",
+        headers={TOKEN_HEADER: TOKEN},
+        json={
+            "session_id": session_id,
+            "target": "Director-authored target",
+            "people": [{"apolloId": "fixed-row", "firstName": "Fixed"}],
+            "bind_original": False,
+        },
+    ).json()
+
+    assert retried["status"] == "success"
+    assert [row["apollo_id"] for row in retried["kept"]] == ["fixed-row"]
+    assert app.state.people.get(successful["person_id"])["version"] == successful[
+        "version"
+    ]
+    assert app.state.people.person_for_session(session_id) is None

--- a/desktop/tests/test_bound_turn.py
+++ b/desktop/tests/test_bound_turn.py
@@ -200,7 +200,7 @@ def _keep(tmp_path, people, sid, row):
                     ToolCall(
                         id="keep_1",
                         name="people_keep",
-                        arguments={"people": [row]},
+                        arguments={"people": [row], "target": "test target"},
                     )
                 ]
             },
@@ -317,7 +317,10 @@ def test_keep_two_people_does_not_bind(tmp_path):
                     ToolCall(
                         id="keep_2",
                         name="people_keep",
-                        arguments={"people": [_ada(), _alonzo()]},
+                            arguments={
+                                "people": [_ada(), _alonzo()],
+                                "target": "test target",
+                            },
                     )
                 ]
             },
@@ -334,6 +337,39 @@ def test_keep_two_people_does_not_bind(tmp_path):
     assert people.person_for_session("sess-a") is None
     assert people.get_by_apollo_id("ada") is not None
     assert people.get_by_apollo_id("alonzo") is not None
+
+
+def test_partial_multi_keep_does_not_guess_owner_from_one_success(tmp_path):
+    people = PersonStore(tmp_path)
+    fake = FakeProvider(
+        steps=[
+            {
+                "tool_calls": [
+                    ToolCall(
+                        id="keep_partial",
+                        name="people_keep",
+                        arguments={
+                            "people": [_ada(), {"firstName": "Missing identity"}],
+                            "target": "Director-authored target",
+                        },
+                    )
+                ]
+            },
+            {"deltas": ("Kept one; one row needs review.",)},
+        ]
+    )
+
+    result = _run(
+        tmp_path=tmp_path,
+        sid="sess-partial",
+        text="review and keep these two",
+        provider=fake,
+        people=people,
+    )
+
+    assert result["status"] == "ok"
+    assert people.get_by_apollo_id("ada") is not None
+    assert people.person_for_session("sess-partial") is None
 
 
 def _draft_call():

--- a/desktop/tests/test_people_keep.py
+++ b/desktop/tests/test_people_keep.py
@@ -56,7 +56,8 @@ def test_keep_row_with_blank_apollo_fields_keeps_what_the_file_has(tmp_path):
                     "title": "",
                     "organizationName": "   ",
                 }
-            ]
+            ],
+            "target": "club research dinner",
         },
         people=people,
     )
@@ -76,7 +77,7 @@ def test_keep_same_apollo_id_twice_does_not_fork(tmp_path):
     people = PersonStore(tmp_path)
     first = execute(
         "people_keep",
-        {"people": [_alyssa()]},
+        {"people": [_alyssa()], "target": "initial outreach"},
         people=people,
     )[1]["kept"][0]
     ok, result = execute(
@@ -117,7 +118,8 @@ def test_keep_two_rows_returns_two_person_ids(tmp_path):
                     "title": "Founder",
                     "organizationName": "Analytic",
                 },
-            ]
+            ],
+            "target": "director-authored target",
         },
         people=people,
     )
@@ -139,6 +141,27 @@ def test_keep_empty_list_succeeds(tmp_path):
     assert result["kept"] == []
 
 
+def test_people_keep_reports_partial_rows_without_losing_success(tmp_path):
+    people = PersonStore(tmp_path)
+
+    ok, result = execute(
+        "people_keep",
+        {
+            "people": [_alyssa(), {"firstName": "Missing Apollo identity"}],
+            "target": "Director-authored target",
+        },
+        people=people,
+    )
+
+    assert ok is True
+    assert result["status"] == "partial"
+    assert result["selected_row_count"] == 2
+    assert [row["apollo_id"] for row in result["kept"]] == ["abc123"]
+    assert result["failed"] == [
+        {"row_index": 1, "apollo_id": None, "code": "missing_apollo_id"}
+    ]
+
+
 def test_people_keep_is_auto():
     from coworker.permissions import decide
 
@@ -157,3 +180,12 @@ def test_versioned_prompt_and_tool_catalog_support_keep_after_search(tmp_path):
     assert "people_keep" in tool_names
     assert "search for People" in prompt
     assert "never invent" in prompt
+
+
+def test_people_keep_schema_requires_the_director_target():
+    from coworker.tools import PEOPLE_KEEP_SCHEMA
+
+    assert PEOPLE_KEEP_SCHEMA["function"]["parameters"]["required"] == [
+        "people",
+        "target",
+    ]


### PR DESCRIPTION
## Stacked dependency\n\nThis PR targets codex/s2-bound-person-chat and depends on PR #94. After #94 merges, this branch will be rebased/retargeted to main.\n\n## Summary\n\n- add accessible one/multi-candidate Apollo selection and explicit review\n- create or update exactly one person file per Apollo identity with the director-authored target\n- keep repeated identities idempotent\n- preserve partial successes and retry only failed rows\n- perform no enrichment, email retrieval, sequence start, credit use, or Apollo HTTP request\n- keep multi-person target conversations unbound and preserve truthful existing bindings\n- link receipts to person files with direct open/create sourcing-chat actions and visible safe errors\n\n## Verification\n\n- focused #64/#62 Python: 74 passed\n- focused GUI: 126 passed\n- make test: 760 Python passed, 3 skipped; 404 GUI passed\n- make build: passed\n- one clean #64 commit above the PR #94 base\n\nRefs #64\n\n## Residual risk\n\nAn in-progress UI retry receipt is not restored after a page remount. No live Apollo call was run; the keep path’s zero-call behavior is explicitly tested.