### PR TITLE
Fix weekly sourcing skill policy

### DIFF
--- a/desktop/coworker/builtin_skills/weekly-sourcing/SKILL.md
+++ b/desktop/coworker/builtin_skills/weekly-sourcing/SKILL.md
@@ -3,9 +3,32 @@ name: weekly-sourcing
 description: Weekly check-in playbook for who to work next and why-now.
 ---
 
-When Fisher asks for a weekly sourcing check-in:
+When Fisher asks for a weekly sourcing check-in, produce a prioritized review of
+who to work next and the next concrete action.
 
-1. Check saved memory and Person Files for relevant People and active Sequences.
-2. Produce a shortlist. Each name has a why-now. A name without a why-now is not a recommendation.
-3. Outreach Drafts are for review. Sending requires a per-message Approved Send.
-4. Surface Knowledge Gaps beside the deliverable.
+1. Start from the director-authored Target. Never invent or silently broaden it.
+2. Treat each Person as the unit of work. Read the Person File and active
+   Sequence; a company is context on a Person, not a record to rank.
+3. Use the current Living Brief and durable evidence. For every recommended
+   Person, state a source-backed why-now and include the relevant Source
+   Reference. A Person without reliable why-now evidence is not a recommendation.
+4. Name important missing, stale, or conflicting context as a Knowledge Gap.
+   Show conflicts instead of silently choosing a convenient claim.
+5. Return a compact shortlist. For each Person show Target fit, Sequence state,
+   why-now evidence, Source References, Knowledge Gaps, and one concrete next
+   action. Update the Living Brief when durable evidence changes. Record an
+   Outreach Outcome only when it actually happened; never infer one.
+
+Keep the outreach actions distinct:
+
+- Drafting: prepare an editable Outreach Draft from the Target and evidence
+  already in the Person File. Drafting does not enrich or send.
+- Enrichment: do it manually, one Person at a time. Explain the Knowledge Gap
+  and credit use, then wait for the runtime's approval before
+  `apollo_enrich_contact`. Never enrich a shortlist in bulk.
+- Sending: use the current `gmail_send` path only for the reviewed message and
+  recipient covered by an explicit, per-message Approved Send. Approval is not
+  standing permission. Never bulk-send or auto-send.
+
+Loading this skill grants no tool or permission. Use only the runtime's current
+effective tools and approval decisions.

--- a/desktop/tests/test_skills.py
+++ b/desktop/tests/test_skills.py
@@ -1,15 +1,56 @@
 from coworker.skills import BUILTIN_SKILLS, SkillLoader, catalog_text, parse_skill
+from coworker.permissions import decide
 from coworker.store import ConversationStore
-from coworker.tools import execute
+from coworker.tools import OPENAI_TOOLS, execute
 
 
-def test_builtin_weekly_sourcing_skill():
+def _weekly_sourcing_skill():
     md = BUILTIN_SKILLS / "weekly-sourcing" / "SKILL.md"
-    skill = parse_skill(md)
+    return parse_skill(md)
+
+
+def test_builtin_weekly_sourcing_skill_uses_the_current_person_centered_job():
+    skill = _weekly_sourcing_skill()
+
     assert skill.name == "weekly-sourcing"
-    assert "why-now" in skill.description or "why-now" in skill.instructions
-    assert "Outreach Drafts are for review" in skill.instructions
-    assert "per-message Approved Send" in skill.instructions
+    for term in (
+        "Target",
+        "Person",
+        "Person File",
+        "Sequence",
+        "Living Brief",
+        "Outreach Outcome",
+        "Source Reference",
+        "Knowledge Gap",
+    ):
+        assert term in skill.instructions
+    assert "Contact" not in skill.instructions
+    assert "Sourcing Lead" not in skill.instructions
+    assert "organization record" not in skill.instructions.lower()
+    assert "company is context" in skill.instructions.lower()
+
+
+def test_builtin_weekly_sourcing_skill_requires_evidence_and_names_uncertainty():
+    instructions = _weekly_sourcing_skill().instructions.lower()
+
+    assert "why-now" in instructions
+    assert "source reference" in instructions
+    assert "missing" in instructions
+    assert "conflicting" in instructions
+    assert "knowledge gap" in instructions
+
+
+def test_builtin_weekly_sourcing_skill_preserves_manual_outreach_authority():
+    instructions = _weekly_sourcing_skill().instructions.lower()
+
+    assert "draft" in instructions
+    assert "enrichment" in instructions
+    assert "credit" in instructions
+    assert "one person at a time" in instructions
+    assert "gmail_send" in instructions
+    assert "approved send" in instructions
+    assert "per-message" in instructions
+    assert "auto-send" in instructions
 
 
 def test_load_skill_returns_full_body(tmp_path):
@@ -18,6 +59,36 @@ def test_load_skill_returns_full_body(tmp_path):
     assert ok is True
     assert result["name"] == "weekly-sourcing"
     assert "shortlist" in result["instructions"].lower() or "why-now" in result["instructions"].lower()
+
+
+def test_loading_weekly_sourcing_cannot_broaden_tools_or_permissions():
+    loader = SkillLoader([BUILTIN_SKILLS])
+    tool_names_before = tuple(
+        schema["function"]["name"] for schema in OPENAI_TOOLS
+    )
+    decisions_before = {
+        name: decide(name)
+        for name in (
+            "load_skill",
+            "gmail_draft",
+            "apollo_enrich_contact",
+            "gmail_send",
+            "unlisted_skill_tool",
+        )
+    }
+
+    ok, result = execute("load_skill", {"name": "weekly-sourcing"}, skills=loader)
+
+    assert ok is True
+    assert set(result) == {"name", "description", "instructions"}
+    assert loader.get("weekly-sourcing").allowed_tools == []
+    assert tuple(schema["function"]["name"] for schema in OPENAI_TOOLS) == tool_names_before
+    assert {
+        name: decide(name) for name in decisions_before
+    } == decisions_before
+    assert decide("gmail_send").needs_user is True
+    assert decide("apollo_enrich_contact").needs_user is True
+    assert decide("unlisted_skill_tool").allowed is False
 
 
 def test_load_skill_missing(tmp_path):


### PR DESCRIPTION
## Summary
- replace the built-in weekly sourcing playbook with the current person-centered Sourcecado vocabulary
- require source-backed why-now evidence plus visible missing, stale, and conflicting context
- separate drafting, manual credit-aware enrichment, and per-message approved Gmail sending
- prove skill loading cannot alter effective tools or permission decisions

## TDD
RED: the prior skill lacked Target, Living Brief, Outreach Outcome, Source Reference, enrichment, credit, and conflict guidance.
GREEN: 7 focused skill tests pass.

## Verification
- 38 focused policy and prompt tests passed
- 768 Python tests passed, 3 skipped
- 396 GUI tests passed

Closes #56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the weekly sourcing guidance with clearer, person-centered recommendations, source-backed evidence, uncertainty tracking, and concrete next steps.
  * Clarified the separate approval requirements for drafting, contact enrichment, and sending outreach.
  * Documented that loading the guidance does not grant additional tools or permissions.

* **Tests**
  * Added coverage for terminology, evidence requirements, outreach controls, and permission boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->