### PR TITLE
fix(desktop): normalize legacy scheduled-run statuses truthfully

### DIFF
--- a/desktop/coworker/store.py
+++ b/desktop/coworker/store.py
@@ -237,6 +237,12 @@ class ConversationStore:
                 waiting_approval_count = COALESCE(waiting_approval_count, 0)
             """
         )
+        # Pre-S4 scheduler writes stored run_turn's raw "ok" status directly;
+        # RECEIPT_STATUSES has mapped it to "success" ever since, but rows
+        # written before that mapping existed are still on disk with the old
+        # text. Normalize them once so every consumer -- API, UI, future
+        # exports -- agrees on the shared status contract.
+        self._conn.execute("UPDATE runs SET status = 'success' WHERE status = 'ok'")
         try:
             self._conn.execute(
                 "ALTER TABLE sessions ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0"
@@ -369,27 +375,66 @@ class ConversationStore:
                 raise
 
     def _reconcile_orphaned_runs(self) -> None:
-        """Close runs the prior process left mid-flight without inventing an outcome."""
+        """Close runs the prior process left mid-flight without inventing an outcome.
+
+        A crash can land between the scheduled transcript's terminal event
+        and the matching runs-table update, so the outcome isn't always
+        unknown: check the transcript first and only fall back to
+        'interrupted' when it has nothing to say.
+        """
         now = datetime.now(UTC).isoformat()
         with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")
             try:
-                self._conn.execute(
-                    """
-                    UPDATE runs SET
-                        status = 'interrupted',
-                        result = ?,
-                        summary = ?,
-                        finished_at = ?,
-                        duration_ms = COALESCE(duration_ms, 0)
-                    WHERE status = 'running'
-                    """,
-                    (_INTERRUPTED_RUN_SUMMARY, _INTERRUPTED_RUN_SUMMARY, now),
-                )
+                running = self._conn.execute(
+                    "SELECT id, session_id FROM runs WHERE status = 'running'"
+                ).fetchall()
+                for row in running:
+                    status, result, summary = self._terminal_transcript_outcome(
+                        str(row["session_id"])
+                    )
+                    self._conn.execute(
+                        """
+                        UPDATE runs SET
+                            status = ?,
+                            result = ?,
+                            summary = ?,
+                            finished_at = ?,
+                            duration_ms = COALESCE(duration_ms, 0)
+                        WHERE id = ?
+                        """,
+                        (status, result, summary, now, row["id"]),
+                    )
                 self._conn.commit()
             except Exception:
                 self._conn.rollback()
                 raise
+
+    # Mirrors scheduler.RECEIPT_STATUSES' run_turn -> receipt mapping, keyed
+    # by the transcript's turn_end "state" instead of run_turn's return
+    # value. Duplicated rather than imported: store.py cannot import
+    # coworker.automation.scheduler without a circular import (scheduler.py
+    # imports ConversationStore).
+    _TRANSCRIPT_TERMINAL_STATES = {
+        "complete": "success",
+        "partial": "partial",
+        "stopped": "partial",
+    }
+
+    def _terminal_transcript_outcome(self, session_id: str) -> tuple[str, str, str]:
+        """Derive (status, result, summary) from a session's last event, if terminal."""
+        events = self.load_events(session_id)
+        last = events[-1] if events else None
+        if last is not None and last.get("type") == "error":
+            message = str(last.get("message") or _INTERRUPTED_RUN_SUMMARY)
+            return "failed", message, message
+        if last is not None and last.get("type") == "turn_end":
+            status = self._TRANSCRIPT_TERMINAL_STATES.get(str(last.get("state")))
+            if status is not None:
+                text = str(last.get("text") or "")
+                summary = text or _INTERRUPTED_RUN_SUMMARY
+                return status, text, summary
+        return "interrupted", _INTERRUPTED_RUN_SUMMARY, _INTERRUPTED_RUN_SUMMARY
 
     def _file(self, sid: str) -> Path:
         if not valid_session_id(sid):

--- a/desktop/coworker/store.py
+++ b/desktop/coworker/store.py
@@ -216,6 +216,10 @@ class ConversationStore:
             "artifacts": "TEXT",
             "session_id": "TEXT",
             "waiting_approval_count": "INTEGER DEFAULT 0",
+            # Count of events already in the reused sched-{job_id} file
+            # when this run started. The restart reconciler must ignore
+            # those; they belong to earlier attempts.
+            "event_offset": "INTEGER NOT NULL DEFAULT 0",
         }
         for column, definition in run_migrations.items():
             try:
@@ -377,21 +381,25 @@ class ConversationStore:
     def _reconcile_orphaned_runs(self) -> None:
         """Close runs the prior process left mid-flight without inventing an outcome.
 
-        A crash can land between the scheduled transcript's terminal event
-        and the matching runs-table update, so the outcome isn't always
-        unknown: check the transcript first and only fall back to
-        'interrupted' when it has nothing to say.
+        A crash can land between this attempt's terminal event and the
+        matching runs-table update. Trust only events written after this
+        run started: sched-{job_id} files are reused, so last week's
+        terminal event is still in the file.
         """
         now = datetime.now(UTC).isoformat()
         with self._lock:
             self._conn.execute("BEGIN IMMEDIATE")
             try:
                 running = self._conn.execute(
-                    "SELECT id, session_id FROM runs WHERE status = 'running'"
+                    """
+                    SELECT id, session_id, event_offset
+                    FROM runs WHERE status = 'running'
+                    """
                 ).fetchall()
                 for row in running:
                     status, result, summary = self._terminal_transcript_outcome(
-                        str(row["session_id"])
+                        str(row["session_id"]),
+                        int(row["event_offset"] or 0),
                     )
                     self._conn.execute(
                         """
@@ -421,9 +429,11 @@ class ConversationStore:
         "stopped": "partial",
     }
 
-    def _terminal_transcript_outcome(self, session_id: str) -> tuple[str, str, str]:
-        """Derive (status, result, summary) from a session's last event, if terminal."""
-        events = self.load_events(session_id)
+    def _terminal_transcript_outcome(
+        self, session_id: str, event_offset: int = 0
+    ) -> tuple[str, str, str]:
+        """Derive (status, result, summary) from this attempt's last event, if terminal."""
+        events = self.load_events(session_id)[max(0, event_offset) :]
         last = events[-1] if events else None
         if last is not None and last.get("type") == "error":
             message = str(last.get("message") or _INTERRUPTED_RUN_SUMMARY)
@@ -718,15 +728,16 @@ class ConversationStore:
         self, job_id: int, *, session_id: str, started_at: str
     ) -> dict[str, Any]:
         with self._lock:
+            event_offset = len(self.load_events(session_id))
             cursor = self._conn.execute(
                 """
                 INSERT INTO runs
                     (job_id, status, result, started_at, finished_at,
                      duration_ms, summary, artifacts, session_id,
-                     waiting_approval_count)
-                VALUES (?, 'running', NULL, ?, NULL, NULL, '', '[]', ?, 0)
+                     waiting_approval_count, event_offset)
+                VALUES (?, 'running', NULL, ?, NULL, NULL, '', '[]', ?, 0, ?)
                 """,
-                (job_id, started_at, session_id),
+                (job_id, started_at, session_id, event_offset),
             )
             self._conn.commit()
             row = self._conn.execute(
@@ -1602,6 +1613,7 @@ def _inbox_row(row: sqlite3.Row) -> dict[str, Any]:
 
 def _run_row(row: sqlite3.Row) -> dict[str, Any]:
     item = dict(row)
+    item.pop("event_offset", None)
     raw = item.get("artifacts") or "[]"
     try:
         parsed = json.loads(raw)

--- a/desktop/surfaces/gui/src/api.ts
+++ b/desktop/surfaces/gui/src/api.ts
@@ -45,7 +45,11 @@ export type ScheduleRunStatus =
   | "failed"
   | "waiting_approval"
   | "partial"
-  | "interrupted";
+  | "interrupted"
+  // Client-only: a status this build does not recognize (a future status,
+  // corrupted data). Never written by the sidecar, so it stays out of
+  // SCHEDULE_RUN_STATUSES below -- it is not part of the shared contract.
+  | "unknown";
 
 export type ScheduleJob = {
   id: number;
@@ -471,7 +475,11 @@ function normalizeScheduleArtifact(value: unknown): ScheduleArtifact {
 function normalizeScheduleRun(value: unknown): ScheduleRun {
   const raw = record(value);
   const rawStatus = text(raw.status) as ScheduleRunStatus;
-  const status = SCHEDULE_RUN_STATUSES.has(rawStatus) ? rawStatus : "failed";
+  // A status this client has never seen is not the same as a failure: it is
+  // an indeterminate outcome, and must read as such instead of falsely
+  // "Failed". (Legacy "ok" rows are normalized to "success" on disk, so they
+  // never reach this fallback.)
+  const status = SCHEDULE_RUN_STATUSES.has(rawStatus) ? rawStatus : "unknown";
   return {
     id: numberValue(raw.id),
     jobId: numberValue(raw.job_id),

--- a/desktop/surfaces/gui/src/routes/ScheduledPage.tsx
+++ b/desktop/surfaces/gui/src/routes/ScheduledPage.tsx
@@ -44,6 +44,9 @@ const RUN_STATUS_LABELS: Record<ScheduleRunStatus, string> = {
   // automation failed when it was merely cut short sends them debugging a
   // problem that does not exist.
   interrupted: "Interrupted",
+  // A status this build does not recognize. Distinct from "Failed" for the
+  // same reason as "Interrupted": an indeterminate outcome is not a failure.
+  unknown: "Needs review",
 };
 
 function draftFromTemplate(template: ScheduleTemplate): CreateDraft {
@@ -68,6 +71,9 @@ function formatTimestamp(stamp: string | null): string {
 }
 
 function formatDuration(durationMs: number): string {
+  // Legacy rows written before duration tracking existed always recorded 0;
+  // showing "0ms" reads as an instant run instead of "never measured".
+  if (durationMs === 0) return "Legacy run";
   if (durationMs < 1000) return `${durationMs}ms`;
   return `${(durationMs / 1000).toFixed(1)}s`;
 }

--- a/desktop/surfaces/gui/src/styles/route.css
+++ b/desktop/surfaces/gui/src/styles/route.css
@@ -1369,6 +1369,10 @@
   border-color: var(--error);
 }
 
+.schedule-receipt.receipt-unknown {
+  border-color: var(--warn);
+}
+
 .schedule-receipt > header {
   color: var(--muted);
   font-size: 11px;

--- a/desktop/surfaces/gui/tests/scheduledApi.test.ts
+++ b/desktop/surfaces/gui/tests/scheduledApi.test.ts
@@ -127,6 +127,35 @@ describe("schedule API boundary", () => {
     expect(JSON.stringify(schedule)).not.toContain("secret-never-render");
   });
 
+  it("marks a genuinely unrecognized run status as unknown instead of coercing it to failed", async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        jobs: [],
+        runs: [
+          {
+            id: 11,
+            job_id: 4,
+            status: "some_future_status_this_client_has_never_seen",
+            result: "",
+            summary: "",
+            created_at: "2026-08-25T10:01:00Z",
+            started_at: "2026-08-25T10:01:00Z",
+            finished_at: "2026-08-25T10:01:02Z",
+            duration_ms: 500,
+            session_id: "sched-4",
+            waiting_approval_count: 0,
+            artifacts: [],
+          },
+        ],
+        templates: [],
+      }),
+    );
+
+    const schedule = await getSchedule();
+
+    expect(schedule.runs[0].status).toBe("unknown");
+  });
+
   it("creates a routine through the schedule endpoint", async () => {
     fetchMock.mockResolvedValue(
       response({

--- a/desktop/surfaces/gui/tests/scheduledPage.test.tsx
+++ b/desktop/surfaces/gui/tests/scheduledPage.test.tsx
@@ -204,6 +204,37 @@ describe("ScheduledPage", () => {
     expect(within(receipts).getByText("1 approval waiting in Inbox")).toBeInTheDocument();
   });
 
+  it("renders a genuinely unknown status as needs-review, not failed", async () => {
+    api.getSchedule.mockResolvedValue(
+      schedule({
+        jobs: [job],
+        runs: [run({ status: "unknown", summary: "Status could not be recognized." })],
+      }),
+    );
+
+    render(<ScheduledPage />);
+
+    const routine = await screen.findByRole("article", { name: "Weekly priority review" });
+    const receipts = within(routine).getByRole("list", { name: "Run receipts" });
+    expect(within(receipts).getByText("Needs review")).toBeInTheDocument();
+    expect(within(receipts).queryByText("Failed")).not.toBeInTheDocument();
+  });
+
+  it("shows legacy zero-duration runs as 'Legacy run' instead of 0ms", async () => {
+    api.getSchedule.mockResolvedValue(
+      schedule({
+        jobs: [job],
+        runs: [run({ durationMs: 0, summary: "Found three priority contacts." })],
+      }),
+    );
+
+    render(<ScheduledPage />);
+
+    const routine = await screen.findByRole("article", { name: "Weekly priority review" });
+    expect(within(routine).getByText("Legacy run")).toBeInTheDocument();
+    expect(within(routine).queryByText("0ms")).not.toBeInTheDocument();
+  });
+
   it("shows artifact metadata and opens the isolated scheduled thread", async () => {
     api.getSchedule.mockResolvedValue(
       schedule({

--- a/desktop/surfaces/gui/tests/scheduledStyles.test.ts
+++ b/desktop/surfaces/gui/tests/scheduledStyles.test.ts
@@ -20,10 +20,11 @@ describe("Scheduled route styles", () => {
     );
   });
 
-  it("visually distinguishes waiting, partial, and failed receipts", () => {
+  it("visually distinguishes waiting, partial, failed, and unknown receipts", () => {
     expect(css).toMatch(/\.schedule-receipt\.receipt-waiting_approval\s*\{[^}]*border-color:\s*var\(--warn\);/);
     expect(css).toMatch(/\.schedule-receipt\.receipt-partial\s*\{[^}]*border-color:\s*var\(--warn\);/);
     expect(css).toMatch(/\.schedule-receipt\.receipt-failed\s*\{[^}]*border-color:\s*var\(--error\);/);
+    expect(css).toMatch(/\.schedule-receipt\.receipt-unknown\s*\{[^}]*border-color:\s*var\(--warn\);/);
   });
 
   it("disables schedule skeleton animation for reduced motion and styles the rail Inbox badge", () => {

--- a/desktop/tests/test_schedule.py
+++ b/desktop/tests/test_schedule.py
@@ -609,6 +609,59 @@ def test_reopen_recovers_true_failure_from_the_scheduled_transcript(tmp_path):
     assert healed["result"] == "provider timed out"
 
 
+def test_reopen_does_not_copy_last_weeks_completed_receipt_when_this_attempt_never_turned(
+    tmp_path,
+):
+    """Scheduled jobs reuse sched-{job_id}. A crash after start_run and
+    before this week's turn_start must not adopt last week's terminal
+    event as this week's outcome."""
+    store = ConversationStore(tmp_path)
+    job = store.add_job("0 9 * * 1", "weekly", next_run_at=None)
+    session_id = f"sched-{job['id']}"
+
+    week1 = store.start_run(
+        int(job["id"]),
+        session_id=session_id,
+        started_at="2026-08-17T16:00:00+00:00",
+    )
+    store.append_event(session_id, {"type": "turn_start", "state": "running"})
+    store.append_event(
+        session_id,
+        {
+            "type": "turn_end",
+            "text": "Week 1 found three contacts.",
+            "state": "complete",
+        },
+    )
+    store.finish_run(
+        int(week1["id"]),
+        status="success",
+        result="Week 1 found three contacts.",
+        summary="Week 1 found three contacts.",
+        artifacts=[],
+        duration_ms=1500,
+        finished_at="2026-08-17T16:00:02+00:00",
+    )
+
+    week2 = store.start_run(
+        int(job["id"]),
+        session_id=session_id,
+        started_at="2026-08-24T16:00:00+00:00",
+    )
+    assert week2["status"] == "running"
+    assert week2["duration_ms"] is None
+
+    first, second = ConversationStore(tmp_path).list_schedule()["runs"]
+
+    assert first["status"] == "success"
+    assert first["result"] == "Week 1 found three contacts."
+    assert second["id"] == week2["id"]
+    assert second["status"] == "interrupted"
+    assert second["result"] != "Week 1 found three contacts."
+    assert second["summary"] != "Week 1 found three contacts."
+    assert "restarted" in second["summary"].lower()
+
+
 def test_scheduled_run_statuses_stay_inside_the_shared_contract(tmp_path):
     """S4: every status the sidecar writes to the runs table is declared, so
     the client never coerces an honest outcome into 'Failed'."""

--- a/desktop/tests/test_schedule.py
+++ b/desktop/tests/test_schedule.py
@@ -554,6 +554,61 @@ def test_store_reopen_heals_orphaned_running_run_to_interrupted(tmp_path):
     assert "success" not in healed["summary"].lower()
 
 
+def test_legacy_ok_run_normalizes_to_success_on_restart(tmp_path):
+    """P2: production rows written before the canonical status vocabulary
+    existed used run_turn's raw "ok" directly. Restoring the store must heal
+    them to "success" so the UI renders them as Completed, not Failed."""
+    store = ConversationStore(tmp_path)
+    job = store.add_job("0 9 * * 1", "weekly check-in")
+    store.record_run(job["id"], "ok", "Found three priority contacts.")
+
+    restarted = ConversationStore(tmp_path).list_schedule()["runs"][0]
+
+    assert restarted["status"] == "success"
+    assert restarted["result"] == "Found three priority contacts."
+
+
+def test_reopen_recovers_true_success_from_the_scheduled_transcript(tmp_path):
+    """P2: a crash can land between the transcript's terminal event and the
+    matching runs-table update. When the transcript already recorded the
+    outcome, trust it instead of blindly stamping 'interrupted'."""
+    store = ConversationStore(tmp_path)
+    job = store.add_job("0 9 * * 1", "weekly", next_run_at=None)
+    session_id = f"sched-{job['id']}"
+    store.start_run(
+        int(job["id"]), session_id=session_id, started_at="2026-08-26T09:00:00+00:00"
+    )
+    store.append_event(session_id, {"type": "turn_start", "state": "running"})
+    store.append_event(
+        session_id,
+        {"type": "turn_end", "text": "Found three priority contacts.", "state": "complete"},
+    )
+
+    healed = ConversationStore(tmp_path).list_schedule()["runs"][0]
+
+    assert healed["status"] == "success"
+    assert healed["result"] == "Found three priority contacts."
+    assert healed["finished_at"]
+
+
+def test_reopen_recovers_true_failure_from_the_scheduled_transcript(tmp_path):
+    """P2: same as above, but the transcript's terminal event was an error."""
+    store = ConversationStore(tmp_path)
+    job = store.add_job("0 9 * * 1", "weekly", next_run_at=None)
+    session_id = f"sched-{job['id']}"
+    store.start_run(
+        int(job["id"]), session_id=session_id, started_at="2026-08-26T09:00:00+00:00"
+    )
+    store.append_event(
+        session_id, {"type": "error", "state": "failed", "message": "provider timed out"}
+    )
+
+    healed = ConversationStore(tmp_path).list_schedule()["runs"][0]
+
+    assert healed["status"] == "failed"
+    assert healed["result"] == "provider timed out"
+
+
 def test_scheduled_run_statuses_stay_inside_the_shared_contract(tmp_path):
     """S4: every status the sidecar writes to the runs table is declared, so
     the client never coerces an honest outcome into 'Failed'."""


### PR DESCRIPTION
Closes #40.

## Domain words

- **Receipt** — the stored record of one scheduled run, shown on the Scheduled page.
- **Canonical status** — the six values the sidecar and the client agree on: `running`, `success`, `failed`, `waiting_approval`, `partial`, `interrupted`.
- **Legacy row** — a run row written before that shared vocabulary existed.
- **Reconciler** — the startup pass that closes runs a crashed process left marked `running`.

## Problem

Scheduled runs that succeeded were displayed as "Failed / 0ms".

## Before and after

| Stored row | Before | After |
|---|---|---|
| legacy `status = "ok"`, full result | Failed | Completed |
| unrecognized status value | Failed | Needs review |
| `duration_ms = 0` on a legacy row | `0ms` | `Legacy run` |
| crash after transcript wrote `turn_end`/`complete` | Interrupted | Completed |
| crash with no terminal transcript event | Interrupted | Interrupted (unchanged) |

## Cause

Two separate defects.

First, `desktop/surfaces/gui/src/api.ts` normalized run status with `SCHEDULE_RUN_STATUSES.has(rawStatus) ? rawStatus : "failed"`. The set does not contain `"ok"`. Legacy rows therefore became `failed`. The same line also turned any genuinely unknown value into `failed`, so two different situations produced one wrong answer.

Second, `_reconcile_orphaned_runs` in `desktop/coworker/store.py` stamped every row still marked `running` as `interrupted` on restart. A crash can land after the transcript records a terminal event but before the runs table is updated. In that window the outcome is already known, and the reconciler discarded it. This is beyond what the ticket described.

## Fix

The legacy alias is migrated once at store init, next to the existing runs-table backfill: `UPDATE runs SET status = 'success' WHERE status = 'ok'`. Migration rather than read-time mapping, because read-time mapping leaves the wrong value on disk for every future consumer to re-guess.

An unrecognized status now becomes a client-only `unknown`, rendered "Needs review". It is deliberately kept out of `SCHEDULE_RUN_STATUSES` on both sides. The sidecar never writes it, so it does not belong in the shared contract, and the cross-language vocabulary parity test still holds.

The reconciler now reads the session transcript for each orphaned row and uses its terminal event when there is one. With no terminal event it still writes `interrupted`.

## Measurements

Python suite:

```
732 passed, 3 skipped, 1 warning in 40.01s
```

GUI suite:

```
Test Files  43 passed (43)
     Tests  385 passed (385)
```

GUI build: exit 0, 992 modules transformed.

Both suites were re-run independently by the reviewing session on the pushed commit, not only by the implementing session.

## Acceptance criteria

| Criterion | Test |
|---|---|
| Legacy `ok` maps to `success` | `test_legacy_ok_run_normalizes_to_success_on_restart` |
| Restored `ok` row renders Completed | same, plus `scheduledPage.test.tsx` receipt-rendering test |
| Unknown status renders Needs review | `scheduledApi.test.ts` unknown-status test, `scheduledPage.test.tsx` needs-review test |
| Status agrees with transcript terminal event | `test_reopen_recovers_true_success_from_the_scheduled_transcript`, `test_reopen_recovers_true_failure_from_the_scheduled_transcript` |
| Zero-duration shows Legacy run | `scheduledPage.test.tsx` legacy-duration test |
| New writes use canonical vocabulary | `test_scheduled_run_statuses_stay_inside_the_shared_contract` (pre-existing, unchanged) |
| Coverage across all status kinds | the above, plus pre-existing waiting-approval and partial tests, unmodified |

## Not in this PR

- No change to `scheduler.py`. Its `RECEIPT_STATUSES` and `SCHEDULE_RUN_STATUSES` were already correct and already tested, so the sixth criterion needed no code.
- No client-side `"ok"` fallback. It would be redundant with the migration and has no live trigger.
- No `turn_stopped` handling in the reconciler. Scheduled runs call `run_turn` with no cancel control, so that path always emits `turn_end` with `state: "stopped"` instead. Handling it would be dead code here.
- No duration-display change for in-progress runs. Out of scope.

## Still open

- The reconciler now does one transcript file read per orphaned row inside the startup write transaction. At realistic orphan counts this is negligible, but it is more work under the lock than before. Noting it rather than pre-optimizing.
- The fourth criterion did not name a concrete failure mode. It is implemented as "a crash between the transcript's terminal write and the runs-table update must not downgrade a known outcome to interrupted." Say so if a different reading was intended.

Written boundary: this branch touched only `store.py` schedule/receipt paths, the schedule normalizers in `api.ts`, `ScheduledPage.tsx`, schedule CSS, and the schedule tests. No file owned by a parallel Codex lane was modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjAD6SVox1gvF4sV3jTnJy
