### PR TITLE
feat(desktop): inspect agent runs through one unified ledger

### DIFF
--- a/desktop/coworker/agent_run_repository.py
+++ b/desktop/coworker/agent_run_repository.py
@@ -32,6 +32,8 @@ from coworker.agent_run_state import (
     validate_transition,
 )
 from coworker.agent_runs import (
+    CHECKPOINT_KINDS,
+    INCOMPLETE_RECORD_KINDS,
     RUN_TRIGGERS,
     add_usage,
     checkpoint_payload,
@@ -185,7 +187,11 @@ class AgentRunRepository:
         self,
         *,
         session_id: str | None = None,
+        person_id: str | None = None,
+        trigger: str | None = None,
         states: Iterable[str] | None = None,
+        created_after: datetime | None = None,
+        created_before: datetime | None = None,
         limit: int = 100,
     ) -> list[dict[str, Any]]:
         clauses: list[str] = []
@@ -193,6 +199,18 @@ class AgentRunRepository:
         if session_id is not None:
             clauses.append("session_id = ?")
             params.append(str(session_id))
+        if person_id is not None:
+            clauses.append("person_id = ?")
+            params.append(str(person_id))
+        if trigger is not None:
+            clauses.append("trigger = ?")
+            params.append(str(trigger))
+        if created_after is not None:
+            clauses.append("created_at >= ?")
+            params.append(_stamp(created_after))
+        if created_before is not None:
+            clauses.append("created_at <= ?")
+            params.append(_stamp(created_before))
         wanted = tuple(states or ())
         if wanted:
             clauses.append(f"current_state IN ({','.join('?' * len(wanted))})")
@@ -406,6 +424,48 @@ class AgentRunRepository:
                 )
             ),
         )
+
+    # --- retention -------------------------------------------------------
+
+    def prune_checkpoints(self, *, finished_before: datetime) -> list[str]:
+        """Drop step detail for runs that finished before the cutoff.
+
+        This is the only write in the store that is not a compare-and-swap
+        against a lease, and it is deliberately narrow: it deletes rows from
+        `agent_run_checkpoints` and touches `agent_runs` never. Run identity,
+        person, source and artifact references, usage, approvals, and outcome
+        all live on the run row and survive. A terminal run never moves again,
+        so no lease can be racing this.
+
+        A run whose record marks a hole, or carries a checkpoint kind this
+        build cannot read, is skipped: retention must not delete the evidence
+        that evidence is missing.
+        """
+        cutoff = _stamp(finished_before)
+        readable = tuple(sorted(CHECKPOINT_KINDS - INCOMPLETE_RECORD_KINDS))
+        pruned: list[str] = []
+        with self._write():
+            rows = self._conn.execute(
+                f"""
+                SELECT run_id FROM agent_runs
+                WHERE finished_at IS NOT NULL AND finished_at < ?
+                  AND NOT EXISTS (
+                      SELECT 1 FROM agent_run_checkpoints c
+                      WHERE c.run_id = agent_runs.run_id
+                        AND c.kind NOT IN ({','.join('?' * len(readable))})
+                  )
+                ORDER BY finished_at
+                """,
+                (cutoff, *readable),
+            ).fetchall()
+            for row in rows:
+                run_id = str(row["run_id"])
+                removed = self._conn.execute(
+                    "DELETE FROM agent_run_checkpoints WHERE run_id = ?", (run_id,)
+                ).rowcount
+                if removed:
+                    pruned.append(run_id)
+        return pruned
 
     # --- recovery --------------------------------------------------------
 

--- a/desktop/coworker/agent_runs.py
+++ b/desktop/coworker/agent_runs.py
@@ -42,6 +42,10 @@ CHECKPOINT_KINDS = frozenset(
         "terminal",
     }
 )
+# A run carrying either of these has a hole in its record: work happened that
+# no checkpoint describes. Readers must not call silence elsewhere an absence,
+# and retention must not delete the only marker that the hole exists.
+INCOMPLETE_RECORD_KINDS = frozenset({"process_interrupted", "tool_outcome_unknown"})
 
 _ID_LIMIT = 256
 _SHORT_LIMIT = 128
@@ -102,6 +106,8 @@ _CHECKPOINT_FIELDS = {
     "person_id": _id_text,
     "provider": _id_text,
     "model_id": _id_text,
+    "persona_id": _id_text,
+    "prompt_version": _short_text,
     "status": _short_text,
     "reason": _short_text,
     "error_class": _short_text,

--- a/desktop/coworker/run_evidence.py
+++ b/desktop/coworker/run_evidence.py
@@ -1,0 +1,126 @@
+"""How well a run's record supports a conclusion, and when it supports none.
+
+Silence is not absence. "No approval was requested" and "we do not know whether
+an approval was requested" are different operator situations, so they are
+different values here and one can never decay into the other.
+
+The separation is a property of the record, computed once before any section of
+a receipt is read. A run's checkpoint sequence is dense from 1 to
+`checkpoint_sequence`, so the stored rows say whether the record covers the
+run's whole life. Everything else follows from that.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any, Iterable
+
+from coworker.agent_run_state import is_terminal
+from coworker.agent_runs import (
+    AGENT_RUN_STATES,
+    CHECKPOINT_KINDS,
+    INCOMPLETE_RECORD_KINDS,
+    RUN_TRIGGERS,
+)
+
+
+class Evidence(StrEnum):
+    """How well the record supports one facet of a run. Never inferred.
+
+    `absent` and `missing` are the pair this vocabulary exists for: "no
+    approval was requested" and "we do not know whether one was" must not
+    render the same way.
+    """
+
+    PRESENT = "present"
+    # Positively did not happen: the record covers the run's whole life.
+    ABSENT = "absent"
+    # Some of the facet settled and some did not.
+    PARTIAL = "partial"
+    # Should be knowable and is not. The record has a hole, or the run is open.
+    MISSING = "missing"
+    # The run knows it does not know: an external effect never reported back.
+    AMBIGUOUS = "ambiguous"
+    # This build cannot express or verify the fact. Never "it did not happen".
+    UNSUPPORTED = "unsupported"
+    # The evidence existed and retention aged it out on purpose.
+    EXPIRED = "expired"
+
+
+_SEVERITY = {
+    Evidence.PRESENT: 0,
+    Evidence.ABSENT: 1,
+    Evidence.PARTIAL: 2,
+    Evidence.EXPIRED: 3,
+    Evidence.MISSING: 4,
+    Evidence.AMBIGUOUS: 5,
+    Evidence.UNSUPPORTED: 6,
+}
+
+
+def most_severe(values: Iterable[Evidence]) -> Evidence:
+    """Roll several entries up without letting the worst one disappear."""
+    return max(values, key=lambda value: _SEVERITY[value])
+
+
+def analyze_record(
+    run: dict[str, Any], checkpoints: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Decide what the record can and cannot support, before reading any facet."""
+    expected = int(run.get("checkpoint_sequence") or 0)
+    sequences = sorted(int(item.get("sequence") or 0) for item in checkpoints)
+    stored = len(sequences)
+    first = sequences[0] if sequences else expected + 1
+    contiguous = sequences == list(range(first, first + stored))
+    # Retention deletes a prefix, so a dense tail ending at the expected
+    # sequence is pruned evidence. Anything else is a record we cannot trust.
+    intact = contiguous and (not sequences or sequences[-1] == expected)
+    pruned_through = max(0, first - 1) if intact else 0
+    unsupported = {
+        str(item.get("kind"))
+        for item in checkpoints
+        if str(item.get("kind")) not in CHECKPOINT_KINDS
+    }
+    unsupported |= {
+        f"state:{item.get('state')}"
+        for item in checkpoints
+        if str(item.get("state")) not in AGENT_RUN_STATES
+    }
+    state = str(run.get("current_state") or "")
+    if state not in AGENT_RUN_STATES:
+        unsupported.add(f"state:{state}")
+    if str(run.get("trigger") or "") not in RUN_TRIGGERS:
+        unsupported.add(f"trigger:{run.get('trigger')}")
+    holed = any(
+        str(item.get("kind")) in INCOMPLETE_RECORD_KINDS for item in checkpoints
+    )
+    # The run row is written in the same transaction as every checkpoint, so
+    # pruning step detail does not weaken what the row itself carries.
+    row_settled = is_terminal(state) and intact and not unsupported and not holed
+    return {
+        "stored": stored,
+        "expected": expected,
+        "pruned_through": pruned_through,
+        "damaged": not intact,
+        "unsupported": tuple(sorted(unsupported)),
+        "row_settled": row_settled,
+        "settled": row_settled and pruned_through == 0,
+    }
+
+
+def absence_evidence(record: dict[str, Any], *, row_backed: bool = False) -> Evidence:
+    """What silence means for one facet, given what the record can support."""
+    if record["unsupported"]:
+        return Evidence.UNSUPPORTED
+    if record["row_settled"] if row_backed else record["settled"]:
+        return Evidence.ABSENT
+    if not row_backed and record["row_settled"] and record["pruned_through"]:
+        return Evidence.EXPIRED
+    return Evidence.MISSING
+
+
+def constrain(record: dict[str, Any], observed: Evidence) -> Evidence:
+    """A record this build cannot fully read cannot support a conclusion."""
+    return Evidence.UNSUPPORTED if record["unsupported"] else observed
+
+

--- a/desktop/coworker/run_ledger.py
+++ b/desktop/coworker/run_ledger.py
@@ -1,0 +1,184 @@
+"""The read side of the durable Agent Run store, plus its retention bound.
+
+`RunLedger` is the only thing that turns run rows into receipts an operator can
+open, and the only place the retention bound is applied. It holds no lease and
+cannot acquire one. Its single write is `prune_checkpoints`, which deletes
+checkpoint rows and touches `agent_runs` never.
+
+Authority never comes from here. The run store records which approval ids a run
+touched; it never records whether the owner said yes. Every decision in a
+receipt is resolved against the owner-native approval receipt, so an approval id
+this module cannot verify renders as `missing` and never as an allowance.
+
+The receipt shape itself lives in `coworker/run_receipt.py`. Person-file events
+live in `coworker/ledger.py`, which is a different thing entirely.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any, Iterable, Protocol
+
+from coworker.agent_run_repository import AgentRunRepository
+from coworker.agent_runs import AGENT_RUN_STATES, RUN_TRIGGERS
+from coworker.run_receipt import (
+    approval_ids,
+    build_receipt,
+    parse_moment,
+    run_summary,
+)
+
+# Step detail for a long-finished run is dropped after this; identity, sources,
+# artifacts, approvals, usage, and outcome live on the run row and stay.
+CHECKPOINT_RETENTION_DAYS = 30
+DEFAULT_QUERY_LIMIT = 50
+MAX_QUERY_LIMIT = 200
+
+
+class ApprovalReceipts(Protocol):
+    """The owner-native approval record. The ledger reads it and never writes it."""
+
+    def get_inbox(self, item_id: str) -> dict[str, Any] | None: ...
+
+
+class RunLedger:
+    """Read-only projection over the durable run store, plus its retention bound."""
+
+    def __init__(
+        self,
+        repository: AgentRunRepository,
+        *,
+        approvals: ApprovalReceipts | None = None,
+    ) -> None:
+        self.repository = repository
+        self.approvals = approvals
+
+    def receipt(self, run_id: str) -> dict[str, Any] | None:
+        run = self.repository.get_run(run_id)
+        if run is None:
+            return None
+        checkpoints = self.repository.list_checkpoints(run_id)
+        return build_receipt(
+            run, checkpoints, approvals=self._resolve_approvals(run, checkpoints)
+        )
+
+    def query(
+        self,
+        *,
+        run_id: str | None = None,
+        session_id: str | None = None,
+        person_id: str | None = None,
+        trigger: str | None = None,
+        statuses: Iterable[str] | None = None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        limit: int = DEFAULT_QUERY_LIMIT,
+    ) -> dict[str, Any]:
+        """Pointers, not evidence: one bounded page of runs to open."""
+        wanted = _validated_statuses(statuses)
+        if trigger is not None and trigger not in RUN_TRIGGERS:
+            raise ValueError(f"unknown run trigger {trigger!r}")
+        bounded = _bounded_limit(limit)
+        truncated = False
+        if run_id:
+            found = self.repository.get_run(run_id)
+            rows = [found] if found is not None else []
+        else:
+            rows = self.repository.list_runs(
+                session_id=session_id,
+                person_id=person_id,
+                trigger=trigger,
+                states=wanted,
+                created_after=since,
+                created_before=until,
+                limit=bounded + 1,
+            )
+            truncated = len(rows) > bounded
+            rows = rows[:bounded]
+        rows = [
+            row
+            for row in rows
+            if _matches(row, session_id, person_id, trigger, wanted, since, until)
+        ]
+        return {
+            "runs": [run_summary(row) for row in rows],
+            "limit": bounded,
+            "truncated": truncated,
+        }
+
+    def enforce_retention(
+        self,
+        *,
+        max_age_days: int | float = CHECKPOINT_RETENTION_DAYS,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Drop step detail for long-finished runs. Identity is never removed.
+
+        A run whose record marks a hole, or carries a checkpoint this build
+        cannot read, keeps its detail: retention must never destroy the
+        evidence that evidence is missing.
+        """
+        moment = now or datetime.now(UTC)
+        cutoff = moment - timedelta(days=float(max_age_days))
+        pruned = self.repository.prune_checkpoints(finished_before=cutoff)
+        return {
+            "cutoff": cutoff.isoformat(),
+            "pruned_runs": len(pruned),
+            "run_ids": pruned,
+        }
+
+    def _resolve_approvals(
+        self, run: dict[str, Any], checkpoints: list[dict[str, Any]]
+    ) -> dict[str, dict[str, Any] | None] | None:
+        if self.approvals is None:
+            return None
+        return {
+            approval_id: self.approvals.get_inbox(approval_id)
+            for approval_id in approval_ids(run, checkpoints)
+        }
+
+
+def _matches(
+    run: dict[str, Any],
+    session_id: str | None,
+    person_id: str | None,
+    trigger: str | None,
+    statuses: tuple[str, ...],
+    since: datetime | None,
+    until: datetime | None,
+) -> bool:
+    """Re-check every filter on the way out, so an exact id cannot bypass one."""
+    if session_id is not None and str(run.get("session_id")) != session_id:
+        return False
+    if person_id is not None and run.get("person_id") != person_id:
+        return False
+    if trigger is not None and str(run.get("trigger")) != trigger:
+        return False
+    if statuses and str(run.get("current_state")) not in statuses:
+        return False
+    created = parse_moment(run.get("created_at"))
+    if created is None:
+        return since is None and until is None
+    if since is not None and created < since:
+        return False
+    if until is not None and created > until:
+        return False
+    return True
+
+
+def _validated_statuses(statuses: Iterable[str] | None) -> tuple[str, ...]:
+    wanted = tuple(str(item) for item in (statuses or ()))
+    unknown = [item for item in wanted if item not in AGENT_RUN_STATES]
+    if unknown:
+        raise ValueError(f"unknown run status {unknown[0]!r}")
+    return wanted
+
+
+def _bounded_limit(limit: int) -> int:
+    try:
+        value = int(limit)
+    except (TypeError, ValueError):
+        return DEFAULT_QUERY_LIMIT
+    return max(1, min(value, MAX_QUERY_LIMIT))
+
+

--- a/desktop/coworker/run_ledger_api.py
+++ b/desktop/coworker/run_ledger_api.py
@@ -1,0 +1,73 @@
+"""HTTP routes for the unified Agent Run ledger.
+
+Read only, on purpose. There is no write verb here, so no request to this
+surface can create a run, change a state, or record an approval. Authority
+lives with the owner-native approval and send receipts, never with the ledger.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, Query
+from fastapi.responses import JSONResponse
+
+from coworker.run_ledger import DEFAULT_QUERY_LIMIT, RunLedger
+
+
+def _no_store(payload: Any, *, status_code: int = 200) -> JSONResponse:
+    return JSONResponse(
+        payload,
+        status_code=status_code,
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+def _moment(value: str | None, field: str) -> datetime | None:
+    if value is None or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip())
+    except ValueError as exc:
+        raise ValueError(f"{field} must be an ISO-8601 timestamp") from exc
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def run_ledger_router(*, ledger: RunLedger) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/v1/agent-runs")
+    def list_agent_runs(
+        run_id: str | None = None,
+        session_id: str | None = None,
+        person_id: str | None = None,
+        trigger: str | None = None,
+        status: list[str] | None = Query(default=None),
+        since: str | None = None,
+        until: str | None = None,
+        limit: int = DEFAULT_QUERY_LIMIT,
+    ):
+        try:
+            page = ledger.query(
+                run_id=run_id,
+                session_id=session_id,
+                person_id=person_id,
+                trigger=trigger,
+                statuses=status,
+                since=_moment(since, "since"),
+                until=_moment(until, "until"),
+                limit=limit,
+            )
+        except ValueError as exc:
+            return _no_store({"error": str(exc)}, status_code=400)
+        return _no_store(page)
+
+    @router.get("/v1/agent-runs/{run_id}")
+    def get_agent_run(run_id: str):
+        receipt = ledger.receipt(run_id)
+        if receipt is None:
+            return _no_store({"error": "run_not_found"}, status_code=404)
+        return _no_store({"receipt": receipt})
+
+    return router

--- a/desktop/coworker/run_receipt.py
+++ b/desktop/coworker/run_receipt.py
@@ -1,0 +1,540 @@
+"""The Agent Run receipt: a pure projection of one run into evidence.
+
+Nothing here reads a store, a clock, or a network. `build_receipt` takes a run
+row, its checkpoints, and already-resolved owner-native approval receipts, and
+returns the one shape an operator inspects. Keeping it pure is the point: an
+allowlist projection with no I/O is a thing a reviewer can read end to end and
+be sure of.
+
+The rule that keeps a receipt from becoming a second transcript is mechanical.
+A receipt renders only fields this module names, and every named field is an
+identifier, an enum, a count, a timestamp, or a bounded reason the runtime
+itself wrote. Message bodies, tool arguments, command output, prompts, raw
+errors, credentials, and model reasoning have no field to land in, and `_pick`
+copies named scalars only, never a nested structure.
+
+This allowlist is deliberately independent of the write-time allowlist in
+`agent_runs.CHECKPOINT_PAYLOAD_FIELDS`. Both have to hold on their own; a read
+side that leaned on the write side would keep passing after the write side
+changed.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from coworker.agent_run_state import is_terminal
+from coworker.agent_runs import (
+    INCOMPLETE_RECORD_KINDS,
+    project_artifact_refs,
+    project_source_refs,
+    project_terminal_result,
+    redact_secrets,
+)
+from coworker.run_evidence import (
+    Evidence,
+    absence_evidence,
+    analyze_record,
+    constrain,
+    most_severe,
+)
+
+RECEIPT_VERSION = 1
+
+RECEIPT_SECTIONS = frozenset(
+    {
+        "prompt",
+        "model_attempts",
+        "usage",
+        "tools",
+        "sources",
+        "artifacts",
+        "approvals",
+        "recovery",
+        "rationale",
+        "outcome",
+    }
+)
+
+_TEXT_LIMIT = 512
+_MAX_ENTRIES = 200
+_PARK_KINDS = frozenset({"waiting_approval", "waiting_input", "waiting_external"})
+_MODEL_FIELDS = (
+    "attempt_id", "provider", "model_id", "status", "error_class", "duration_ms",
+)
+_TOOL_FIELDS = (
+    "tool_call_id",
+    "tool_name",
+    "status",
+    "error_class",
+    "duration_ms",
+    "item_count",
+    "reason",
+)
+
+
+def build_receipt(
+    run: dict[str, Any],
+    checkpoints: list[dict[str, Any]],
+    *,
+    approvals: dict[str, dict[str, Any] | None] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """One receipt shape for every run, whatever triggered it or ended it."""
+    moment = now or datetime.now(UTC)
+    record = analyze_record(run, checkpoints)
+    state = str(run.get("current_state") or "")
+    created = parse_moment(run.get("created_at"))
+    finished = parse_moment(run.get("finished_at"))
+    return {
+        "receipt_version": RECEIPT_VERSION,
+        "run": {
+            "run_id": str(run.get("run_id") or ""),
+            "session_id": str(run.get("session_id") or ""),
+            "person_id": run.get("person_id"),
+            "parent_run_id": run.get("parent_run_id"),
+            "trigger": str(run.get("trigger") or ""),
+            "state": state,
+            "goal_fingerprint": run.get("goal_fingerprint"),
+            "created_at": run.get("created_at"),
+            "updated_at": run.get("updated_at"),
+            "finished_at": run.get("finished_at"),
+            "duration_ms": _elapsed_ms(created, finished or moment),
+            "version": run.get("version"),
+            "owned": _owned(run, moment),
+        },
+        "record": {
+            "complete": record["settled"],
+            "checkpoints_stored": record["stored"],
+            "checkpoints_expected": record["expected"],
+            "pruned_through_sequence": record["pruned_through"],
+            "damaged": record["damaged"],
+            "unsupported": list(record["unsupported"]),
+        },
+        "prompt": _prompt(checkpoints, record),
+        "model_attempts": _model_attempts(checkpoints, record),
+        "usage": _usage(run, record),
+        "tools": _tools(checkpoints, record),
+        "sources": _sources(run, record),
+        "artifacts": _artifacts(run, record),
+        "approvals": _approvals(run, checkpoints, approvals, record),
+        "recovery": _recovery(checkpoints, record),
+        "rationale": _rationale(checkpoints, record),
+        "outcome": _outcome(run, record, state, created, finished),
+    }
+
+
+def _prompt(
+    checkpoints: list[dict[str, Any]], record: dict[str, Any]
+) -> dict[str, Any]:
+    persona_id: str | None = None
+    prompt_version: str | None = None
+    for item in checkpoints:
+        payload = item.get("payload") or {}
+        persona_id = persona_id or _text(payload.get("persona_id"))
+        prompt_version = prompt_version or _text(payload.get("prompt_version"))
+    found = persona_id is not None or prompt_version is not None
+    return {
+        "evidence": (
+            constrain(record, Evidence.PRESENT) if found else absence_evidence(record)
+        ),
+        "persona_id": persona_id,
+        "prompt_version": prompt_version,
+    }
+
+
+def _model_attempts(
+    checkpoints: list[dict[str, Any]], record: dict[str, Any]
+) -> dict[str, Any]:
+    attempts = _lifecycle(
+        checkpoints,
+        start_kinds={"model_pending"},
+        end_kinds={"model_completed"},
+        key_field="attempt_id",
+        fields=_MODEL_FIELDS,
+    )
+    for attempt in attempts:
+        attempt.pop("_unknown")
+        attempt["outcome"] = "completed" if attempt.pop("_settled") else "pending"
+    observed = Evidence.PRESENT
+    if not attempts:
+        observed = absence_evidence(record)
+    elif any(attempt["outcome"] == "pending" for attempt in attempts):
+        observed = Evidence.PARTIAL
+    return {
+        "evidence": constrain(record, observed) if attempts else observed,
+        "attempts": attempts,
+        "attempt_count": len(attempts),
+        "distinct_models": len({a["model_id"] for a in attempts if a["model_id"]}),
+    }
+
+
+def _tools(checkpoints: list[dict[str, Any]], record: dict[str, Any]) -> dict[str, Any]:
+    calls = _lifecycle(
+        checkpoints,
+        start_kinds={"tool_pending"},
+        end_kinds={"tool_completed", "tool_outcome_unknown"},
+        key_field="tool_call_id",
+        fields=_TOOL_FIELDS,
+        unknown_kinds={"tool_outcome_unknown"},
+    )
+    pending = 0
+    unknown = 0
+    for call in calls:
+        never_reported = call.pop("_unknown")
+        settled = call.pop("_settled")
+        if never_reported:
+            call["lifecycle"] = "unknown"
+            unknown += 1
+        elif settled:
+            call["lifecycle"] = "completed"
+        else:
+            call["lifecycle"] = "pending"
+            pending += 1
+    if not calls:
+        observed = absence_evidence(record)
+    elif unknown:
+        observed = Evidence.AMBIGUOUS
+    elif pending:
+        observed = Evidence.PARTIAL
+    else:
+        observed = Evidence.PRESENT
+    return {
+        "evidence": constrain(record, observed) if calls else observed,
+        "calls": calls,
+        "pending_count": pending,
+        "unknown_count": unknown,
+    }
+
+
+def _lifecycle(
+    checkpoints: list[dict[str, Any]],
+    *,
+    start_kinds: set[str],
+    end_kinds: set[str],
+    key_field: str,
+    fields: tuple[str, ...],
+    unknown_kinds: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Pair opening and closing checkpoints into one entry per call or attempt."""
+    entries: dict[str, dict[str, Any]] = {}
+    for item in checkpoints:
+        kind = str(item.get("kind"))
+        if kind not in start_kinds and kind not in end_kinds:
+            continue
+        payload = item.get("payload") or {}
+        sequence = int(item.get("sequence") or 0)
+        key = _text(payload.get(key_field)) or f"sequence:{sequence}"
+        entry = entries.get(key)
+        if entry is None:
+            if len(entries) >= _MAX_ENTRIES:
+                continue
+            entry = {name: None for name in fields}
+            entry.update(
+                {"first_sequence": sequence, "last_sequence": sequence,
+                 "_settled": False, "_unknown": False}
+            )
+            entries[key] = entry
+        for name, value in _pick(payload, fields).items():
+            entry[name] = value
+        entry["last_sequence"] = sequence
+        if kind in end_kinds:
+            entry["_settled"] = True
+        if unknown_kinds and kind in unknown_kinds:
+            entry["_unknown"] = True
+    return sorted(entries.values(), key=lambda entry: entry["first_sequence"])
+
+
+def _usage_totals(run: dict[str, Any]) -> dict[str, int | float]:
+    """Numbers only. A usage map is a count, never somewhere text can ride."""
+    return {
+        _text(key) or "": value
+        for key, value in (run.get("usage") or {}).items()
+        if isinstance(value, (int, float)) and not isinstance(value, bool)
+    }
+
+
+def _usage(run: dict[str, Any], record: dict[str, Any]) -> dict[str, Any]:
+    totals = _usage_totals(run)
+    return {
+        "evidence": (
+            Evidence.PRESENT if totals else absence_evidence(record, row_backed=True)
+        ),
+        "totals": totals,
+    }
+
+
+def _sources(run: dict[str, Any], record: dict[str, Any]) -> dict[str, Any]:
+    refs = project_source_refs(run.get("source_refs") or [])[:_MAX_ENTRIES]
+    return {
+        "evidence": (
+            Evidence.PRESENT if refs else absence_evidence(record, row_backed=True)
+        ),
+        "refs": refs,
+        "stale_count": sum(1 for ref in refs if ref.get("stale")),
+    }
+
+
+def _artifacts(run: dict[str, Any], record: dict[str, Any]) -> dict[str, Any]:
+    refs = project_artifact_refs(run.get("artifact_refs") or [])[:_MAX_ENTRIES]
+    return {
+        "evidence": (
+            Evidence.PRESENT if refs else absence_evidence(record, row_backed=True)
+        ),
+        "refs": refs,
+    }
+
+
+def approval_ids(run: dict[str, Any], checkpoints: list[dict[str, Any]]) -> list[str]:
+    ordered: list[str] = []
+    seen: set[str] = set()
+    candidates = list(run.get("approval_ids") or []) + [
+        (item.get("payload") or {}).get("approval_id") for item in checkpoints
+    ]
+    for raw in candidates:
+        approval_id = _text(raw)
+        if approval_id is None or approval_id in seen or len(ordered) >= _MAX_ENTRIES:
+            continue
+        seen.add(approval_id)
+        ordered.append(approval_id)
+    return ordered
+
+
+def _approvals(
+    run: dict[str, Any],
+    checkpoints: list[dict[str, Any]],
+    resolved: dict[str, dict[str, Any] | None] | None,
+    record: dict[str, Any],
+) -> dict[str, Any]:
+    ids = approval_ids(run, checkpoints)
+    requests = _approval_requests(checkpoints)
+    decisions = [
+        _approval_entry(approval_id, requests.get(approval_id, {}), resolved, record)
+        for approval_id in ids
+    ]
+    if not decisions:
+        # No id to verify, so no verifier is needed: the run row itself says
+        # whether an approval was ever requested.
+        evidence = absence_evidence(record, row_backed=True)
+    else:
+        evidence = most_severe(item["evidence"] for item in decisions)
+    return {"evidence": evidence, "decisions": decisions}
+
+
+def _approval_requests(checkpoints: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    requests: dict[str, dict[str, Any]] = {}
+    for item in checkpoints:
+        payload = item.get("payload") or {}
+        approval_id = _text(payload.get("approval_id"))
+        if approval_id is None:
+            continue
+        entry = requests.setdefault(
+            approval_id, {"requested_sequence": None, "tool_name": None}
+        )
+        if str(item.get("kind")) in _PARK_KINDS and entry["requested_sequence"] is None:
+            entry["requested_sequence"] = int(item.get("sequence") or 0)
+        entry["tool_name"] = entry["tool_name"] or _text(payload.get("tool_name"))
+    return requests
+
+
+def _approval_entry(
+    approval_id: str,
+    request: dict[str, Any],
+    resolved: dict[str, dict[str, Any] | None] | None,
+    record: dict[str, Any],
+) -> dict[str, Any]:
+    """One decision, always sourced from the owner-native receipt.
+
+    The run store's own fields never become the decision. An id this module
+    cannot verify is `missing`; it is never an allowance.
+    """
+    entry = {
+        "approval_id": approval_id,
+        "requested": request.get("requested_sequence") is not None,
+        "requested_sequence": request.get("requested_sequence"),
+        "tool_name": request.get("tool_name"),
+        "decision": None,
+        "state": None,
+        "execution_status": None,
+        "actor": None,
+        "evidence": Evidence.UNSUPPORTED,
+    }
+    if resolved is None:
+        return entry
+    native = resolved.get(approval_id)
+    if native is None:
+        entry["evidence"] = Evidence.MISSING
+        return entry
+    state = _text(native.get("state"))
+    execution = _text(native.get("execution_status"))
+    decision = _text(native.get("decision"))
+    entry["state"] = state
+    entry["execution_status"] = execution
+    if state == "expired":
+        entry["evidence"] = Evidence.EXPIRED
+    elif state == "pending":
+        entry["evidence"] = Evidence.PARTIAL
+    elif state == "resolved" and decision in {"allow", "deny"}:
+        entry["decision"] = decision
+        entry["actor"] = _text(native.get("actor"))
+        entry["evidence"] = (
+            Evidence.AMBIGUOUS if execution == "interrupted" else Evidence.PRESENT
+        )
+    elif state == "resolved":
+        entry["evidence"] = Evidence.MISSING
+    else:
+        entry["evidence"] = Evidence.UNSUPPORTED
+    return entry
+
+
+def _recovery(
+    checkpoints: list[dict[str, Any]], record: dict[str, Any]
+) -> dict[str, Any]:
+    events = [
+        {
+            "sequence": int(item.get("sequence") or 0),
+            "kind": str(item.get("kind")),
+            "state": str(item.get("state")),
+            "reason": _text((item.get("payload") or {}).get("reason")),
+            "tool_call_id": _text((item.get("payload") or {}).get("tool_call_id")),
+            "created_at": item.get("created_at"),
+        }
+        for item in checkpoints
+        if str(item.get("kind")) in INCOMPLETE_RECORD_KINDS
+    ][:_MAX_ENTRIES]
+    return {
+        "evidence": Evidence.PRESENT if events else absence_evidence(record),
+        "events": events,
+    }
+
+
+def _rationale(
+    checkpoints: list[dict[str, Any]], record: dict[str, Any]
+) -> dict[str, Any]:
+    """The bounded reasons the runtime wrote down. Never model reasoning.
+
+    There is deliberately no free-text field of the ledger's own here: a note
+    can only repeat `reason` or `error_summary`, both already bounded and
+    redacted by the checkpoint allowlist.
+    """
+    notes = []
+    for item in checkpoints:
+        payload = item.get("payload") or {}
+        reason = _text(payload.get("reason"))
+        summary = _text(payload.get("error_summary"))
+        if reason is None and summary is None:
+            continue
+        notes.append(
+            {
+                "sequence": int(item.get("sequence") or 0),
+                "kind": str(item.get("kind")),
+                "reason": reason,
+                "error_summary": summary,
+            }
+        )
+        if len(notes) >= _MAX_ENTRIES:
+            break
+    return {
+        "evidence": (
+            constrain(record, Evidence.PRESENT) if notes else absence_evidence(record)
+        ),
+        "notes": notes,
+    }
+
+
+def _outcome(
+    run: dict[str, Any],
+    record: dict[str, Any],
+    state: str,
+    created: datetime | None,
+    finished: datetime | None,
+) -> dict[str, Any]:
+    result = project_terminal_result(run.get("terminal_result"))
+    terminal = is_terminal(state)
+    if record["unsupported"]:
+        evidence = Evidence.UNSUPPORTED
+    elif not terminal:
+        # Not "we lost the record" — the run has not ended. `open` says which.
+        evidence = Evidence.MISSING
+    elif result:
+        evidence = Evidence.PRESENT
+    else:
+        evidence = Evidence.PARTIAL
+    return {
+        "evidence": evidence,
+        "state": state,
+        "open": not terminal,
+        "result": result or None,
+        "finished_at": run.get("finished_at"),
+        "duration_ms": _elapsed_ms(created, finished) if finished else None,
+    }
+
+
+def run_summary(run: dict[str, Any]) -> dict[str, Any]:
+    """A pointer to a run, cheap enough to list. Evidence lives in the receipt."""
+    result = project_terminal_result(run.get("terminal_result")) or {}
+    created = parse_moment(run.get("created_at"))
+    finished = parse_moment(run.get("finished_at"))
+    return {
+        "run_id": str(run.get("run_id") or ""),
+        "session_id": str(run.get("session_id") or ""),
+        "person_id": run.get("person_id"),
+        "parent_run_id": run.get("parent_run_id"),
+        "trigger": str(run.get("trigger") or ""),
+        "state": str(run.get("current_state") or ""),
+        "created_at": run.get("created_at"),
+        "updated_at": run.get("updated_at"),
+        "finished_at": run.get("finished_at"),
+        "duration_ms": _elapsed_ms(created, finished) if finished else None,
+        "source_count": len(run.get("source_refs") or []),
+        "artifact_count": len(run.get("artifact_refs") or []),
+        "approval_count": len(run.get("approval_ids") or []),
+        "usage": _usage_totals(run),
+        "outcome_status": result.get("status"),
+    }
+
+
+def _pick(payload: dict[str, Any], fields: tuple[str, ...]) -> dict[str, Any]:
+    """Only named scalars escape a payload. Nested structures never do."""
+    picked: dict[str, Any] = {}
+    for name in fields:
+        value = payload.get(name)
+        if value is None or isinstance(value, bool):
+            continue
+        if isinstance(value, (int, float)):
+            picked[name] = value
+        elif isinstance(value, str):
+            text = _text(value)
+            if text is not None:
+                picked[name] = text
+    return picked
+
+
+def _text(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = redact_secrets(value)[:_TEXT_LIMIT].strip()
+    return text or None
+
+
+def parse_moment(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def _elapsed_ms(start: datetime | None, end: datetime | None) -> int | None:
+    if start is None or end is None:
+        return None
+    return max(0, int((end - start).total_seconds() * 1000))
+
+
+def _owned(run: dict[str, Any], now: datetime) -> bool:
+    """Whether a process holds this run right now. The owner's id stays private."""
+    expires = parse_moment(run.get("lease_expires_at"))
+    return bool(run.get("lease_owner")) and expires is not None and expires > now

--- a/desktop/coworker/server.py
+++ b/desktop/coworker/server.py
@@ -28,6 +28,7 @@ from coworker.automation.scheduler import (
     next_monday_0900,
     now_iso,
 )
+from coworker.agent_run_repository import AgentRunRepository
 from coworker.apollo_curation import curate_apollo_candidates
 from coworker.calendar import calendar_from_secrets
 from coworker.connectors.google_oauth import (
@@ -80,6 +81,8 @@ from coworker.provider import (
     safe_model_identifier,
 )
 from coworker.provider_retry import verified_provider_chain
+from coworker.run_ledger import RunLedger
+from coworker.run_ledger_api import run_ledger_router
 from coworker.secrets import SecretStore
 from coworker.store import ConversationStore, valid_session_id
 from coworker.telemetry import (
@@ -372,6 +375,11 @@ def create_app(
             people=app.state.people,
         )
     )
+    # Read side only. Registering an owner and reclaiming leases belongs to
+    # whatever starts the sidecar process, not to opening the store.
+    app.state.agent_runs = AgentRunRepository(root)
+    app.state.run_ledger = RunLedger(app.state.agent_runs, approvals=app.state.store)
+    app.include_router(run_ledger_router(ledger=app.state.run_ledger))
     app.state.calendar = calendar_from_secrets(app.state.secrets, http=http)
     app.state.apollo_key = apollo_key if apollo_key is not None else os.environ.get("APOLLO_API_KEY")
     app.state.tavily_key = os.environ.get("TAVILY_API_KEY")

--- a/desktop/docs/run-ledger.md
+++ b/desktop/docs/run-ledger.md
@@ -1,0 +1,174 @@
+# The unified run ledger: one receipt per Agent Run
+
+Status: active-stack engineering reference. Covers the read side of the durable
+run store — the receipt projection, the query surface, and the retention bound.
+Writing runs is `docs/agent-runs.md`; this document assumes it.
+
+Not to be confused with `coworker/ledger.py`, which maps tool results into
+person-file events. That is the person timeline. This is the run receipt.
+Nothing in this document changes it.
+
+Four modules, in dependency order:
+
+| Module | Holds |
+| --- | --- |
+| `coworker/run_evidence.py` | The evidence vocabulary and the record analysis behind it. |
+| `coworker/run_receipt.py` | The receipt projection. Pure: no store, no clock, no network. |
+| `coworker/run_ledger.py` | The reader over the run store, the query, and retention. |
+| `coworker/run_ledger_api.py` | The HTTP surface. No write verb. |
+
+## What a receipt is
+
+An Agent Run already has one identity for chat, queued, and scheduled work. A
+receipt is that identity rendered as operational evidence: what ran, which
+sources and artifacts it touched, which permissions it asked for, how recovery
+behaved, which model attempts it used, and how it ended.
+
+A receipt is not a transcript and not chain-of-thought. The rule that keeps it
+from becoming one is mechanical rather than aspirational:
+
+> A receipt renders only fields `coworker/run_receipt.py` names, and every named
+> field is an identifier, an enum, a count, a timestamp, or a bounded reason the
+> runtime itself wrote.
+
+Message bodies, tool arguments, command output, prompts, raw provider errors,
+credentials, and model reasoning have no field to land in. `_pick` copies named
+scalars and never a nested structure, so a payload cannot ride out whole. This
+is a second allowlist, independent of the write-time allowlist in
+`agent_runs.CHECKPOINT_PAYLOAD_FIELDS`. Both must hold on their own: a read side
+that leaned on the write side would keep passing its tests after the write side
+changed.
+
+Free text appears in exactly three places, all of them bounded and already
+passed through `redact_secrets` when they were stored: `reason`,
+`error_summary`, and reference titles. The ledger adds no free-text field of its
+own. "Rationale summaries" in a receipt are those bounded reasons — the
+assistant's prose stays in the transcript and the person file, and the receipt
+points at the run rather than copying it.
+
+## Evidence, never inference
+
+Silence is not absence. Every section of a receipt carries an `evidence` value
+from one closed vocabulary, and the two that matter most are the two that are
+easiest to collapse.
+
+| Value | Means |
+| --- | --- |
+| `present` | The record says so directly. |
+| `absent` | It positively did not happen. |
+| `partial` | Some of it settled and some did not. |
+| `missing` | We do not know. The record has a hole, or the run is still open. |
+| `ambiguous` | The run knows it does not know: an external effect never reported back. |
+| `unsupported` | This build cannot express or verify the fact. Never "it did not happen". |
+| `expired` | The evidence existed and retention aged it out on purpose. |
+
+"No approval was requested" is `absent`. "We do not know whether an approval was
+requested" is `missing`. They are different operator situations and they must
+never render the same way.
+
+The rule that separates them is one property of the record, computed before any
+section is read. A run's checkpoint sequence is dense from 1 to
+`checkpoint_sequence`, so a receipt can tell whether the record covers the run's
+whole life. A facet with no evidence is `absent` only when all of the following
+hold:
+
+- the run is terminal, and
+- the stored checkpoints are contiguous and end at `checkpoint_sequence`, and
+- no checkpoint kind is unknown to this build, and
+- no checkpoint is in `INCOMPLETE_RECORD_KINDS` — `process_interrupted` or
+  `tool_outcome_unknown`, each of which means work happened that no checkpoint
+  describes.
+
+Otherwise the facet is `unsupported`, `missing`, or `expired`, in that order of
+precedence. An unreadable record withholds a conclusion even where the receipt
+does have entries to show: the entries stay visible, but the section reads
+`unsupported`, because a checkpoint this build cannot interpret might have been
+another tool call, another approval, or another model attempt.
+
+Sections backed by the run row — sources, artifacts, usage, approvals, outcome —
+are judged slightly differently from sections backed by checkpoints. The row is
+written in the same transaction as every checkpoint, so pruning step detail does
+not weaken what the row carries. Pruning turns a checkpoint-backed section
+`expired`; it leaves a row-backed section alone.
+
+## A ledger row is not authority
+
+Criterion 7 is a safety property, not a convention. The run store records which
+approval ids a run touched. It never records whether the owner said yes.
+
+Every decision in a receipt is resolved against the owner-native approval
+receipt — the Inbox item in `ConversationStore`. An approval id that store does
+not know renders `missing`, never an allowance. A pending decision renders
+`partial`. An expired one renders `expired` and carries no decision. Only a
+`resolved` owner-native item with an `allow` or `deny` decision produces a
+decision field at all, and an authorized action whose execution was interrupted
+renders `ambiguous`, because the outcome is genuinely unknown.
+
+Three structures hold this up:
+
+1. `RunLedger` reads the run store. Its only write is `prune_checkpoints`, which
+   deletes checkpoint rows and touches `agent_runs` never. It holds no lease and
+   cannot acquire one.
+2. `run_ledger_api` has no write verb. There is no route that creates a run,
+   changes a state, or records a decision.
+3. `_approval_entry` sources `decision`, `state`, and `actor` only from the
+   owner-native record. A `status` field in the run store's own checkpoint
+   payload can never become the decision.
+
+## Retention
+
+`CHECKPOINT_RETENTION_DAYS` bounds step detail. `RunLedger.enforce_retention`
+deletes the checkpoints of runs that finished before the cutoff. It never
+deletes a run row, so the person, session, source references, artifact
+references, approval ids, usage, and outcome that other records point at all
+survive; a pruned run stays inspectable and stays linkable.
+
+Two kinds of run are skipped. A run whose record marks a hole keeps its detail,
+because that detail is the only evidence that evidence is missing — pruning it
+would silently turn `missing` into `absent`. A run carrying a checkpoint kind
+this build cannot read is also skipped, for the same reason.
+
+A pruned run is recognised without a schema column. Retention deletes a prefix
+of a dense sequence, so surviving checkpoints that are contiguous and end at
+`checkpoint_sequence` but start above 1 are pruned evidence, and no stored
+checkpoints at all with a non-zero `checkpoint_sequence` means the whole prefix
+went. Any other deviation is a damaged record, which reads `missing`.
+
+## Query
+
+`GET /v1/agent-runs/{run_id}` returns one receipt. `GET /v1/agent-runs` returns
+a bounded page of pointers — identity, state, timestamps, counts, outcome status
+— cheap enough to list and carrying no evidence of its own.
+
+The filters are the four entry points an operator arrives from:
+
+| Entry point | Filter |
+| --- | --- |
+| Chat activity | `session_id` |
+| A scheduled receipt | `session_id` (the `sched-{id}` session) or `trigger=scheduled` |
+| A person timeline | `person_id` |
+| A diagnostic result | `run_id`, or the receipt route directly |
+
+Filters are re-checked on the projection, so an exact `run_id` cannot bypass a
+`person_id` filter. `limit` is clamped to `MAX_QUERY_LIMIT`. An unknown status
+or trigger is a 400, not a silently wider result — refusing is honest where
+ignoring would infer.
+
+## Known gaps
+
+- Nothing calls `enforce_retention` yet. It is a library call on purpose: the
+  process that starts the sidecar owns startup work, and that wiring is a
+  separate lane.
+- `create_app` now opens an `AgentRunRepository` so the ledger has something to
+  read. It deliberately does not register an owner or reclaim leases, which is
+  the write-side startup work `docs/agent-runs.md` describes. That document's
+  claim that nothing constructs a repository in the running application is now
+  half stale, and belongs to the lane that owns it.
+- A run whose record marks a hole is never pruned, so its checkpoints are
+  unbounded. Those runs are rare, and the alternative loses the distinction
+  between `missing` and `absent`.
+- `redact_secrets` matches credential shapes and assignments. A bare
+  high-entropy secret pasted into a source title is stored, and rendered, as
+  written. That is inherited from the write path, not introduced here.
+- The receipt exposes `goal_fingerprint`, a SHA-256 of the operator's words. It
+  is local-only and already on the run row, but it is guessable for short goals.

--- a/desktop/tests/test_run_ledger.py
+++ b/desktop/tests/test_run_ledger.py
@@ -1,0 +1,834 @@
+"""S5: one unified run receipt — operational evidence, never a second transcript."""
+
+import json
+import sqlite3
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from coworker.agent_run_repository import AgentRunRepository
+from coworker.run_ledger import (
+    CHECKPOINT_RETENTION_DAYS,
+    MAX_QUERY_LIMIT,
+    RunLedger,
+)
+from coworker.run_evidence import Evidence
+from coworker.run_receipt import RECEIPT_SECTIONS
+from coworker.store import ConversationStore
+
+GOAL = "Find three Codeology leads at Ramp"
+EPOCH = datetime(2026, 8, 1, 9, 0, tzinfo=UTC)
+
+
+def _ledger(tmp_path, *, approvals=None):
+    repo = AgentRunRepository(tmp_path / "runs")
+    return RunLedger(repo, approvals=approvals), repo, repo.registry.register()
+
+
+def _start(repo, owner, **kwargs):
+    return repo.create_run(
+        session_id=kwargs.pop("session_id", "sess-1"),
+        trigger=kwargs.pop("trigger", "chat"),
+        goal=kwargs.pop("goal", GOAL),
+        owner=owner,
+        **kwargs,
+    )
+
+
+def _complete(repo, started, *, at=None):
+    return repo.checkpoint(
+        started.lease,
+        kind="terminal",
+        state="complete",
+        terminal_result={"status": "complete", "text": "the answer the operator reads"},
+        now=at,
+    )
+
+
+# --- criterion 1: one shape for every kind of run -------------------------
+
+
+def test_every_trigger_and_ending_shares_one_receipt_shape(tmp_path):
+    ledger, repo, owner = _ledger(tmp_path)
+    shapes = []
+
+    chat = _start(repo, owner, session_id="sess-chat", trigger="chat")
+    _complete(repo, chat)
+    shapes.append(chat.run["run_id"])
+
+    queued = _start(repo, owner, session_id="sess-queue", trigger="queued_chat")
+    shapes.append(queued.run["run_id"])
+
+    scheduled = _start(repo, owner, session_id="sched-7", trigger="scheduled")
+    repo.checkpoint(scheduled.lease, kind="terminal", state="stopped")
+    shapes.append(scheduled.run["run_id"])
+
+    broken = _start(repo, owner, session_id="sess-fail")
+    repo.checkpoint(
+        broken.lease,
+        kind="terminal",
+        state="failed",
+        terminal_result={"status": "failed", "error_class": "ProviderError"},
+    )
+    shapes.append(broken.run["run_id"])
+
+    resumed = _start(repo, owner, session_id="sess-resume")
+    repo.checkpoint(
+        resumed.lease, kind="process_interrupted", state="interrupted",
+        payload={"reason": "owner_process_dead"},
+    )
+    lease = repo.acquire_lease(resumed.run["run_id"], owner, 120)
+    commit = repo.checkpoint(lease, kind="model_pending", state="running")
+    repo.checkpoint(commit.lease, kind="terminal", state="complete")
+    shapes.append(resumed.run["run_id"])
+
+    receipts = [ledger.receipt(run_id) for run_id in shapes]
+    assert all(receipt is not None for receipt in receipts)
+    first = set(receipts[0])
+    assert RECEIPT_SECTIONS <= first
+    for receipt in receipts[1:]:
+        assert set(receipt) == first
+        for section in RECEIPT_SECTIONS:
+            assert set(receipt[section]) == set(receipts[0][section]), section
+    assert [receipt["run"]["trigger"] for receipt in receipts] == [
+        "chat", "queued_chat", "scheduled", "chat", "chat",
+    ]
+    assert [receipt["run"]["state"] for receipt in receipts] == [
+        "complete", "running", "stopped", "failed", "complete",
+    ]
+
+
+# --- criterion 2: the receipt is the whole operational record --------------
+
+
+def test_a_successful_run_receipt_carries_the_whole_operational_record(tmp_path):
+    ledger, repo, owner = _ledger(tmp_path)
+    started = _start(
+        repo, owner, person_id="person-7", provider_model_id="fake-model", now=EPOCH
+    )
+    first = repo.checkpoint(
+        started.lease,
+        kind="model_pending",
+        payload={
+            "step": 1,
+            "attempt_id": "att-1",
+            "provider": "openai",
+            "model_id": "fake-model",
+            "persona_id": "sourcing",
+            "prompt_version": "2026-08-25",
+        },
+        now=EPOCH,
+    )
+    second = repo.checkpoint(
+        first.lease,
+        kind="model_completed",
+        payload={"attempt_id": "att-1", "status": "ok", "duration_ms": 1200},
+        usage={"input_tokens": 900, "output_tokens": 120},
+        now=EPOCH + timedelta(seconds=2),
+    )
+    third = repo.checkpoint(
+        second.lease,
+        kind="tool_pending",
+        payload={"tool_call_id": "call-1", "tool_name": "apollo_search_people"},
+        now=EPOCH + timedelta(seconds=3),
+    )
+    fourth = repo.checkpoint(
+        third.lease,
+        kind="tool_completed",
+        payload={
+            "tool_call_id": "call-1",
+            "tool_name": "apollo_search_people",
+            "status": "ok",
+            "item_count": 3,
+            "reason": "shortlist within credit budget",
+        },
+        source_refs=[
+            {
+                "id": "src-1",
+                "title": "Ramp careers",
+                "url": "https://ramp.test/jobs",
+                "provider": "web",
+            }
+        ],
+        artifact_refs=[{"id": "art-1", "artifact_type": "brief", "title": "Ramp brief"}],
+        now=EPOCH + timedelta(seconds=4),
+    )
+    repo.checkpoint(
+        fourth.lease,
+        kind="terminal",
+        state="complete",
+        terminal_result={"status": "complete", "text": "three leads found"},
+        now=EPOCH + timedelta(seconds=6),
+    )
+
+    receipt = ledger.receipt(started.run["run_id"])
+    run = receipt["run"]
+    assert run["run_id"] == started.run["run_id"]
+    assert run["session_id"] == "sess-1"
+    assert run["person_id"] == "person-7"
+    assert run["trigger"] == "chat"
+    assert run["goal_fingerprint"] == started.run["goal_fingerprint"]
+    assert run["duration_ms"] == 6000
+    assert run["owned"] is False
+
+    assert receipt["prompt"] == {
+        "evidence": Evidence.PRESENT,
+        "persona_id": "sourcing",
+        "prompt_version": "2026-08-25",
+    }
+    assert receipt["model_attempts"]["evidence"] == Evidence.PRESENT
+    assert receipt["model_attempts"]["attempt_count"] == 1
+    assert receipt["model_attempts"]["attempts"][0]["model_id"] == "fake-model"
+    assert receipt["model_attempts"]["attempts"][0]["outcome"] == "completed"
+    assert receipt["usage"] == {
+        "evidence": Evidence.PRESENT,
+        "totals": {"input_tokens": 900, "output_tokens": 120},
+    }
+    assert receipt["tools"]["evidence"] == Evidence.PRESENT
+    assert receipt["tools"]["calls"][0]["tool_name"] == "apollo_search_people"
+    assert receipt["tools"]["calls"][0]["lifecycle"] == "completed"
+    assert receipt["sources"]["refs"][0]["url"] == "https://ramp.test/jobs"
+    assert receipt["artifacts"]["refs"][0]["id"] == "art-1"
+    assert receipt["outcome"]["evidence"] == Evidence.PRESENT
+    assert receipt["outcome"]["state"] == "complete"
+    assert receipt["outcome"]["open"] is False
+    assert receipt["outcome"]["result"] == {
+        "status": "complete",
+        "text_length": len("three leads found"),
+    }
+    assert receipt["record"]["complete"] is True
+    assert receipt["record"]["checkpoints_stored"] == 6
+    rationale = receipt["rationale"]["notes"]
+    assert {note["reason"] for note in rationale} == {"shortlist within credit budget"}
+    assert receipt["recovery"]["evidence"] == Evidence.ABSENT
+    assert receipt["approvals"]["evidence"] == Evidence.ABSENT
+
+
+# --- criterion 3: evidence, never content ---------------------------------
+
+
+PLANTED = {
+    "api_key": "sk-proj-QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ",
+    "bearer": "Bearer QQQQQQQQQQQQQQQQQQQQQQQQ",
+    "message": "the director wrote something private here",
+    "reasoning": "step one I secretly suspect the candidate is lying",
+    "command_output": "drwxr-xr-x 5 fisher staff 160 payroll.csv",
+    "draft_body": "Hi Dana, I wanted to reach out about Codeology",
+}
+
+
+def _run_full_of_planted_content(repo, owner, *, approval_id="ap-leak"):
+    started = _start(repo, owner, person_id="person-leak")
+    first = repo.checkpoint(
+        started.lease,
+        kind="tool_pending",
+        payload={
+            "tool_call_id": "call-leak",
+            "tool_name": "gmail_draft",
+            # Every one of these is either off the allowlist or redacted.
+            "arguments": {"body": PLANTED["draft_body"], "api_key": PLANTED["api_key"]},
+            "message": PLANTED["message"],
+            "reasoning": PLANTED["reasoning"],
+            "stdout": PLANTED["command_output"],
+            "error_summary": (
+                f"authorization: {PLANTED['bearer']} failed with {PLANTED['api_key']}"
+            ),
+        },
+    )
+    second = repo.checkpoint(
+        first.lease,
+        kind="tool_completed",
+        payload={"tool_call_id": "call-leak", "tool_name": "gmail_draft", "status": "ok"},
+        source_refs=[
+            {
+                "id": "src-leak",
+                "title": f"Ramp brief {PLANTED['api_key']}",
+                "url": f"https://ramp.test/doc?access_token={PLANTED['api_key']}",
+            }
+        ],
+        artifact_refs=[{"id": "art-leak", "artifact_type": "draft", "title": "Outreach draft"}],
+        approval_ids=[approval_id],
+    )
+    repo.checkpoint(
+        second.lease,
+        kind="terminal",
+        state="complete",
+        terminal_result={"status": "complete", "text": PLANTED["draft_body"]},
+    )
+    return started.run["run_id"]
+
+
+def _blob(receipt) -> str:
+    return json.dumps(receipt, sort_keys=True, default=str)
+
+
+def test_the_receipt_is_operational_evidence_and_never_content(tmp_path):
+    """Non-vacuous: the receipt must first prove it retained the real fields."""
+    store = ConversationStore(tmp_path / "club")
+    store.park_inbox(
+        "ap-leak",
+        "gmail_draft",
+        # An owner-native approval carries the raw tool arguments. The ledger
+        # joins against it for authority and must copy none of them.
+        {"body": PLANTED["draft_body"], "api_key": PLANTED["api_key"]},
+        reason=PLANTED["message"],
+        session_id="sess-1",
+    )
+    store.resolve_inbox("ap-leak", "allow", actor="director")
+    ledger, repo, owner = _ledger(tmp_path, approvals=store)
+    run_id = _run_full_of_planted_content(repo, owner)
+
+    receipt = ledger.receipt(run_id)
+    assert receipt is not None
+    assert receipt["run"]["run_id"] == run_id
+    assert receipt["run"]["person_id"] == "person-leak"
+    assert receipt["tools"]["calls"][0]["tool_name"] == "gmail_draft"
+    assert receipt["tools"]["calls"][0]["lifecycle"] == "completed"
+    assert receipt["sources"]["refs"][0]["url"] == "https://ramp.test/doc"
+    assert receipt["artifacts"]["refs"][0]["artifact_type"] == "draft"
+    assert receipt["approvals"]["decisions"][0]["decision"] == "allow"
+    assert receipt["outcome"]["result"]["text_length"] == len(PLANTED["draft_body"])
+    assert receipt["rationale"]["notes"], "a rationale note must survive"
+
+    rendered = _blob(receipt)
+    assert "gmail_draft" in rendered, "the receipt must really be populated"
+    for secret in PLANTED.values():
+        assert secret not in rendered, secret
+    assert "access_token" not in rendered
+
+
+def test_the_receipt_projection_is_its_own_allowlist(tmp_path):
+    """The read side must hold even when the write side's allowlist did not.
+
+    Without this the projection tests are vacuous: `checkpoint_payload` strips
+    the planted keys before they are ever stored, so a receipt that echoed
+    whole payloads would still look clean.
+    """
+    ledger, repo, owner = _ledger(tmp_path)
+    started = _start(repo, owner)
+    commit = repo.checkpoint(
+        started.lease,
+        kind="tool_completed",
+        payload={"tool_call_id": "call-1", "tool_name": "web_search", "status": "ok"},
+    )
+    repo.checkpoint(commit.lease, kind="terminal", state="complete")
+    smuggled = json.dumps(
+        {
+            "tool_call_id": "call-1",
+            "tool_name": "web_search",
+            "status": "ok",
+            "arguments": {"body": PLANTED["draft_body"]},
+            "message": PLANTED["message"],
+            "reasoning": PLANTED["reasoning"],
+            "stdout": PLANTED["command_output"],
+        }
+    )
+    with sqlite3.connect(repo.path) as db:
+        db.execute(
+            "UPDATE agent_run_checkpoints SET payload = ? "
+            "WHERE run_id = ? AND sequence = 2",
+            (smuggled, started.run["run_id"]),
+        )
+        db.execute(
+            "UPDATE agent_runs SET usage = ? WHERE run_id = ?",
+            (json.dumps({"input_tokens": 12, "note": PLANTED["message"]}),
+             started.run["run_id"]),
+        )
+
+    receipt = ledger.receipt(started.run["run_id"])
+    call = receipt["tools"]["calls"][0]
+    assert call["tool_name"] == "web_search"
+    assert call["status"] == "ok"
+    assert receipt["usage"]["totals"] == {"input_tokens": 12}
+    summary = ledger.query(run_id=started.run["run_id"])["runs"][0]
+    assert summary["usage"] == {"input_tokens": 12}
+
+    rendered = _blob(receipt) + _blob(summary)
+    assert "web_search" in rendered, "the receipt must really be populated"
+    for secret in PLANTED.values():
+        assert secret not in rendered, secret
+    assert "arguments" not in rendered
+
+
+def test_query_results_carry_pointers_and_never_content(tmp_path):
+    store = ConversationStore(tmp_path / "club")
+    ledger, repo, owner = _ledger(tmp_path, approvals=store)
+    run_id = _run_full_of_planted_content(repo, owner)
+
+    page = ledger.query(session_id="sess-1")
+    assert [row["run_id"] for row in page["runs"]] == [run_id]
+    assert page["runs"][0]["person_id"] == "person-leak"
+    assert page["runs"][0]["source_count"] == 1
+    assert page["runs"][0]["outcome_status"] == "complete"
+
+    rendered = _blob(page)
+    assert run_id in rendered
+    for secret in PLANTED.values():
+        assert secret not in rendered, secret
+
+
+# --- criterion 6: distinguished, never inferred ---------------------------
+
+
+def test_no_approval_requested_is_not_the_same_as_not_knowing(tmp_path):
+    ledger, repo, owner = _ledger(tmp_path, approvals=_FakeApprovals({}))
+    settled = _start(repo, owner, session_id="sess-settled")
+    _complete(repo, settled)
+
+    holed = _start(repo, owner, session_id="sess-holed")
+    repo.checkpoint(
+        holed.lease, kind="process_interrupted", state="interrupted",
+        payload={"reason": "owner_process_dead"},
+    )
+    lease = repo.acquire_lease(holed.run["run_id"], owner, 120)
+    commit = repo.checkpoint(lease, kind="model_pending", state="running")
+    repo.checkpoint(commit.lease, kind="terminal", state="complete")
+
+    open_run = _start(repo, owner, session_id="sess-open")
+
+    assert ledger.receipt(settled.run["run_id"])["approvals"]["evidence"] == Evidence.ABSENT
+    assert ledger.receipt(holed.run["run_id"])["approvals"]["evidence"] == Evidence.MISSING
+    assert ledger.receipt(open_run.run["run_id"])["approvals"]["evidence"] == Evidence.MISSING
+    # The same rule must hold for tools, or absence would be inferred there.
+    assert ledger.receipt(settled.run["run_id"])["tools"]["evidence"] == Evidence.ABSENT
+    assert ledger.receipt(holed.run["run_id"])["tools"]["evidence"] == Evidence.MISSING
+
+
+def test_partial_evidence_is_partial_not_absent(tmp_path):
+    ledger, repo, owner = _ledger(tmp_path)
+    started = _start(repo, owner)
+    first = repo.checkpoint(
+        started.lease,
+        kind="model_pending",
+        payload={"attempt_id": "att-1", "model_id": "fake-model"},
+    )
+    second = repo.checkpoint(
+        first.lease,
+        kind="tool_pending",
+        payload={"tool_call_id": "call-1", "tool_name": "web_search"},
+    )
+    repo.checkpoint(second.lease, kind="terminal", state="partial")
+
+    receipt = ledger.receipt(started.run["run_id"])
+    assert receipt["model_attempts"]["evidence"] == Evidence.PARTIAL
+    assert receipt["model_attempts"]["attempts"][0]["outcome"] == "pending"
+    assert receipt["tools"]["evidence"] == Evidence.PARTIAL
+    assert receipt["tools"]["calls"][0]["lifecycle"] == "pending"
+    assert receipt["tools"]["pending_count"] == 1
+
+
+def test_an_ambiguous_external_outcome_is_its_own_value(tmp_path):
+    ledger, repo, owner = _ledger(tmp_path)
+    started = _start(repo, owner)
+    first = repo.checkpoint(
+        started.lease,
+        kind="tool_pending",
+        payload={"tool_call_id": "call-send", "tool_name": "gmail_send"},
+    )
+    repo.checkpoint(
+        first.lease,
+        kind="tool_outcome_unknown",
+        state="partial",
+        payload={"tool_call_id": "call-send", "tool_name": "gmail_send",
+                 "reason": "no result reported"},
+    )
+
+    receipt = ledger.receipt(started.run["run_id"])
+    assert receipt["tools"]["evidence"] == Evidence.AMBIGUOUS
+    assert receipt["tools"]["calls"][0]["lifecycle"] == "unknown"
+    assert receipt["tools"]["unknown_count"] == 1
+    # An unknown external outcome is a hole, so silence elsewhere stays unknown.
+    assert receipt["approvals"]["evidence"] == Evidence.MISSING
+    assert receipt["recovery"]["evidence"] == Evidence.PRESENT
+
+
+def test_a_kind_this_build_cannot_read_is_unsupported_not_ignored(tmp_path):
+    ledger, repo, owner = _ledger(tmp_path, approvals=_FakeApprovals({}))
+    started = _start(repo, owner)
+    first = repo.checkpoint(
+        started.lease,
+        kind="tool_completed",
+        payload={"tool_call_id": "call-1", "tool_name": "web_search", "status": "ok",
+                 "reason": "one shortlist page"},
+    )
+    commit = repo.checkpoint(first.lease, kind="terminal", state="complete")
+    run_id = started.run["run_id"]
+    # A newer build wrote a checkpoint kind this build has never heard of.
+    with sqlite3.connect(repo.path) as db:
+        db.execute(
+            "UPDATE agent_runs SET checkpoint_sequence = 4 WHERE run_id = ?", (run_id,)
+        )
+        db.execute(
+            "INSERT INTO agent_run_checkpoints "
+            "(run_id, sequence, kind, state, payload, created_at) "
+            "VALUES (?, 4, 'quantum_leap', 'complete', '{}', ?)",
+            (run_id, commit.run["updated_at"]),
+        )
+
+    receipt = ledger.receipt(run_id)
+    assert receipt["record"]["unsupported"] == ["quantum_leap"]
+    assert receipt["record"]["complete"] is False
+    # A facet with no entries cannot claim absence...
+    assert receipt["approvals"]["evidence"] == Evidence.UNSUPPORTED
+    assert receipt["model_attempts"]["evidence"] == Evidence.UNSUPPORTED
+    # ...and a facet that does have entries cannot claim they are the whole
+    # story either. The entries stay visible; only the conclusion is withheld.
+    assert receipt["tools"]["calls"][0]["tool_name"] == "web_search"
+    assert receipt["tools"]["evidence"] == Evidence.UNSUPPORTED
+    assert receipt["rationale"]["notes"][0]["reason"] == "one shortlist page"
+    assert receipt["rationale"]["evidence"] == Evidence.UNSUPPORTED
+
+
+def test_an_expired_approval_is_neither_a_denial_nor_a_silence(tmp_path):
+    store = ConversationStore(tmp_path / "club", approval_ttl_seconds=0.01)
+    store.park_inbox("ap-expired", "gmail_send", {"draft_id": "d1"}, session_id="sess-1")
+    ledger, repo, owner = _ledger(tmp_path, approvals=store)
+    started = _start(repo, owner)
+    repo.checkpoint(
+        started.lease,
+        kind="waiting_approval",
+        state="waiting_approval",
+        payload={"approval_id": "ap-expired", "tool_name": "gmail_send"},
+        approval_ids=["ap-expired"],
+    )
+    import time
+
+    time.sleep(0.05)
+
+    decision = ledger.receipt(started.run["run_id"])["approvals"]["decisions"][0]
+    assert decision["approval_id"] == "ap-expired"
+    assert decision["evidence"] == Evidence.EXPIRED
+    assert decision["decision"] is None
+    assert decision["requested"] is True
+
+
+def test_pruned_detail_reads_as_expired_evidence_not_as_absence(tmp_path):
+    ledger, repo, owner = _ledger(tmp_path)
+    old = EPOCH - timedelta(days=CHECKPOINT_RETENTION_DAYS + 5)
+    started = _start(repo, owner, person_id="person-9", now=old)
+    first = repo.checkpoint(
+        started.lease,
+        kind="tool_completed",
+        payload={"tool_call_id": "call-1", "tool_name": "web_search", "status": "ok"},
+        source_refs=[{"id": "src-1", "title": "Ramp", "url": "https://ramp.test/a"}],
+        artifact_refs=[{"id": "art-1", "artifact_type": "brief", "title": "Brief"}],
+        now=old + timedelta(seconds=1),
+    )
+    repo.checkpoint(
+        first.lease, kind="terminal", state="complete",
+        terminal_result={"status": "complete", "text_length": 12},
+        now=old + timedelta(seconds=2),
+    )
+    before = ledger.receipt(started.run["run_id"])
+    assert before["tools"]["evidence"] == Evidence.PRESENT
+
+    swept = ledger.enforce_retention(now=EPOCH)
+    assert swept["pruned_runs"] == 1
+
+    after = ledger.receipt(started.run["run_id"])
+    assert after["record"]["checkpoints_stored"] == 0
+    assert after["record"]["pruned_through_sequence"] == 3
+    # Detail aged out on purpose; identity and outcome are still evidence.
+    assert after["tools"]["evidence"] == Evidence.EXPIRED
+    assert after["model_attempts"]["evidence"] == Evidence.EXPIRED
+    assert after["rationale"]["evidence"] == Evidence.EXPIRED
+    assert after["run"]["person_id"] == "person-9"
+    assert after["sources"] == before["sources"]
+    assert after["artifacts"] == before["artifacts"]
+    assert after["outcome"]["result"] == {"status": "complete", "text_length": 12}
+    assert after["approvals"]["evidence"] == Evidence.ABSENT
+
+    # Retention is idempotent and never touches a run that is still open.
+    live = _start(repo, owner, session_id="sess-live", now=old)
+    assert ledger.enforce_retention(now=EPOCH)["pruned_runs"] == 0
+    assert ledger.receipt(live.run["run_id"])["record"]["checkpoints_stored"] == 1
+
+
+def test_retention_never_deletes_the_marker_that_evidence_is_missing(tmp_path):
+    ledger, repo, owner = _ledger(tmp_path)
+    stale = EPOCH - timedelta(days=CHECKPOINT_RETENTION_DAYS + 5)
+    holed = _start(repo, owner, session_id="sess-holed", now=stale)
+    repo.checkpoint(
+        holed.lease,
+        kind="tool_outcome_unknown",
+        state="partial",
+        payload={"tool_call_id": "call-send", "tool_name": "gmail_send"},
+        now=stale + timedelta(seconds=1),
+    )
+    foreign = _start(repo, owner, session_id="sess-foreign", now=stale)
+    repo.checkpoint(
+        foreign.lease, kind="terminal", state="complete", now=stale + timedelta(seconds=1)
+    )
+    with sqlite3.connect(repo.path) as db:
+        db.execute(
+            "UPDATE agent_run_checkpoints SET kind = 'quantum_leap' "
+            "WHERE run_id = ? AND sequence = 2",
+            (foreign.run["run_id"],),
+        )
+
+    assert ledger.enforce_retention(now=EPOCH)["pruned_runs"] == 0
+    still_ambiguous = ledger.receipt(holed.run["run_id"])
+    assert still_ambiguous["record"]["checkpoints_stored"] == 2
+    assert still_ambiguous["tools"]["evidence"] == Evidence.AMBIGUOUS
+    assert ledger.receipt(foreign.run["run_id"])["record"]["unsupported"] == [
+        "quantum_leap"
+    ]
+
+
+# --- criterion 7: a ledger row is not authority ---------------------------
+
+
+class _FakeApprovals:
+    def __init__(self, items):
+        self.items = items
+        self.asked = []
+
+    def get_inbox(self, item_id):
+        self.asked.append(item_id)
+        return self.items.get(item_id)
+
+
+def test_a_run_row_cannot_assert_an_approval_the_owner_never_gave(tmp_path):
+    approvals = _FakeApprovals({})
+    ledger, repo, owner = _ledger(tmp_path, approvals=approvals)
+    started = _start(repo, owner)
+    repo.checkpoint(
+        started.lease,
+        kind="waiting_approval",
+        state="waiting_approval",
+        payload={"approval_id": "ap-forged", "tool_name": "gmail_send", "status": "allow"},
+        approval_ids=["ap-forged"],
+    )
+
+    decisions = ledger.receipt(started.run["run_id"])["approvals"]["decisions"]
+    assert [item["approval_id"] for item in decisions] == ["ap-forged"]
+    assert decisions[0]["evidence"] == Evidence.MISSING
+    assert decisions[0]["decision"] is None
+    assert approvals.asked == ["ap-forged"]
+    # The run store's own "status" field must never become the decision.
+    assert "allow" not in str(decisions[0].values())
+
+
+def test_a_pending_owner_decision_never_reads_as_allowed(tmp_path):
+    store = ConversationStore(tmp_path / "club")
+    store.park_inbox("ap-pending", "gmail_send", {"draft_id": "d1"}, session_id="sess-1")
+    ledger, repo, owner = _ledger(tmp_path, approvals=store)
+    started = _start(repo, owner)
+    repo.checkpoint(
+        started.lease,
+        kind="waiting_approval",
+        state="waiting_approval",
+        payload={"approval_id": "ap-pending"},
+        approval_ids=["ap-pending"],
+    )
+
+    decision = ledger.receipt(started.run["run_id"])["approvals"]["decisions"][0]
+    assert decision["evidence"] == Evidence.PARTIAL
+    assert decision["decision"] is None
+    assert decision["state"] == "pending"
+
+
+def test_a_denied_approval_is_reported_as_denied(tmp_path):
+    store = ConversationStore(tmp_path / "club")
+    store.park_inbox("ap-deny", "gmail_send", {"draft_id": "d1"}, session_id="sess-1")
+    store.resolve_inbox("ap-deny", "deny", actor="director")
+    ledger, repo, owner = _ledger(tmp_path, approvals=store)
+    started = _start(repo, owner)
+    repo.checkpoint(
+        started.lease,
+        kind="waiting_approval",
+        state="waiting_approval",
+        payload={"approval_id": "ap-deny", "tool_name": "gmail_send"},
+        approval_ids=["ap-deny"],
+    )
+
+    receipt = ledger.receipt(started.run["run_id"])
+    decision = receipt["approvals"]["decisions"][0]
+    assert decision["decision"] == "deny"
+    assert decision["evidence"] == Evidence.PRESENT
+    assert decision["tool_name"] == "gmail_send"
+    assert receipt["run"]["state"] == "waiting_approval"
+
+
+def test_an_authorized_send_with_no_reported_outcome_is_ambiguous(tmp_path):
+    store = ConversationStore(tmp_path / "club", approval_ttl_seconds=0.01)
+    store.park_inbox("ap-send", "gmail_send", {"draft_id": "d1"}, session_id="sess-1")
+    store.decide_and_claim_inbox_execution(
+        "ap-send", "allow", actor="director", scope="once", claimant="turn-1"
+    )
+    import time
+
+    time.sleep(0.05)
+    store.reap_overdue_inbox()
+    ledger, repo, owner = _ledger(tmp_path, approvals=store)
+    started = _start(repo, owner)
+    repo.checkpoint(
+        started.lease,
+        kind="waiting_external",
+        state="waiting_external",
+        payload={"approval_id": "ap-send", "tool_name": "gmail_send"},
+        approval_ids=["ap-send"],
+    )
+
+    decision = ledger.receipt(started.run["run_id"])["approvals"]["decisions"][0]
+    assert decision["decision"] == "allow"
+    assert decision["execution_status"] == "interrupted"
+    assert decision["evidence"] == Evidence.AMBIGUOUS
+
+
+def test_without_an_owner_native_source_approvals_are_unsupported(tmp_path):
+    ledger, repo, owner = _ledger(tmp_path, approvals=None)
+    started = _start(repo, owner)
+    repo.checkpoint(
+        started.lease,
+        kind="waiting_approval",
+        state="waiting_approval",
+        payload={"approval_id": "ap-1"},
+        approval_ids=["ap-1"],
+    )
+    receipt = ledger.receipt(started.run["run_id"])
+    assert receipt["approvals"]["evidence"] == Evidence.UNSUPPORTED
+    assert receipt["approvals"]["decisions"][0]["decision"] is None
+
+
+def test_the_ledger_never_writes_to_the_run_itself(tmp_path):
+    ledger, repo, owner = _ledger(tmp_path)
+    started = _start(repo, owner)
+    before = repo.get_run(started.run["run_id"])
+    ledger.receipt(started.run["run_id"])
+    ledger.query(session_id="sess-1")
+    ledger.enforce_retention(now=EPOCH)
+    assert repo.get_run(started.run["run_id"]) == before
+
+
+# --- criteria 4 and 5: opening a run from anywhere, bounded ---------------
+
+
+def test_query_supports_exact_id_and_bounded_filters(tmp_path):
+    ledger, repo, owner = _ledger(tmp_path)
+    chat = _start(repo, owner, session_id="sess-chat", person_id="person-a", now=EPOCH)
+    _complete(repo, chat, at=EPOCH + timedelta(seconds=1))
+    sched = _start(
+        repo, owner, session_id="sched-3", trigger="scheduled",
+        person_id="person-b", now=EPOCH + timedelta(hours=1),
+    )
+    older = _start(repo, owner, session_id="sess-chat", now=EPOCH - timedelta(days=2))
+
+    # exact id — the diagnostic and scheduled-receipt entry points
+    assert ledger.query(run_id=sched.run["run_id"])["runs"][0]["run_id"] == sched.run["run_id"]
+    assert ledger.query(run_id="nope")["runs"] == []
+    # chat activity
+    assert {row["run_id"] for row in ledger.query(session_id="sess-chat")["runs"]} == {
+        chat.run["run_id"], older.run["run_id"],
+    }
+    # a person timeline
+    assert [row["run_id"] for row in ledger.query(person_id="person-b")["runs"]] == [
+        sched.run["run_id"]
+    ]
+    # status
+    assert [row["run_id"] for row in ledger.query(statuses=["complete"])["runs"]] == [
+        chat.run["run_id"]
+    ]
+    # time
+    windowed = ledger.query(since=EPOCH - timedelta(hours=1), until=EPOCH + timedelta(minutes=5))
+    assert [row["run_id"] for row in windowed["runs"]] == [chat.run["run_id"]]
+    # trigger
+    assert [row["run_id"] for row in ledger.query(trigger="scheduled")["runs"]] == [
+        sched.run["run_id"]
+    ]
+    # bounded
+    page = ledger.query(limit=2)
+    assert len(page["runs"]) == 2 and page["truncated"] is True
+    assert ledger.query(limit=10_000)["limit"] == MAX_QUERY_LIMIT
+    with pytest.raises(ValueError):
+        ledger.query(statuses=["vibing"])
+    with pytest.raises(ValueError):
+        ledger.query(trigger="telepathy")
+
+
+def test_one_person_never_sees_another_persons_runs(tmp_path):
+    ledger, repo, owner = _ledger(tmp_path)
+    mine = _start(repo, owner, session_id="sess-a", person_id="person-a")
+    theirs = _start(repo, owner, session_id="sess-b", person_id="person-b")
+    unbound = _start(repo, owner, session_id="sess-c")
+
+    rows = ledger.query(person_id="person-a")["runs"]
+    assert [row["run_id"] for row in rows] == [mine.run["run_id"]]
+    assert theirs.run["run_id"] not in str(rows)
+    assert unbound.run["run_id"] not in str(rows)
+    assert ledger.query(person_id="person-a", session_id="sess-b")["runs"] == []
+    assert ledger.receipt(theirs.run["run_id"])["run"]["person_id"] == "person-b"
+
+
+def test_a_cancelled_run_is_not_a_failed_one(tmp_path):
+    ledger, repo, owner = _ledger(tmp_path)
+    stopped = _start(repo, owner)
+    repo.checkpoint(
+        stopped.lease, kind="terminal", state="stopped",
+        terminal_result={"status": "stopped", "error_class": "OperatorCancelled"},
+    )
+    failed = _start(repo, owner)
+    repo.checkpoint(
+        failed.lease, kind="terminal", state="failed",
+        terminal_result={"status": "failed", "error_class": "ProviderError"},
+    )
+
+    assert ledger.receipt(stopped.run["run_id"])["outcome"]["state"] == "stopped"
+    assert ledger.receipt(failed.run["run_id"])["outcome"]["state"] == "failed"
+    assert ledger.receipt(stopped.run["run_id"])["outcome"]["result"]["error_class"] == (
+        "OperatorCancelled"
+    )
+
+
+def test_a_failed_over_run_lists_every_model_attempt(tmp_path):
+    ledger, repo, owner = _ledger(tmp_path)
+    started = _start(repo, owner)
+    first = repo.checkpoint(
+        started.lease,
+        kind="model_pending",
+        payload={"attempt_id": "att-1", "provider": "anthropic", "model_id": "model-a"},
+    )
+    second = repo.checkpoint(
+        first.lease,
+        kind="model_completed",
+        payload={"attempt_id": "att-1", "status": "error", "error_class": "BillingError"},
+    )
+    third = repo.checkpoint(
+        second.lease,
+        kind="model_pending",
+        payload={"attempt_id": "att-2", "provider": "openai", "model_id": "model-b"},
+    )
+    fourth = repo.checkpoint(
+        third.lease,
+        kind="model_completed",
+        payload={"attempt_id": "att-2", "status": "ok"},
+    )
+    repo.checkpoint(fourth.lease, kind="terminal", state="complete")
+
+    attempts = ledger.receipt(started.run["run_id"])["model_attempts"]
+    assert [item["attempt_id"] for item in attempts["attempts"]] == ["att-1", "att-2"]
+    assert [item["model_id"] for item in attempts["attempts"]] == ["model-a", "model-b"]
+    assert attempts["attempts"][0]["error_class"] == "BillingError"
+    assert attempts["distinct_models"] == 2
+    assert attempts["evidence"] == Evidence.PRESENT
+
+
+def test_an_interrupted_run_shows_its_recovery_decision(tmp_path):
+    ledger, repo, owner = _ledger(tmp_path)
+    started = _start(repo, owner)
+    repo.checkpoint(
+        started.lease, kind="process_interrupted", state="interrupted",
+        payload={"reason": "owner_process_dead"},
+    )
+
+    receipt = ledger.receipt(started.run["run_id"])
+    assert receipt["run"]["state"] == "interrupted"
+    assert receipt["recovery"]["evidence"] == Evidence.PRESENT
+    assert receipt["recovery"]["events"][0]["reason"] == "owner_process_dead"
+    assert receipt["outcome"]["open"] is True
+    assert receipt["outcome"]["evidence"] == Evidence.MISSING
+
+
+def test_a_missing_run_has_no_receipt(tmp_path):
+    ledger, _repo, _owner = _ledger(tmp_path)
+    assert ledger.receipt("run-that-never-was") is None

--- a/desktop/tests/test_run_ledger_api.py
+++ b/desktop/tests/test_run_ledger_api.py
@@ -1,0 +1,162 @@
+"""S5: the run ledger's HTTP surface — read only, bounded, and content free."""
+
+import importlib.util
+from datetime import UTC, datetime, timedelta
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from coworker.agent_run_repository import AgentRunRepository
+from coworker.run_ledger import MAX_QUERY_LIMIT, RunLedger
+from coworker.run_ledger_api import run_ledger_router
+from coworker.server import TOKEN_HEADER, create_app
+
+TOKEN = "run-ledger-token"
+EPOCH = datetime(2026, 8, 1, 9, 0, tzinfo=UTC)
+SECRET = "sk-proj-WWWWWWWWWWWWWWWWWWWWWWWWWWWW"
+BODY = "the director wrote something private here"
+
+
+def test_run_ledger_api_module_exists():
+    assert importlib.util.find_spec("coworker.run_ledger_api") is not None
+
+
+def _client(tmp_path):
+    repo = AgentRunRepository(tmp_path / "runs")
+    ledger = RunLedger(repo)
+    app = FastAPI()
+    app.include_router(run_ledger_router(ledger=ledger))
+    return TestClient(app), repo, repo.registry.register()
+
+
+def _run(repo, owner, **kwargs):
+    return repo.create_run(
+        session_id=kwargs.pop("session_id", "sess-1"),
+        trigger=kwargs.pop("trigger", "chat"),
+        goal="Find three Codeology leads at Ramp",
+        owner=owner,
+        **kwargs,
+    )
+
+
+def test_a_run_opens_from_its_id_and_the_body_is_evidence_only(tmp_path):
+    client, repo, owner = _client(tmp_path)
+    started = _run(repo, owner, person_id="person-7")
+    commit = repo.checkpoint(
+        started.lease,
+        kind="tool_completed",
+        payload={
+            "tool_call_id": "call-1",
+            "tool_name": "web_search",
+            "status": "ok",
+            "message": BODY,
+            "error_summary": f"noise {SECRET}",
+        },
+        source_refs=[
+            {"id": "src-1", "title": "Ramp", "url": f"https://ramp.test/a?token={SECRET}"}
+        ],
+    )
+    repo.checkpoint(
+        commit.lease, kind="terminal", state="complete",
+        terminal_result={"status": "complete", "text": BODY},
+    )
+
+    response = client.get(f"/v1/agent-runs/{started.run['run_id']}")
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store"
+    receipt = response.json()["receipt"]
+    assert receipt["run"]["run_id"] == started.run["run_id"]
+    assert receipt["tools"]["calls"][0]["tool_name"] == "web_search"
+    assert receipt["sources"]["refs"][0]["url"] == "https://ramp.test/a"
+    assert receipt["outcome"]["result"]["text_length"] == len(BODY)
+    assert SECRET not in response.text
+    assert BODY not in response.text
+
+    missing = client.get("/v1/agent-runs/run-that-never-was")
+    assert missing.status_code == 404
+    assert missing.json() == {"error": "run_not_found"}
+
+
+def test_every_entry_point_reaches_the_same_run(tmp_path):
+    client, repo, owner = _client(tmp_path)
+    chat = _run(repo, owner, session_id="sess-chat", person_id="person-a", now=EPOCH)
+    sched = _run(
+        repo, owner, session_id="sched-3", trigger="scheduled",
+        person_id="person-a", now=EPOCH + timedelta(minutes=5),
+    )
+
+    # chat activity, a scheduled receipt, a person timeline, a diagnostic id
+    by_session = client.get("/v1/agent-runs", params={"session_id": "sess-chat"})
+    by_schedule = client.get("/v1/agent-runs", params={"session_id": "sched-3"})
+    by_person = client.get("/v1/agent-runs", params={"person_id": "person-a"})
+    by_id = client.get(f"/v1/agent-runs/{sched.run['run_id']}")
+
+    assert [row["run_id"] for row in by_session.json()["runs"]] == [chat.run["run_id"]]
+    assert [row["run_id"] for row in by_schedule.json()["runs"]] == [sched.run["run_id"]]
+    assert {row["run_id"] for row in by_person.json()["runs"]} == {
+        chat.run["run_id"], sched.run["run_id"],
+    }
+    assert by_id.json()["receipt"]["run"]["run_id"] == sched.run["run_id"]
+
+
+def test_filters_are_bounded_and_bad_ones_are_refused(tmp_path):
+    client, repo, owner = _client(tmp_path)
+    first = _run(repo, owner, session_id="sess-a", now=EPOCH)
+    repo.checkpoint(
+        first.lease, kind="terminal", state="failed", now=EPOCH + timedelta(seconds=1)
+    )
+    _run(repo, owner, session_id="sess-a", now=EPOCH + timedelta(days=1))
+
+    assert [row["run_id"] for row in client.get(
+        "/v1/agent-runs", params={"status": "failed"}
+    ).json()["runs"]] == [first.run["run_id"]]
+    windowed = client.get(
+        "/v1/agent-runs",
+        params={"since": EPOCH.isoformat(), "until": (EPOCH + timedelta(hours=1)).isoformat()},
+    )
+    assert [row["run_id"] for row in windowed.json()["runs"]] == [first.run["run_id"]]
+
+    capped = client.get("/v1/agent-runs", params={"limit": 5000})
+    assert capped.json()["limit"] == MAX_QUERY_LIMIT
+    assert client.get("/v1/agent-runs", params={"limit": 1}).json()["truncated"] is True
+
+    for bad in ({"status": "vibing"}, {"trigger": "telepathy"}, {"since": "yesterday"}):
+        response = client.get("/v1/agent-runs", params=bad)
+        assert response.status_code == 400, bad
+        assert "error" in response.json()
+
+
+def test_the_ledger_surface_has_no_write_verb(tmp_path):
+    client, repo, owner = _client(tmp_path)
+    started = _run(repo, owner)
+    run_id = started.run["run_id"]
+    for method, path in (
+        ("POST", "/v1/agent-runs"),
+        ("POST", f"/v1/agent-runs/{run_id}"),
+        ("PUT", f"/v1/agent-runs/{run_id}"),
+        ("PATCH", f"/v1/agent-runs/{run_id}"),
+        ("DELETE", f"/v1/agent-runs/{run_id}"),
+    ):
+        response = client.request(method, path, json={"current_state": "complete"})
+        assert response.status_code in {404, 405}, (method, path, response.status_code)
+    assert repo.get_run(run_id)["current_state"] == "running"
+
+
+def test_the_sidecar_serves_the_ledger_behind_its_token(tmp_path):
+    app = create_app(token=TOKEN, provider=None, state=tmp_path)
+    client = TestClient(app)
+    started = app.state.agent_runs.create_run(
+        session_id="sess-1",
+        trigger="chat",
+        goal="Find three Codeology leads at Ramp",
+        owner=app.state.agent_runs.registry.register(),
+    )
+
+    assert client.get("/v1/agent-runs").status_code == 401
+    listed = client.get("/v1/agent-runs", headers={TOKEN_HEADER: TOKEN})
+    assert listed.status_code == 200
+    assert [row["run_id"] for row in listed.json()["runs"]] == [started.run["run_id"]]
+    receipt = client.get(
+        f"/v1/agent-runs/{started.run['run_id']}", headers={TOKEN_HEADER: TOKEN}
+    )
+    assert receipt.json()["receipt"]["run"]["session_id"] == "sess-1"


### PR DESCRIPTION
Closes #74.

## Domain words

- **Receipt** — one Agent Run rendered as operational evidence: what ran, what it touched, how it ended.
- **Owner-native receipt** — the record kept by whatever system actually holds the authority, e.g. the Inbox item for an approval. The source of truth for whether a human said yes.
- **Facet** — one section of a receipt: approvals, sources, artifacts, usage, model attempts, outcome.
- **Checkpoint sequence** — the dense 1..N numbering the run store writes, which makes it possible to tell whether a record covers a run's whole life.

## Problem

The durable Agent Run landed in #63, but there was no way to look at one. An operator could not ask what a run did, which sources it touched, what it asked permission for, or how it ended.

## What this adds

Four modules, read-only:

| Module | Holds |
|---|---|
| `run_evidence.py` | Evidence vocabulary and record analysis |
| `run_receipt.py` | The receipt projection. Pure — no store, no clock, no network |
| `run_ledger.py` | Reader over the run store, query, retention |
| `run_ledger_api.py` | HTTP surface. **No write verb** |

Not to be confused with the existing `coworker/ledger.py`, which maps tool results into person-file events. That is the person timeline; this is the run receipt. It is untouched.

## Keeping it from becoming a second transcript

The rule is mechanical rather than aspirational:

> A receipt renders only fields `run_receipt.py` names, and every named field is an identifier, an enum, a count, a timestamp, or a bounded reason the runtime itself wrote.

Message bodies, tool arguments, command output, prompts, raw provider errors, credentials, and model reasoning **have no field to land in**. `_pick` copies named scalars and never a nested structure, so a payload cannot ride out whole.

This is a second allowlist, independent of the write-time one in `agent_runs.CHECKPOINT_PAYLOAD_FIELDS`. Both must hold on their own. A read side that leaned on the write side would keep passing its tests after the write side changed — which is exactly the kind of coupling that turns into a leak six months later.

Free text appears in exactly three bounded places, all already through `redact_secrets` at write time: `reason`, `error_summary`, and reference titles. The ledger adds no free-text field of its own.

## Criterion 6: silence is not absence

Every facet carries one value from a closed vocabulary:

| Value | Means |
|---|---|
| `present` | The record says so directly |
| `absent` | It positively did not happen |
| `partial` | Some settled, some did not |
| `missing` | We do not know — the record has a hole, or the run is open |
| `ambiguous` | The run knows it does not know: an external effect never reported back |
| `unsupported` | This build cannot express or verify the fact. Never "it did not happen" |
| `expired` | The evidence existed and retention aged it out on purpose |

"No approval was requested" is `absent`. "We do not know whether an approval was requested" is `missing`. Different operator situations; they must never render the same.

What separates them is a computed property, not a guess. A facet with no evidence is `absent` only when the run is terminal, **and** the stored checkpoints are contiguous ending at `checkpoint_sequence`, **and** no checkpoint kind is unknown to this build, **and** no checkpoint is `process_interrupted` or `tool_outcome_unknown`. Otherwise it is `unsupported`, `missing`, or `expired`, in that precedence.

An unreadable record withholds a conclusion even where entries exist. The entries stay visible, but the section reads `unsupported` — because a checkpoint this build cannot interpret might have been another tool call, another approval, or another model attempt.

## Criterion 7: a ledger row is not authority

The run store records which approval ids a run touched. **It never records whether the owner said yes.**

Every decision is resolved against the owner-native record. An approval id the Inbox does not know renders `missing`, never an allowance. Pending renders `partial`. Expired renders `expired` and carries no decision. Only a resolved owner-native item with `allow` or `deny` produces a decision field at all, and an authorized action whose execution was interrupted renders `ambiguous`.

Three structures hold this up:

1. `RunLedger`'s only write is `prune_checkpoints`, which deletes checkpoint rows and touches `agent_runs` never. It holds no lease and cannot acquire one.
2. `run_ledger_api` has no write verb — no route creates a run, changes a state, or records a decision.
3. `_approval_entry` sources `decision`, `state`, and `actor` only from the owner-native record.

## Measurements

```
1048 passed, 3 skipped, 1 warning in 43.87s
```

Re-run independently by the reviewing session on the pushed commit.

## Edits to code merged in #63

Additive only, and small: `agent_runs.py` +6 lines, `server.py` +8 lines. The compare-and-swap write path and the lease semantics from #105 are untouched — those are load-bearing correctness that already shipped.

## Not in this PR

- No new GUI surface. Criterion 4's entry points are proven at the API layer; adding UI would have meant touching files parallel lanes hold.
- Retention prunes checkpoint detail only. Row-backed facets — sources, artifacts, usage, approvals, outcome — survive pruning, because the row is written in the same transaction as every checkpoint. Pruning turns a checkpoint-backed facet `expired` and leaves a row-backed one alone.

## Still open

- Retention is bounded by checkpoint pruning, not by run-row deletion. Runs accumulate. That is deliberate for now — the rows are small and referenced person/source/artifact identities must survive — but it is a growth curve worth watching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjAD6SVox1gvF4sV3jTnJy
