### PR TITLE
feat(desktop): bind and prove the approved Gmail send path

### DIFF
--- a/desktop/coworker/apollo.py
+++ b/desktop/coworker/apollo.py
@@ -13,6 +13,10 @@ MATCH_URL = "https://api.apollo.io/api/v1/people/match"
 
 MISSING_KEY = "APOLLO_API_KEY is not configured."
 
+# One people/match call spends one Apollo credit. The approval card states the
+# cost before the director allows it; nothing here decides to spend on its own.
+ENRICH_CREDIT_COST = 1
+
 
 class HttpError(RuntimeError):
     def __init__(self, status: int, url: str = "", body: object | None = None) -> None:
@@ -252,10 +256,63 @@ def enrich_contact(
     phones = person.get("phone_numbers") or []
     phone = phones[0].get("raw_number") if phones else None
     return {
+        "apolloId": person.get("id") or None,
         "name": person.get("name") or None,
         "title": person.get("title") or None,
         "organizationName": (person.get("organization") or {}).get("name") or None,
         "linkedinUrl": person.get("linkedin_url") or None,
         "email": person.get("email") or None,
         "phone": phone or None,
+    }
+
+
+def enrichment_match(person: dict[str, Any]) -> dict[str, Any] | None:
+    """The lookup Apollo will be asked for, taken from the person file.
+
+    Returns None when the person file cannot identify anybody. Apollo's match
+    endpoint needs an email, or a first and last name; guessing either one is
+    how the wrong contact gets enriched and the credit gets wasted.
+    """
+    email = str(person.get("email") or "").strip()
+    first = str(person.get("first_name") or "").strip()
+    last = str(person.get("last_name") or "").strip()
+    company = str(person.get("company") or "").strip()
+    if email:
+        return {"email": email, "organization_name": company or None}
+    if first and last:
+        return {
+            "first_name": first,
+            "last_name": last,
+            "organization_name": company or None,
+        }
+    return None
+
+
+def enrichment_resource(
+    person: dict[str, Any], match: dict[str, Any]
+) -> dict[str, Any]:
+    """The approval card for one enrichment: which person, and what it costs.
+
+    Names the exact person file being changed, not a search row, so Allow can
+    never land the facts on somebody else.
+    """
+    display = " ".join(
+        part
+        for part in (person.get("first_name"), person.get("last_name"))
+        if part
+    ).strip()
+    matched_on = "email" if match.get("email") else "name"
+    return {
+        "kind": "apollo_enrichment",
+        "person_id": str(person.get("person_id") or ""),
+        "person": display or "Unnamed person",
+        "title": person.get("title") or None,
+        "company": person.get("company") or None,
+        "matched_on": matched_on,
+        "credits": ENRICH_CREDIT_COST,
+        "reason": (
+            f"Spends {ENRICH_CREDIT_COST} Apollo credit to look up "
+            f"{display or 'this person'} by {matched_on} and write the result "
+            "to this person file only."
+        ),
     }

--- a/desktop/coworker/gmail.py
+++ b/desktop/coworker/gmail.py
@@ -1,12 +1,21 @@
 """Gmail draft client — injectable so tests never hit the network.
 
-Slice 12: Gmail API users.drafts.create after OAuth. There is no send method on
-the live client. FakeGmail stays for pytest. Secrets stay out of prompts.
+Slice 12: Gmail API users.drafts.create after OAuth. FakeGmail stays for
+pytest. Secrets stay out of prompts.
+
+Send is the one external effect in this module that costs a real message to a
+real person. It is guarded by a SendAuthority: the identity the director
+actually reviewed and approved. The authority is re-checked against the live
+draft immediately before the send call, so a draft edited after review sends
+nothing. The authority carries a digest of the reviewed body, never the body
+itself and never a token.
 """
 
 from __future__ import annotations
 
 import base64
+import hashlib
+from dataclasses import dataclass
 from email.message import EmailMessage
 from typing import Any, Protocol
 
@@ -72,23 +81,40 @@ class GmailClient(Protocol):
 
 
 class FakeGmail:
+    """Test double that mirrors the parts of Gmail this flow depends on.
+
+    ``send_attempts`` records every call into ``send``, including the ones that
+    raise. ``sends`` records only the messages that actually left. Tests count
+    both: at-most-once is proved by the real call count, not by a status
+    string.
+    """
+
     def __init__(self) -> None:
         self.drafts: list[dict[str, Any]] = []
         self.sends: list[dict[str, Any]] = []
+        self.send_attempts: list[str] = []
         self.account_email: str | None = None
 
     def account(self) -> str | None:
         return self.account_email
 
-    def get_draft(self, *, draft_id: str) -> dict[str, Any]:
+    def _find(self, draft_id: str) -> dict[str, Any] | None:
         for item in self.drafts:
             if item["id"] == draft_id:
-                return {
-                    "id": item["id"],
-                    "to": item["to"],
-                    "subject": item["subject"],
-                }
-        raise GmailError(f"Draft {draft_id} was not found.")
+                return item
+        return None
+
+    def get_draft(self, *, draft_id: str) -> dict[str, Any]:
+        item = self._find(draft_id)
+        if item is None or item["sent"]:
+            raise GmailError(f"Draft {draft_id} was not found.")
+        return {
+            "id": item["id"],
+            "to": item["to"],
+            "subject": item["subject"],
+            "body": item["body"],
+            "sent": False,
+        }
 
     def create_draft(self, *, to: str, subject: str, body: str) -> dict[str, Any]:
         item = {
@@ -108,8 +134,25 @@ class FakeGmail:
         }
 
     def send(self, *, draft_id: str) -> dict[str, Any]:
+        self.send_attempts.append(draft_id)
+        item = self._find(draft_id)
+        if item is None or item["sent"]:
+            # Gmail removes a draft when drafts.send succeeds, so a second send
+            # of the same draft id is a 404 there too. Model that: a duplicate
+            # send is loud, never a silent second message.
+            raise GmailError(f"Draft {draft_id} was not found.")
+        item["sent"] = True
+        message_id = f"msg_{len(self.sends) + 1}"
+        thread_id = f"thread_{len(self.sends) + 1}"
+        item["message_id"] = message_id
+        item["thread_id"] = thread_id
         self.sends.append({"draft_id": draft_id})
-        return {"id": f"msg_{len(self.sends)}", "draft_id": draft_id, "sent": True}
+        return {
+            "id": message_id,
+            "threadId": thread_id,
+            "draft_id": draft_id,
+            "sent": True,
+        }
 
     def search(self, query: str, max_results: int = 10) -> dict[str, Any]:
         return {"messages": []}
@@ -269,30 +312,41 @@ class GmailApi:
         message_id = str(data.get("id") or "")
         if not message_id:
             raise GmailError("Gmail did not return a sent message id.")
-        item = {"id": message_id, "draft_id": draft_id, "sent": True}
+        item = {
+            "id": message_id,
+            "threadId": str(data.get("threadId") or "") or None,
+            "draft_id": draft_id,
+            "sent": True,
+        }
         self.sends.append(item)
         return item
 
     def get_draft(self, *, draft_id: str) -> dict[str, Any]:
-        for item in self.drafts:
-            if str(item.get("id")) == draft_id:
-                return dict(item)
+        """Always read the live draft.
+
+        A cached copy of what Sourcecado created would hide an edit made in
+        Gmail after the draft was written, and hiding that edit is exactly the
+        stale-draft hazard the send gate exists to catch.
+        """
         try:
             data = self._request(
                 "get",
                 f"{DRAFTS_URL}/{draft_id}",
-                params={"format": "metadata"},
+                params={"format": "full"},
             ) or {}
         except GmailError:
             raise
         except Exception as exc:
             raise _from_http_error(exc) from exc
-        payload = ((data.get("message") or {}).get("payload")) or {}
+        message = (data.get("message") or {})
+        payload = message.get("payload") or {}
         headers = _header_map(payload)
         return {
             "id": draft_id,
             "to": headers.get("to", ""),
             "subject": headers.get("subject", ""),
+            "body": _flatten_body(payload),
+            "sent": False,
         }
 
     def account(self) -> str | None:
@@ -377,6 +431,205 @@ def _flatten_body(payload: dict[str, Any]) -> str:
 def _b64(data: str) -> str:
     pad = "=" * (-len(data) % 4)
     return base64.urlsafe_b64decode(data + pad).decode("utf-8", errors="replace")
+
+
+class SendAuthorityError(GmailError):
+    """The reviewed binding no longer matches the live draft. Nothing was sent."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def normalize_body(body: str) -> str:
+    """Compare bodies as the operator read them, not as MIME carried them.
+
+    Gmail round-trips a plain-text body through quoted-printable and CRLF line
+    endings, so the bytes that come back are not the bytes that went out. Line
+    endings and trailing whitespace are transport, not content: normalizing
+    them keeps the digest stable across the round trip while still changing the
+    moment a human edits a word.
+    """
+    text = body.replace("\r\n", "\n").replace("\r", "\n")
+    return "\n".join(line.rstrip() for line in text.split("\n")).strip()
+
+
+def body_digest(body: str) -> str:
+    """The reviewed body version, as an identifier that is safe to persist."""
+    return hashlib.sha256(normalize_body(body).encode("utf-8")).hexdigest()
+
+
+def _same_address(left: str | None, right: str | None) -> bool:
+    return (left or "").strip().casefold() == (right or "").strip().casefold()
+
+
+@dataclass(frozen=True)
+class SendAuthority:
+    """Exactly what the director approved: one draft, one recipient, one body.
+
+    Identity only. No access token, no refresh token, no message body ever
+    lands in an approval record.
+    """
+
+    approval_id: str
+    person_id: str
+    draft_id: str
+    account: str | None
+    to: str
+    subject: str
+    body_digest: str
+
+    def as_resource(self) -> dict[str, Any]:
+        """The approval-card payload. Safe to persist and to show."""
+        return {
+            "kind": "gmail_send_authority",
+            "person_id": self.person_id,
+            "draft_id": self.draft_id,
+            "account": self.account,
+            "to": self.to,
+            "subject": self.subject,
+            "body_digest": self.body_digest,
+            "sent": False,
+        }
+
+    @classmethod
+    def from_resource(
+        cls, resource: Any, *, approval_id: str
+    ) -> "SendAuthority | None":
+        if not isinstance(resource, dict):
+            return None
+        if resource.get("kind") != "gmail_send_authority":
+            return None
+        required = ("person_id", "draft_id", "to", "subject", "body_digest")
+        if not all(str(resource.get(field) or "") for field in required):
+            return None
+        account = resource.get("account")
+        return cls(
+            approval_id=approval_id,
+            person_id=str(resource["person_id"]),
+            draft_id=str(resource["draft_id"]),
+            account=str(account) if account else None,
+            to=str(resource["to"]),
+            subject=str(resource["subject"]),
+            body_digest=str(resource["body_digest"]),
+        )
+
+
+def draft_snapshot(client: Any, *, draft_id: str) -> dict[str, Any]:
+    """Read the live draft plus the account that would send it.
+
+    Gmail deletes a draft when drafts.send succeeds, so a draft that reads back
+    is a draft that has not been sent. That is why an already-sent draft
+    surfaces here as ``draft_unavailable`` rather than as a separate check.
+    """
+    try:
+        draft = client.get_draft(draft_id=draft_id)
+    except GmailError as exc:
+        raise SendAuthorityError("draft_unavailable", str(exc)) from exc
+    except Exception as exc:
+        raise SendAuthorityError("draft_unavailable", str(exc)) from exc
+    body = str(draft.get("body") or "")
+    account = None
+    reader = getattr(client, "account", None)
+    if callable(reader):
+        try:
+            account = reader() or None
+        except Exception:
+            account = None
+    return {
+        "draft_id": str(draft.get("id") or draft_id),
+        "to": str(draft.get("to") or ""),
+        "subject": str(draft.get("subject") or ""),
+        "body": body,
+        "body_digest": body_digest(body),
+        "account": account,
+    }
+
+
+def authority_for_draft(
+    client: Any,
+    *,
+    approval_id: str,
+    person_id: str,
+    draft_id: str,
+    reviewed_body_digest: str,
+) -> SendAuthority:
+    """Bind an approval to the draft as it stands right now.
+
+    ``reviewed_body_digest`` is the operator's attestation of the version they
+    read. A draft edited between the review and this call is refused here, so
+    an approval is never created for a body nobody reviewed.
+    """
+    snapshot = draft_snapshot(client, draft_id=draft_id)
+    if snapshot["body_digest"] != reviewed_body_digest:
+        raise SendAuthorityError(
+            "stale_draft",
+            "This draft changed after it was reviewed. Read it again before sending.",
+        )
+    return SendAuthority(
+        approval_id=approval_id,
+        person_id=person_id,
+        draft_id=draft_id,
+        account=snapshot["account"],
+        to=snapshot["to"],
+        subject=snapshot["subject"],
+        body_digest=snapshot["body_digest"],
+    )
+
+
+def verify_send_authority(client: Any, authority: SendAuthority) -> dict[str, Any]:
+    """Re-check every bound field against the live draft. Raises, or returns it."""
+    snapshot = draft_snapshot(client, draft_id=authority.draft_id)
+    if authority.account is not None and not _same_address(
+        snapshot["account"], authority.account
+    ):
+        raise SendAuthorityError(
+            "account_mismatch",
+            "The connected Gmail account changed after this send was approved.",
+        )
+    if not _same_address(snapshot["to"], authority.to):
+        raise SendAuthorityError(
+            "recipient_mismatch",
+            "The draft recipient changed after this send was approved.",
+        )
+    if snapshot["subject"].strip() != authority.subject.strip():
+        raise SendAuthorityError(
+            "subject_mismatch",
+            "The draft subject changed after this send was approved.",
+        )
+    if snapshot["body_digest"] != authority.body_digest:
+        raise SendAuthorityError(
+            "stale_draft",
+            "The draft body changed after this send was approved. Nothing was sent.",
+        )
+    return snapshot
+
+
+def send_reviewed_draft(client: Any, authority: SendAuthority) -> dict[str, Any]:
+    """The only sanctioned path to a real send.
+
+    Verifies the binding, then makes exactly one send call. This function does
+    not decide whether a send is allowed to happen at all — that is the
+    approval claim in ConversationStore.decide_and_claim_inbox_execution, which
+    hands the work to exactly one caller.
+    """
+    verify_send_authority(client, authority)
+    result = client.send(draft_id=authority.draft_id) or {}
+    message_id = str(result.get("id") or "")
+    if not message_id:
+        raise GmailError("Gmail did not return a sent message id.")
+    return {
+        "sent": True,
+        "message_id": message_id,
+        "thread_id": str(result.get("threadId") or "") or None,
+        "draft_id": authority.draft_id,
+        "account": authority.account,
+        "to": authority.to,
+        "subject": authority.subject,
+        "body_digest": authority.body_digest,
+        "person_id": authority.person_id,
+        "approval_id": authority.approval_id,
+    }
 
 
 def gmail_from_secrets(secrets: SecretStore, *, http: Any | None = None) -> FakeGmail | GmailApi | MissingGmail:

--- a/desktop/coworker/people.py
+++ b/desktop/coworker/people.py
@@ -469,6 +469,178 @@ class PersonStore:
             self._conn.commit()
         return self.get(person_id)
 
+    def record_apollo_enrichment(
+        self,
+        person_id: str,
+        *,
+        result: dict[str, Any],
+        approval_id: str,
+        credits: int,
+        matched_on: str,
+        actor: str = "director",
+        session_id: str | None = None,
+        run_id: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Apply one approved enrichment and file the Apollo source receipt.
+
+        Only ``person_id`` is written. The receipt records which Apollo record
+        the facts came from and what the spend bought, so a later reader can
+        tell an enriched field from a typed one.
+        """
+        person = self.apply_enrichment(
+            person_id,
+            name=result.get("name"),
+            title=result.get("title"),
+            company=result.get("organizationName"),
+            email=result.get("email"),
+            linkedin_url=result.get("linkedinUrl"),
+            phone=result.get("phone"),
+        )
+        if person is None:
+            return None
+        applied = sorted(
+            field
+            for field, value in (
+                ("name", result.get("name")),
+                ("title", result.get("title")),
+                ("company", result.get("organizationName")),
+                ("email", result.get("email")),
+                ("linkedin_url", result.get("linkedinUrl")),
+                ("phone", result.get("phone")),
+            )
+            if value
+        )
+        source = self.upsert_attachment(
+            person_id,
+            record_type="source_ref",
+            fields={
+                "source": "apollo",
+                "apollo_id": str(result.get("apolloId") or "") or None,
+                "matched_on": matched_on,
+                "approval_id": approval_id,
+                "credits": int(credits),
+                "fields_applied": applied,
+                "fetched_at": self._now(),
+            },
+            idempotency_key=f"apollo:enrich:{approval_id}",
+            actor=actor,
+            rationale_summary="Approved Apollo enrichment",
+            session_id=session_id,
+            run_id=run_id,
+        )
+        with self._lock:
+            self._receipt(
+                person_id,
+                kind="enrich",
+                summary=f"Enriched from Apollo ({credits} credit)",
+                payload={
+                    "approval_id": approval_id,
+                    "apollo_id": str(result.get("apolloId") or "") or None,
+                    "credits": int(credits),
+                    "matched_on": matched_on,
+                    "fields_applied": applied,
+                    "source_ref_id": source["id"],
+                },
+                actor=actor,
+                session_id=session_id,
+                run_id=run_id,
+                tool="apollo_enrich_contact",
+            )
+            self._conn.commit()
+        return {
+            "person": self.get(person_id),
+            "source_ref": source,
+            "fields_applied": applied,
+        }
+
+    def record_approved_send(
+        self,
+        person_id: str,
+        *,
+        message_id: str,
+        thread_id: str | None,
+        draft_id: str,
+        to: str,
+        subject: str,
+        body_digest: str,
+        account: str | None,
+        approval_id: str,
+        actor: str = "director",
+        session_id: str | None = None,
+        run_id: str | None = None,
+    ) -> dict[str, Any]:
+        """File the durable receipt for one approved send, then open the person.
+
+        Keyed on the Gmail message id, so re-filing the same message can never
+        produce a second receipt. Advancing to Open only happens when the person
+        is not already on the board; an in-conversation or done person is left
+        where the director put them.
+        """
+        if not message_id.strip():
+            raise ValueError("message_id is required")
+        external_key = f"gmail:message:{message_id}"
+        payload = {
+            "sent": True,
+            "message_id": message_id,
+            "thread_id": thread_id,
+            "draft_id": draft_id,
+            "to": to,
+            "subject": subject,
+            "body_digest": body_digest,
+            "account": account,
+            "approval_id": approval_id,
+        }
+        with self._lock:
+            row = self._load_person_row(person_id)
+            already = self._conn.execute(
+                "SELECT event_id FROM events WHERE person_id = ? AND external_key = ?",
+                (person_id, external_key),
+            ).fetchone()
+            if already is None:
+                self._conn.execute(
+                    """
+                    INSERT INTO events (
+                        event_id, person_id, external_key, source, kind, summary,
+                        payload, actor, session_id, run_id, tool
+                    ) VALUES (?, ?, ?, 'gmail', 'send', ?, ?, ?, ?, ?, 'gmail_send')
+                    """,
+                    (
+                        _new_event_id(),
+                        person_id,
+                        external_key,
+                        f"Sent approved outreach to {to}".strip(),
+                        json.dumps(payload),
+                        actor,
+                        session_id,
+                        run_id,
+                    ),
+                )
+                self._conn.execute(
+                    "UPDATE people SET updated_at = ? WHERE person_id = ?",
+                    (self._now(), person_id),
+                )
+                self._conn.commit()
+            event = self._event_dict(
+                self._conn.execute(
+                    "SELECT * FROM events WHERE person_id = ? AND external_key = ?",
+                    (person_id, external_key),
+                ).fetchone()
+            )
+            needs_open = not str(row["sequence_state"] or "").strip()
+        person = (
+            self.set_sequence(
+                person_id,
+                "open",
+                actor=actor if actor in ACTORS else "director",
+                session_id=session_id,
+                run_id=run_id,
+                rationale_summary="Approved outreach sent",
+            )
+            if needs_open
+            else self.get(person_id)
+        )
+        return {"event": event, "person": person, "advanced_to_open": needs_open}
+
     def get(
         self,
         person_id: str,

--- a/desktop/coworker/server.py
+++ b/desktop/coworker/server.py
@@ -29,6 +29,13 @@ from coworker.automation.scheduler import (
     now_iso,
 )
 from coworker.agent_run_repository import AgentRunRepository
+from coworker.apollo import (
+    ENRICH_CREDIT_COST,
+    MISSING_KEY as APOLLO_MISSING_KEY,
+    enrich_contact,
+    enrichment_match,
+    enrichment_resource,
+)
 from coworker.apollo_curation import curate_apollo_candidates
 from coworker.calendar import calendar_from_secrets
 from coworker.connectors.google_oauth import (
@@ -58,7 +65,16 @@ from coworker.effective_tools import (
     effective_tool_catalog,
 )
 from coworker.events import build_event, new_turn_identity, TurnIdentity
-from coworker.gmail import MissingGmail, gmail_from_secrets
+from coworker.gmail import (
+    GmailError,
+    MissingGmail,
+    SendAuthority,
+    SendAuthorityError,
+    authority_for_draft,
+    draft_snapshot,
+    gmail_from_secrets,
+    send_reviewed_draft,
+)
 from coworker.inbox import Inbox
 from coworker.mcp import LiveMcp, write_default_mcp_json
 from coworker.mcp_oauth import McpOAuth
@@ -541,6 +557,111 @@ def create_app(
                 except Exception:
                     app.state.live_event_senders.discard(registration)
 
+    def _bound_resource(item: dict[str, Any]) -> dict[str, Any] | None:
+        """The person-bound authority this approval was parked with, if any."""
+        resource = item.get("resource")
+        if not isinstance(resource, dict):
+            return None
+        if resource.get("kind") in {"gmail_send_authority", "apollo_enrichment"}:
+            return resource
+        return None
+
+    def _execute_bound_send(item: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
+        """One approved send, against the binding the director actually read.
+
+        Reached only by the single caller that won the execution claim in
+        ConversationStore.decide_and_claim_inbox_execution. Everything below is
+        about sending the *right* message; whether a send happens at all is
+        already settled by that claim.
+        """
+        authority = SendAuthority.from_resource(
+            item.get("resource"), approval_id=str(item.get("id") or "")
+        )
+        if authority is None:
+            return False, {"error": "This send approval is missing its binding."}
+        try:
+            sent = send_reviewed_draft(app.state.gmail, authority)
+        except SendAuthorityError as exc:
+            return False, {"error": str(exc), "code": exc.code, "sent": False}
+        except GmailError as exc:
+            return False, {"error": str(exc), "code": "gmail_failed", "sent": False}
+        except Exception as exc:
+            return False, {"error": str(exc), "code": "gmail_failed", "sent": False}
+        try:
+            filed = app.state.people.record_approved_send(
+                authority.person_id,
+                message_id=sent["message_id"],
+                thread_id=sent["thread_id"],
+                draft_id=authority.draft_id,
+                to=authority.to,
+                subject=authority.subject,
+                body_digest=authority.body_digest,
+                account=authority.account,
+                approval_id=authority.approval_id,
+                actor="director",
+                session_id=str(item.get("session_id") or "") or None,
+                run_id=str(item.get("run_id") or "") or None,
+            )
+        except Exception as exc:
+            # The message is already gone. Report the send truthfully and say
+            # the receipt failed, rather than implying nothing was sent.
+            return True, {
+                **sent,
+                "receipt_error": str(exc),
+                "person_event_id": None,
+            }
+        return True, {
+            **sent,
+            "person_event_id": filed["event"]["event_id"],
+            "sequence_state": (filed["person"] or {}).get("sequence_state"),
+            "advanced_to_open": filed["advanced_to_open"],
+        }
+
+    def _execute_bound_enrichment(
+        item: dict[str, Any]
+    ) -> tuple[bool, dict[str, Any]]:
+        """One approved Apollo enrichment, onto exactly the approved person."""
+        resource = item.get("resource")
+        if not isinstance(resource, dict):
+            return False, {"error": "This enrichment approval is missing its binding."}
+        person_id = str(resource.get("person_id") or "")
+        person = app.state.people.get(person_id) if person_id else None
+        if person is None:
+            return False, {"error": "unknown person"}
+        if not app.state.apollo_key:
+            return False, {"error": APOLLO_MISSING_KEY}
+        match = enrichment_match(person)
+        if match is None:
+            return False, {"error": "This person file has no email and no full name."}
+        from coworker.apollo import LiveHttp
+
+        http = app.state.http if app.state.http is not None else LiveHttp()
+        try:
+            result = enrich_contact(
+                http=http, api_key=app.state.apollo_key, **match
+            )
+        except Exception as exc:
+            return False, {"error": str(exc)}
+        filed = app.state.people.record_apollo_enrichment(
+            person_id,
+            result=result,
+            approval_id=str(item.get("id") or ""),
+            credits=ENRICH_CREDIT_COST,
+            matched_on=str(resource.get("matched_on") or "name"),
+            actor="director",
+            session_id=str(item.get("session_id") or "") or None,
+            run_id=str(item.get("run_id") or "") or None,
+        )
+        if filed is None:
+            return False, {"error": "unknown person"}
+        return True, {
+            "person_id": person_id,
+            "credits": ENRICH_CREDIT_COST,
+            "fields_applied": filed["fields_applied"],
+            "source_ref_id": filed["source_ref"]["id"],
+            "apollo_id": result.get("apolloId"),
+        }
+
     async def _execute_claimed_approval(
         item: dict[str, Any], *, claimant: str
     ) -> dict[str, Any] | None:
@@ -568,34 +689,43 @@ def create_app(
             approval_tool_span = approval_span.child(tool_schema)
         except ValueError:
             pass
+        bound = _bound_resource(item)
         try:
-            ok, result = await asyncio.to_thread(
-                execute,
-                item["name"],
-                _claimed_arguments(item),
-                store=app.state.store,
-                gmail=app.state.gmail,
-                drive=app.state.drive,
-                calendar=app.state.calendar,
-                http=app.state.http,
-                apollo_key=app.state.apollo_key,
-                tavily_key=app.state.tavily_key,
-                skills=app.state.skills,
-                mcp=app.state.mcp,
-                people=app.state.people,
-                workspace_runtime=app.state.workspace_runtime,
-                approval_granted=True,
-                approval_scope=str(item.get("scope") or "once"),
-                approval_fingerprint=(
-                    str((item.get("resource") or {}).get("fingerprint"))
-                    if isinstance(item.get("resource"), dict)
-                    and (item.get("resource") or {}).get("fingerprint")
-                    else None
-                ),
-                session_id=str(item.get("session_id") or ""),
-                actor=str(item.get("actor") or "assistant"),
-                run_id=str(item.get("run_id") or "") or None,
-            )
+            if bound is not None:
+                runner = (
+                    _execute_bound_send
+                    if bound["kind"] == "gmail_send_authority"
+                    else _execute_bound_enrichment
+                )
+                ok, result = await asyncio.to_thread(runner, item)
+            else:
+                ok, result = await asyncio.to_thread(
+                    execute,
+                    item["name"],
+                    _claimed_arguments(item),
+                    store=app.state.store,
+                    gmail=app.state.gmail,
+                    drive=app.state.drive,
+                    calendar=app.state.calendar,
+                    http=app.state.http,
+                    apollo_key=app.state.apollo_key,
+                    tavily_key=app.state.tavily_key,
+                    skills=app.state.skills,
+                    mcp=app.state.mcp,
+                    people=app.state.people,
+                    workspace_runtime=app.state.workspace_runtime,
+                    approval_granted=True,
+                    approval_scope=str(item.get("scope") or "once"),
+                    approval_fingerprint=(
+                        str((item.get("resource") or {}).get("fingerprint"))
+                        if isinstance(item.get("resource"), dict)
+                        and (item.get("resource") or {}).get("fingerprint")
+                        else None
+                    ),
+                    session_id=str(item.get("session_id") or ""),
+                    actor=str(item.get("actor") or "assistant"),
+                    run_id=str(item.get("run_id") or "") or None,
+                )
         except asyncio.CancelledError:
             if approval_tool_span is not None:
                 approval_tool_span.cancel()
@@ -1888,6 +2018,196 @@ def create_app(
             },
             status_code=201,
         )
+
+    def _bound_sourcing_session(
+        person_id: str, payload: dict[str, Any]
+    ) -> tuple[str | None, JSONResponse | None]:
+        """A costly step starts from this person's own sourcing chat, or not at all."""
+        session_id = str(payload.get("session_id") or "").strip()
+        if not session_id:
+            return None, JSONResponse(
+                {"error": "session_id is required", "code": "unbound_session"},
+                status_code=400,
+            )
+        owner = app.state.people.person_for_session(session_id)
+        if owner != person_id:
+            return None, JSONResponse(
+                {
+                    "error": (
+                        "This chat is bound to a different person."
+                        if owner is not None
+                        else "This chat is not bound to this person."
+                    ),
+                    "code": "unbound_session",
+                },
+                status_code=409,
+            )
+        return session_id, None
+
+    @app.post("/v1/people/{person_id}/outreach/draft", status_code=201)
+    async def people_outreach_draft(person_id: str, request: Request):
+        """Draft outreach for a bound person. The recipient is never guessed.
+
+        The address comes from the person file, not from the request and not
+        from the model. Creating a draft sends nothing.
+        """
+        person = app.state.people.get(person_id)
+        if person is None:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        payload = await request.json()
+        session_id, refusal = _bound_sourcing_session(person_id, payload)
+        if refusal is not None:
+            return refusal
+        to = str(person.get("email") or "").strip()
+        if not to:
+            return JSONResponse(
+                {
+                    "error": "This person file has no email address yet.",
+                    "code": "no_recipient",
+                },
+                status_code=409,
+            )
+        subject = str(payload.get("subject") or "").strip()
+        body = str(payload.get("body") or "").strip()
+        if not subject or not body:
+            return JSONResponse(
+                {"error": "subject and body are required"}, status_code=400
+            )
+        try:
+            created = app.state.gmail.create_draft(to=to, subject=subject, body=body)
+        except GmailError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=502)
+        draft_id = str(created.get("id") or "")
+        try:
+            snapshot = draft_snapshot(app.state.gmail, draft_id=draft_id)
+        except SendAuthorityError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=502)
+        return {
+            "draft": {
+                "id": draft_id,
+                "to": snapshot["to"],
+                "subject": snapshot["subject"],
+                "body": snapshot["body"],
+                "body_digest": snapshot["body_digest"],
+                "account": snapshot["account"],
+                "sent": False,
+            },
+            "person_id": person_id,
+            "session_id": session_id,
+        }
+
+    @app.get("/v1/people/{person_id}/outreach/draft/{draft_id}")
+    def people_outreach_draft_read(person_id: str, draft_id: str):
+        """Re-read the live draft so the director reviews what Gmail holds now."""
+        if app.state.people.get(person_id) is None:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        try:
+            snapshot = draft_snapshot(app.state.gmail, draft_id=draft_id)
+        except SendAuthorityError as exc:
+            return JSONResponse(
+                {"error": str(exc), "code": exc.code}, status_code=404
+            )
+        return {
+            "draft": {
+                "id": snapshot["draft_id"],
+                "to": snapshot["to"],
+                "subject": snapshot["subject"],
+                "body": snapshot["body"],
+                "body_digest": snapshot["body_digest"],
+                "account": snapshot["account"],
+                # Reaching this line means Gmail still holds the draft, and
+                # Gmail only holds drafts that have not been sent.
+                "sent": False,
+            }
+        }
+
+    @app.post("/v1/people/{person_id}/outreach/send-approval", status_code=201)
+    async def people_outreach_send_approval(person_id: str, request: Request):
+        """Park one send approval bound to one reviewed draft version.
+
+        Nothing is sent here. This records what the director is being asked to
+        authorize: the account, the draft, the recipient, the subject, and the
+        digest of the body version they read. POST /v1/inbox/{id} decides it.
+        """
+        person = app.state.people.get(person_id)
+        if person is None:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        payload = await request.json()
+        session_id, refusal = _bound_sourcing_session(person_id, payload)
+        if refusal is not None:
+            return refusal
+        draft_id = str(payload.get("draft_id") or "").strip()
+        reviewed = str(payload.get("reviewed_body_digest") or "").strip()
+        if not draft_id or not reviewed:
+            return JSONResponse(
+                {"error": "draft_id and reviewed_body_digest are required"},
+                status_code=400,
+            )
+        approval_id = f"send_{secrets.token_hex(8)}"
+        try:
+            authority = authority_for_draft(
+                app.state.gmail,
+                approval_id=approval_id,
+                person_id=person_id,
+                draft_id=draft_id,
+                reviewed_body_digest=reviewed,
+            )
+        except SendAuthorityError as exc:
+            return JSONResponse(
+                {"error": str(exc), "code": exc.code}, status_code=409
+            )
+        expected = str(person.get("email") or "").strip().casefold()
+        if authority.to.strip().casefold() != expected:
+            return JSONResponse(
+                {
+                    "error": "This draft is addressed to someone other than this person.",
+                    "code": "recipient_not_bound",
+                },
+                status_code=409,
+            )
+        parked = app.state.inbox.park(
+            "gmail_send",
+            {"draft_id": draft_id},
+            item_id=approval_id,
+            reason="Sending this email reaches a real person. Allow or Deny.",
+            session_id=session_id,
+            run_id=str(payload.get("run_id") or "").strip() or None,
+            resource=authority.as_resource(),
+        )
+        return {"item": parked}
+
+    @app.post("/v1/people/{person_id}/enrich-approval", status_code=201)
+    async def people_enrich_approval(person_id: str, request: Request):
+        """Park one Apollo enrichment approval naming the person and the spend."""
+        person = app.state.people.get(person_id)
+        if person is None:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        payload = await request.json()
+        session_id, refusal = _bound_sourcing_session(person_id, payload)
+        if refusal is not None:
+            return refusal
+        if not app.state.apollo_key:
+            return JSONResponse({"error": APOLLO_MISSING_KEY}, status_code=409)
+        match = enrichment_match(person)
+        if match is None:
+            return JSONResponse(
+                {
+                    "error": "This person file has no email and no full name to match on.",
+                    "code": "no_match_key",
+                },
+                status_code=409,
+            )
+        resource = enrichment_resource(person, match)
+        parked = app.state.inbox.park(
+            "apollo_enrich_contact",
+            {"person_id": person_id},
+            item_id=f"enrich_{secrets.token_hex(8)}",
+            reason=str(resource["reason"]),
+            session_id=session_id,
+            run_id=str(payload.get("run_id") or "").strip() or None,
+            resource=resource,
+        )
+        return {"item": parked}
 
     @app.post("/v1/people/{person_id}/revert")
     async def people_revert(person_id: str, request: Request):

--- a/desktop/docs/approved-send.md
+++ b/desktop/docs/approved-send.md
@@ -1,0 +1,93 @@
+# Reviewed enrichment, draft, and approved Gmail send
+
+Status: active-stack engineering reference. Covers the person-bound outreach
+routes, the send authority, and the at-most-once guarantee. It does not cover
+process-crash ambiguity — a send interrupted by a crash is recorded as
+`interrupted`, outcome unknown, and hardening that is separate later work.
+
+## Domain words
+
+- **Person file** — the durable record for one candidate. Holds the email
+  address outreach is sent to.
+- **Sourcing chat** — a chat session bound to exactly one person file.
+- **Approval** — a row in the `inbox` table. It has a decision (allow, deny,
+  none) and an execution status, and they are not the same thing.
+- **Send authority** — the identity the director approved: one Gmail account,
+  one draft, one recipient, one subject, one body version.
+- **Body digest** — a SHA-256 of the message body after line endings and
+  trailing whitespace are normalized. It identifies a body version. It is not
+  the body, and it is safe to store and to display.
+
+## The chain
+
+1. `POST /v1/people/{id}/outreach/draft` creates a Gmail draft. The recipient
+   comes from the person file. The request cannot supply one. The route refuses
+   unless `session_id` names a sourcing chat bound to this person.
+2. `GET /v1/people/{id}/outreach/draft/{draft_id}` re-reads the live draft. The
+   draft is edited in Gmail; this is how an edit becomes visible, and how the
+   director reviews the version that exists right now.
+3. `POST /v1/people/{id}/outreach/send-approval` parks one approval. The caller
+   sends `reviewed_body_digest` — the version they read. The route re-reads the
+   draft and refuses if it has changed since, so no approval is ever created for
+   a body nobody reviewed. It also refuses a draft addressed to anyone other
+   than this person. Nothing is sent here.
+4. `POST /v1/inbox/{approval_id}` with `allow` decides it. This is the existing
+   approval route; the send is not a special case of it.
+
+Apollo enrichment follows the same shape:
+`POST /v1/people/{id}/enrich-approval` parks an approval whose resource names
+the exact person file, the match key, and the credit cost, then the same inbox
+route decides it.
+
+## At most once
+
+The guarantee is that one allow produces at most one Gmail message. Four
+independent mechanisms hold it, and none of them is new:
+
+1. **The claim.** `ConversationStore.decide_and_claim_inbox_execution` records
+   the decision and claims execution in one statement:
+   `UPDATE inbox SET execution_status = 'executing' WHERE id = ? AND
+   COALESCE(execution_status, 'pending') = 'pending'`. Exactly one caller sees
+   `rowcount == 1`. Every other caller — a duplicate submission, a reconnected
+   window, a second socket — gets `claimed = False` and waits for the outcome
+   instead of producing one.
+2. **The terminal guard.** `complete_inbox_execution` refuses to overwrite a
+   row already in `succeeded`, `failed`, `not_run`, `cancelled`, `expired`, or
+   `interrupted`. A retry after a failed submission reads that result. It does
+   not re-run the work.
+3. **The authority check.** `gmail.send_reviewed_draft` re-reads the live draft
+   and compares the account, recipient, subject, and body digest before it calls
+   Gmail. Any mismatch raises and nothing is sent.
+4. **Gmail itself.** `drafts.send` deletes the draft. A second send of the same
+   draft id is a 404 there, so two approvals for one draft cannot both deliver.
+   `FakeGmail` models this, which is why the duplicate case is loud in tests.
+
+Deny sets `execution_status = 'not_run'` without ever claiming. Cancel and
+expiry move the row out of `pending`, so `decide_and_claim` returns nothing and
+the route answers 409. A provider retry cannot replay a send because
+`gmail_send` is not in `permissions.RETRY_SAFE`, from which the turn retry
+allowlist is derived.
+
+## What a send records
+
+A successful send calls `PersonStore.record_approved_send`, which:
+
+- files one timeline event keyed on `gmail:message:{message_id}`, carrying the
+  Gmail message id, thread id, draft id, recipient, subject, body digest,
+  account, and approval id, correlated to the session and run;
+- advances the person to `open` only when they have no sequence state yet. A
+  person already in conversation or done is left where the director put them.
+
+A refused or failed send files nothing and advances nobody.
+
+## Testing
+
+`tests/test_approved_send.py` and `tests/test_approved_enrichment.py` count real
+calls into the fake service — `FakeGmail.send_attempts` for every submission
+including the ones that raise, `FakeGmail.sends` for the messages that left, and
+`FakeHttp.calls` for Apollo credits. No test decides whether an external effect
+happened by reading a status string.
+
+Each negative case asserts how far the flow got before proving nothing was sent.
+`execution_status == "failed"` means the claim was granted and the executor ran,
+so a zero send count is a guard working rather than a path nobody reached.

--- a/desktop/surfaces/gui/src/OutreachPanel.tsx
+++ b/desktop/surfaces/gui/src/OutreachPanel.tsx
@@ -1,0 +1,260 @@
+import { useState } from "react";
+
+import {
+  createOutreachDraft,
+  decideApproval,
+  readOutreachDraft,
+  requestSendApproval,
+  type OutreachDraft,
+  type PendingSendApproval,
+} from "./api";
+
+/**
+ * Draft, review, approve, send — for one bound person.
+ *
+ * The draft lives in Gmail, so that is where it gets edited. This panel shows
+ * the version Gmail holds right now and binds the approval to the version the
+ * director actually read. Editing in Gmail and re-reading here is the edit
+ * loop; approving a version and then editing it sends nothing.
+ */
+export function OutreachPanel({
+  personId,
+  sessionId,
+  recipient,
+}: {
+  readonly personId: string;
+  readonly sessionId: string | null;
+  readonly recipient: string | null;
+}) {
+  const [subject, setSubject] = useState("");
+  const [body, setBody] = useState("");
+  const [draft, setDraft] = useState<OutreachDraft | null>(null);
+  const [approval, setApproval] = useState<PendingSendApproval | null>(null);
+  const [sent, setSent] = useState<Record<string, unknown> | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [problem, setProblem] = useState<string | null>(null);
+
+  const reviewedHere =
+    approval !== null &&
+    draft !== null &&
+    approval.resource.body_digest === draft.body_digest;
+
+  async function run(label: string, work: () => Promise<void>) {
+    if (busy) return;
+    setBusy(label);
+    setProblem(null);
+    try {
+      await work();
+    } catch (error) {
+      setProblem(error instanceof Error ? error.message : "Something went wrong.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  if (!sessionId) {
+    return (
+      <section className="person-section" aria-labelledby="person-outreach-heading">
+        <h2 id="person-outreach-heading">Outreach</h2>
+        <p className="person-empty">
+          Open this person’s sourcing chat first. Outreach starts from the chat
+          that is bound to them, so the recipient is never guessed.
+        </p>
+      </section>
+    );
+  }
+
+  if (!recipient) {
+    return (
+      <section className="person-section" aria-labelledby="person-outreach-heading">
+        <h2 id="person-outreach-heading">Outreach</h2>
+        <p className="person-empty">
+          This person file has no email address yet. Enrich or add one before
+          drafting.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="person-section" aria-labelledby="person-outreach-heading">
+      <h2 id="person-outreach-heading">Outreach</h2>
+
+      {sent ? (
+        <div className="person-outreach-sent" role="status">
+          <strong>Sent</strong>
+          <dl>
+            <div>
+              <dt>To</dt>
+              <dd>{recipient}</dd>
+            </div>
+            <div>
+              <dt>Gmail message</dt>
+              <dd>
+                <code>{String(sent.message_id ?? "unknown")}</code>
+              </dd>
+            </div>
+            <div>
+              <dt>Gmail thread</dt>
+              <dd>
+                <code>{String(sent.thread_id ?? "unknown")}</code>
+              </dd>
+            </div>
+          </dl>
+        </div>
+      ) : null}
+
+      {!draft && !sent ? (
+        <form
+          className="person-outreach-compose"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void run("draft", async () => {
+              setDraft(
+                await createOutreachDraft(personId, {
+                  sessionId,
+                  subject,
+                  body,
+                }),
+              );
+            });
+          }}
+        >
+          <p className="person-outreach-recipient">
+            To <strong>{recipient}</strong> — taken from this person file.
+          </p>
+          <label htmlFor="outreach-subject">Subject</label>
+          <input
+            id="outreach-subject"
+            value={subject}
+            onChange={(event) => setSubject(event.target.value)}
+            required
+          />
+          <label htmlFor="outreach-body">Message</label>
+          <textarea
+            id="outreach-body"
+            value={body}
+            rows={8}
+            onChange={(event) => setBody(event.target.value)}
+            required
+          />
+          <button type="submit" disabled={busy !== null}>
+            {busy === "draft" ? "Creating draft…" : "Create Gmail draft"}
+          </button>
+        </form>
+      ) : null}
+
+      {draft && !sent ? (
+        <div className="person-outreach-review">
+          <p className="person-outreach-account">
+            Gmail · {draft.account ?? "Account could not be determined"}
+          </p>
+          <strong className="person-outreach-status">Not sent</strong>
+          <dl>
+            <div>
+              <dt>To</dt>
+              <dd>{draft.to}</dd>
+            </div>
+            <div>
+              <dt>Subject</dt>
+              <dd>{draft.subject}</dd>
+            </div>
+          </dl>
+          <pre className="person-outreach-body">{draft.body}</pre>
+          <p className="person-outreach-version">
+            Reviewed version <code>{draft.body_digest.slice(0, 12)}</code>
+          </p>
+          <div className="person-outreach-actions">
+            <button
+              type="button"
+              disabled={busy !== null}
+              onClick={() =>
+                void run("reread", async () => {
+                  setDraft(await readOutreachDraft(personId, draft.id));
+                })
+              }
+            >
+              {busy === "reread" ? "Re-reading…" : "Re-read draft from Gmail"}
+            </button>
+            {!approval ? (
+              <button
+                type="button"
+                disabled={busy !== null}
+                onClick={() =>
+                  void run("approval", async () => {
+                    setApproval(
+                      await requestSendApproval(personId, {
+                        sessionId,
+                        draftId: draft.id,
+                        reviewedBodyDigest: draft.body_digest,
+                      }),
+                    );
+                  })
+                }
+              >
+                {busy === "approval" ? "Requesting…" : "Request approval to send"}
+              </button>
+            ) : null}
+          </div>
+
+          {approval ? (
+            <div className="person-outreach-approval">
+              <p>
+                Send <strong>{approval.resource.subject}</strong> to{" "}
+                <strong>{approval.resource.to}</strong> from{" "}
+                {approval.resource.account ?? "the connected account"}, body
+                version <code>{approval.resource.body_digest.slice(0, 12)}</code>.
+              </p>
+              {reviewedHere ? null : (
+                <p role="alert">
+                  This draft changed after the approval was requested. Re-read it
+                  and ask again — allowing now sends nothing.
+                </p>
+              )}
+              <div className="person-outreach-actions">
+                <button
+                  type="button"
+                  disabled={busy !== null}
+                  onClick={() =>
+                    void run("allow", async () => {
+                      const outcome = await decideApproval(approval.id, "allow");
+                      setApproval(null);
+                      if (outcome.ok) {
+                        setSent(outcome.result);
+                        setDraft(null);
+                      } else {
+                        setProblem(
+                          String(outcome.result.error ?? "The send did not go out."),
+                        );
+                      }
+                    })
+                  }
+                >
+                  {busy === "allow" ? "Sending…" : "Allow once and send"}
+                </button>
+                <button
+                  type="button"
+                  disabled={busy !== null}
+                  onClick={() =>
+                    void run("deny", async () => {
+                      await decideApproval(approval.id, "deny");
+                      setApproval(null);
+                    })
+                  }
+                >
+                  {busy === "deny" ? "Denying…" : "Deny"}
+                </button>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {problem ? (
+        <p className="person-outreach-error" role="alert">
+          {problem}
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/desktop/surfaces/gui/src/PersonFile.tsx
+++ b/desktop/surfaces/gui/src/PersonFile.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState, type FormEvent } from "react";
 
+import { OutreachPanel } from "./OutreachPanel";
+
 import {
   attachPersonMeeting,
   attachPersonDriveEvidence,
@@ -274,6 +276,14 @@ export function PersonFileView({ personId }: { personId: string }) {
           </ul>
         )}
       </section>
+
+      <OutreachPanel
+        personId={personId}
+        sessionId={file.sourcing_chat?.session_id ?? null}
+        recipient={
+          typeof file.person.email === "string" ? file.person.email : null
+        }
+      />
 
       <section className="person-section" aria-labelledby="person-meetings-heading">
         <div className="person-section-heading-row">

--- a/desktop/surfaces/gui/src/api.ts
+++ b/desktop/surfaces/gui/src/api.ts
@@ -719,6 +719,113 @@ export async function curateApolloCandidates(input: {
   };
 }
 
+export type OutreachDraft = {
+  readonly id: string;
+  readonly to: string;
+  readonly subject: string;
+  readonly body: string;
+  readonly body_digest: string;
+  readonly account: string | null;
+  readonly sent: boolean;
+};
+
+/** The binding a send approval carries. Never the body, only its digest. */
+export type SendAuthorityResource = {
+  readonly kind: "gmail_send_authority";
+  readonly person_id: string;
+  readonly draft_id: string;
+  readonly account: string | null;
+  readonly to: string;
+  readonly subject: string;
+  readonly body_digest: string;
+};
+
+export type PendingSendApproval = {
+  readonly id: string;
+  readonly name: string;
+  readonly state: string;
+  readonly resource: SendAuthorityResource;
+};
+
+async function personPost(
+  id: string,
+  path: string,
+  payload: Record<string, unknown>,
+): Promise<unknown> {
+  const res = await fetch(
+    `${httpBase()}/v1/people/${encodeURIComponent(id)}/${path}`,
+    {
+      method: "POST",
+      headers: { "X-Club-Token": apiToken(), "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    },
+  );
+  const body = await res.json();
+  if (!res.ok) throw new Error(body.error || `${path} ${res.status}`);
+  return body;
+}
+
+export async function createOutreachDraft(
+  personId: string,
+  input: { sessionId: string; subject: string; body: string },
+): Promise<OutreachDraft> {
+  const body = await personPost(personId, "outreach/draft", {
+    session_id: input.sessionId,
+    subject: input.subject,
+    body: input.body,
+  });
+  return (body as { draft: OutreachDraft }).draft;
+}
+
+export async function readOutreachDraft(
+  personId: string,
+  draftId: string,
+): Promise<OutreachDraft> {
+  const res = await get(
+    `/v1/people/${encodeURIComponent(personId)}/outreach/draft/${encodeURIComponent(draftId)}`,
+  );
+  const body = await res.json();
+  if (!res.ok) throw new Error(body.error || `draft ${res.status}`);
+  return (body as { draft: OutreachDraft }).draft;
+}
+
+export async function requestSendApproval(
+  personId: string,
+  input: { sessionId: string; draftId: string; reviewedBodyDigest: string },
+): Promise<PendingSendApproval> {
+  const body = await personPost(personId, "outreach/send-approval", {
+    session_id: input.sessionId,
+    draft_id: input.draftId,
+    reviewed_body_digest: input.reviewedBodyDigest,
+  });
+  return (body as { item: PendingSendApproval }).item;
+}
+
+export async function requestEnrichApproval(
+  personId: string,
+  sessionId: string,
+): Promise<{ readonly id: string; readonly reason: string }> {
+  const body = await personPost(personId, "enrich-approval", {
+    session_id: sessionId,
+  });
+  const item = (body as { item: { id: string; reason: string } }).item;
+  return { id: item.id, reason: item.reason };
+}
+
+export async function decideApproval(
+  id: string,
+  decision: "allow" | "deny",
+): Promise<{ readonly ok: boolean; readonly result: Record<string, unknown> }> {
+  const res = await fetch(`${httpBase()}/v1/inbox/${encodeURIComponent(id)}`, {
+    method: "POST",
+    headers: { "X-Club-Token": apiToken(), "Content-Type": "application/json" },
+    body: JSON.stringify({ decision, actor: "director", scope: "once" }),
+  });
+  const body = await res.json();
+  if (!res.ok) throw new Error(body.error || `approval ${res.status}`);
+  return body;
+}
+
 export async function setPersonSequence(
   id: string,
   state: string,

--- a/desktop/surfaces/gui/src/styles.css
+++ b/desktop/surfaces/gui/src/styles.css
@@ -367,3 +367,122 @@
     flex-direction: column;
   }
 }
+
+/* Outreach: draft, review, approve. Dense and quiet; the only colour is the
+   accent tint on the reviewed version and the warm error on a refusal. */
+.person-outreach-compose,
+.person-outreach-review {
+  display: grid;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.person-outreach-compose label {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.person-outreach-compose input,
+.person-outreach-compose textarea {
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  line-height: 1.55;
+}
+
+.person-outreach-compose button,
+.person-outreach-actions button {
+  min-height: 44px;
+  padding: 0 14px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.person-outreach-compose button {
+  justify-self: start;
+}
+
+.person-outreach-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.person-outreach-actions button:disabled,
+.person-outreach-compose button:disabled {
+  cursor: wait;
+  opacity: .65;
+}
+
+.person-outreach-recipient,
+.person-outreach-account,
+.person-outreach-version {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.person-outreach-status {
+  color: var(--accent-deep);
+  font-size: 11px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.person-outreach-body {
+  margin: 0;
+  max-height: 260px;
+  overflow: auto;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--raised);
+  color: var(--text);
+  font: inherit;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+.person-outreach-version code,
+.person-outreach-approval code,
+.person-outreach-sent code {
+  font-family: ui-monospace, "Geist Mono", monospace;
+}
+
+.person-outreach-approval {
+  margin-top: 4px;
+  padding: 12px;
+  border: 1px solid var(--accent);
+  border-radius: 8px;
+  background: var(--accent-tint);
+}
+
+.person-outreach-approval p {
+  margin: 0 0 8px;
+  line-height: 1.55;
+}
+
+.person-outreach-approval [role="alert"],
+.person-outreach-error {
+  margin: 0;
+  color: var(--error);
+  line-height: 1.45;
+}
+
+.person-outreach-sent {
+  margin-top: 14px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--raised);
+}

--- a/desktop/surfaces/gui/tests/outreachPanel.test.tsx
+++ b/desktop/surfaces/gui/tests/outreachPanel.test.tsx
@@ -1,0 +1,205 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OutreachPanel } from "../src/OutreachPanel";
+
+const api = vi.hoisted(() => ({
+  createOutreachDraft: vi.fn(),
+  readOutreachDraft: vi.fn(),
+  requestSendApproval: vi.fn(),
+  decideApproval: vi.fn(),
+}));
+
+vi.mock("../src/api", () => api);
+
+const DRAFT = {
+  id: "draft_1",
+  to: "ada@analytic.example",
+  subject: "Thursday?",
+  body: "Hi Ada,\n\nWould Thursday work?",
+  body_digest: "abc123def456789",
+  account: "director@sourcecado.test",
+  sent: false,
+};
+
+function approvalFor(digest: string) {
+  return {
+    id: "send_1",
+    name: "gmail_send",
+    state: "pending",
+    resource: {
+      kind: "gmail_send_authority" as const,
+      person_id: "per_1",
+      draft_id: "draft_1",
+      account: "director@sourcecado.test",
+      to: "ada@analytic.example",
+      subject: "Thursday?",
+      body_digest: digest,
+    },
+  };
+}
+
+function panel(overrides: Record<string, unknown> = {}) {
+  return render(
+    <OutreachPanel
+      personId="per_1"
+      sessionId="sess_1"
+      recipient="ada@analytic.example"
+      {...overrides}
+    />,
+  );
+}
+
+async function composeAndDraft() {
+  panel();
+  fireEvent.change(screen.getByLabelText("Subject"), {
+    target: { value: "Thursday?" },
+  });
+  fireEvent.change(screen.getByLabelText("Message"), {
+    target: { value: "Hi Ada,\n\nWould Thursday work?" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "Create Gmail draft" }));
+  await screen.findByText("Not sent");
+}
+
+describe("Outreach panel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.createOutreachDraft.mockResolvedValue(DRAFT);
+    api.readOutreachDraft.mockResolvedValue(DRAFT);
+    api.requestSendApproval.mockResolvedValue(approvalFor(DRAFT.body_digest));
+    api.decideApproval.mockResolvedValue({
+      ok: true,
+      result: { message_id: "msg_1", thread_id: "thread_1", sent: true },
+    });
+  });
+
+  it("refuses to draft without a bound sourcing chat", () => {
+    panel({ sessionId: null });
+
+    expect(
+      screen.getByText(/Open this person’s sourcing chat first/),
+    ).toBeTruthy();
+    expect(screen.queryByLabelText("Subject")).toBeNull();
+    expect(api.createOutreachDraft).not.toHaveBeenCalled();
+  });
+
+  it("refuses to draft to a person with no email", () => {
+    panel({ recipient: null });
+
+    expect(screen.getByText(/no email address yet/)).toBeTruthy();
+    expect(screen.queryByLabelText("Subject")).toBeNull();
+    expect(api.createOutreachDraft).not.toHaveBeenCalled();
+  });
+
+  it("shows the recipient from the person file, not a field to type into", async () => {
+    panel();
+
+    expect(screen.getByText("ada@analytic.example")).toBeTruthy();
+    expect(screen.queryByLabelText("To")).toBeNull();
+  });
+
+  it("creates a draft and shows it as not sent", async () => {
+    await composeAndDraft();
+
+    expect(api.createOutreachDraft).toHaveBeenCalledWith("per_1", {
+      sessionId: "sess_1",
+      subject: "Thursday?",
+      body: "Hi Ada,\n\nWould Thursday work?",
+    });
+    expect(screen.getByText("Not sent")).toBeTruthy();
+    expect(screen.getByText("Would Thursday work?", { exact: false })).toBeTruthy();
+    expect(screen.getByText("abc123def456")).toBeTruthy();
+    expect(api.decideApproval).not.toHaveBeenCalled();
+  });
+
+  it("binds the approval to the body version on screen", async () => {
+    await composeAndDraft();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Request approval to send" }),
+    );
+
+    await waitFor(() =>
+      expect(api.requestSendApproval).toHaveBeenCalledWith("per_1", {
+        sessionId: "sess_1",
+        draftId: "draft_1",
+        reviewedBodyDigest: "abc123def456789",
+      }),
+    );
+    expect(api.decideApproval).not.toHaveBeenCalled();
+  });
+
+  it("re-reads an edit made in Gmail and warns that the approval is stale", async () => {
+    await composeAndDraft();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Request approval to send" }),
+    );
+    await screen.findByRole("button", { name: "Allow once and send" });
+    api.readOutreachDraft.mockResolvedValue({
+      ...DRAFT,
+      body: "Hi Ada,\n\nWould Friday work?",
+      body_digest: "999999999999zzz",
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Re-read draft from Gmail" }),
+    );
+
+    await screen.findByText("Would Friday work?", { exact: false });
+    expect(screen.getByRole("alert").textContent).toContain(
+      "allowing now sends nothing",
+    );
+    expect(api.decideApproval).not.toHaveBeenCalled();
+  });
+
+  it("reports the Gmail message and thread after an approved send", async () => {
+    await composeAndDraft();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Request approval to send" }),
+    );
+    await screen.findByRole("button", { name: "Allow once and send" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Allow once and send" }));
+
+    await screen.findByText("Sent");
+    expect(api.decideApproval).toHaveBeenCalledWith("send_1", "allow");
+    expect(api.decideApproval).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("msg_1")).toBeTruthy();
+    expect(screen.getByText("thread_1")).toBeTruthy();
+  });
+
+  it("reports a refused send without claiming anything went out", async () => {
+    api.decideApproval.mockResolvedValue({
+      ok: false,
+      result: { error: "The draft body changed after this send was approved." },
+    });
+    await composeAndDraft();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Request approval to send" }),
+    );
+    await screen.findByRole("button", { name: "Allow once and send" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Allow once and send" }));
+
+    await screen.findByText(/The draft body changed/);
+    expect(screen.queryByText("Sent")).toBeNull();
+  });
+
+  it("denies without sending", async () => {
+    await composeAndDraft();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Request approval to send" }),
+    );
+    await screen.findByRole("button", { name: "Deny" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Deny" }));
+
+    await waitFor(() =>
+      expect(api.decideApproval).toHaveBeenCalledWith("send_1", "deny"),
+    );
+    expect(api.decideApproval).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("Sent")).toBeNull();
+    expect(screen.getByText("Not sent")).toBeTruthy();
+  });
+});

--- a/desktop/surfaces/gui/tests/outreachStyles.test.ts
+++ b/desktop/surfaces/gui/tests/outreachStyles.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const styles = readFileSync("src/styles.css", "utf8");
+
+describe("Outreach panel styles", () => {
+  it("keeps approval controls touch sized and the reviewed body readable", () => {
+    expect(styles).toMatch(
+      /\.person-outreach-compose button,\s*\n\.person-outreach-actions button\s*\{[^}]*min-height:\s*44px;/,
+    );
+    expect(styles).toMatch(
+      /\.person-outreach-body\s*\{[^}]*white-space:\s*pre-wrap;/,
+    );
+    expect(styles).toMatch(
+      /\.person-outreach-body\s*\{[^}]*overflow:\s*auto;/,
+    );
+  });
+
+  it("stays on the warm token palette instead of hardcoded colour", () => {
+    const block = styles.slice(styles.indexOf(".person-outreach-compose,"));
+    expect(block).toMatch(/background:\s*var\(--surface\)/);
+    expect(block).toMatch(/color:\s*var\(--error\)/);
+    expect(block).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+  });
+});

--- a/desktop/tests/test_approved_enrichment.py
+++ b/desktop/tests/test_approved_enrichment.py
@@ -1,0 +1,251 @@
+"""S3: deliberate Apollo enrichment for one bound person.
+
+Apollo credits are the money in this flow, so the counter that matters is
+``http.calls`` — the real requests that left. No test here reads a status field
+to decide whether a credit was spent.
+"""
+
+from fastapi.testclient import TestClient
+
+from coworker.apollo import MATCH_URL, FakeHttp
+from coworker.gmail import FakeGmail
+from coworker.server import TOKEN_HEADER, create_app
+
+TOKEN = "test-token-approved-enrich"
+HEADERS = {TOKEN_HEADER: TOKEN}
+
+APOLLO_PERSON = {
+    "person": {
+        "id": "apollo_person_77",
+        "name": "Ada Lovelace",
+        "title": "Head of Data",
+        "organization": {"name": "Analytic Engines"},
+        "linkedin_url": "https://www.linkedin.com/in/ada",
+        "email": "ada@analytic.example",
+        "phone_numbers": [{"raw_number": "+1 555 0100"}],
+    }
+}
+
+
+def _app(tmp_path, http):
+    return create_app(
+        token=TOKEN,
+        provider=None,
+        state=tmp_path,
+        gmail=FakeGmail(),
+        http=http,
+        apollo_key="test-key",
+    )
+
+
+def _person(app, *, apollo_id, first, last, company="Analytic"):
+    people = app.state.people
+    person = people.keep_from_apollo(
+        apollo_id=apollo_id,
+        first_name=first,
+        last_name_obfuscated=last,
+        title="Head of Data",
+        company=company,
+    )
+    session_id = app.state.store.create_session()["session_id"]
+    people.bind_session(
+        session_id, person["person_id"], expected_person_version=int(person["version"])
+    )
+    return person["person_id"], session_id
+
+
+def _park(client, person_id, session_id, **overrides):
+    payload = {"session_id": session_id}
+    payload.update(overrides)
+    return client.post(
+        f"/v1/people/{person_id}/enrich-approval", headers=HEADERS, json=payload
+    )
+
+
+def _decide(client, item_id, decision="allow"):
+    return client.post(
+        f"/v1/inbox/{item_id}",
+        headers=HEADERS,
+        json={"decision": decision, "actor": "Fisher", "scope": "once"},
+    )
+
+
+def _match_calls(http):
+    return [call for call in http.calls if call["url"] == MATCH_URL]
+
+
+# --------------------------------------------------------------------------
+# Criterion 2 — the approval shows the exact person and the credit spend
+# --------------------------------------------------------------------------
+
+
+def test_the_enrichment_approval_names_the_person_and_the_credit_cost(tmp_path):
+    http = FakeHttp({MATCH_URL: APOLLO_PERSON})
+    app = _app(tmp_path, http)
+    client = TestClient(app)
+    person_id, session_id = _person(app, apollo_id="ada", first="Ada", last="Lovelace")
+
+    res = _park(client, person_id, session_id)
+
+    assert res.status_code == 201, res.text
+    resource = res.json()["item"]["resource"]
+    assert resource["kind"] == "apollo_enrichment"
+    assert resource["person_id"] == person_id
+    assert resource["person"] == "Ada Lovelace"
+    assert resource["company"] == "Analytic"
+    assert resource["credits"] == 1
+    assert resource["matched_on"] == "name"
+    assert "1 Apollo credit" in resource["reason"]
+    assert "Ada Lovelace" in resource["reason"]
+    # Parking an approval spends nothing.
+    assert _match_calls(http) == []
+
+
+def test_an_enrichment_cannot_start_from_another_persons_chat(tmp_path):
+    http = FakeHttp({MATCH_URL: APOLLO_PERSON})
+    app = _app(tmp_path, http)
+    client = TestClient(app)
+    person_id, session_id = _person(app, apollo_id="ada", first="Ada", last="Lovelace")
+    _other, other_session = _person(
+        app, apollo_id="grace", first="Grace", last="Hopper"
+    )
+
+    unbound = _park(client, person_id, session_id=None)
+    wrong = _park(client, person_id, other_session)
+
+    assert unbound.status_code == 400
+    assert wrong.status_code == 409
+    assert wrong.json()["code"] == "unbound_session"
+    assert app.state.inbox.pending() == []
+    assert _match_calls(http) == []
+    # The control: this person's own chat parks an approval.
+    assert _park(client, person_id, session_id).status_code == 201
+
+
+def test_a_person_apollo_cannot_be_matched_on_is_refused_before_the_spend(tmp_path):
+    http = FakeHttp({MATCH_URL: APOLLO_PERSON})
+    app = _app(tmp_path, http)
+    client = TestClient(app)
+    person_id, session_id = _person(app, apollo_id="ada", first="Ada", last=None)
+
+    res = _park(client, person_id, session_id)
+
+    assert res.status_code == 409
+    assert res.json()["code"] == "no_match_key"
+    assert _match_calls(http) == []
+
+
+# --------------------------------------------------------------------------
+# Criterion 3 — one person updated, one Apollo source receipt
+# --------------------------------------------------------------------------
+
+
+def test_an_approved_enrichment_updates_only_that_person_and_files_the_receipt(
+    tmp_path,
+):
+    http = FakeHttp({MATCH_URL: APOLLO_PERSON})
+    app = _app(tmp_path, http)
+    client = TestClient(app)
+    person_id, session_id = _person(app, apollo_id="ada", first="Ada", last="Lovelace")
+    other_id, _ = _person(app, apollo_id="grace", first="Grace", last="Hopper")
+    before_other = app.state.people.get(other_id)
+    item_id = _park(client, person_id, session_id, run_id="run-enrich-1").json()["item"][
+        "id"
+    ]
+
+    res = _decide(client, item_id)
+
+    assert res.status_code == 200, res.text
+    assert res.json()["ok"] is True
+    assert len(_match_calls(http)) == 1
+    assert _match_calls(http)[0]["json"]["first_name"] == "Ada"
+    assert _match_calls(http)[0]["json"]["last_name"] == "Lovelace"
+
+    person = app.state.people.get(person_id, expand_sources=True)
+    assert person["email"] == "ada@analytic.example"
+    assert person["linkedin_url"] == "https://www.linkedin.com/in/ada"
+    assert person["company"] == "Analytic Engines"
+    # Only the approved person moved.
+    assert app.state.people.get(other_id) == before_other
+
+    sources = [row for row in person["sources"] if row["fields"]["source"] == "apollo"]
+    assert len(sources) == 1
+    fields = sources[0]["fields"]
+    assert fields["apollo_id"] == "apollo_person_77"
+    assert fields["approval_id"] == item_id
+    assert fields["credits"] == 1
+    assert fields["matched_on"] == "name"
+    assert fields["fields_applied"] == [
+        "company",
+        "email",
+        "linkedin_url",
+        "name",
+        "phone",
+        "title",
+    ]
+
+    enrich_events = [
+        row for row in app.state.people.timeline(person_id) if row["kind"] == "enrich"
+    ]
+    assert len(enrich_events) == 1
+    assert enrich_events[0]["payload"]["approval_id"] == item_id
+    assert enrich_events[0]["payload"]["credits"] == 1
+    assert enrich_events[0]["run_id"] == "run-enrich-1"
+    assert enrich_events[0]["session_id"] == session_id
+
+
+def test_a_denied_enrichment_spends_no_credit(tmp_path):
+    http = FakeHttp({MATCH_URL: APOLLO_PERSON})
+    app = _app(tmp_path, http)
+    client = TestClient(app)
+    person_id, session_id = _person(app, apollo_id="ada", first="Ada", last="Lovelace")
+    item_id = _park(client, person_id, session_id).json()["item"]["id"]
+    assert app.state.inbox.get(item_id)["state"] == "pending"
+
+    res = _decide(client, item_id, "deny")
+
+    # The denial was really recorded; this is not a route that never ran.
+    assert res.json()["item"]["decision"] == "deny"
+    assert res.json()["item"]["execution_status"] == "not_run"
+    assert _match_calls(http) == []
+    assert app.state.people.get(person_id)["email"] is None
+    assert app.state.people.get(person_id, expand_sources=True)["sources"] == []
+
+
+def test_a_duplicate_enrichment_submission_spends_one_credit(tmp_path):
+    http = FakeHttp({MATCH_URL: APOLLO_PERSON})
+    app = _app(tmp_path, http)
+    client = TestClient(app)
+    person_id, session_id = _person(app, apollo_id="ada", first="Ada", last="Lovelace")
+    item_id = _park(client, person_id, session_id).json()["item"]["id"]
+
+    first = _decide(client, item_id)
+    second = _decide(client, item_id)
+
+    assert first.json()["ok"] is True
+    assert second.json()["idempotent"] is True
+    assert second.json()["result"] == first.json()["result"]
+    assert len(_match_calls(http)) == 1
+    person = app.state.people.get(person_id, expand_sources=True)
+    assert len([row for row in person["sources"] if row["fields"]["source"] == "apollo"]) == 1
+
+
+def test_an_expired_enrichment_approval_spends_no_credit(tmp_path):
+    http = FakeHttp({MATCH_URL: APOLLO_PERSON})
+    app = _app(tmp_path, http)
+    app.state.store.approval_ttl_seconds = 0.05
+    client = TestClient(app)
+    person_id, session_id = _person(app, apollo_id="ada", first="Ada", last="Lovelace")
+    item_id = _park(client, person_id, session_id).json()["item"]["id"]
+    import time
+
+    time.sleep(0.12)
+
+    res = _decide(client, item_id)
+
+    assert res.status_code == 409
+    expired = app.state.inbox.get(item_id)
+    assert expired["state"] == "expired"
+    assert expired["decision"] is None
+    assert _match_calls(http) == []
+    assert app.state.people.get(person_id)["email"] is None

--- a/desktop/tests/test_approved_send.py
+++ b/desktop/tests/test_approved_send.py
@@ -1,0 +1,815 @@
+"""S3: reviewed enrich, draft, and approved Gmail send for one bound person.
+
+Every test here counts real calls into the fake Gmail service. ``send_attempts``
+records every invocation of ``send``, including the ones that raise;
+``sends`` records only the messages that actually left. A test that asserted a
+status string would keep passing after the guard broke, so nothing below does
+that.
+
+Each negative case proves it bites before it proves nothing was sent. The
+strongest signal is ``execution_status``: ``failed`` means the approval claim
+was granted and the executor really ran, so a zero send count is a guard doing
+its job rather than a code path nobody reached. ``not_run`` means the decision
+was recorded as a denial. ``cancelled`` and ``expired`` mean the item reached a
+terminal state before any claim was possible.
+"""
+
+import threading
+import time
+
+from fastapi.testclient import TestClient
+
+from coworker.gmail import (
+    FakeGmail,
+    GmailError,
+    SendAuthority,
+    body_digest,
+    send_reviewed_draft,
+)
+from coworker.server import TOKEN_HEADER, create_app
+
+TOKEN = "test-token-approved-send"
+HEADERS = {TOKEN_HEADER: TOKEN}
+
+BODY = "Hi Ada,\n\nWould Thursday work for a short call?\n\nFisher"
+SUBJECT = "Thursday?"
+ADA_EMAIL = "ada@analytic.example"
+ACCOUNT = "director@sourcecado.test"
+
+
+class FailingSendGmail(FakeGmail):
+    """Gmail that accepts the submission and then fails it.
+
+    The attempt is still recorded, so a test can tell "we never reached Gmail"
+    apart from "Gmail refused us".
+    """
+
+    def __init__(self, failures: int = 1) -> None:
+        super().__init__()
+        self.failures = failures
+
+    def send(self, *, draft_id: str):
+        if self.failures > 0:
+            self.failures -= 1
+            self.send_attempts.append(draft_id)
+            raise GmailError("Gmail rejected the submission.")
+        return super().send(draft_id=draft_id)
+
+
+class SlowSendGmail(FakeGmail):
+    """Gmail whose send is slow enough to overlap two approval submissions."""
+
+    def __init__(self, delay: float = 0.25) -> None:
+        super().__init__()
+        self.delay = delay
+        self.entered = threading.Event()
+
+    def send(self, *, draft_id: str):
+        self.entered.set()
+        time.sleep(self.delay)
+        return super().send(draft_id=draft_id)
+
+
+def _gmail(cls=FakeGmail, **kwargs) -> FakeGmail:
+    gmail = cls(**kwargs)
+    gmail.account_email = ACCOUNT
+    return gmail
+
+
+def _app(tmp_path, gmail, **kwargs):
+    return create_app(
+        token=TOKEN, provider=None, state=tmp_path, gmail=gmail, **kwargs
+    )
+
+
+def _bound_person(app, *, email: str | None = ADA_EMAIL, apollo_id="ada"):
+    """One person file with a sourcing chat bound to it."""
+    people = app.state.people
+    person = people.keep_from_apollo(
+        apollo_id=apollo_id,
+        first_name="Ada",
+        last_name_obfuscated="L.",
+        title="Head of Data",
+        company="Analytic",
+    )
+    if email:
+        people.apply_enrichment(person["person_id"], name="Ada Lovelace", email=email)
+    person = people.get(person["person_id"])
+    session_id = app.state.store.create_session()["session_id"]
+    people.bind_session(
+        session_id, person["person_id"], expected_person_version=int(person["version"])
+    )
+    return person["person_id"], session_id
+
+
+def _draft(client, person_id, session_id, *, subject=SUBJECT, body=BODY):
+    res = client.post(
+        f"/v1/people/{person_id}/outreach/draft",
+        headers=HEADERS,
+        json={"session_id": session_id, "subject": subject, "body": body},
+    )
+    assert res.status_code == 201, res.text
+    return res.json()["draft"]
+
+
+def _approval(client, person_id, session_id, draft, **overrides):
+    payload = {
+        "session_id": session_id,
+        "draft_id": draft["id"],
+        "reviewed_body_digest": draft["body_digest"],
+    }
+    payload.update(overrides)
+    return client.post(
+        f"/v1/people/{person_id}/outreach/send-approval",
+        headers=HEADERS,
+        json=payload,
+    )
+
+
+def _park(client, person_id, session_id, draft, **overrides):
+    res = _approval(client, person_id, session_id, draft, **overrides)
+    assert res.status_code == 201, res.text
+    return res.json()["item"]["id"]
+
+
+def _decide(client, item_id, decision="allow"):
+    return client.post(
+        f"/v1/inbox/{item_id}",
+        headers=HEADERS,
+        json={"decision": decision, "actor": "Fisher", "scope": "once"},
+    )
+
+
+def _live_draft(gmail: FakeGmail, draft_id: str) -> dict:
+    return next(item for item in gmail.drafts if item["id"] == draft_id)
+
+
+def _reached_the_send_gate(app, item_id: str) -> dict:
+    """Non-vacuity guard: the approval really is a bound send, still decidable."""
+    item = app.state.inbox.get(item_id)
+    assert item is not None, "the approval never existed"
+    assert item["name"] == "gmail_send"
+    assert item["resource"]["kind"] == "gmail_send_authority"
+    return item
+
+
+def _nothing_was_filed(app, person_id: str) -> bool:
+    """No send receipt, and the person was not advanced off the shelf."""
+    timeline = app.state.people.timeline(person_id)
+    return (
+        [row for row in timeline if row["kind"] == "send"] == []
+        and app.state.people.get(person_id)["sequence_state"] is None
+    )
+
+
+def _sends_when_nothing_is_wrong(tmp_path, subdir: str) -> int:
+    """Positive control: the same fixture, untampered, really does send.
+
+    Every negative test calls this. Without it, a zero send count could mean the
+    guard worked or could mean the flow never got off the ground.
+    """
+    gmail = _gmail()
+    app = _app(tmp_path / subdir, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    draft = _draft(client, person_id, session_id)
+    item_id = _park(client, person_id, session_id, draft)
+    res = _decide(client, item_id)
+    assert res.status_code == 200, res.text
+    assert res.json()["ok"] is True
+    assert len(gmail.send_attempts) == 1
+    return len(gmail.sends)
+
+
+# --------------------------------------------------------------------------
+# Criterion 1 — the flow starts from a person-bound chat and never guesses
+# --------------------------------------------------------------------------
+
+
+def test_the_draft_takes_its_recipient_from_the_person_file(tmp_path):
+    gmail = _gmail()
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+
+    draft = _draft(client, person_id, session_id)
+
+    assert draft["to"] == ADA_EMAIL
+    assert gmail.drafts[0]["to"] == ADA_EMAIL
+    assert gmail.send_attempts == []
+
+
+def test_an_unbound_chat_cannot_draft_or_park_a_send(tmp_path):
+    gmail = _gmail()
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    other_id, other_session = _bound_person(app, apollo_id="grace", email="g@x.test")
+
+    missing = client.post(
+        f"/v1/people/{person_id}/outreach/draft",
+        headers=HEADERS,
+        json={"subject": SUBJECT, "body": BODY},
+    )
+    wrong = client.post(
+        f"/v1/people/{person_id}/outreach/draft",
+        headers=HEADERS,
+        json={"session_id": other_session, "subject": SUBJECT, "body": BODY},
+    )
+
+    assert missing.status_code == 400
+    assert missing.json()["code"] == "unbound_session"
+    assert wrong.status_code == 409
+    assert wrong.json()["code"] == "unbound_session"
+    assert gmail.drafts == []
+    assert gmail.send_attempts == []
+    # The control: the person's own chat does work.
+    assert _draft(client, person_id, session_id)["to"] == ADA_EMAIL
+    assert other_id != person_id
+
+
+def test_a_person_with_no_email_cannot_be_drafted_to(tmp_path):
+    gmail = _gmail()
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app, email=None)
+
+    res = client.post(
+        f"/v1/people/{person_id}/outreach/draft",
+        headers=HEADERS,
+        json={"session_id": session_id, "subject": SUBJECT, "body": BODY},
+    )
+
+    assert res.status_code == 409
+    assert res.json()["code"] == "no_recipient"
+    assert gmail.drafts == []
+    assert gmail.send_attempts == []
+
+
+def test_a_draft_addressed_elsewhere_cannot_be_approved_under_this_person(tmp_path):
+    gmail = _gmail()
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    draft = _draft(client, person_id, session_id)
+    # Someone redirects the draft in Gmail after it was written.
+    _live_draft(gmail, draft["id"])["to"] = "someone.else@example.com"
+
+    res = _approval(client, person_id, session_id, draft)
+
+    assert res.status_code == 409
+    assert res.json()["code"] == "recipient_not_bound"
+    assert app.state.inbox.pending() == []
+    assert gmail.send_attempts == []
+
+
+# --------------------------------------------------------------------------
+# Criterion 4 — the draft is editable and visibly not sent
+# --------------------------------------------------------------------------
+
+
+def test_creating_a_draft_sends_nothing_and_reports_not_sent(tmp_path):
+    gmail = _gmail()
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+
+    draft = _draft(client, person_id, session_id)
+
+    assert draft["sent"] is False
+    assert gmail.send_attempts == []
+    assert gmail.sends == []
+
+
+def test_an_edit_to_the_draft_is_visible_and_changes_the_reviewed_version(tmp_path):
+    gmail = _gmail()
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    draft = _draft(client, person_id, session_id)
+
+    _live_draft(gmail, draft["id"])["body"] = BODY + "\n\nPS: bringing Charles."
+    res = client.get(
+        f"/v1/people/{person_id}/outreach/draft/{draft['id']}", headers=HEADERS
+    )
+
+    reread = res.json()["draft"]
+    assert res.status_code == 200
+    assert "PS: bringing Charles." in reread["body"]
+    assert reread["body_digest"] != draft["body_digest"]
+    assert reread["sent"] is False
+    assert gmail.send_attempts == []
+
+
+# --------------------------------------------------------------------------
+# Criteria 5 and 8 — the binding, and what a successful send records
+# --------------------------------------------------------------------------
+
+
+def test_the_send_approval_binds_account_draft_recipient_subject_and_body_version(
+    tmp_path,
+):
+    gmail = _gmail()
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    draft = _draft(client, person_id, session_id)
+
+    item_id = _park(client, person_id, session_id, draft)
+
+    item = app.state.inbox.get(item_id)
+    resource = item["resource"]
+    assert resource == {
+        "kind": "gmail_send_authority",
+        "person_id": person_id,
+        "draft_id": draft["id"],
+        "account": ACCOUNT,
+        "to": ADA_EMAIL,
+        "subject": SUBJECT,
+        "body_digest": body_digest(BODY),
+        "sent": False,
+    }
+    assert item["session_id"] == session_id
+    # The binding names the body version. It never carries the body itself.
+    assert "Thursday work for a short call" not in str(item)
+    listing = client.get("/v1/inbox", headers=HEADERS).json()
+    assert "Thursday work for a short call" not in str(listing)
+    assert gmail.send_attempts == []
+
+
+def test_an_approved_send_delivers_once_and_files_an_inspectable_receipt(tmp_path):
+    gmail = _gmail()
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    draft = _draft(client, person_id, session_id)
+    item_id = _park(client, person_id, session_id, draft, run_id="run-ada-1")
+
+    res = _decide(client, item_id)
+
+    body = res.json()
+    assert res.status_code == 200
+    assert body["ok"] is True
+    assert gmail.send_attempts == [draft["id"]]
+    assert gmail.sends == [{"draft_id": draft["id"]}]
+    assert body["result"]["message_id"] == "msg_1"
+    assert body["result"]["thread_id"] == "thread_1"
+    assert body["item"]["execution_status"] == "succeeded"
+
+    timeline = app.state.people.timeline(person_id)
+    sends = [row for row in timeline if row["kind"] == "send"]
+    assert len(sends) == 1
+    payload = sends[0]["payload"]
+    assert payload["message_id"] == "msg_1"
+    assert payload["thread_id"] == "thread_1"
+    assert payload["draft_id"] == draft["id"]
+    assert payload["to"] == ADA_EMAIL
+    assert payload["subject"] == SUBJECT
+    assert payload["body_digest"] == draft["body_digest"]
+    assert payload["approval_id"] == item_id
+    assert payload["sent"] is True
+    assert sends[0]["run_id"] == "run-ada-1"
+    assert sends[0]["session_id"] == session_id
+    assert app.state.people.get(person_id)["sequence_state"] == "open"
+    assert body["result"]["advanced_to_open"] is True
+
+
+def test_a_send_leaves_an_already_placed_person_where_the_director_put_them(tmp_path):
+    gmail = _gmail()
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    app.state.people.set_sequence(person_id, "in_conversation", actor="director")
+    draft = _draft(client, person_id, session_id)
+    item_id = _park(client, person_id, session_id, draft)
+
+    res = _decide(client, item_id)
+
+    assert res.json()["ok"] is True
+    assert gmail.sends == [{"draft_id": draft["id"]}]
+    assert res.json()["result"]["advanced_to_open"] is False
+    assert app.state.people.get(person_id)["sequence_state"] == "in_conversation"
+
+
+# --------------------------------------------------------------------------
+# Criterion 6 — deny, cancel, expiry, stale draft, failed submission
+# --------------------------------------------------------------------------
+
+
+def test_deny_sends_nothing(tmp_path):
+    gmail = _gmail()
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    draft = _draft(client, person_id, session_id)
+    item_id = _park(client, person_id, session_id, draft)
+    _reached_the_send_gate(app, item_id)
+
+    res = _decide(client, item_id, "deny")
+
+    assert res.status_code == 200
+    # The denial was really recorded: this is not a route that 404'd.
+    assert res.json()["item"]["decision"] == "deny"
+    assert res.json()["item"]["execution_status"] == "not_run"
+    assert gmail.send_attempts == []
+    assert gmail.sends == []
+    assert _nothing_was_filed(app, person_id)
+    assert _sends_when_nothing_is_wrong(tmp_path, "control") == 1
+
+
+def test_cancel_before_the_decision_sends_nothing(tmp_path):
+    gmail = _gmail()
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    draft = _draft(client, person_id, session_id)
+    item_id = _park(client, person_id, session_id, draft)
+    _reached_the_send_gate(app, item_id)
+
+    cancelled = app.state.inbox.cancel(item_id)
+    res = _decide(client, item_id)
+
+    assert cancelled["execution_status"] == "cancelled"
+    assert res.status_code == 409
+    assert app.state.inbox.get(item_id)["execution_status"] == "cancelled"
+    assert gmail.send_attempts == []
+    assert gmail.sends == []
+    assert _nothing_was_filed(app, person_id)
+    assert _sends_when_nothing_is_wrong(tmp_path, "control") == 1
+
+
+def test_an_expired_approval_sends_nothing(tmp_path):
+    gmail = _gmail()
+    app = _app(tmp_path, gmail)
+    app.state.store.approval_ttl_seconds = 0.05
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    draft = _draft(client, person_id, session_id)
+    item_id = _park(client, person_id, session_id, draft)
+    _reached_the_send_gate(app, item_id)
+    time.sleep(0.12)
+
+    res = _decide(client, item_id)
+
+    assert res.status_code == 409
+    expired = app.state.inbox.get(item_id)
+    # Expiry is not a denial: nobody decided, and the record says so.
+    assert expired["state"] == "expired"
+    assert expired["execution_status"] == "expired"
+    assert expired["decision"] is None
+    assert gmail.send_attempts == []
+    assert gmail.sends == []
+    assert _nothing_was_filed(app, person_id)
+    assert _sends_when_nothing_is_wrong(tmp_path, "control") == 1
+
+
+def test_a_body_edited_after_review_sends_nothing(tmp_path):
+    gmail = _gmail()
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    draft = _draft(client, person_id, session_id)
+    item_id = _park(client, person_id, session_id, draft)
+    _reached_the_send_gate(app, item_id)
+    _live_draft(gmail, draft["id"])["body"] = BODY + "\n\nPS: wire me $500 first."
+
+    res = _decide(client, item_id)
+
+    body = res.json()
+    assert res.status_code == 200
+    # execution_status 'failed' proves the claim was granted and the executor
+    # ran: the guard stopped this, not an unreached code path.
+    assert body["item"]["execution_status"] == "failed"
+    assert body["result"]["code"] == "stale_draft"
+    assert body["ok"] is False
+    assert gmail.send_attempts == []
+    assert gmail.sends == []
+    assert _nothing_was_filed(app, person_id)
+    assert _sends_when_nothing_is_wrong(tmp_path, "control") == 1
+
+
+def test_a_recipient_changed_after_review_sends_nothing(tmp_path):
+    gmail = _gmail()
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    draft = _draft(client, person_id, session_id)
+    item_id = _park(client, person_id, session_id, draft)
+    _live_draft(gmail, draft["id"])["to"] = "attacker@example.com"
+
+    res = _decide(client, item_id)
+
+    assert res.json()["item"]["execution_status"] == "failed"
+    assert res.json()["result"]["code"] == "recipient_mismatch"
+    assert gmail.send_attempts == []
+    assert gmail.sends == []
+    assert _nothing_was_filed(app, person_id)
+    assert _sends_when_nothing_is_wrong(tmp_path, "control") == 1
+
+
+def test_a_subject_changed_after_review_sends_nothing(tmp_path):
+    gmail = _gmail()
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    draft = _draft(client, person_id, session_id)
+    item_id = _park(client, person_id, session_id, draft)
+    _live_draft(gmail, draft["id"])["subject"] = "Invoice attached"
+
+    res = _decide(client, item_id)
+
+    assert res.json()["item"]["execution_status"] == "failed"
+    assert res.json()["result"]["code"] == "subject_mismatch"
+    assert gmail.send_attempts == []
+    assert gmail.sends == []
+    assert _nothing_was_filed(app, person_id)
+    assert _sends_when_nothing_is_wrong(tmp_path, "control") == 1
+
+
+def test_a_changed_gmail_account_sends_nothing(tmp_path):
+    gmail = _gmail()
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    draft = _draft(client, person_id, session_id)
+    item_id = _park(client, person_id, session_id, draft)
+    gmail.account_email = "someone.else@sourcecado.test"
+
+    res = _decide(client, item_id)
+
+    assert res.json()["item"]["execution_status"] == "failed"
+    assert res.json()["result"]["code"] == "account_mismatch"
+    assert gmail.send_attempts == []
+    assert gmail.sends == []
+    assert _nothing_was_filed(app, person_id)
+    assert _sends_when_nothing_is_wrong(tmp_path, "control") == 1
+
+
+def test_a_failed_submission_sends_nothing_and_a_retry_does_not_resend(tmp_path):
+    gmail = _gmail(FailingSendGmail, failures=5)
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    draft = _draft(client, person_id, session_id)
+    item_id = _park(client, person_id, session_id, draft)
+
+    first = _decide(client, item_id)
+    retry = _decide(client, item_id)
+
+    # It really reached Gmail: one submission, refused there.
+    assert gmail.send_attempts == [draft["id"]]
+    assert gmail.sends == []
+    assert first.json()["ok"] is False
+    assert first.json()["result"]["code"] == "gmail_failed"
+    assert first.json()["item"]["execution_status"] == "failed"
+    # The retry hits the terminal guard instead of submitting again.
+    assert retry.status_code == 200
+    assert retry.json()["idempotent"] is True
+    assert retry.json()["result"] == first.json()["result"]
+    assert gmail.send_attempts == [draft["id"]]
+    assert _nothing_was_filed(app, person_id)
+
+
+def test_a_send_that_fails_leaves_the_person_unadvanced(tmp_path):
+    gmail = _gmail(FailingSendGmail, failures=5)
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    draft = _draft(client, person_id, session_id)
+    item_id = _park(client, person_id, session_id, draft)
+
+    _decide(client, item_id)
+
+    assert _nothing_was_filed(app, person_id)
+    assert gmail.sends == []
+
+
+# --------------------------------------------------------------------------
+# Criterion 7 — duplicate submission, retry, reconnect
+# --------------------------------------------------------------------------
+
+
+def test_a_duplicate_allow_submitted_again_sends_once(tmp_path):
+    gmail = _gmail()
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    draft = _draft(client, person_id, session_id)
+    item_id = _park(client, person_id, session_id, draft)
+
+    first = _decide(client, item_id)
+    second = _decide(client, item_id)
+    third = _decide(client, item_id)
+
+    assert gmail.send_attempts == [draft["id"]]
+    assert gmail.sends == [{"draft_id": draft["id"]}]
+    assert first.json()["ok"] is True
+    assert "idempotent" not in first.json()
+    for repeat in (second, third):
+        assert repeat.status_code == 200
+        assert repeat.json()["idempotent"] is True
+        assert repeat.json()["result"] == first.json()["result"]
+    assert len([r for r in app.state.people.timeline(person_id) if r["kind"] == "send"]) == 1
+
+
+def test_two_concurrent_allow_submissions_send_once(tmp_path):
+    gmail = _gmail(SlowSendGmail, delay=0.3)
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    draft = _draft(client, person_id, session_id)
+    item_id = _park(client, person_id, session_id, draft)
+
+    start = threading.Barrier(2)
+    responses: list = []
+    lock = threading.Lock()
+
+    def submit():
+        start.wait(timeout=5)
+        response = _decide(client, item_id)
+        with lock:
+            responses.append(response)
+
+    threads = [threading.Thread(target=submit) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=15)
+
+    assert all(not thread.is_alive() for thread in threads)
+    # Both submissions really were in flight against a send that had begun.
+    assert gmail.entered.is_set()
+    assert gmail.send_attempts == [draft["id"]]
+    assert gmail.sends == [{"draft_id": draft["id"]}]
+    assert [r.status_code for r in responses] == [200, 200]
+    winners = [r for r in responses if "idempotent" not in r.json()]
+    losers = [r for r in responses if r.json().get("idempotent") is True]
+    assert len(winners) == 1
+    assert len(losers) == 1
+    assert losers[0].json()["result"] == winners[0].json()["result"]
+    assert len([r for r in app.state.people.timeline(person_id) if r["kind"] == "send"]) == 1
+
+
+def test_a_reconnect_and_resubmit_during_the_send_does_not_repeat_it(tmp_path):
+    """The transport drops mid-send; the window comes back and asks again."""
+    gmail = _gmail(SlowSendGmail, delay=0.4)
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    draft = _draft(client, person_id, session_id)
+    item_id = _park(client, person_id, session_id, draft)
+
+    in_flight: dict = {}
+
+    def submit():
+        in_flight["response"] = _decide(client, item_id)
+
+    sender = threading.Thread(target=submit)
+    sender.start()
+    assert gmail.entered.wait(timeout=5), "the send never started"
+
+    # The window reconnects while the send is still running and resubmits.
+    with client.websocket_connect("/ws/chat", subprotocols=["club", TOKEN]):
+        pass
+    resubmit = _decide(client, item_id)
+    sender.join(timeout=15)
+
+    assert not sender.is_alive()
+    assert gmail.send_attempts == [draft["id"]]
+    assert gmail.sends == [{"draft_id": draft["id"]}]
+    assert in_flight["response"].json()["ok"] is True
+    # The resubmission either waited out the live claim and saw the same
+    # outcome, or was told the work is still in flight. Never a second send.
+    if resubmit.status_code == 202:
+        assert resubmit.json()["pending"] is True
+    else:
+        assert resubmit.status_code == 200
+        assert resubmit.json()["idempotent"] is True
+        assert resubmit.json()["result"] == in_flight["response"].json()["result"]
+
+
+def test_two_approvals_for_one_draft_send_it_only_once(tmp_path):
+    """Two authorities, one draft. The per-approval claim cannot see this."""
+    gmail = _gmail()
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    draft = _draft(client, person_id, session_id)
+    first_id = _park(client, person_id, session_id, draft)
+    second_id = _park(client, person_id, session_id, draft)
+
+    assert first_id != second_id
+    first = _decide(client, first_id)
+    second = _decide(client, second_id)
+
+    assert first.json()["ok"] is True
+    assert gmail.sends == [{"draft_id": draft["id"]}]
+    # The second approval was claimed and executed. It stopped at the draft.
+    assert second.json()["item"]["execution_status"] == "failed"
+    assert second.json()["ok"] is False
+    assert second.json()["result"]["code"] == "draft_unavailable"
+    assert gmail.send_attempts == [draft["id"]]
+    assert len([r for r in app.state.people.timeline(person_id) if r["kind"] == "send"]) == 1
+
+
+def test_a_sent_draft_can_no_longer_be_read_back_as_a_draft(tmp_path):
+    """Gmail deletes a draft on send. Nothing can bind to it afterwards."""
+    gmail = _gmail()
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    draft = _draft(client, person_id, session_id)
+    before = client.get(
+        f"/v1/people/{person_id}/outreach/draft/{draft['id']}", headers=HEADERS
+    )
+    _decide(client, _park(client, person_id, session_id, draft))
+
+    after = client.get(
+        f"/v1/people/{person_id}/outreach/draft/{draft['id']}", headers=HEADERS
+    )
+
+    assert before.status_code == 200
+    assert before.json()["draft"]["sent"] is False
+    assert after.status_code == 404
+    assert after.json()["code"] == "draft_unavailable"
+    assert gmail.send_attempts == [draft["id"]]
+    assert gmail.sends == [{"draft_id": draft["id"]}]
+
+
+def test_an_approval_cannot_be_parked_for_an_already_sent_draft(tmp_path):
+    gmail = _gmail()
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    draft = _draft(client, person_id, session_id)
+    _decide(client, _park(client, person_id, session_id, draft))
+
+    res = _approval(client, person_id, session_id, draft)
+
+    assert res.status_code == 409
+    assert res.json()["code"] == "draft_unavailable"
+    assert gmail.send_attempts == [draft["id"]]
+    assert gmail.sends == [{"draft_id": draft["id"]}]
+
+
+def test_a_send_whose_receipt_cannot_be_filed_is_still_reported_as_sent(tmp_path):
+    """The message is gone. Saying otherwise would be a lie the operator acts on."""
+    gmail = _gmail()
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    draft = _draft(client, person_id, session_id)
+    item_id = _park(client, person_id, session_id, draft)
+    # The person file goes away between approval and send.
+    app.state.people.delete(
+        person_id,
+        expected_version=int(app.state.people.get(person_id)["version"]),
+        actor="director",
+        rationale_summary="Removed mid-flight",
+    )
+
+    res = _decide(client, item_id)
+
+    assert gmail.sends == [{"draft_id": draft["id"]}]
+    assert res.json()["ok"] is True
+    assert res.json()["result"]["message_id"] == "msg_1"
+    assert res.json()["result"]["person_event_id"] is None
+    assert "unknown person" in res.json()["result"]["receipt_error"]
+
+
+def test_gmail_send_is_never_replayed_by_a_provider_retry(tmp_path):
+    from coworker.permissions import ASK, AUTO, RETRY_SAFE
+    from coworker.turn import _SAFE_RETRY_TOOLS
+
+    assert "gmail_send" in ASK
+    assert "gmail_send" not in AUTO
+    assert "gmail_send" not in RETRY_SAFE
+    assert "gmail_send" not in _SAFE_RETRY_TOOLS
+    assert "apollo_enrich_contact" not in _SAFE_RETRY_TOOLS
+
+
+def test_the_send_authority_refuses_a_draft_it_already_consumed():
+    """Below the approval layer: the client itself will not send twice."""
+    gmail = _gmail()
+    gmail.create_draft(to=ADA_EMAIL, subject=SUBJECT, body=BODY)
+    authority = SendAuthority(
+        approval_id="ap-1",
+        person_id="per_1",
+        draft_id="draft_1",
+        account=ACCOUNT,
+        to=ADA_EMAIL,
+        subject=SUBJECT,
+        body_digest=body_digest(BODY),
+    )
+
+    sent = send_reviewed_draft(gmail, authority)
+    try:
+        send_reviewed_draft(gmail, authority)
+        repeated = True
+    except GmailError:
+        repeated = False
+
+    assert sent["message_id"] == "msg_1"
+    assert repeated is False
+    assert gmail.send_attempts == ["draft_1"]
+    assert gmail.sends == [{"draft_id": "draft_1"}]


### PR DESCRIPTION
Addresses #66, criteria 1 through 9. **Criterion 10, the live canary, is not done and needs Fisher.** See the last section.

## Domain words

- **Claim** — the single database write that decides which caller is allowed to execute an approved action. Exactly one caller wins.
- **Reviewed version** — the exact draft body the director saw when they approved. Identified by a digest, not stored as content.
- **Attempt vs send** — two separate counters on the Gmail fake. Attempts counts every call into `send`, including ones that raise. Sends counts messages that actually left. This makes "we never reached Gmail" distinguishable from "Gmail refused us".

## Problem

The highest-stakes path in the product — enrich, draft, review, send — had no binding between what the director approved and what actually went out. A duplicate submission, a reconnect, or an edited draft could each have produced a send nobody authorized.

## At-most-once: four layers, three of them already existed

The important design decision here was **not** to build a new locking mechanism.

| Layer | Where | New? |
|---|---|---|
| The claim | `store.py:1000`, `decide_and_claim_inbox_execution` | No — reused, untouched |
| Terminal guard | `store.py:1089`, `complete_inbox_execution` | No — reused, untouched |
| Retry allowlist | `permissions.RETRY_SAFE` | No — reused, untouched |
| Authority check | `gmail.py`, `send_reviewed_draft` | Yes |

The claim records the decision and claims execution in one statement:

```sql
UPDATE inbox SET execution_status='executing'
WHERE id=? AND COALESCE(execution_status,'pending')='pending'
```

Exactly one caller sees `rowcount == 1`. Every other caller — a duplicate POST, a reconnected window, a second socket — gets `claimed=False` and is routed to `wait_for_execution`, which reads an outcome and cannot produce one. **The second submitter never reaches send code at all.**

`gmail_send` is in `ASK`, absent from `AUTO`, and absent from `RETRY_SAFE`, which is what makes a provider retry unable to replay a send. A test asserts all four facts so a future edit to those sets breaks loudly. `permissions.py` was deliberately not modified — the machinery was already correct.

The one hole per-approval claiming cannot see is two separate approvals for one draft. That is closed because Gmail deletes a draft on send, and `FakeGmail` now models that, so a second send of the same draft id is a 404.

## Boundary matrix

Every row measured on the fake's counters, not on a status string.

| Case | attempts | sends |
|---|---|---|
| allow once | 1 | 1 |
| deny | 0 | 0 |
| cancel before decision | 0 | 0 |
| expiry | 0 | 0 |
| body edited after review | 1 | 0 |
| recipient changed after review | 1 | 0 |
| subject changed after review | 1 | 0 |
| account changed | 1 | 0 |
| failed submission, then retry | 1 | 0 |
| duplicate submission ×3 | 1 | 1 |
| two concurrent submissions on a barrier | 1 | 1 |
| reconnect mid-send, then resubmit | 1 | 1 |
| two approvals, one draft | 1 | 1 |
| approval for an already-sent draft | 1 | 1 |
| draft addressed elsewhere | 0 | 0 |
| unbound or wrong-person chat | 0 | 0 |
| receipt write fails after a real send | 1 | 1 |

Apollo, counted on HTTP calls because credits are money: deny 0, expiry 0, duplicate submission 1, unmatched person 0, approved 1.

## Proving the negative tests are not vacuous

A test asserting "zero sends" is worthless if the flow never reached the point where a send was possible. Two independent mechanisms:

**In-test**, the signal is `execution_status`. `failed` means the claim was granted and the executor really ran, so zero sends is a guard working rather than a path nobody reached. Every negative test also runs a positive control on the identical untampered fixture and asserts it sends exactly once.

**Out-of-test**, a mutation harness breaks one guard at a time and requires the owning test to go red. **21 breaks, 21 red, zero vacuous.**

It found three things that would otherwise have shipped:

1. Two `already_sent` guards were dead code. Gmail deletes a sent draft, so `get_draft` 404s first and those branches were unreachable. Removed, so the tested mechanism is the real one.
2. The authority-mismatch tests did not assert that a refusal leaves no send receipt and no sequence advance. Injecting a phantom receipt into the refusal path *passed*. Fixed.
3. The harness itself had a stale-`.pyc` bug — same-second writes with identical size deltas let CPython reuse the previous mutation's bytecode — producing two false GREENs. Fixed by clearing `__pycache__` per run; both then went red.

That third one is worth naming. It is the same class of failure as the rebase hazard below: it looks clean and is wrong.

## Measurements

```
1082 passed, 3 skipped, 1 warning in 47.80s
 Test Files  47 passed (47)
      Tests  425 passed (425)
tsc --noEmit && vite build   clean
```

All re-run independently by the reviewing session on the pushed commit.

## Rebase note

Rebased onto `7563a77`. One conflict in `server.py`, a plain import collision; both kept.

A sibling lane found that git can place an identical closing line *outside* the conflict markers as though both sides shared it, so a naive both-sides-keep silently drops a brace without producing a conflict marker. Rather than trusting a careful read, this lane ran delimiter arithmetic per file: merged count must equal base + (mine − base) + (theirs − base) for each of `{ } ( ) [ ]`, and each file must be internally balanced. All five overlapping files passed.

Test arithmetic also closes exactly: base 919 + main's 129 new + this branch's 34 = 1082, which is what the tree gives. Nothing was lost on either side.

## Design decisions

- **Dedicated person-bound server routes over extending the model's `gmail_send` tool path**, because taking the recipient from the person file is a stronger guarantee than trusting model-generated arguments, and the park and receipt sites are in `turn.py`/`ledger.py`, outside this lane's boundary.
- **A body digest over the body itself** in the approval record, because a digest identifies the reviewed version without storing content.
- **A normalized digest over a raw one**, because Gmail round-trips bodies through quoted-printable and CRLF; a raw digest would false-positive on every live send.
- **`get_draft` always reads live, over the previous local-cache short-circuit**, because a cached copy hides an edit made in Gmail — the exact hazard the gate exists to catch.
- **Modelling Gmail's delete-on-send in the fake over a permissive fake**, because it makes a duplicate send loud instead of silent.
- **Reusing `decide_and_claim_inbox_execution` over a new send-specific lock**, because a second at-most-once mechanism is a second thing that can disagree with the first.

## NOT DONE: criterion 10, the live canary

This PR sends no real mail and touches no real credential. Criterion 10 requires a human. Steps, in order:

1. Connect Gmail via `/v1/gmail/connect` with an account you will send from. Confirm `/v1/gmail` reports `connected`.
2. Optionally set `APOLLO_API_KEY` to exercise enrichment. Without it the enrich route returns 409 cleanly.
3. Pick one real person — yourself or a colleague who expects it. Open the person file, **Create sourcing chat**, then in **Outreach**: compose, **Create Gmail draft**.
4. **The step that matters most.** Open the draft in Gmail, confirm it is unsent, edit one word, return, click **Re-read draft from Gmail**, and confirm the reviewed-version hash changes. This is the only exercise of the live `format=full` read path, which today has fake coverage only.
5. **Request approval to send**, then **Allow once and send**.
6. Confirm exactly one message in Sent. Check the person timeline shows one `send` event with the real Gmail `message_id` and `thread_id`, and that the person moved to Open.
7. One live negative worth doing: request approval, edit the draft in Gmail, then Allow. It must refuse with "The draft body changed after this send was approved" and send nothing.

## Still open

- **The live digest risk, and it is the real one.** The body digest depends on `_flatten_body`'s decoding matching what `create_draft` wrote. `normalize_body` handles CRLF and trailing whitespace, but a real quoted-printable round trip on long lines or non-ASCII could shift bytes and cause a false stale-draft refusal. It fails safe — nothing sends — but it would be an annoying false alarm, and step 4 above is the cheapest way to find out. Fakes cannot settle this.
- The reconnect test asserts a disjunction (200-idempotent or 202-pending) because the branch depends on timing against a 60s deadline. In practice it always takes 200. The send-count assertion is exact either way.
- `enrichment_match` will match on an obfuscated last name like `"L."`, wasting a credit on a bad query. Pre-existing behaviour of what `keep_from_apollo` stores, not introduced here. Worth a follow-up ticket.
- `record_approved_send` is idempotent on the Gmail message id, but if the receipt write fails *after* the send, the message is already gone. That path returns `ok: true` with a `receipt_error` and no person event, and has a test. Honest, but it leaves a sent message with no timeline entry.

## Not in this PR

- The chat-driven `gmail_send` tool path still has no body-version binding. Its park site is `turn.py`, outside this boundary.
- No `permission_required` chat event for the new bound approvals, so they surface in the person file rather than in chat. Wiring needs `turn.py` and the `protocol.ts` allowlist.
- No in-app draft editor. Gmail owns the draft; the panel re-reads it.
- No spend ceiling on Apollo, only per-call approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjAD6SVox1gvF4sV3jTnJy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added person-bound outreach drafting, review, approval, and Gmail sending.
  * Added safeguards that prevent sending modified, duplicate, or mismatched drafts.
  * Added Apollo contact enrichment with approval, credit-cost visibility, and source tracking.
  * Added outreach controls and status details to person profiles.
* **Bug Fixes**
  * Improved protection against duplicate sends and repeated enrichment charges.
* **Documentation**
  * Added a reference guide for the reviewed outreach and sending workflow.
* **Tests**
  * Added comprehensive coverage for outreach, approvals, enrichment, and delivery safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->