### PR TITLE
feat(desktop): export a redacted diagnostic bundle for one failed run

### DIFF
--- a/desktop/coworker/bundle_redaction.py
+++ b/desktop/coworker/bundle_redaction.py
@@ -1,0 +1,272 @@
+"""The last line of defence before a diagnostic bundle leaves this machine.
+
+Two upstream layers already bound what a bundle can carry: the run receipt's
+closed field allowlist, and the state report's own bounded, redacted output
+contract. This module is the third, and it is deliberately independent of both.
+
+Independence is the whole point. A scan that imported an upstream redactor
+would keep passing after that redactor changed, which is exactly the failure a
+third layer exists to catch. So this file imports nothing from the rest of
+Sourcecado, carries its own pattern vocabulary, and is tested on its own.
+
+Two jobs:
+
+`relativize` and `scrub` rewrite absolute paths before anything is packaged.
+A path anchored in the operator's home directory identifies a real person, so
+the whole path token collapses to `<home>`; a path inside the state directory
+keeps its remainder, because `<state>/club.db` is diagnostic and safe.
+
+`scan` refuses. It reports a category and a location and never the matched
+value, so a refusal can be logged and shown without becoming the leak it was
+trying to prevent.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+STATE_LABEL = "<state>"
+HOME_LABEL = "<home>"
+
+# The shortest string in the registered store worth treating as a credential.
+# Below this a value is a connector name, a scope word, or a status.
+MIN_REGISTERED_LENGTH = 12
+
+
+@dataclass(frozen=True)
+class ScanMatch:
+    """One refusal. Carries where and what kind, never the value itself."""
+
+    category: str
+    location: str
+
+
+SCAN_CATEGORIES = frozenset(
+    {
+        "registered_secret",
+        "private_key",
+        "json_web_token",
+        "issued_credential",
+        "authorization_header",
+        "credential_assignment",
+        "home_path",
+    }
+)
+
+_PRIVATE_KEY = re.compile(
+    r"-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----", re.IGNORECASE
+)
+_JSON_WEB_TOKEN = re.compile(
+    r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"
+)
+# Issuer prefixes that mean "credential" on their own. Each one is a published
+# token format, so a match here is never a guess about entropy.
+_ISSUED_CREDENTIAL = re.compile(
+    r"(?:sk-(?:ant-|proj-|live-|test-)?[A-Za-z0-9_-]{16,}"
+    r"|rk-[A-Za-z0-9_-]{16,}"
+    r"|pk_(?:live|test)_[A-Za-z0-9]{16,}"
+    r"|gh[pousr]_[A-Za-z0-9]{16,}"
+    r"|github_pat_[A-Za-z0-9_]{20,}"
+    r"|glpat-[A-Za-z0-9_-]{16,}"
+    r"|xox[baprs]-[A-Za-z0-9-]{16,}"
+    r"|shpat_[A-Za-z0-9]{16,}"
+    r"|dop_v1_[A-Za-z0-9]{16,}"
+    r"|npm_[A-Za-z0-9]{20,}"
+    r"|SG\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}"
+    r"|A(?:KIA|SIA)[0-9A-Z]{16}"
+    r"|AIza[A-Za-z0-9_-]{20,}"
+    r"|ya29\.[A-Za-z0-9._-]{12,}"
+    r"|1//[A-Za-z0-9_-]{12,})"
+)
+# An authorization value, either behind the header name or bare. The value is
+# captured so a plain English sentence — "Basic authentication is required" —
+# cannot refuse an export: a real one is never all letters.
+_AUTHORIZATION_HEADER = re.compile(
+    r"(?i)(?:authorization[\"']?\s*[:=]\s*[\"']?)?"
+    r"\b(?:Bearer|Basic)\s+(?P<value>[A-Za-z0-9._\-+/=]{12,})"
+)
+_WORD = re.compile(r"^[A-Za-z]+$")
+# A named credential assigned a value. The name must end at a word boundary so
+# `input_tokens` and `context_window_tokens` are not credential names.
+_CREDENTIAL_ASSIGNMENT = re.compile(
+    r"(?i)\b[\w.\-]*"
+    r"(?:api[_-]?key|secret|password|passphrase|credential|cookie|token"
+    r"|authorization|client[_-]?secret)"
+    r"\b[\"']?\s*[:=]\s*[\"']?"
+    r"(?P<value>[^\s\"',;}\]]{12,})"
+)
+_HOME_PATH = re.compile(
+    r"(?<![\w/])(?:/Users/|/home/)[^\s\"',;:]+"
+    r"|\b[A-Za-z]:\\[Uu]sers\\[^\s\"',;]+"
+)
+# A placeholder is not a value. Without this a redacted assignment would look
+# like a credential assignment on the next pass.
+_PLACEHOLDER = re.compile(r"^[<\[](?:redacted|home|state)", re.IGNORECASE)
+_DECIMAL = re.compile(r"^-?\d+(?:\.\d+)?$")
+
+
+def relativize(value: Any, *, home: Path, state_root: Path) -> str:
+    """Anchor every absolute path, and erase the ones anchored in a home.
+
+    The state directory keeps its remainder because the file that is broken is
+    the diagnostic fact. A home path loses everything after `<home>`: the
+    directory names and the file name are the operator's business, and the only
+    thing a reader needs is that the path pointed outside Sourcecado's state.
+    """
+    text = str(value)
+    root = str(state_root)
+    if len(root) > 1:
+        text = text.replace(root, STATE_LABEL)
+    dwelling = str(home)
+    if len(dwelling) > 1:
+        text = re.sub(re.escape(dwelling) + r"[^\s\"',;:]*", HOME_LABEL, text)
+    return _HOME_PATH.sub(HOME_LABEL, text)
+
+
+def scrub(value: Any, *, home: Path, state_root: Path) -> Any:
+    """Apply `relativize` to every string in a JSON-shaped structure."""
+    if isinstance(value, str):
+        return relativize(value, home=home, state_root=state_root)
+    if isinstance(value, dict):
+        return {
+            key: scrub(item, home=home, state_root=state_root)
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [scrub(item, home=home, state_root=state_root) for item in value]
+    return value
+
+
+def registered_secret_values(payload: Any) -> frozenset[str]:
+    """Every value in the registered secret store worth scanning for.
+
+    A URL and an email address are excluded deliberately. Both appear in that
+    store beside the credentials — scope URLs, token endpoints, the connected
+    account — and both also appear legitimately elsewhere, so treating them as
+    secrets would refuse every export rather than the leaking ones.
+    """
+    found: set[str] = set()
+    _collect(payload, found)
+    return frozenset(found)
+
+
+def _collect(value: Any, found: set[str]) -> None:
+    if isinstance(value, str):
+        if len(value) < MIN_REGISTERED_LENGTH:
+            return
+        if "://" in value or _looks_like_address(value):
+            return
+        found.add(value)
+    elif isinstance(value, dict):
+        for item in value.values():
+            _collect(item, found)
+    elif isinstance(value, (list, tuple)):
+        for item in value:
+            _collect(item, found)
+
+
+def _looks_like_address(value: str) -> bool:
+    local, separator, domain = value.partition("@")
+    return bool(separator) and "." in domain and " " not in value
+
+
+def scan(
+    value: Any,
+    *,
+    registered: Iterable[str],
+    home: Path,
+    state_root: Path,
+    location: str = "",
+) -> tuple[ScanMatch, ...]:
+    """Walk a JSON-shaped structure and report every refusal reason found."""
+    secrets = tuple(registered)
+    matches: list[ScanMatch] = []
+    _walk(value, secrets, home, state_root, location, matches)
+    return tuple(matches)
+
+
+def scan_text(
+    text: str,
+    *,
+    registered: Iterable[str],
+    home: Path,
+    state_root: Path,
+    location: str,
+) -> tuple[ScanMatch, ...]:
+    """Scan one already-serialised blob, such as a file about to be packaged."""
+    return _scan_one(text, tuple(registered), home, state_root, location)
+
+
+def _walk(
+    value: Any,
+    secrets: tuple[str, ...],
+    home: Path,
+    state_root: Path,
+    location: str,
+    matches: list[ScanMatch],
+) -> None:
+    if isinstance(value, str):
+        matches.extend(_scan_one(value, secrets, home, state_root, location))
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            _walk(item, secrets, home, state_root, _join(location, key), matches)
+    elif isinstance(value, (list, tuple)):
+        for index, item in enumerate(value):
+            _walk(item, secrets, home, state_root, _join(location, index), matches)
+
+
+def _join(location: str, part: Any) -> str:
+    return f"{location}.{part}" if location else str(part)
+
+
+def _scan_one(
+    text: str,
+    secrets: tuple[str, ...],
+    home: Path,
+    state_root: Path,
+    location: str,
+) -> tuple[ScanMatch, ...]:
+    found: list[ScanMatch] = []
+    for secret in secrets:
+        if secret and secret in text:
+            found.append(ScanMatch("registered_secret", location or "<root>"))
+            break
+    if _PRIVATE_KEY.search(text):
+        found.append(ScanMatch("private_key", location or "<root>"))
+    if _JSON_WEB_TOKEN.search(text):
+        found.append(ScanMatch("json_web_token", location or "<root>"))
+    if _ISSUED_CREDENTIAL.search(text):
+        found.append(ScanMatch("issued_credential", location or "<root>"))
+    if any(
+        not _WORD.match(match.group("value"))
+        for match in _AUTHORIZATION_HEADER.finditer(text)
+    ):
+        found.append(ScanMatch("authorization_header", location or "<root>"))
+    if _assigned_credential(text):
+        found.append(ScanMatch("credential_assignment", location or "<root>"))
+    if _HOME_PATH.search(_state_relative(text, state_root=state_root)):
+        found.append(ScanMatch("home_path", location or "<root>"))
+    return tuple(found)
+
+
+def _state_relative(text: str, *, state_root: Path) -> str:
+    """Take the state directory out of the way before looking for home paths.
+
+    A state directory legitimately sits inside a home directory, and the export
+    prints it as `<state>/…`. Only what survives that substitution is an
+    unmodelled home path.
+    """
+    root = str(state_root)
+    return text.replace(root, STATE_LABEL) if len(root) > 1 else text
+
+
+def _assigned_credential(text: str) -> bool:
+    for match in _CREDENTIAL_ASSIGNMENT.finditer(text):
+        value = match.group("value")
+        if _PLACEHOLDER.match(value) or _DECIMAL.match(value):
+            continue
+        return True
+    return False

--- a/desktop/coworker/diagnostic_bundle.py
+++ b/desktop/coworker/diagnostic_bundle.py
@@ -1,0 +1,1113 @@
+"""A redacted diagnostic bundle for one failed or interrupted run.
+
+A bundle is the most dangerous artifact Sourcecado produces, because its whole
+purpose is to be handed to someone else. Everything here is arranged around
+that one fact.
+
+Three independent layers stand between local state and a bundle:
+
+1. The run receipt's closed field allowlist, upstream in `run_receipt.py`.
+2. The state report's bounded, redacted output contract, upstream in
+   `doctor.py`, whose findings this module copies without widening.
+3. This module's own projection plus `bundle_redaction`, which imports neither
+   of the first two. A scan that leaned on the layers above it would keep
+   passing after one of them changed.
+
+Free text in a bundle is limited to the bounded runtime notes a run recorded
+(`reason`, `error_summary`) and the bounded findings the state report already
+redacts. Everything else is an identifier, an enum, a count, or a timestamp.
+Prompts, message bodies, source titles and URLs, tool arguments and results,
+command output, credentials, authorization material, private reasoning, and raw
+home paths have no field to land in.
+
+Two properties are structural rather than aspirational:
+
+**Fail closed.** If the scan matches, nothing is produced. Not a redacted
+bundle, not a warning file. A match is evidence that something reached the
+document by a path this module did not model, and refusing is the only honest
+response.
+
+**No partial artifact.** The archive is assembled entirely in memory and
+scanned there. Only complete, scanned bytes are ever written, into a private
+temporary directory on the destination filesystem, and only `os.replace` puts
+them in place. Any failure removes that directory, so no half-written file can
+be mistaken for a bundle.
+
+This module opens no network client and imports nothing that could. It is also
+the offline inspector: `python -m coworker.diagnostic_bundle inspect <archive>`
+verifies the manifest and every checksum with no Sourcecado state at all.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import platform
+import shutil
+import sys
+import tempfile
+import uuid
+import zipfile
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from coworker.bundle_redaction import ScanMatch, scan, scan_text, scrub
+
+BUNDLE_VERSION = 1
+ARCHIVE_PREFIX = "sourcecado-diagnostic-"
+MANIFEST_NAME = "manifest.json"
+CHECKSUMS_NAME = "checksums.txt"
+
+# Every evidence file in a bundle. The manifest and the checksum list are
+# generated from these and are not themselves evidence.
+MEMBERS = (
+    "connectors.json",
+    "environment.json",
+    "health.json",
+    "logs.json",
+    "run.json",
+    "state.json",
+    "subject.json",
+)
+
+# How much history a bundle carries. Bounds are counts, never durations: a
+# time window would make two exports of identical state differ.
+HEALTH_WINDOW_RUNS = 50
+HEALTH_RECENT = 20
+MAX_LOG_RECORDS = 100
+MAX_ENTRIES = 200
+
+PREVIEW_FINDINGS = 8
+PREVIEW_LOG_RECORDS = 12
+MAX_PREVIEW_CHARS = 16000
+
+_ID = 256
+_SHORT = 128
+_SUMMARY = 512
+_LIST = 20
+
+# A fixed member timestamp. A real one would vary between two exports of the
+# same state, which criterion 6 forbids.
+ZIP_EPOCH = (1980, 1, 1, 0, 0, 0)
+MEMBER_MODE = 0o600
+_DIRECTORY_MODE = 0o700
+
+LOG_RECORD_FIELDS = frozenset(
+    {
+        "index",
+        "type",
+        "state",
+        "turn_id",
+        "event_id",
+        "tool_call_id",
+        "tool_name",
+        "ok",
+        "action",
+        "status",
+        "provider",
+        "model",
+        "reason_length",
+        "attempt",
+        "delay_ms",
+        "resolution",
+        "execution_status",
+        "decision",
+        "scope",
+        "requested_at",
+        "resolved_at",
+        "message_length",
+        "delta_length",
+        "text_length",
+    }
+)
+
+EVIDENCE_CATEGORIES = (
+    {
+        "id": "subject",
+        "title": "What this bundle is about",
+        "description": (
+            "The exact run or state-integrity finding the export started from, "
+            "and the list of categories below."
+        ),
+    },
+    {
+        "id": "environment",
+        "title": "Versions and platform",
+        "description": (
+            "Sourcecado's version and slice, the Python runtime, and the "
+            "operating system family, release, and machine architecture. The "
+            "machine's hostname is not included."
+        ),
+    },
+    {
+        "id": "run",
+        "title": "Run lifecycle and timing",
+        "description": (
+            "Lifecycle codes for the run, model attempts and their durations, "
+            "tool calls and their durations, token counts, approval decisions "
+            "resolved against the owner-native record, and how the run ended. "
+            "No prompt, no message body, no tool argument, no tool result."
+        ),
+    },
+    {
+        "id": "health",
+        "title": "Bounded health history",
+        "description": (
+            f"The last {HEALTH_WINDOW_RUNS} runs by state, trigger, and "
+            "outcome, so a reader can tell an isolated failure from a pattern. "
+            "Bounded by count, never by a time window."
+        ),
+    },
+    {
+        "id": "state",
+        "title": "State integrity and migration state",
+        "description": (
+            "Every local store's version against the registry, the pending "
+            "migration steps, and the integrity findings, copied from the "
+            "state report's own bounded and redacted output."
+        ),
+    },
+    {
+        "id": "connectors",
+        "title": "Connector status",
+        "description": (
+            "Each connector's identity, status, and missing permissions. No "
+            "authorization material and no connected account address."
+        ),
+    },
+    {
+        "id": "logs",
+        "title": "Redacted log records",
+        "description": (
+            f"Up to {MAX_LOG_RECORDS} structured event records from the run's "
+            "session, projected onto a closed field list. Assistant text, tool "
+            "arguments, tool results, and error text are carried as lengths."
+        ),
+    },
+)
+
+EXCLUDED = (
+    "Prompts, persona text, and message bodies.",
+    "Source excerpts, source titles, and source URLs.",
+    "Tool arguments, tool results, and command output.",
+    "Credentials, authorization headers, and OAuth grants.",
+    "Private model reasoning.",
+    "Raw home paths. Anything anchored in a home directory reads as <home>.",
+    "The machine's hostname and the connected account's email address.",
+)
+
+
+class BundleScanFailed(Exception):
+    """The pre-export scan matched, so nothing was produced.
+
+    The message names categories and locations. It never carries the matched
+    value: a refusal that printed the secret would be the leak it prevented.
+    """
+
+    def __init__(self, matches: tuple[ScanMatch, ...] | list[ScanMatch]) -> None:
+        self.matches = tuple(matches)
+        detail = ", ".join(
+            f"{match.category} at {match.location}" for match in self.matches
+        )
+        super().__init__(f"diagnostic bundle refused: {detail}")
+
+
+@dataclass(frozen=True, kw_only=True)
+class BundleSubject:
+    """The exact thing an export starts from."""
+
+    kind: str
+    run_id: str | None = None
+    check: str | None = None
+    store_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        if self.kind == "run":
+            return {"kind": "run", "run_id": _text(self.run_id, _ID) or ""}
+        return {
+            "kind": _text(self.kind, _SHORT) or "",
+            "check": _text(self.check, _SHORT),
+            "store_id": _text(self.store_id, _SHORT),
+        }
+
+
+@dataclass(frozen=True, kw_only=True)
+class BundleSources:
+    """Everything a bundle reads, resolved by the caller.
+
+    Passing these in rather than reaching for them keeps this module free of
+    the state directory, the run store, and the connector layer, so the whole
+    projection can be tested against exact inputs.
+    """
+
+    application: dict[str, Any]
+    doctor: dict[str, Any]
+    connectors: list[dict[str, Any]]
+    events: list[dict[str, Any]]
+    state_root: Path
+    receipt: dict[str, Any] | None = None
+    recent_runs: dict[str, Any] = field(default_factory=dict)
+    registered_secrets: frozenset[str] = frozenset()
+    home: Path = field(default_factory=Path.home)
+
+
+# --- the document --------------------------------------------------------
+
+
+def build_document(
+    subject: BundleSubject, sources: BundleSources
+) -> dict[str, dict[str, Any]]:
+    """Project every source onto the bundle's own allowlist.
+
+    Pure: no clock, no randomness, no filesystem. Two calls against identical
+    state return equal documents, which is what makes criterion 6 a property of
+    the code rather than a claim about it.
+    """
+    document = {
+        "subject.json": _subject(subject, sources),
+        "environment.json": _environment(sources),
+        "run.json": _run(sources.receipt),
+        "health.json": _health(sources.recent_runs),
+        "state.json": _state(sources.doctor),
+        "connectors.json": _connectors(sources.connectors),
+        "logs.json": _logs(sources.events),
+    }
+    return scrub(document, home=sources.home, state_root=sources.state_root)
+
+
+def _subject(subject: BundleSubject, sources: BundleSources) -> dict[str, Any]:
+    included = {
+        "subject": True,
+        "environment": True,
+        "run": sources.receipt is not None,
+        "health": bool((sources.recent_runs or {}).get("runs")),
+        "state": bool(sources.doctor),
+        "connectors": bool(sources.connectors),
+        "logs": bool(sources.events),
+    }
+    return {
+        "bundle_version": BUNDLE_VERSION,
+        "subject": subject.to_dict(),
+        "evidence_categories": [
+            {**category, "included": included[category["id"]]}
+            for category in EVIDENCE_CATEGORIES
+        ],
+        "excluded": list(EXCLUDED),
+    }
+
+
+def _environment(sources: BundleSources) -> dict[str, Any]:
+    application = sources.application or {}
+    return {
+        "application": {
+            "name": _text(application.get("name"), _SHORT),
+            "version": _text(application.get("version"), _SHORT),
+            "slice": _number(application.get("slice")),
+        },
+        "python": {
+            "version": platform.python_version(),
+            "implementation": platform.python_implementation(),
+        },
+        # `platform.node()` is the machine's hostname and is deliberately absent.
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+        },
+    }
+
+
+_RUN_FIELDS = (
+    "run_id",
+    "session_id",
+    "person_id",
+    "parent_run_id",
+    "trigger",
+    "state",
+    "goal_fingerprint",
+    "created_at",
+    "updated_at",
+    "finished_at",
+    "version",
+)
+_ATTEMPT_FIELDS = (
+    "attempt_id",
+    "provider",
+    "model_id",
+    "status",
+    "error_class",
+    "duration_ms",
+    "outcome",
+    "first_sequence",
+    "last_sequence",
+)
+_CALL_FIELDS = (
+    "tool_call_id",
+    "tool_name",
+    "status",
+    "error_class",
+    "duration_ms",
+    "item_count",
+    "lifecycle",
+    "first_sequence",
+    "last_sequence",
+)
+_DECISION_FIELDS = (
+    "approval_id",
+    "requested",
+    "requested_sequence",
+    "tool_name",
+    "decision",
+    "state",
+    "execution_status",
+    "evidence",
+)
+_RECOVERY_FIELDS = ("sequence", "kind", "state", "tool_call_id", "created_at")
+_NOTE_FIELDS = ("sequence", "kind")
+# Every free-text field a run recorded, carried as a length and never as a
+# value. `reason` and `error_summary` are bounded and redacted at write time,
+# but both are written from caller text: a body, a traceback, or a path lands
+# in them whenever the runtime summarises what went wrong. `error_class` and
+# the lifecycle codes carry the diagnostic signal instead.
+_RUN_TEXT_LENGTHS = (
+    ("reason", "reason_length"),
+    ("error_summary", "error_summary_length"),
+)
+
+
+def _run(receipt: dict[str, Any] | None) -> dict[str, Any]:
+    """Re-project the receipt onto this module's own field list.
+
+    The receipt is already an allowlist. Naming the fields again here is the
+    point: if a field is added upstream, it does not silently join every bundle
+    an operator ever shares.
+    """
+    if not receipt:
+        return {
+            "run": None,
+            "record": None,
+            "prompt": None,
+            "model_attempts": None,
+            "usage": None,
+            "tools": None,
+            "sources": None,
+            "artifacts": None,
+            "approvals": None,
+            "recovery": None,
+            "rationale": None,
+            "outcome": None,
+        }
+    run = receipt.get("run") or {}
+    record = receipt.get("record") or {}
+    prompt = receipt.get("prompt") or {}
+    attempts = receipt.get("model_attempts") or {}
+    tools = receipt.get("tools") or {}
+    approvals = receipt.get("approvals") or {}
+    outcome = receipt.get("outcome") or {}
+    result = outcome.get("result") or {}
+    projected_run = _pick(run, _RUN_FIELDS)
+    # A duration measured against "now" would differ between two exports of one
+    # unchanged run. Only a finished run has a duration a bundle may carry.
+    if run.get("finished_at"):
+        projected_run["duration_ms"] = _number(run.get("duration_ms"))
+    return {
+        "run": projected_run,
+        "record": {
+            "complete": bool(record.get("complete")),
+            "checkpoints_stored": _number(record.get("checkpoints_stored")) or 0,
+            "checkpoints_expected": _number(record.get("checkpoints_expected")) or 0,
+            "pruned_through_sequence": _number(record.get("pruned_through_sequence")),
+            "damaged": bool(record.get("damaged")),
+            "unsupported": _strings(record.get("unsupported")),
+        },
+        "prompt": {
+            "evidence": _text(prompt.get("evidence"), _SHORT),
+            "persona_id": _text(prompt.get("persona_id"), _SHORT),
+            "prompt_version": _text(prompt.get("prompt_version"), _SHORT),
+        },
+        "model_attempts": {
+            "evidence": _text(attempts.get("evidence"), _SHORT),
+            "attempt_count": _number(attempts.get("attempt_count")) or 0,
+            "distinct_models": _number(attempts.get("distinct_models")) or 0,
+            "attempts": _entries(attempts.get("attempts"), _ATTEMPT_FIELDS),
+        },
+        "usage": {
+            "evidence": _text((receipt.get("usage") or {}).get("evidence"), _SHORT),
+            "totals": {
+                str(key)[:_SHORT]: value
+                for key, value in ((receipt.get("usage") or {}).get("totals") or {}).items()
+                if _number(value) is not None
+            },
+        },
+        "tools": {
+            "evidence": _text(tools.get("evidence"), _SHORT),
+            "pending_count": _number(tools.get("pending_count")) or 0,
+            "unknown_count": _number(tools.get("unknown_count")) or 0,
+            "calls": _entries(tools.get("calls"), _CALL_FIELDS, lengths=_RUN_TEXT_LENGTHS),
+        },
+        # Reference titles and URLs are document content. A bundle counts them
+        # by provider and never names them.
+        "sources": _references(receipt.get("sources"), "provider"),
+        "artifacts": _references(receipt.get("artifacts"), "artifact_type"),
+        "approvals": {
+            "evidence": _text(approvals.get("evidence"), _SHORT),
+            # `actor` names a person and is deliberately dropped.
+            "decisions": _entries(approvals.get("decisions"), _DECISION_FIELDS),
+        },
+        "recovery": {
+            "evidence": _text((receipt.get("recovery") or {}).get("evidence"), _SHORT),
+            "events": _entries(
+                (receipt.get("recovery") or {}).get("events"),
+                _RECOVERY_FIELDS,
+                lengths=_RUN_TEXT_LENGTHS,
+            ),
+        },
+        "rationale": {
+            "evidence": _text((receipt.get("rationale") or {}).get("evidence"), _SHORT),
+            "notes": _entries(
+                (receipt.get("rationale") or {}).get("notes"),
+                _NOTE_FIELDS,
+                lengths=_RUN_TEXT_LENGTHS,
+            ),
+        },
+        "outcome": {
+            "evidence": _text(outcome.get("evidence"), _SHORT),
+            "state": _text(outcome.get("state"), _SHORT),
+            "open": bool(outcome.get("open")),
+            "finished_at": _text(outcome.get("finished_at"), _SHORT),
+            "duration_ms": _number(outcome.get("duration_ms")),
+            # `error` and `message_id` are dropped: the class says what failed,
+            # and the free-text error is where a path or a body would ride out.
+            "result": {
+                "status": _text(result.get("status"), _SHORT),
+                "error_class": _text(result.get("error_class"), _SHORT),
+                "text_length": _number(result.get("text_length")),
+            }
+            if result
+            else None,
+        },
+    }
+
+
+def _references(section: Any, group: str) -> dict[str, Any]:
+    """Counts by provider or type. Never an id, a title, or a URL."""
+    block = section or {}
+    refs = block.get("refs") if isinstance(block, dict) else None
+    tally: dict[str, dict[str, int]] = {}
+    for ref in refs if isinstance(refs, list) else []:
+        if not isinstance(ref, dict):
+            continue
+        key = _text(ref.get(group), _SHORT) or "unknown"
+        entry = tally.setdefault(key, {"count": 0, "stale_count": 0})
+        entry["count"] += 1
+        if ref.get("stale"):
+            entry["stale_count"] += 1
+    return {
+        "evidence": _text(block.get("evidence"), _SHORT) if isinstance(block, dict) else None,
+        "count": sum(entry["count"] for entry in tally.values()),
+        "stale_count": sum(entry["stale_count"] for entry in tally.values()),
+        "providers": [
+            {group: key, **tally[key]} for key in sorted(tally)[:MAX_ENTRIES]
+        ],
+    }
+
+
+def _health(page: Any) -> dict[str, Any]:
+    """Recent run outcomes, bounded by count so the window cannot drift."""
+    runs = (page or {}).get("runs") if isinstance(page, dict) else None
+    rows = [row for row in (runs or []) if isinstance(row, dict)]
+    states: dict[str, int] = {}
+    triggers: dict[str, int] = {}
+    outcomes: dict[str, int] = {}
+    for row in rows:
+        _tally(states, _text(row.get("state"), _SHORT))
+        _tally(triggers, _text(row.get("trigger"), _SHORT))
+        _tally(outcomes, _text(row.get("outcome_status"), _SHORT))
+    return {
+        "runs_considered": len(rows),
+        "window_runs": HEALTH_WINDOW_RUNS,
+        "truncated": bool((page or {}).get("truncated")) if isinstance(page, dict) else False,
+        "states": states,
+        "triggers": triggers,
+        "outcomes": outcomes,
+        "recent": [
+            {
+                "run_id": _text(row.get("run_id"), _ID),
+                "trigger": _text(row.get("trigger"), _SHORT),
+                "state": _text(row.get("state"), _SHORT),
+                "outcome_status": _text(row.get("outcome_status"), _SHORT),
+                "created_at": _text(row.get("created_at"), _SHORT),
+                "finished_at": _text(row.get("finished_at"), _SHORT),
+                "duration_ms": _number(row.get("duration_ms")),
+                "source_count": _number(row.get("source_count")) or 0,
+                "artifact_count": _number(row.get("artifact_count")) or 0,
+                "approval_count": _number(row.get("approval_count")) or 0,
+            }
+            for row in rows[:HEALTH_RECENT]
+        ],
+    }
+
+
+_STORE_FIELDS = (
+    "store_id",
+    "kind",
+    "version_channel",
+    "present",
+    "version",
+    "target_version",
+    "status",
+)
+_FINDING_FIELDS = (
+    "check",
+    "store_id",
+    "severity",
+    "repair",
+    "summary",
+    "record_count",
+    "blocking",
+)
+
+
+def _state(report: Any) -> dict[str, Any]:
+    """Copy the state report's own contract. Never widen it."""
+    source = report if isinstance(report, dict) else {}
+    stores = [item for item in (source.get("stores") or []) if isinstance(item, dict)]
+    findings = []
+    for item in (source.get("findings") or [])[:MAX_ENTRIES]:
+        if not isinstance(item, dict):
+            continue
+        projected = _pick(item, _FINDING_FIELDS)
+        projected["blocking"] = bool(item.get("blocking"))
+        projected["detail"] = _strings(item.get("detail"))
+        findings.append(projected)
+    return {
+        "healthy": bool(source.get("healthy")),
+        "blocked": bool(source.get("blocked")),
+        "stores": [_pick(item, _STORE_FIELDS) for item in stores[:MAX_ENTRIES]],
+        "findings": findings,
+        "migration": {
+            "target_versions": {
+                str(item.get("store_id")): _number(item.get("target_version"))
+                for item in stores
+                if item.get("store_id")
+            },
+            "pending": [
+                {
+                    "store_id": _text(item.get("store_id"), _SHORT),
+                    "from_version": _number(item.get("version")),
+                    "to_version": _number(item.get("target_version")),
+                }
+                for item in stores
+                if item.get("version") is not None
+                and item.get("version") != item.get("target_version")
+            ],
+        },
+        "dependencies": [
+            {
+                "name": _text(item.get("name"), _SHORT),
+                "required": bool(item.get("required")),
+                "present": bool(item.get("present")),
+            }
+            for item in (source.get("dependencies") or [])
+            if isinstance(item, dict)
+        ],
+        "proposed_repairs": [
+            {
+                "action": _text(item.get("action"), _SHORT),
+                "store_id": _text(item.get("store_id"), _SHORT),
+                "record_count": _number(item.get("record_count")) or 0,
+            }
+            for item in (source.get("proposed_repairs") or [])
+            if isinstance(item, dict)
+        ],
+    }
+
+
+def _connectors(connectors: Any) -> dict[str, Any]:
+    """Identity, status, and missing permissions. No grant, no address."""
+    projected = []
+    for item in (connectors or [])[:MAX_ENTRIES]:
+        if not isinstance(item, dict):
+            continue
+        health = item.get("health") if isinstance(item.get("health"), dict) else {}
+        recovery = item.get("recovery") if isinstance(item.get("recovery"), dict) else {}
+        projected.append(
+            {
+                "id": _text(item.get("id"), _SHORT),
+                "title": _text(item.get("title"), _SHORT),
+                "status": _text(item.get("status"), _SHORT),
+                "catalog_group": _text(item.get("catalog_group"), _SHORT),
+                "health_category": _text(health.get("category"), _SHORT),
+                "health_label": _text(health.get("label"), _SHORT),
+                "recovery_category": _text(recovery.get("category"), _SHORT),
+                "required_scopes": _strings(item.get("required_scopes")),
+                "missing_scopes": _strings(item.get("missing_scopes")),
+                "supported_actions": _strings(item.get("supported_actions")),
+                "available_actions": _strings(item.get("available_actions")),
+            }
+        )
+    return {"connectors": projected}
+
+
+_LOG_SCALARS = (
+    ("type", _SHORT),
+    ("state", _SHORT),
+    ("event_id", _ID),
+    ("action", _SHORT),
+    ("status", _SHORT),
+    ("provider", _SHORT),
+    ("model", _SHORT),
+    ("resolution", _SHORT),
+    ("execution_status", _SHORT),
+    ("decision", _SHORT),
+    ("scope", _SHORT),
+    ("requested_at", _SHORT),
+    ("resolved_at", _SHORT),
+)
+_LOG_NUMBERS = ("attempt", "delay_ms")
+_LOG_LENGTHS = (
+    ("message", "message_length"),
+    ("delta", "delta_length"),
+    ("text", "text_length"),
+    ("reason", "reason_length"),
+)
+
+
+def _logs(events: Any) -> dict[str, Any]:
+    """The structured event log, projected onto a closed field list.
+
+    Anything a person or a model wrote — assistant text, an error message, a
+    tool argument map, a tool result — is carried as a length and never as a
+    value. `run_id` here is the turn identity the presentation log records; it
+    is a different identifier space from the Agent Run id.
+    """
+    rows = [row for row in (events or []) if isinstance(row, dict)]
+    counts: dict[str, int] = {}
+    for row in rows:
+        _tally(counts, _text(row.get("type"), _SHORT))
+    records = []
+    for index, row in enumerate(rows[-MAX_LOG_RECORDS:], start=max(0, len(rows) - MAX_LOG_RECORDS)):
+        record: dict[str, Any] = {"index": index}
+        for name, limit in _LOG_SCALARS:
+            value = _text(row.get(name), limit)
+            if value is not None:
+                record[name] = value
+        for name in _LOG_NUMBERS:
+            value = _number(row.get(name))
+            if value is not None:
+                record[name] = value
+        for name, target in _LOG_LENGTHS:
+            if isinstance(row.get(name), str):
+                record[target] = len(row[name])
+        if isinstance(row.get("ok"), bool):
+            record["ok"] = row["ok"]
+        turn = _text(row.get("run_id"), _ID)
+        if turn is not None:
+            record["turn_id"] = turn
+        call = _text(row.get("id"), _ID)
+        if call is not None:
+            record["tool_call_id"] = call
+        name = _text(row.get("name"), _SHORT)
+        if name is not None:
+            record["tool_name"] = name
+        records.append(record)
+    return {
+        "total_records": len(rows),
+        "record_limit": MAX_LOG_RECORDS,
+        "truncated": len(rows) > MAX_LOG_RECORDS,
+        "counts": counts,
+        "records": records,
+    }
+
+
+# --- the preview ---------------------------------------------------------
+
+
+def build_preview(document: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    """A bounded summary the operator reviews before deciding to save."""
+    subject = document.get("subject.json") or {}
+    state = document.get("state.json") or {}
+    logs = document.get("logs.json") or {}
+    run = (document.get("run.json") or {}).get("run") or {}
+    outcome = (document.get("run.json") or {}).get("outcome") or {}
+    health = document.get("health.json") or {}
+    connectors = (document.get("connectors.json") or {}).get("connectors") or []
+    preview = {
+        "bundle_version": BUNDLE_VERSION,
+        "subject": subject.get("subject"),
+        "evidence_categories": subject.get("evidence_categories") or [],
+        "excluded": subject.get("excluded") or [],
+        "members": list(MEMBERS),
+        "counts": {
+            "log_records": len(logs.get("records") or []),
+            "findings": len(state.get("findings") or []),
+            "connectors": len(connectors),
+            "runs_considered": health.get("runs_considered") or 0,
+        },
+        "run": {
+            "run_id": run.get("run_id"),
+            "state": outcome.get("state"),
+            "outcome_status": (outcome.get("result") or {}).get("status"),
+            "finished_at": outcome.get("finished_at"),
+        }
+        if run
+        else None,
+        "state": {"healthy": state.get("healthy"), "blocked": state.get("blocked")},
+        "findings": [
+            {
+                "check": item.get("check"),
+                "store_id": item.get("store_id"),
+                "severity": item.get("severity"),
+                "summary": item.get("summary"),
+            }
+            for item in (state.get("findings") or [])[:PREVIEW_FINDINGS]
+        ],
+        "log_records": list((logs.get("records") or [])[:PREVIEW_LOG_RECORDS]),
+    }
+    while len(json.dumps(preview)) > MAX_PREVIEW_CHARS:
+        if preview["log_records"]:
+            preview["log_records"].pop()
+        elif preview["findings"]:
+            preview["findings"].pop()
+        else:
+            break
+    return preview
+
+
+# --- packaging -----------------------------------------------------------
+
+
+def sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _serialize(payload: Any) -> bytes:
+    return (
+        json.dumps(payload, sort_keys=True, indent=2, ensure_ascii=False) + "\n"
+    ).encode("utf-8")
+
+
+def archive_members(
+    document: dict[str, dict[str, Any]], *, bundle_id: str, generated_at: str
+) -> dict[str, bytes]:
+    """Every file that will go into the archive, as exact bytes.
+
+    `checksums.txt` covers the evidence files and `manifest.json` covers
+    everything except itself, so the only bytes that move between two exports
+    of one state are the package identity inside `manifest.json`.
+    """
+    members = {name: _serialize(payload) for name, payload in document.items()}
+    checksums = "".join(
+        f"{sha256_bytes(members[name])}  {name}\n" for name in sorted(members)
+    )
+    members[CHECKSUMS_NAME] = checksums.encode("utf-8")
+    manifest = {
+        "bundle_version": BUNDLE_VERSION,
+        "package": {"bundle_id": bundle_id, "generated_at": generated_at},
+        "entries": [
+            {
+                "name": name,
+                "sha256": sha256_bytes(members[name]),
+                "size_bytes": len(members[name]),
+            }
+            for name in sorted(members)
+        ],
+    }
+    members[MANIFEST_NAME] = _serialize(manifest)
+    return members
+
+
+def _pack(members: dict[str, bytes]) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(
+        buffer, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=9
+    ) as archive:
+        for name in sorted(members):
+            info = zipfile.ZipInfo(filename=name, date_time=ZIP_EPOCH)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.create_system = 3
+            info.external_attr = MEMBER_MODE << 16
+            archive.writestr(info, members[name])
+    return buffer.getvalue()
+
+
+def archive_bytes(
+    document: dict[str, dict[str, Any]], *, bundle_id: str, generated_at: str
+) -> bytes:
+    return _pack(archive_members(document, bundle_id=bundle_id, generated_at=generated_at))
+
+
+# --- export --------------------------------------------------------------
+
+
+def scan_bundle(
+    document: dict[str, dict[str, Any]], sources: BundleSources
+) -> tuple[ScanMatch, ...]:
+    """The refusal check on its own, so a preview refuses on the same terms."""
+    return scan(
+        document,
+        registered=sources.registered_secrets,
+        home=sources.home,
+        state_root=sources.state_root,
+    )
+
+
+def export_bundle(
+    subject: BundleSubject,
+    sources: BundleSources,
+    *,
+    destination_dir: str | Path,
+    bundle_id: str | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Assemble, scan, and only then put one complete file in place.
+
+    Two scans run before anything touches the disk: one over the projected
+    document, and one over the exact bytes of every member, which catches
+    anything the manifest or the serialisation introduces. Either match raises
+    and nothing is written.
+    """
+    destination = Path(destination_dir)
+    document = build_document(subject, sources)
+    _refuse_on_match(scan_bundle(document, sources))
+
+    identity = bundle_id or uuid.uuid4().hex
+    generated = (now or datetime.now(UTC)).isoformat()
+    members = archive_members(document, bundle_id=identity, generated_at=generated)
+    matches: list[ScanMatch] = []
+    for name in sorted(members):
+        matches.extend(
+            scan_text(
+                members[name].decode("utf-8", errors="replace"),
+                registered=sources.registered_secrets,
+                home=sources.home,
+                state_root=sources.state_root,
+                location=name,
+            )
+        )
+    _refuse_on_match(tuple(matches))
+
+    payload = _pack(members)
+    name = f"{ARCHIVE_PREFIX}{identity}.zip"
+    target = destination / name
+    # Created only now. A refusal leaves no directory behind either, so an
+    # empty folder never suggests an export that half happened.
+    destination.mkdir(parents=True, exist_ok=True)
+    workspace = Path(tempfile.mkdtemp(dir=destination, prefix=".sourcecado-bundle-"))
+    try:
+        os.chmod(workspace, _DIRECTORY_MODE)
+        staged = workspace / name
+        descriptor = os.open(
+            staged, os.O_WRONLY | os.O_CREAT | os.O_EXCL, MEMBER_MODE
+        )
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(staged, target)
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+    os.chmod(target, MEMBER_MODE)
+    return {
+        "bundle_id": identity,
+        "generated_at": generated,
+        "path": str(target),
+        "sha256": sha256_bytes(payload),
+        "size_bytes": len(payload),
+        "members": sorted(members),
+    }
+
+
+def _refuse_on_match(matches: tuple[ScanMatch, ...]) -> None:
+    if matches:
+        raise BundleScanFailed(matches)
+
+
+# --- offline inspection --------------------------------------------------
+
+
+def inspect_archive(path: str | Path) -> dict[str, Any]:
+    """Verify a bundle's manifest and every checksum, with no state at all."""
+    archive_path = Path(path)
+    problems: list[str] = []
+    with zipfile.ZipFile(archive_path) as archive:
+        names = sorted(archive.namelist())
+        if MANIFEST_NAME not in names:
+            return {
+                "path": str(archive_path),
+                "bundle_version": None,
+                "package": None,
+                "entries": [],
+                "ok": False,
+                "problems": [f"{MANIFEST_NAME} is missing"],
+            }
+        manifest = json.loads(archive.read(MANIFEST_NAME))
+        payloads = {name: archive.read(name) for name in names}
+
+    entries = manifest.get("entries") or []
+    listed = sorted(entry.get("name") for entry in entries)
+    expected = sorted(name for name in payloads if name != MANIFEST_NAME)
+    if listed != expected:
+        problems.append(
+            f"the manifest lists {listed} but the archive holds {expected}"
+        )
+
+    verified = []
+    for entry in entries:
+        name = entry.get("name")
+        payload = payloads.get(name)
+        if payload is None:
+            problems.append(f"{name} is listed in the manifest but not in the archive")
+            verified.append({**entry, "ok": False})
+            continue
+        digest = sha256_bytes(payload)
+        ok = digest == entry.get("sha256") and len(payload) == entry.get("size_bytes")
+        if not ok:
+            problems.append(f"{name} does not match its manifest checksum or size")
+        verified.append(
+            {
+                "name": name,
+                "sha256": entry.get("sha256"),
+                "size_bytes": entry.get("size_bytes"),
+                "ok": ok,
+            }
+        )
+
+    problems.extend(_checksum_problems(payloads))
+    return {
+        "path": str(archive_path),
+        "bundle_version": manifest.get("bundle_version"),
+        "package": manifest.get("package"),
+        "entries": verified,
+        "ok": not problems,
+        "problems": problems,
+    }
+
+
+def _checksum_problems(payloads: dict[str, bytes]) -> list[str]:
+    listing = payloads.get(CHECKSUMS_NAME)
+    if listing is None:
+        return [f"{CHECKSUMS_NAME} is missing"]
+    problems: list[str] = []
+    for line in listing.decode("utf-8").splitlines():
+        if not line.strip():
+            continue
+        digest, _, name = line.partition("  ")
+        payload = payloads.get(name)
+        if payload is None:
+            problems.append(f"{name} is listed in {CHECKSUMS_NAME} but not present")
+        elif sha256_bytes(payload) != digest:
+            problems.append(f"{name} does not match its line in {CHECKSUMS_NAME}")
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m coworker.diagnostic_bundle",
+        description="Inspect a Sourcecado diagnostic bundle offline.",
+    )
+    subcommands = parser.add_subparsers(dest="command", required=True)
+    inspector = subcommands.add_parser("inspect", help="verify manifest and checksums")
+    inspector.add_argument("archive")
+    inspector.add_argument("--json", action="store_true", help="print the raw report")
+    arguments = parser.parse_args(argv)
+
+    report = inspect_archive(arguments.archive)
+    if arguments.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 0 if report["ok"] else 1
+    package = report.get("package") or {}
+    print(f"archive        {report['path']}")
+    print(f"bundle version {report.get('bundle_version')}")
+    print(f"bundle id      {package.get('bundle_id')}")
+    print(f"generated at   {package.get('generated_at')}")
+    print(f"entries        {len(report['entries'])}")
+    for entry in report["entries"]:
+        mark = "ok  " if entry["ok"] else "FAIL"
+        print(f"  {mark} {entry['sha256']}  {entry['name']}  ({entry['size_bytes']} bytes)")
+    for problem in report["problems"]:
+        print(f"problem        {problem}")
+    print("result         " + ("verified" if report["ok"] else "FAILED"))
+    return 0 if report["ok"] else 1
+
+
+# --- small shared coercions ----------------------------------------------
+
+
+def _text(value: Any, limit: int) -> str | None:
+    if not isinstance(value, str):
+        return None
+    trimmed = value[:limit].strip()
+    return trimmed or None
+
+
+def _number(value: Any) -> int | float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return value
+
+
+def _strings(values: Any) -> list[str]:
+    if not isinstance(values, (list, tuple)):
+        return []
+    kept = []
+    for item in values[:_LIST]:
+        text = _text(item, _SUMMARY)
+        if text is not None:
+            kept.append(text)
+    return kept
+
+
+def _pick(payload: dict[str, Any], fields: tuple[str, ...]) -> dict[str, Any]:
+    """Named scalars only. A nested structure never escapes a source."""
+    picked: dict[str, Any] = {}
+    for name in fields:
+        value = payload.get(name)
+        if isinstance(value, bool):
+            picked[name] = value
+        elif isinstance(value, (int, float)):
+            picked[name] = value
+        elif isinstance(value, str):
+            picked[name] = _text(value, _SUMMARY)
+        else:
+            picked[name] = None
+    return picked
+
+
+def _entries(
+    values: Any,
+    fields: tuple[str, ...],
+    *,
+    lengths: tuple[tuple[str, str], ...] = (),
+) -> list[dict[str, Any]]:
+    if not isinstance(values, (list, tuple)):
+        return []
+    entries = []
+    for item in values[:MAX_ENTRIES]:
+        if not isinstance(item, dict):
+            continue
+        entry = _pick(item, fields)
+        for name, target in lengths:
+            entry[target] = _length(item.get(name))
+        entries.append(entry)
+    return entries
+
+
+def _length(value: Any) -> int | None:
+    """How much text there was, never the text."""
+    return len(value) if isinstance(value, str) else None
+
+
+def _tally(counts: dict[str, int], key: str | None) -> None:
+    if key is None:
+        return
+    counts[key] = counts.get(key, 0) + 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/desktop/coworker/server.py
+++ b/desktop/coworker/server.py
@@ -16,7 +16,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Callable
 
-from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
+from fastapi import Body, FastAPI, Request, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse
 
@@ -30,6 +30,7 @@ from coworker.automation.scheduler import (
 )
 from coworker.agent_run_repository import AgentRunRepository
 from coworker.apollo_curation import curate_apollo_candidates
+from coworker.bundle_redaction import registered_secret_values
 from coworker.calendar import calendar_from_secrets
 from coworker.connectors.google_oauth import (
     CALENDAR_SCOPE,
@@ -46,6 +47,16 @@ from coworker.connectors.google_oauth import (
     load_google,
     merge_scopes,
     save_google,
+)
+from coworker.diagnostic_bundle import (
+    HEALTH_WINDOW_RUNS,
+    BundleScanFailed,
+    BundleSources,
+    BundleSubject,
+    build_document,
+    build_preview,
+    export_bundle,
+    scan_bundle,
 )
 from coworker.drive import drive_from_secrets
 from coworker.drive_evidence import attach as attach_drive_evidence
@@ -1905,6 +1916,129 @@ def create_app(
         except ValueError as exc:
             return JSONResponse({"error": str(exc)}, status_code=409)
         return {"person": person}
+
+    # --- diagnostic bundle ---------------------------------------------
+    #
+    # Two verbs on purpose. `preview` assembles and scans without writing, so
+    # the operator reviews exactly what a bundle would hold. `export` repeats
+    # the work and writes one file. Nothing here uploads anything: the module
+    # it calls opens no network client, and the only destination is a local
+    # directory inside the state root.
+
+    def _registered_secrets() -> frozenset[str]:
+        """Every credential this build holds, so the scan can refuse on any one.
+
+        These values are used for matching only. They are never rendered, never
+        logged, and never placed in a refusal.
+        """
+        values: set[str] = set()
+        secrets_path = Path(root) / "secrets.json"
+        if secrets_path.is_file():
+            try:
+                values |= registered_secret_values(
+                    json.loads(secrets_path.read_text(encoding="utf-8"))
+                )
+            except (OSError, ValueError):
+                pass
+        for name, value in os.environ.items():
+            named = name.upper()
+            if not any(
+                word in named
+                for word in ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL")
+            ):
+                continue
+            if len(value) < 16 or value.startswith("/") or "://" in value:
+                continue
+            values.add(value)
+        return frozenset(values)
+
+    def _diagnostic_sources(receipt: dict[str, Any] | None) -> BundleSources:
+        # Imported here rather than at module scope: the state inspector pulls
+        # in the whole migration registry, and the sidecar should not pay for
+        # that unless an operator actually asks for a bundle.
+        from coworker import doctor
+
+        session_id = str(((receipt or {}).get("run") or {}).get("session_id") or "")
+        try:
+            events = store.load_events(session_id) if session_id else []
+        except ValueError:
+            events = []
+        return BundleSources(
+            application={"name": "Sourcecado", "version": app.version, "slice": SLICE},
+            receipt=receipt,
+            recent_runs=app.state.run_ledger.query(limit=HEALTH_WINDOW_RUNS),
+            doctor=doctor.diagnose(root).to_dict(),
+            connectors=list(connectors().get("connectors") or []),
+            events=events,
+            registered_secrets=_registered_secrets(),
+            state_root=Path(root),
+            home=Path.home(),
+        )
+
+    def _bundle_start(payload: Any):
+        """Resolve the exact run or state finding an export starts from."""
+        body = payload if isinstance(payload, dict) else {}
+        run_id = str(body.get("run_id") or "").strip()
+        if run_id:
+            receipt = app.state.run_ledger.receipt(run_id)
+            if receipt is None:
+                return JSONResponse({"error": "run_not_found"}, status_code=404)
+            return BundleSubject(kind="run", run_id=run_id), receipt
+        check = str(body.get("check") or "").strip()
+        if not check:
+            return JSONResponse(
+                {"error": "run_id or check is required"}, status_code=400
+            )
+        return (
+            BundleSubject(
+                kind="doctor_finding",
+                check=check,
+                store_id=str(body.get("store_id") or "").strip() or None,
+            ),
+            None,
+        )
+
+    def _refused(matches) -> JSONResponse:
+        """A refusal names categories and locations. Never a value."""
+        return JSONResponse(
+            {
+                "error": "scan_refused",
+                "matches": [
+                    {"category": match.category, "location": match.location}
+                    for match in matches
+                ],
+            },
+            status_code=409,
+        )
+
+    @app.post("/v1/diagnostics/bundle/preview")
+    def diagnostics_bundle_preview(payload: dict[str, Any] | None = Body(default=None)):
+        started = _bundle_start(payload)
+        if isinstance(started, JSONResponse):
+            return started
+        subject, receipt = started
+        sources = _diagnostic_sources(receipt)
+        document = build_document(subject, sources)
+        matches = scan_bundle(document, sources)
+        if matches:
+            return _refused(matches)
+        return {"preview": build_preview(document)}
+
+    @app.post("/v1/diagnostics/bundle/export")
+    def diagnostics_bundle_export(payload: dict[str, Any] | None = Body(default=None)):
+        started = _bundle_start(payload)
+        if isinstance(started, JSONResponse):
+            return started
+        subject, receipt = started
+        try:
+            written = export_bundle(
+                subject,
+                _diagnostic_sources(receipt),
+                destination_dir=Path(root) / "diagnostics",
+            )
+        except BundleScanFailed as refused:
+            return _refused(refused.matches)
+        return {"bundle": written}
 
     @app.get("/v1/sessions")
     def sessions_list():

--- a/desktop/docs/diagnostic-bundle.md
+++ b/desktop/docs/diagnostic-bundle.md
@@ -1,0 +1,265 @@
+# The diagnostic bundle
+
+Status: active-stack engineering reference. Covers the export surface for one
+failed or interrupted run, its three redaction layers, and how to verify an
+archive offline.
+
+A diagnostic bundle is a local ZIP file that joins run evidence, versions,
+health history, state integrity, connector status, and structured log records
+for one failed run. Its whole purpose is to be handed to someone else. That is
+what makes it the most dangerous artifact Sourcecado can produce, and it is why
+this document leads with what cannot get into one.
+
+## Words used here
+
+- **Bundle** — one ZIP file describing one failed run or one state finding.
+- **Subject** — the exact run id, or the exact state-integrity check, an export
+  started from. Every bundle names one.
+- **Member** — one file inside the archive.
+- **Scan** — the pre-export check that refuses to build a bundle at all.
+- **Fail closed** — a matched scan produces nothing. Not a redacted bundle, not
+  a warning file, not an empty folder.
+
+## Running it
+
+The operator surface is Settings → Diagnostic bundle. It has two steps and they
+are separate on purpose.
+
+1. **Review bundle.** Assembles the bundle, runs the scan, and shows a bounded
+   preview: the subject, every evidence category with its description, what is
+   left out, and the counts. Nothing is written.
+2. **Save bundle to this Mac.** Repeats the work and writes one file to
+   `<state>/diagnostics/sourcecado-diagnostic-<bundle id>.zip`, mode 0600, and
+   reports the path, the size, and the SHA-256.
+
+Sourcecado never uploads a bundle. `coworker/diagnostic_bundle.py` opens no
+network client and imports nothing that could; `test_the_bundle_module_opens_no_network_client`
+holds that line.
+
+The same two steps are available directly:
+
+```
+POST /v1/diagnostics/bundle/preview   {"run_id": "run-…"}
+POST /v1/diagnostics/bundle/export    {"run_id": "run-…"}
+```
+
+Either accepts `{"check": "...", "store_id": "..."}` instead, to start from a
+state-integrity finding when there is no run to point at. An unknown run is a
+404. Neither field is a 400.
+
+## What a bundle holds
+
+| Member | Holds |
+| --- | --- |
+| `subject.json` | The run or finding this bundle is about, every evidence category with its description, and the exclusion list. |
+| `environment.json` | Sourcecado's version and slice, the Python runtime, and the OS family, release, and architecture. |
+| `run.json` | The run's lifecycle codes, model attempts and durations, tool calls and durations, token counts, approval decisions, recovery events, and how it ended. |
+| `health.json` | The last 50 runs by state, trigger, and outcome. |
+| `state.json` | Every store's version against the registry, pending migrations, integrity findings, and runtime dependencies. |
+| `connectors.json` | Each connector's identity, status, and missing permissions. |
+| `logs.json` | Up to 100 structured event records from the run's session. |
+| `checksums.txt` | SHA-256 for every evidence member, in `shasum -c` format. |
+| `manifest.json` | The bundle version, the package identity, and SHA-256 plus size for every other member. |
+
+## What a bundle never holds
+
+- Prompts, persona text, and message bodies.
+- Source excerpts, source titles, and source URLs.
+- Tool arguments, tool results, and command output.
+- Credentials, authorization headers, and OAuth grants.
+- Private model reasoning.
+- Raw home paths.
+- The machine's hostname and the connected account's email address.
+
+### Free text is carried as a length
+
+This is the rule that does the most work, and it costs something, so it is
+stated plainly.
+
+A run records two bounded free-text fields, `reason` and `error_summary`. Both
+are already truncated and passed through the write-time redactor. Both are
+still written from caller text: a summary of a failure routinely quotes a file
+path, a provider's error body, or the message the run was working on. A bundle
+therefore carries `reason_length` and `error_summary_length` and never the text.
+The same applies to an event log's `message`, `delta`, and `text`.
+
+What replaces it is `error_class`, the tool name, the lifecycle code, the
+duration, and the evidence value. That is enough to say *which tool failed, with
+what class of error, after how long, with what left unknown*. It is not enough
+to read the provider's own error string. That trade is deliberate: an error
+string is the single most likely carrier of every category in the list above.
+
+The one exception is `state.json`. Its findings are copied verbatim from the
+state report, whose summaries and details are structurally generated from store
+ids and counts rather than from caller text, and are separately bounded to 8
+detail lines of 200 characters each. `docs/doctor.md` documents that contract.
+
+## Evidence, not inference
+
+Every section of `run.json` carries an `evidence` value, passed through
+unchanged from the run receipt. The bundle does not define a vocabulary of its
+own: `present`, `absent`, `partial`, `missing`, `ambiguous`, `unsupported`, and
+`expired` are `coworker/run_evidence.py`'s words, and `docs/run-ledger.md`
+defines them. Two vocabularies for one distinction is how they drift apart.
+
+The distinction that matters most is `absent` against `missing`. "No source was
+touched" and "we do not know whether one was" are different operator
+situations, and a bundle that flattened them would be worse than no bundle.
+`test_absent_and_missing_stay_different_through_the_projection` builds two
+bundles — one from a run whose record has a hole, one from a run that ended
+cleanly — and asserts the same empty section reads `missing` in the first and
+`absent` in the second.
+
+`test_the_bundle_reuses_the_merged_evidence_vocabulary` asserts every
+`evidence` value anywhere in a bundle is a member of that enum, so neither side
+can coin a word the other does not have.
+
+`evidence_categories` in `subject.json` is a different thing despite the shared
+word: it lists *which kinds of data* a bundle holds, not how well the record
+supports a conclusion.
+
+## Three layers, and why the third is independent
+
+| Layer | Where | What it does |
+| --- | --- | --- |
+| 1 | `coworker/run_receipt.py` | A closed field allowlist over one run. Only identifiers, enums, counts, timestamps, and bounded runtime notes exist as fields. |
+| 2 | `coworker/doctor.py` | Checks report what they counted, not what they read, and every summary passes through `redact()`. |
+| 3 | `coworker/diagnostic_bundle.py` and `coworker/bundle_redaction.py` | A second projection that names its own fields, plus a path rewrite and a scan that refuses. |
+
+Layer 3 imports neither of the first two. `bundle_redaction.py` imports only
+`re`, `dataclasses`, `pathlib`, and `typing`; it carries its own credential
+vocabulary and its own path rules. `diagnostic_bundle.py` receives the receipt,
+the state report, and the connector view as plain data from its caller, and
+re-projects each onto field lists it names itself.
+
+That independence is the point rather than a style preference. A scan that
+called the write-time redactor would keep passing its tests after that redactor
+changed, which is exactly the failure the third layer exists to catch. Two tests
+hold it: `test_the_third_layer_imports_neither_of_the_first_two` reads the
+source, and `test_the_scan_still_catches_a_secret_when_the_upstream_layers_are_disabled`
+replaces both upstream redactors with identity functions and asserts the export
+still refuses.
+
+## Fail closed
+
+The scan runs twice before anything reaches the disk: once over the projected
+document, and once over the exact bytes of every member, which covers whatever
+the manifest and the serialisation add.
+
+It refuses on seven categories:
+
+| Category | Matches |
+| --- | --- |
+| `registered_secret` | Any value from `secrets.json`, plus any credential-named environment value this build holds. |
+| `private_key` | A PEM private key header. |
+| `json_web_token` | A three-segment JWT. |
+| `issued_credential` | A published issuer prefix: `sk-`, `ghp_`, `github_pat_`, `glpat-`, `xox…-`, `AKIA`/`ASIA`, `AIza`, `ya29.`, `1//`, and the rest. |
+| `authorization_header` | An `Authorization:` assignment, or a bare `Bearer`/`Basic` value. |
+| `credential_assignment` | A named credential assigned a value, such as `api_key=…`. |
+| `home_path` | An absolute path under `/Users/`, `/home/`, or `…:\Users\` that survived the path rewrite. |
+
+A match produces `BundleScanFailed` and nothing else. The HTTP surface answers
+409 with `{"error": "scan_refused", "matches": [{"category", "location"}]}`.
+The matched value is never in the exception, never in the response, and never
+in a log. A `location` is a dotted path into the bundle, such as
+`connectors.json.connectors.0.title`.
+
+Refusing rather than redacting is the whole design. A scan that matched means
+something reached the document by a path the projection did not model. Redacting
+it and continuing would ship a bundle built on a wrong assumption.
+
+### Known limit: no entropy heuristic
+
+The scan has no "this looks like a high-entropy secret" rule. Such a rule fires
+on legitimate identifiers — a Drive file id mixes three character classes over
+44 characters — and a false positive here refuses every export rather than one.
+So a bare, unregistered, prefix-free secret is not caught by the scan. Two
+things stand between that and a bundle: it has no field to land in, because free
+text is carried as a length; and if the operator registered it, the
+registered-secret rule catches it exactly. This is the same gap
+`docs/run-ledger.md` records for the write path, narrowed rather than closed.
+
+## Paths
+
+`relativize` rewrites every string in the document before packaging:
+
+- The state directory keeps its remainder: `<state>/club.db`. That is the
+  diagnostic fact, and it is safe.
+- A home-anchored path loses everything: `/Users/dana/Documents/plan.pdf`
+  becomes `<home>`. The directory names and the file name identify a person and
+  their work, and a reader only needs to know the path pointed outside
+  Sourcecado's state.
+
+A URL path is not a home path: `https://example.com/home/dana` is untouched.
+
+## Determinism
+
+`build_document` has no clock, no randomness, and no filesystem access. Two
+calls against unchanged state return equal documents. Every archive member is
+written with a fixed timestamp of 1980-01-01 and mode 0600, in sorted order.
+
+The only bytes that move between two exports of one state are `manifest.json`'s
+`package` object, which holds `bundle_id` and `generated_at`. `checksums.txt`
+covers the evidence members and not `manifest.json`, so it too is byte-stable.
+
+Anything clock-relative is left out rather than allowed to drift. A run's
+`duration_ms` appears only when the run has finished. The health window is
+bounded by a count of runs, never by a time window. Whether a process currently
+holds the run's lease is not in the bundle at all.
+
+## No partial artifact
+
+The archive is assembled in memory and scanned there. Only complete, scanned
+bytes are written, into a private temporary directory created inside the
+destination — same filesystem, so the rename is atomic — and `os.replace` is the
+only thing that puts a file in place. A `finally` removes the temporary
+directory whatever happens. The destination directory itself is created only
+after both scans pass, so a refusal leaves not even an empty folder.
+
+`test_a_crash_after_the_temporary_archive_is_written_leaves_nothing_readable`
+forces the riskiest case: it fails `os.replace` at the instant the complete
+archive is on disk, asserts the staged file was real and non-empty, and then
+asserts nothing readable remains anywhere under the destination.
+
+## Inspecting a bundle offline
+
+Sourcecado's own inspector verifies the manifest, every member checksum and
+size, and every line of `checksums.txt`:
+
+```
+cd desktop
+.venv/bin/python -m coworker.diagnostic_bundle inspect <path to the .zip>
+```
+
+Exit code 0 means verified, 1 means a problem was found and named. Add `--json`
+for the raw report.
+
+The archive is also verifiable with nothing but standard tools, which matters
+because the person you send it to may not have Sourcecado:
+
+```
+unzip -q sourcecado-diagnostic-<bundle id>.zip -d bundle
+cd bundle
+shasum -a 256 -c checksums.txt
+```
+
+`checksums.txt` covers every evidence member. `manifest.json` covers everything
+except itself, including `checksums.txt`, so a tampered checksum list is caught
+by the inspector even though the plain-tools path cannot see it.
+
+## Known gaps
+
+- The presentation event log's `run_id` is the turn identity, which is still a
+  different identifier space from the Agent Run id. Log records are therefore
+  selected by the run's session rather than by the run itself, and
+  `logs.json` carries the turn id as `turn_id` to keep the two apart. This
+  closes when the write side wires the two identities together.
+- Health history is a bounded window over all recent runs, not the runs related
+  to this one. A person filter would be more useful and is not here.
+- A bundle is written into the state directory. There is no operator-chosen save
+  location, because writing outside the state root belongs to the workspace
+  grant model rather than to this surface.
+- `state.json` runs a full state inspection on every preview and every export.
+  For a large state directory that is the slowest part of an export.
+- The GUI takes a run id by hand. Opening the export from a run receipt or from
+  a state finding directly is the natural next step and is not here.

--- a/desktop/surfaces/gui/src/api.ts
+++ b/desktop/surfaces/gui/src/api.ts
@@ -1747,3 +1747,100 @@ export function openChat(onEvent: (event: SourcecadoSocketEvent) => void): {
     },
   };
 }
+
+// --- diagnostic bundle -----------------------------------------------------
+
+export type DiagnosticEvidenceCategory = {
+  id: string;
+  title: string;
+  description: string;
+  included: boolean;
+};
+
+export type DiagnosticBundlePreview = {
+  bundle_version: number;
+  subject: { kind: string; run_id?: string; check?: string | null; store_id?: string | null };
+  evidence_categories: DiagnosticEvidenceCategory[];
+  excluded: string[];
+  members: string[];
+  counts: {
+    log_records: number;
+    findings: number;
+    connectors: number;
+    runs_considered: number;
+  };
+  run: {
+    run_id: string | null;
+    state: string | null;
+    outcome_status: string | null;
+    finished_at: string | null;
+  } | null;
+  state: { healthy: boolean | null; blocked: boolean | null };
+  findings: {
+    check: string | null;
+    store_id: string | null;
+    severity: string | null;
+    summary: string | null;
+  }[];
+  log_records: Record<string, unknown>[];
+};
+
+export type DiagnosticBundleResult = {
+  bundle_id: string;
+  generated_at: string;
+  path: string;
+  sha256: string;
+  size_bytes: number;
+  members: string[];
+};
+
+/** A scan match. The sidecar never sends the matched value, only where it was. */
+export type DiagnosticScanMatch = { category: string; location: string };
+
+export type DiagnosticBundleStart = {
+  run_id?: string;
+  check?: string;
+  store_id?: string;
+};
+
+export type DiagnosticBundleOutcome<T> =
+  | { status: "ok"; value: T }
+  | { status: "refused"; matches: DiagnosticScanMatch[] };
+
+async function diagnosticsPost<T>(
+  path: string,
+  start: DiagnosticBundleStart,
+  read: (payload: Record<string, unknown>) => T,
+): Promise<DiagnosticBundleOutcome<T>> {
+  const res = await fetch(`${httpBase()}${path}`, {
+    method: "POST",
+    headers: { "X-Club-Token": apiToken(), "Content-Type": "application/json" },
+    body: JSON.stringify(start),
+  });
+  const payload = await res.json();
+  if (res.status === 409 && payload?.error === "scan_refused") {
+    return { status: "refused", matches: payload.matches ?? [] };
+  }
+  if (!res.ok) throw new Error(payload?.error || `diagnostics ${res.status}`);
+  return { status: "ok", value: read(payload) };
+}
+
+export async function previewDiagnosticBundle(
+  start: DiagnosticBundleStart,
+): Promise<DiagnosticBundleOutcome<DiagnosticBundlePreview>> {
+  return diagnosticsPost(
+    "/v1/diagnostics/bundle/preview",
+    start,
+    (payload) => payload.preview as DiagnosticBundlePreview,
+  );
+}
+
+export async function exportDiagnosticBundle(
+  start: DiagnosticBundleStart,
+): Promise<DiagnosticBundleOutcome<DiagnosticBundleResult>> {
+  return diagnosticsPost(
+    "/v1/diagnostics/bundle/export",
+    start,
+    (payload) => payload.bundle as DiagnosticBundleResult,
+  );
+}

--- a/desktop/surfaces/gui/src/routes/DiagnosticBundle.tsx
+++ b/desktop/surfaces/gui/src/routes/DiagnosticBundle.tsx
@@ -1,0 +1,192 @@
+import { useState } from "react";
+
+import {
+  exportDiagnosticBundle,
+  previewDiagnosticBundle,
+  type DiagnosticBundlePreview,
+  type DiagnosticBundleResult,
+  type DiagnosticScanMatch,
+} from "../api";
+
+type State =
+  | { status: "idle" }
+  | { status: "working" }
+  | { status: "reviewing"; preview: DiagnosticBundlePreview }
+  | { status: "saving"; preview: DiagnosticBundlePreview }
+  | { status: "saved"; preview: DiagnosticBundlePreview; bundle: DiagnosticBundleResult }
+  | { status: "refused"; matches: DiagnosticScanMatch[] }
+  | { status: "failed" };
+
+function sizeLabel(bytes: number): string {
+  if (bytes < 1024) return `${bytes} bytes`;
+  return `${Math.round(bytes / 102.4) / 10} KB`;
+}
+
+/**
+ * Review first, save second.
+ *
+ * The two steps are separate on purpose. Preview assembles and scans the same
+ * bundle the save would write, and writes nothing. Nothing here uploads: the
+ * save action puts one file in the local state directory and reports where.
+ */
+export function DiagnosticBundle() {
+  const [runId, setRunId] = useState("");
+  const [state, setState] = useState<State>({ status: "idle" });
+
+  async function review() {
+    setState({ status: "working" });
+    try {
+      const outcome = await previewDiagnosticBundle({ run_id: runId.trim() });
+      setState(
+        outcome.status === "refused"
+          ? { status: "refused", matches: outcome.matches }
+          : { status: "reviewing", preview: outcome.value },
+      );
+    } catch {
+      setState({ status: "failed" });
+    }
+  }
+
+  async function save(preview: DiagnosticBundlePreview) {
+    setState({ status: "saving", preview });
+    try {
+      const outcome = await exportDiagnosticBundle({ run_id: runId.trim() });
+      setState(
+        outcome.status === "refused"
+          ? { status: "refused", matches: outcome.matches }
+          : { status: "saved", preview, bundle: outcome.value },
+      );
+    } catch {
+      setState({ status: "failed" });
+    }
+  }
+
+  const preview =
+    state.status === "reviewing" ||
+    state.status === "saving" ||
+    state.status === "saved"
+      ? state.preview
+      : null;
+
+  return (
+    <section className="settings-section" aria-labelledby="diagnostic-bundle-heading">
+      <h2 id="diagnostic-bundle-heading">Diagnostic bundle</h2>
+      <p className="settings-status">
+        <span>
+          Package one failed or interrupted run as a local file you can review
+          before you share it. Sourcecado never uploads a bundle.
+        </span>
+      </p>
+
+      <div className="bundle-start">
+        <label htmlFor="bundle-run-id">Run ID</label>
+        <input
+          id="bundle-run-id"
+          value={runId}
+          placeholder="run-…"
+          onChange={(event) => setRunId(event.target.value)}
+        />
+        <button
+          type="button"
+          onClick={review}
+          disabled={!runId.trim() || state.status === "working"}
+        >
+          {state.status === "working" ? "Preparing…" : "Review bundle"}
+        </button>
+      </div>
+
+      {state.status === "refused" && (
+        <div className="bundle-refused" role="alert">
+          <strong>Nothing was written.</strong>
+          <span>
+            The pre-export scan matched, so Sourcecado refused to build the
+            bundle. The matched values are never shown or saved.
+          </span>
+          <ul aria-label="Scan matches">
+            {state.matches.map((match) => (
+              <li key={`${match.category}:${match.location}`}>
+                <code>{match.category}</code> at <code>{match.location}</code>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {state.status === "failed" && (
+        <p className="settings-status settings-status-missing">
+          <strong>The bundle could not be prepared</strong>
+          <span>Check the run ID and try again.</span>
+        </p>
+      )}
+
+      {preview && (
+        <div className="bundle-preview">
+          <dl className="settings-facts">
+            <div>
+              <dt>Run</dt>
+              <dd>{preview.run?.run_id ?? "—"}</dd>
+            </div>
+            <div>
+              <dt>Ended</dt>
+              <dd>{preview.run?.state ?? "—"}</dd>
+            </div>
+            <div>
+              <dt>Log records</dt>
+              <dd>{preview.counts.log_records}</dd>
+            </div>
+            <div>
+              <dt>State findings</dt>
+              <dd>{preview.counts.findings}</dd>
+            </div>
+          </dl>
+
+          <h3>What this bundle includes</h3>
+          <ul className="bundle-categories" aria-label="Included evidence">
+            {preview.evidence_categories.map((category) => (
+              <li key={category.id}>
+                <header>
+                  <strong>{category.title}</strong>
+                  <span className={category.included ? "bundle-in" : "bundle-out"}>
+                    {category.included ? "Included" : "Not in this bundle"}
+                  </span>
+                </header>
+                <p>{category.description}</p>
+              </li>
+            ))}
+          </ul>
+
+          <h3>What is left out</h3>
+          <ul className="bundle-excluded" aria-label="Excluded content">
+            {preview.excluded.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+
+          {state.status !== "saved" && (
+            <button
+              type="button"
+              className="bundle-save"
+              onClick={() => save(preview)}
+              disabled={state.status === "saving"}
+            >
+              {state.status === "saving" ? "Saving…" : "Save bundle to this Mac"}
+            </button>
+          )}
+
+          {state.status === "saved" && (
+            <p className="settings-status">
+              <strong>Saved</strong>
+              <span>
+                <code>{state.bundle.path}</code>
+              </span>
+              <span>
+                {sizeLabel(state.bundle.size_bytes)} · sha256{" "}
+                <code>{state.bundle.sha256.slice(0, 16)}…</code>
+              </span>
+            </p>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/desktop/surfaces/gui/src/routes/SettingsPage.tsx
+++ b/desktop/surfaces/gui/src/routes/SettingsPage.tsx
@@ -9,6 +9,7 @@ import {
   type Settings,
   type WorkspaceDiagnostics,
 } from "../api";
+import { DiagnosticBundle } from "./DiagnosticBundle";
 import { WorkspaceSettings } from "./WorkspaceSettings";
 
 type SettingsState =
@@ -280,6 +281,8 @@ export function SettingsPage() {
               )
             }
           />
+
+          <DiagnosticBundle />
         </div>
       )}
     </main>

--- a/desktop/surfaces/gui/src/styles/route.css
+++ b/desktop/surfaces/gui/src/styles/route.css
@@ -1494,3 +1494,111 @@
     animation: none;
   }
 }
+
+/* Diagnostic bundle: review first, save second. Quiet by default -- this is a
+   recovery surface, not a place to decorate. */
+.bundle-start {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 14px 0 0;
+}
+
+.bundle-start label {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.bundle-start input {
+  flex: 1 1 220px;
+  min-width: 0;
+  padding: 7px 9px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12px;
+}
+
+.bundle-preview h3 {
+  margin: 20px 0 0;
+  font-size: 13px;
+}
+
+.bundle-categories,
+.bundle-excluded {
+  margin: 8px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.bundle-categories > li {
+  padding: 9px 0;
+  border-top: 1px solid var(--border);
+}
+
+.bundle-categories header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 7px;
+}
+
+.bundle-categories p,
+.bundle-excluded li {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.bundle-in,
+.bundle-out {
+  padding: 2px 7px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 650;
+}
+
+.bundle-in {
+  background: var(--accent-tint);
+  color: var(--accent-deep);
+}
+
+.bundle-out {
+  background: var(--raised);
+  color: var(--muted);
+}
+
+.bundle-save {
+  margin: 18px 0 0;
+}
+
+.bundle-refused {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 14px 0 0;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--error-bg);
+}
+
+.bundle-refused strong {
+  color: var(--error);
+}
+
+.bundle-refused span,
+.bundle-refused li {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.bundle-refused ul {
+  margin: 6px 0 0;
+  padding-left: 18px;
+}

--- a/desktop/surfaces/gui/tests/diagnosticBundle.test.tsx
+++ b/desktop/surfaces/gui/tests/diagnosticBundle.test.tsx
@@ -1,0 +1,150 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DiagnosticBundle } from "../src/routes/DiagnosticBundle";
+
+const api = vi.hoisted(() => ({
+  previewDiagnosticBundle: vi.fn(),
+  exportDiagnosticBundle: vi.fn(),
+}));
+
+vi.mock("../src/api", () => ({
+  previewDiagnosticBundle: api.previewDiagnosticBundle,
+  exportDiagnosticBundle: api.exportDiagnosticBundle,
+}));
+
+const PREVIEW = {
+  bundle_version: 1,
+  subject: { kind: "run", run_id: "run-9f21" },
+  evidence_categories: [
+    {
+      id: "run",
+      title: "Run lifecycle and timing",
+      description: "Lifecycle codes, model attempts, tool calls, and how it ended.",
+      included: true,
+    },
+    {
+      id: "logs",
+      title: "Redacted log records",
+      description: "Structured event records projected onto a closed field list.",
+      included: true,
+    },
+    {
+      id: "health",
+      title: "Bounded health history",
+      description: "Recent runs by state, trigger, and outcome.",
+      included: false,
+    },
+  ],
+  excluded: ["Prompts, persona text, and message bodies.", "Raw home paths."],
+  members: ["run.json", "logs.json"],
+  counts: { log_records: 6, findings: 2, connectors: 5, runs_considered: 1 },
+  run: {
+    run_id: "run-9f21",
+    state: "failed",
+    outcome_status: "failed",
+    finished_at: "2026-08-20T09:04:00+00:00",
+  },
+  state: { healthy: false, blocked: false },
+  findings: [],
+  log_records: [],
+};
+
+const BUNDLE = {
+  bundle_id: "3f9c",
+  generated_at: "2026-08-20T09:05:00+00:00",
+  path: "<state>/diagnostics/sourcecado-diagnostic-3f9c.zip",
+  sha256: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  size_bytes: 20480,
+  members: ["run.json", "logs.json"],
+};
+
+function start(runId = "run-9f21") {
+  render(<DiagnosticBundle />);
+  fireEvent.change(screen.getByLabelText("Run ID"), { target: { value: runId } });
+  fireEvent.click(screen.getByRole("button", { name: "Review bundle" }));
+}
+
+describe("DiagnosticBundle", () => {
+  beforeEach(() => {
+    api.previewDiagnosticBundle.mockReset();
+    api.exportDiagnosticBundle.mockReset();
+  });
+
+  it("reviews the bundle before anything is saved, then saves only when asked", async () => {
+    api.previewDiagnosticBundle.mockResolvedValue({ status: "ok", value: PREVIEW });
+    api.exportDiagnosticBundle.mockResolvedValue({ status: "ok", value: BUNDLE });
+
+    start();
+
+    expect(await screen.findByText("Run lifecycle and timing")).toBeInTheDocument();
+    expect(screen.getByText("Redacted log records")).toBeInTheDocument();
+    expect(screen.getByText("Not in this bundle")).toBeInTheDocument();
+    expect(
+      screen.getByText("Prompts, persona text, and message bodies."),
+    ).toBeInTheDocument();
+    expect(api.exportDiagnosticBundle).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save bundle to this Mac" }));
+
+    expect(await screen.findByText("Saved")).toBeInTheDocument();
+    expect(screen.getByText(BUNDLE.path)).toBeInTheDocument();
+    expect(screen.getByText("20 KB", { exact: false })).toBeInTheDocument();
+    expect(api.exportDiagnosticBundle).toHaveBeenCalledWith({ run_id: "run-9f21" });
+    expect(
+      screen.queryByRole("button", { name: "Save bundle to this Mac" }),
+    ).toBeNull();
+  });
+
+  it("reports a refused scan by category and location, and saves nothing", async () => {
+    api.previewDiagnosticBundle.mockResolvedValue({
+      status: "refused",
+      matches: [
+        { category: "registered_secret", location: "connectors.json.connectors.0.title" },
+      ],
+    });
+
+    start();
+
+    expect(await screen.findByText("Nothing was written.")).toBeInTheDocument();
+    expect(screen.getByText("registered_secret")).toBeInTheDocument();
+    expect(
+      screen.getByText("connectors.json.connectors.0.title"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Save bundle to this Mac" }),
+    ).toBeNull();
+    expect(api.exportDiagnosticBundle).not.toHaveBeenCalled();
+  });
+
+  it("reports a refusal raised at save time and leaves no saved path on screen", async () => {
+    api.previewDiagnosticBundle.mockResolvedValue({ status: "ok", value: PREVIEW });
+    api.exportDiagnosticBundle.mockResolvedValue({
+      status: "refused",
+      matches: [{ category: "issued_credential", location: "logs.json.records.4" }],
+    });
+
+    start();
+    fireEvent.click(await screen.findByRole("button", { name: "Save bundle to this Mac" }));
+
+    expect(await screen.findByText("Nothing was written.")).toBeInTheDocument();
+    expect(screen.getByText("logs.json.records.4")).toBeInTheDocument();
+    expect(screen.queryByText("Saved")).toBeNull();
+  });
+
+  it("cannot start a review without a run", () => {
+    render(<DiagnosticBundle />);
+    expect(screen.getByRole("button", { name: "Review bundle" })).toBeDisabled();
+  });
+
+  it("reports a failed request without claiming anything was saved", async () => {
+    api.previewDiagnosticBundle.mockRejectedValue(new Error("diagnostics 500"));
+
+    start();
+
+    await waitFor(() =>
+      expect(screen.getByText("The bundle could not be prepared")).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("Saved")).toBeNull();
+  });
+});

--- a/desktop/surfaces/gui/tests/settingsPage.test.tsx
+++ b/desktop/surfaces/gui/tests/settingsPage.test.tsx
@@ -5,6 +5,8 @@ import { SettingsPage } from "../src/routes/SettingsPage";
 
 const api = vi.hoisted(() => ({
   createWorkspaceGrant: vi.fn(),
+  exportDiagnosticBundle: vi.fn(),
+  previewDiagnosticBundle: vi.fn(),
   getConnectors: vi.fn(),
   getSettings: vi.fn(),
   pickDirectory: vi.fn(),
@@ -16,6 +18,8 @@ const api = vi.hoisted(() => ({
 
 vi.mock("../src/api", () => ({
   createWorkspaceGrant: api.createWorkspaceGrant,
+  exportDiagnosticBundle: api.exportDiagnosticBundle,
+  previewDiagnosticBundle: api.previewDiagnosticBundle,
   getConnectors: api.getConnectors,
   getSettings: api.getSettings,
   pickDirectory: api.pickDirectory,

--- a/desktop/tests/test_diagnostic_bundle.py
+++ b/desktop/tests/test_diagnostic_bundle.py
@@ -1,0 +1,1113 @@
+"""S6: a redacted diagnostic bundle for one failed run.
+
+The bundle exists to be handed to someone else, so the tests that matter are
+the ones that prove nothing rides out in it. Every leak test plants a canary,
+asserts the evidence category that carries the canary is actually populated,
+and only then asserts the canary is gone. A leak test that passes because its
+category produced no output proves nothing and keeps passing after redaction
+breaks.
+
+No credential-shaped literal is written in this file. Every canary is assembled
+at runtime from fragments.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from coworker import bundle_redaction, diagnostic_bundle
+from coworker.agent_run_repository import AgentRunRepository
+from coworker.diagnostic_bundle import (
+    BundleScanFailed,
+    BundleSources,
+    BundleSubject,
+    EVIDENCE_CATEGORIES,
+    archive_bytes,
+    build_document,
+    build_preview,
+    export_bundle,
+    inspect_archive,
+)
+from coworker.run_evidence import Evidence
+from coworker.run_ledger import RunLedger
+from coworker.store import ConversationStore
+from tests.state_fixtures import build_current_state
+
+# --- canaries, assembled at runtime --------------------------------------
+
+MARK = "BUNDLELEAKCANARY"
+API_KEY = "s" + "k-" + "live-" + MARK + "0123456789abcdefGHIJ"
+ACCESS_TOKEN = "ya" + "29." + MARK + "GoogleOauthAccessToken0123"
+REFRESH_TOKEN = "1/" + "/0g" + MARK + "RefreshTokenValue01234"
+FORGE_TOKEN = "gh" + "p_" + MARK + "0123456789abcdefGHIJ"
+AWS_KEY = "AK" + "IA" + "BUNDLECANARY0123"
+WEB_TOKEN = (
+    "ey" + "JhbGciOiJIUzI1NiJ9." + "eyJzdWIiOiJCVU5ETEVDQU5BUlkifQ." + MARK + "sig"
+)
+PRIVATE_KEY = (
+    "-----BEGIN RSA PRIVATE KEY-----\n"
+    + MARK
+    + "keymaterial\n-----END RSA PRIVATE KEY-----"
+)
+AUTH_HEADER = "Authorization: " + "Bear" + "er " + MARK + "headervalue0123456789"
+ASSIGNMENT = "api" + "_key=" + MARK + "assignedvalue"
+
+MESSAGE_BODY = (
+    "Hi Dana, the Codeology offer is 180k base and my cell is 555-0147. "
+    + MARK
+    + "body"
+)
+REASONING = "private reasoning: Dana looked lukewarm on the last thread " + MARK + "why"
+TOOL_ARGUMENTS = {"query": "layoffs at Rippling " + MARK + "args", "limit": 5}
+TOOL_RESULT = {"text": "row one\nrow two " + MARK + "result"}
+COMMAND_OUTPUT = "$ ls -la\ntotal 48\n" + MARK + "stdout"
+
+HOME = Path("/Users/leakcanary")
+HOME_PATH = "/Users/leakcanary/Documents/Q3-layoff-plan.pdf"
+
+EPOCH = datetime(2026, 8, 20, 9, 0, tzinfo=UTC)
+APPLICATION = {"name": "Sourcecado", "version": "0.0.2", "slice": 29}
+
+
+# --- harness -------------------------------------------------------------
+
+
+class Harness:
+    """One failed run, one state directory, and everything the bundle reads."""
+
+    def __init__(self, tmp_path: Path, *, plant: bool = False) -> None:
+        self.root = build_current_state(tmp_path / "state", plant_secrets=plant)
+        self.store = ConversationStore(self.root)
+        self.repo = AgentRunRepository(self.root)
+        self.owner = self.repo.registry.register()
+        self.ledger = RunLedger(self.repo, approvals=self.store)
+        self.plant = plant
+        self.run_id = self._failed_run()
+        self.connectors = self._connectors()
+        self._events()
+
+    def _failed_run(self) -> str:
+        started = self.repo.create_run(
+            session_id="main",
+            trigger="chat",
+            goal="Find three Codeology leads at Rippling",
+            owner=self.owner,
+            person_id="per_" + "0" * 32,
+        )
+        commit = self.repo.checkpoint(
+            started.lease,
+            kind="model_pending",
+            state="running",
+            payload={
+                "attempt_id": "attempt_1",
+                "provider": "openai",
+                "model_id": "gpt-5",
+                "persona_id": "sourcing",
+                "prompt_version": "sourcing-v1",
+            },
+        )
+        commit = self.repo.checkpoint(
+            commit.lease,
+            kind="model_completed",
+            state="running",
+            payload={
+                "attempt_id": "attempt_1",
+                "status": "ok",
+                "duration_ms": 1840,
+            },
+            usage={"input_tokens": 4120, "output_tokens": 310},
+        )
+        commit = self.repo.checkpoint(
+            commit.lease,
+            kind="tool_pending",
+            state="running",
+            payload={
+                "tool_call_id": "call_gmail_send_1",
+                "tool_name": "gmail_send",
+                "approval_id": "call_gmail_send_1",
+                # A caller handing the write path a whole argument map. The
+                # checkpoint allowlist drops it; the bundle must not resurrect it.
+                **({"arguments": TOOL_ARGUMENTS} if self.plant else {}),
+            },
+            approval_ids=["call_gmail_send_1"],
+        )
+        run_id = str(started.run["run_id"])
+        commit = self.repo.checkpoint(
+            commit.lease,
+            kind="tool_completed",
+            state="running",
+            payload={
+                "tool_call_id": "call_gmail_send_1",
+                "tool_name": "gmail_send",
+                "status": "failed",
+                "error_class": "GmailSendError",
+                "duration_ms": 620,
+                **({"result": TOOL_RESULT} if self.plant else {}),
+            },
+        )
+        commit = self.repo.checkpoint(
+            commit.lease,
+            kind="tool_outcome_unknown",
+            state="interrupted",
+            payload={
+                "tool_call_id": "call_gmail_send_1",
+                "reason": "process exited before the tool reported",
+            },
+        )
+        summary = (
+            f"send refused while reading {HOME_PATH} for {MESSAGE_BODY}"
+            if self.plant
+            else "send refused by the provider"
+        )
+        self.repo.checkpoint(
+            commit.lease or self.repo.acquire_lease(run_id, self.owner, 300),
+            kind="terminal",
+            state="failed",
+            payload={"error_class": "GmailSendError", "error_summary": summary},
+            terminal_result={
+                "status": "failed",
+                "error_class": "GmailSendError",
+                "error": summary,
+                "text": MESSAGE_BODY if self.plant else "no answer",
+            },
+        )
+        self.store.resolve_inbox(
+            "call_gmail_send_1",
+            "allow",
+            actor=(MARK + "operator@example.com") if self.plant else "operator",
+        )
+        return run_id
+
+    def _connectors(self) -> list[dict]:
+        """The shape `GET /v1/connectors` returns, with a token planted in it."""
+        return [
+            {
+                "id": "gmail",
+                "title": "Gmail",
+                "description": "Search email and create review-only drafts.",
+                "status": "connected",
+                "catalog_group": "connected",
+                "email": (MARK + "@example.com") if self.plant else "op@example.com",
+                "required_scopes": ["Read Gmail messages"],
+                "missing_scopes": [],
+                "health": {
+                    "category": "healthy",
+                    "label": "Ready",
+                    "message": (
+                        f"refresh_token={REFRESH_TOKEN}"
+                        if self.plant
+                        else "This connection is ready to use."
+                    ),
+                },
+                "recovery": None,
+                "supported_actions": ["Search and read email"],
+                "available_actions": ["disconnect"],
+                "repair_route": "#/connections/gmail",
+                "authorization_group": "google",
+            },
+            {
+                "id": "apollo",
+                "title": "Apollo",
+                "description": "Search people and enrich sourcing records.",
+                "status": "available",
+                "catalog_group": "available",
+                "email": None,
+                "required_scopes": [],
+                "missing_scopes": [],
+                "health": {
+                    "category": "setup_required",
+                    "label": "Available",
+                    "message": "This connection has not been set up yet.",
+                },
+                "recovery": {
+                    "category": "configure",
+                    "action_label": "View setup guide",
+                    "message": (
+                        f"Set APOLLO_API_KEY={API_KEY}"
+                        if self.plant
+                        else "Set APOLLO_API_KEY in the local environment."
+                    ),
+                },
+                "supported_actions": ["Search people"],
+                "available_actions": ["view_guidance"],
+                "repair_route": "#/connections/apollo",
+                "authorization_group": None,
+            },
+        ]
+
+    def _events(self) -> None:
+        base = {
+            "version": 2,
+            "session_id": "main",
+            "run_id": "run_b1",
+            "message_id": "message_b1",
+            "part_id": "part_b1",
+        }
+        rows = [
+            {**base, "type": "turn_start", "event_id": "event_b1", "state": "running"},
+            {
+                **base,
+                "type": "assistant_delta",
+                "event_id": "event_b2",
+                "delta": MESSAGE_BODY if self.plant else "Searching Apollo.",
+            },
+            {
+                **base,
+                "type": "tool_started",
+                "event_id": "event_b3",
+                "id": "call_gmail_send_1",
+                "name": "gmail_send",
+                "arguments": TOOL_ARGUMENTS if self.plant else {"query": "rippling"},
+            },
+            {
+                **base,
+                "type": "tool_finished",
+                "event_id": "event_b4",
+                "id": "call_gmail_send_1",
+                "name": "gmail_send",
+                "ok": False,
+                "result": TOOL_RESULT if self.plant else {"text": "ok"},
+            },
+            {
+                **base,
+                "type": "provider_recovery",
+                "event_id": "event_b5",
+                "action": "retry",
+                "provider": "openai",
+                "model": "gpt-5",
+                "reason": "RateLimited",
+                "attempt": 2,
+                "delay_ms": 500,
+                "message": AUTH_HEADER if self.plant else "retrying shortly",
+            },
+            {
+                **base,
+                "type": "error",
+                "event_id": "event_b6",
+                "state": "failed",
+                "message": (
+                    f"Traceback (most recent call last):\n"
+                    f'  File "{HOME_PATH}", line 12\n'
+                    f"{PRIVATE_KEY}\n{COMMAND_OUTPUT}\n{REASONING}"
+                    if self.plant
+                    else "the provider refused the request"
+                ),
+            },
+        ]
+        for row in rows:
+            self.store.append_event("main", row)
+
+    def sources(self, **overrides) -> BundleSources:
+        doctor_report = _doctor_report(self.root)
+        registered = bundle_redaction.registered_secret_values(
+            json.loads((self.root / "secrets.json").read_text(encoding="utf-8"))
+        )
+        defaults = dict(
+            application=APPLICATION,
+            receipt=self.ledger.receipt(self.run_id),
+            recent_runs=self.ledger.query(limit=diagnostic_bundle.HEALTH_WINDOW_RUNS),
+            doctor=doctor_report,
+            connectors=self.connectors,
+            events=self.store.load_events("main"),
+            registered_secrets=registered,
+            state_root=self.root,
+            home=HOME,
+        )
+        defaults.update(overrides)
+        return BundleSources(**defaults)
+
+    def subject(self) -> BundleSubject:
+        return BundleSubject(kind="run", run_id=self.run_id)
+
+
+def _doctor_report(root: Path) -> dict:
+    from coworker import doctor
+
+    return doctor.diagnose(root).to_dict()
+
+
+def _document_text(document: dict) -> str:
+    return json.dumps(document, sort_keys=True, ensure_ascii=False)
+
+
+def _archive_text(path: Path) -> str:
+    with zipfile.ZipFile(path) as archive:
+        return "\n".join(
+            archive.read(name).decode("utf-8", errors="replace")
+            for name in archive.namelist()
+        )
+
+
+# --- criterion 1 and 2: what the bundle carries ---------------------------
+
+
+def test_a_bundle_from_a_failed_run_carries_every_declared_evidence_category(tmp_path):
+    harness = Harness(tmp_path)
+    document = build_document(harness.subject(), harness.sources())
+
+    assert set(document) == set(diagnostic_bundle.MEMBERS)
+
+    subject = document["subject.json"]
+    assert subject["subject"] == {"kind": "run", "run_id": harness.run_id}
+    declared = {item["id"] for item in subject["evidence_categories"]}
+    assert declared == {item["id"] for item in EVIDENCE_CATEGORIES}
+    for item in subject["evidence_categories"]:
+        assert item["description"].strip()
+    assert subject["excluded"]
+
+    environment = document["environment.json"]
+    assert environment["application"] == APPLICATION
+    assert environment["python"]["version"]
+    assert environment["platform"]["system"]
+    assert "node" not in environment["platform"]
+
+    run = document["run.json"]
+    assert run["run"]["run_id"] == harness.run_id
+    assert run["outcome"]["state"] == "failed"
+    assert run["outcome"]["result"]["error_class"] == "GmailSendError"
+    assert run["model_attempts"]["attempts"][0]["duration_ms"] == 1840
+    assert run["tools"]["calls"][0]["duration_ms"] == 620
+    assert run["usage"]["totals"]["input_tokens"] == 4120
+    assert run["approvals"]["decisions"][0]["decision"] == "allow"
+    assert run["recovery"]["events"]
+    assert run["record"]["checkpoints_stored"] == 7
+
+    health = document["health.json"]
+    assert health["runs_considered"] >= 1
+    assert health["states"]["failed"] >= 1
+    assert health["recent"][0]["run_id"] == harness.run_id
+
+    state = document["state.json"]
+    assert state["stores"]
+    assert {item["store_id"] for item in state["stores"]} >= {"conversation_db"}
+    assert state["migration"]["target_versions"]["conversation_db"] >= 1
+
+    connectors = document["connectors.json"]
+    assert {item["id"] for item in connectors["connectors"]} == {"gmail", "apollo"}
+
+    logs = document["logs.json"]
+    assert logs["records"]
+    assert logs["counts"]["error"] == 1
+    assert {record["type"] for record in logs["records"]} >= {"error", "tool_finished"}
+
+
+def test_a_bundle_can_start_from_a_doctor_finding_without_a_run(tmp_path):
+    harness = Harness(tmp_path)
+    subject = BundleSubject(kind="doctor_finding", check="permissions", store_id="state_root")
+    document = build_document(subject, harness.sources(receipt=None))
+
+    assert document["subject.json"]["subject"] == {
+        "kind": "doctor_finding",
+        "check": "permissions",
+        "store_id": "state_root",
+    }
+    included = {
+        item["id"] for item in document["subject.json"]["evidence_categories"] if item["included"]
+    }
+    assert "run" not in included
+    assert "state" in included
+    assert document["run.json"]["run"] is None
+    assert document["state.json"]["stores"]
+
+
+def _clean_run(harness: Harness) -> str:
+    """A run that ended with nothing to report. Its silence is an absence."""
+    started = harness.repo.create_run(
+        session_id="main",
+        trigger="chat",
+        goal="Confirm the Rippling shortlist",
+        owner=harness.owner,
+    )
+    harness.repo.checkpoint(started.lease, kind="terminal", state="complete")
+    return str(started.run["run_id"])
+
+
+def _evidence_values(payload, found=None):
+    found = set() if found is None else found
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            if key == "evidence" and isinstance(value, str):
+                found.add(value)
+            else:
+                _evidence_values(value, found)
+    elif isinstance(payload, list):
+        for item in payload:
+            _evidence_values(item, found)
+    return found
+
+
+def test_the_bundle_reuses_the_merged_evidence_vocabulary(tmp_path):
+    """One vocabulary for "we do not know", not a parallel one.
+
+    The bundle carries the ledger's own `evidence` value through unchanged.
+    This fails if either side coins a word the other does not have.
+    """
+    harness = Harness(tmp_path)
+    document = build_document(harness.subject(), harness.sources())
+
+    values = _evidence_values(document["run.json"])
+    assert values, "no section carried evidence, so this test proves nothing"
+    assert values <= {member.value for member in Evidence}
+
+
+def test_absent_and_missing_stay_different_through_the_projection(tmp_path):
+    """A hole in the record must not read like a positive absence.
+
+    The failed run's record carries `tool_outcome_unknown`, so nothing about it
+    is settled. The clean run's record covers its whole life. The same section
+    has to render differently for the two, or the bundle has flattened the one
+    distinction the evidence vocabulary exists for.
+    """
+    harness = Harness(tmp_path)
+    clean_id = _clean_run(harness)
+
+    failed = build_document(harness.subject(), harness.sources())["run.json"]
+    clean = build_document(
+        BundleSubject(kind="run", run_id=clean_id),
+        harness.sources(receipt=harness.ledger.receipt(clean_id)),
+    )["run.json"]
+
+    assert failed["record"]["complete"] is False
+    assert clean["record"]["complete"] is True
+
+    # Nothing was recorded about sources in either run. Only one of them can
+    # honestly say that means none were touched.
+    assert failed["sources"]["count"] == clean["sources"]["count"] == 0
+    assert failed["sources"]["evidence"] == Evidence.MISSING.value
+    assert clean["sources"]["evidence"] == Evidence.ABSENT.value
+
+    assert failed["tools"]["evidence"] == Evidence.AMBIGUOUS.value
+    assert clean["tools"]["evidence"] == Evidence.ABSENT.value
+
+
+# --- criterion 8: the planted-secret matrix -------------------------------
+
+
+def test_every_planted_category_is_carried_by_the_bundle_before_any_leak_check(tmp_path):
+    """Non-vacuity guard. Each leak category must produce real evidence."""
+    harness = Harness(tmp_path, plant=True)
+    document = build_document(harness.subject(), harness.sources())
+
+    # logs
+    assert len(document["logs.json"]["records"]) >= 6
+    # errors
+    assert document["run.json"]["outcome"]["result"]["error_class"] == "GmailSendError"
+    assert document["run.json"]["rationale"]["notes"]
+    # connector payloads
+    assert len(document["connectors.json"]["connectors"]) == 2
+    # paths
+    assert MARK not in _document_text(document)
+    assert "<home>" in _document_text(document) or "<state>" in _document_text(document)
+    # approval data
+    assert document["run.json"]["approvals"]["decisions"][0]["decision"] == "allow"
+    # state integrity, which is where the fixture's own canaries live
+    assert document["state.json"]["findings"]
+
+
+@pytest.mark.parametrize(
+    "member, probe",
+    [
+        ("logs.json", lambda doc: len(doc["logs.json"]["records"]) >= 6),
+        ("run.json", lambda doc: bool(doc["run.json"]["rationale"]["notes"])),
+        ("connectors.json", lambda doc: len(doc["connectors.json"]["connectors"]) == 2),
+        ("state.json", lambda doc: bool(doc["state.json"]["findings"])),
+        (
+            "health.json",
+            lambda doc: doc["health.json"]["states"].get("failed", 0) >= 1,
+        ),
+    ],
+)
+def test_no_planted_secret_survives_into_any_member(tmp_path, member, probe):
+    harness = Harness(tmp_path, plant=True)
+    document = build_document(harness.subject(), harness.sources())
+
+    assert probe(document), f"{member} carried no evidence, so this test proves nothing"
+
+    text = json.dumps(document[member], sort_keys=True, ensure_ascii=False)
+    for canary in (
+        API_KEY,
+        ACCESS_TOKEN,
+        REFRESH_TOKEN,
+        FORGE_TOKEN,
+        AWS_KEY,
+        WEB_TOKEN,
+        PRIVATE_KEY,
+        MESSAGE_BODY,
+        REASONING,
+        COMMAND_OUTPUT,
+        json.dumps(TOOL_ARGUMENTS),
+        json.dumps(TOOL_RESULT),
+        MARK,
+    ):
+        assert canary not in text, f"{member} carried a planted secret"
+
+
+def test_a_home_path_in_carried_text_becomes_the_home_placeholder(tmp_path):
+    """Proves the path rewrite is load-bearing, not incidental.
+
+    A connector label is text the bundle does carry, so a home path planted
+    there reaches the projection and has to be rewritten on the way through.
+    """
+    harness = Harness(tmp_path, plant=True)
+    connectors = harness.connectors
+    connectors[0]["title"] = f"Gmail {HOME_PATH}"
+    document = build_document(harness.subject(), harness.sources(connectors=connectors))
+
+    carried = document["connectors.json"]["connectors"]
+    assert len(carried) == 2, "no connector was carried, so this test proves nothing"
+    assert carried[0]["title"] == "Gmail <home>"
+    assert "/Users/" not in _document_text(document)
+    assert "leakcanary" not in _document_text(document)
+
+
+def test_a_raw_home_path_never_survives(tmp_path):
+    harness = Harness(tmp_path, plant=True)
+    document = build_document(harness.subject(), harness.sources())
+    text = _document_text(document)
+
+    notes = document["run.json"]["rationale"]["notes"]
+    assert notes and any(note["error_summary_length"] for note in notes), (
+        "no note carried the planted path, so this test proves nothing"
+    )
+    assert "/Users/" not in text
+    assert "leakcanary" not in text
+    assert "Q3-layoff-plan" not in text
+
+
+def test_prompts_and_message_bodies_have_no_field_to_land_in(tmp_path):
+    harness = Harness(tmp_path, plant=True)
+    document = build_document(harness.subject(), harness.sources())
+    run = document["run.json"]
+
+    assert run["prompt"]["persona_id"] == "sourcing"
+    assert set(run["prompt"]) == {"evidence", "persona_id", "prompt_version"}
+    assert "text" not in run["outcome"]["result"]
+    assert "error" not in run["outcome"]["result"]
+    assert run["outcome"]["result"]["text_length"] > 0
+    assert all("title" not in ref for ref in run["sources"]["providers"])
+    for record in document["logs.json"]["records"]:
+        assert set(record) <= diagnostic_bundle.LOG_RECORD_FIELDS
+
+
+# --- criterion 4: fail closed --------------------------------------------
+
+
+def test_a_registered_secret_reaching_the_bundle_fails_the_export_closed(tmp_path):
+    harness = Harness(tmp_path)
+    secret = "notarealsecret-" + MARK + "-registered"
+    connectors = harness.connectors
+    connectors[0]["title"] = f"Gmail {secret}"
+
+    with pytest.raises(BundleScanFailed) as raised:
+        export_bundle(
+            harness.subject(),
+            harness.sources(connectors=connectors, registered_secrets=frozenset({secret})),
+            destination_dir=tmp_path / "out",
+        )
+
+    assert [match.category for match in raised.value.matches] == ["registered_secret"]
+    assert not list((tmp_path / "out").glob("*"))
+
+
+def test_a_credential_pattern_reaching_the_bundle_fails_the_export_closed(tmp_path):
+    harness = Harness(tmp_path)
+    connectors = harness.connectors
+    connectors[0]["title"] = f"Gmail {FORGE_TOKEN}"
+
+    with pytest.raises(BundleScanFailed) as raised:
+        export_bundle(
+            harness.subject(),
+            harness.sources(connectors=connectors),
+            destination_dir=tmp_path / "out",
+        )
+
+    assert "issued_credential" in {match.category for match in raised.value.matches}
+
+
+def test_a_scan_failure_names_a_category_and_a_location_but_never_the_value(tmp_path):
+    harness = Harness(tmp_path)
+    connectors = harness.connectors
+    connectors[0]["title"] = f"Gmail {API_KEY}"
+
+    with pytest.raises(BundleScanFailed) as raised:
+        export_bundle(
+            harness.subject(),
+            harness.sources(connectors=connectors),
+            destination_dir=tmp_path / "out",
+        )
+
+    rendered = str(raised.value) + repr(raised.value.matches)
+    assert "connectors" in rendered
+    assert "issued_credential" in rendered
+    assert MARK not in rendered
+    assert API_KEY not in rendered
+
+
+def test_the_scan_still_catches_a_secret_when_the_upstream_layers_are_disabled(
+    tmp_path, monkeypatch
+):
+    """Layer three must not lean on layers one and two.
+
+    Both upstream redactors become identity functions here. The receipt
+    allowlist and Doctor's filter stop doing anything, and the export must
+    still refuse.
+    """
+    from coworker import doctor, run_receipt
+
+    monkeypatch.setattr(run_receipt, "redact_secrets", lambda value: value)
+    monkeypatch.setattr(doctor, "redact", lambda text, root: str(text))
+
+    harness = Harness(tmp_path)
+    connectors = harness.connectors
+    connectors[0]["title"] = f"Gmail {ACCESS_TOKEN}"
+
+    with pytest.raises(BundleScanFailed):
+        export_bundle(
+            harness.subject(),
+            harness.sources(connectors=connectors),
+            destination_dir=tmp_path / "out",
+        )
+
+
+def test_the_third_layer_imports_neither_of_the_first_two(tmp_path):
+    source = Path(bundle_redaction.__file__).read_text(encoding="utf-8")
+    assert "doctor" not in source
+    assert "agent_runs" not in source
+    assert "run_receipt" not in source
+
+
+# --- criterion 5: preview, and never an upload ----------------------------
+
+
+def test_the_preview_is_bounded_and_explains_what_is_included(tmp_path):
+    harness = Harness(tmp_path)
+    document = build_document(harness.subject(), harness.sources())
+    preview = build_preview(document)
+
+    assert preview["subject"]["kind"] == "run"
+    assert len(preview["evidence_categories"]) == len(EVIDENCE_CATEGORIES)
+    assert preview["excluded"]
+    assert len(preview["findings"]) <= diagnostic_bundle.PREVIEW_FINDINGS
+    assert len(preview["log_records"]) <= diagnostic_bundle.PREVIEW_LOG_RECORDS
+    assert preview["counts"]["log_records"] == len(document["logs.json"]["records"])
+    assert len(json.dumps(preview)) <= diagnostic_bundle.MAX_PREVIEW_CHARS
+
+
+def test_the_bundle_module_opens_no_network_client():
+    source = Path(diagnostic_bundle.__file__).read_text(encoding="utf-8")
+    for forbidden in ("httpx", "requests", "urllib.request", "socket", "smtplib"):
+        assert forbidden not in source
+
+
+# --- criterion 6: determinism --------------------------------------------
+
+
+def test_two_exports_from_identical_state_differ_only_in_package_identity(tmp_path):
+    harness = Harness(tmp_path)
+    destination = tmp_path / "out"
+
+    first = export_bundle(harness.subject(), harness.sources(), destination_dir=destination)
+    second = export_bundle(harness.subject(), harness.sources(), destination_dir=destination)
+
+    assert first["bundle_id"] != second["bundle_id"]
+
+    with zipfile.ZipFile(first["path"]) as one, zipfile.ZipFile(second["path"]) as two:
+        assert one.namelist() == two.namelist()
+        for info in [*one.infolist(), *two.infolist()]:
+            # A real member timestamp would make one state produce two archives.
+            assert info.date_time == diagnostic_bundle.ZIP_EPOCH
+            assert info.external_attr >> 16 == diagnostic_bundle.MEMBER_MODE
+        for name in one.namelist():
+            if name == diagnostic_bundle.MANIFEST_NAME:
+                left = json.loads(one.read(name))
+                right = json.loads(two.read(name))
+                del left["package"], right["package"]
+                assert left == right
+                continue
+            assert one.read(name) == two.read(name), f"{name} was not deterministic"
+
+
+def test_the_document_builder_has_no_clock_and_no_randomness(tmp_path):
+    harness = Harness(tmp_path)
+    first = build_document(harness.subject(), harness.sources())
+    second = build_document(harness.subject(), harness.sources())
+    assert first == second
+
+
+# --- criterion 7: no partially readable artifact --------------------------
+
+
+def _leftovers(destination: Path) -> list[Path]:
+    return [path for path in destination.rglob("*") if path.is_file()]
+
+
+def test_a_failed_scan_leaves_no_file_and_no_temporary(tmp_path):
+    harness = Harness(tmp_path)
+    destination = tmp_path / "out"
+    connectors = harness.connectors
+    connectors[0]["title"] = f"Gmail {API_KEY}"
+
+    with pytest.raises(BundleScanFailed):
+        export_bundle(
+            harness.subject(),
+            harness.sources(connectors=connectors),
+            destination_dir=destination,
+        )
+
+    assert _leftovers(destination) == []
+
+
+def test_a_crash_while_assembling_leaves_no_file_and_no_temporary(tmp_path, monkeypatch):
+    harness = Harness(tmp_path)
+    destination = tmp_path / "out"
+    destination.mkdir()
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("assembly failed")
+
+    monkeypatch.setattr(diagnostic_bundle, "build_document", boom)
+    with pytest.raises(RuntimeError):
+        export_bundle(harness.subject(), harness.sources(), destination_dir=destination)
+
+    assert _leftovers(destination) == []
+
+
+def test_a_crash_after_the_temporary_archive_is_written_leaves_nothing_readable(
+    tmp_path, monkeypatch
+):
+    """The riskiest window: full bytes on disk, one rename from being a bundle."""
+    harness = Harness(tmp_path)
+    destination = tmp_path / "out"
+    destination.mkdir()
+    seen: list[Path] = []
+
+    real_replace = diagnostic_bundle.os.replace
+
+    def boom(source, target):
+        seen.append(Path(source))
+        assert Path(source).is_file() and Path(source).stat().st_size > 0
+        raise OSError("rename failed")
+
+    monkeypatch.setattr(diagnostic_bundle.os, "replace", boom)
+    with pytest.raises(OSError):
+        export_bundle(harness.subject(), harness.sources(), destination_dir=destination)
+
+    assert seen, "the export never reached the rename"
+    assert not seen[0].exists()
+    assert _leftovers(destination) == []
+    assert real_replace is not boom
+
+
+def test_a_successful_export_writes_one_owner_only_file(tmp_path):
+    harness = Harness(tmp_path)
+    destination = tmp_path / "out"
+    result = export_bundle(harness.subject(), harness.sources(), destination_dir=destination)
+
+    written = Path(result["path"])
+    assert written.is_file()
+    assert _leftovers(destination) == [written]
+    assert written.stat().st_mode & 0o077 == 0
+    assert result["sha256"] == diagnostic_bundle.sha256_bytes(written.read_bytes())
+
+
+# --- criterion 9: offline inspection --------------------------------------
+
+
+def test_the_inspection_command_verifies_the_manifest_and_the_checksums(tmp_path):
+    harness = Harness(tmp_path)
+    result = export_bundle(
+        harness.subject(), harness.sources(), destination_dir=tmp_path / "out"
+    )
+
+    report = inspect_archive(Path(result["path"]))
+    assert report["ok"] is True
+    assert report["problems"] == []
+    assert report["package"]["bundle_id"] == result["bundle_id"]
+    assert {entry["name"] for entry in report["entries"]} == set(
+        diagnostic_bundle.MEMBERS
+    ) | {diagnostic_bundle.CHECKSUMS_NAME}
+    assert all(entry["ok"] for entry in report["entries"])
+
+    assert diagnostic_bundle.main(["inspect", result["path"]]) == 0
+
+
+def test_the_inspection_command_reports_a_tampered_member(tmp_path):
+    harness = Harness(tmp_path)
+    result = export_bundle(
+        harness.subject(), harness.sources(), destination_dir=tmp_path / "out"
+    )
+    original = Path(result["path"])
+    tampered = tmp_path / "tampered.zip"
+
+    with zipfile.ZipFile(original) as source, zipfile.ZipFile(tampered, "w") as target:
+        for info in source.infolist():
+            payload = source.read(info.filename)
+            if info.filename == "connectors.json":
+                payload = payload.replace(b"gmail", b"gmai1")
+            target.writestr(info, payload)
+
+    report = inspect_archive(tampered)
+    assert report["ok"] is False
+    assert any("connectors.json" in problem for problem in report["problems"])
+    assert diagnostic_bundle.main(["inspect", str(tampered)]) == 1
+
+
+def test_the_inspection_command_reports_a_tampered_checksum_list(tmp_path):
+    """`checksums.txt` cannot vouch for itself. The manifest is what covers it."""
+    harness = Harness(tmp_path)
+    result = export_bundle(
+        harness.subject(), harness.sources(), destination_dir=tmp_path / "out"
+    )
+    tampered = tmp_path / "tampered.zip"
+
+    with zipfile.ZipFile(result["path"]) as source, zipfile.ZipFile(tampered, "w") as target:
+        for info in source.infolist():
+            payload = source.read(info.filename)
+            if info.filename == diagnostic_bundle.CHECKSUMS_NAME:
+                payload = payload.replace(b"connectors.json", b"connectors.json ")
+            target.writestr(info, payload)
+
+    report = inspect_archive(tampered)
+    assert report["ok"] is False
+    assert any(
+        entry["name"] == diagnostic_bundle.CHECKSUMS_NAME and not entry["ok"]
+        for entry in report["entries"]
+    )
+
+
+def test_the_checksums_file_verifies_with_plain_tools(tmp_path):
+    harness = Harness(tmp_path)
+    result = export_bundle(
+        harness.subject(), harness.sources(), destination_dir=tmp_path / "out"
+    )
+    extracted = tmp_path / "extracted"
+    with zipfile.ZipFile(result["path"]) as archive:
+        archive.extractall(extracted)
+
+    lines = (extracted / diagnostic_bundle.CHECKSUMS_NAME).read_text(encoding="utf-8")
+    named = [line.split("  ", 1)[1] for line in lines.strip().splitlines()]
+    assert set(named) == set(diagnostic_bundle.MEMBERS)
+    for line in lines.strip().splitlines():
+        digest, name = line.split("  ", 1)
+        assert digest == diagnostic_bundle.sha256_bytes((extracted / name).read_bytes())
+
+
+# --- the redaction layer on its own ---------------------------------------
+
+
+def test_relativize_keeps_state_paths_and_erases_home_paths():
+    state_root = HOME / ".config" / "club"
+    relativize = bundle_redaction.relativize
+
+    assert (
+        relativize(f"{state_root}/club.db", home=HOME, state_root=state_root)
+        == "<state>/club.db"
+    )
+    assert relativize(HOME_PATH, home=HOME, state_root=state_root) == "<home>"
+    assert (
+        relativize("/Users/someone-else/Desktop/a.txt", home=HOME, state_root=state_root)
+        == "<home>"
+    )
+    assert (
+        relativize("/home/dana/notes.md", home=HOME, state_root=state_root) == "<home>"
+    )
+    assert (
+        relativize("https://example.com/home/dana", home=HOME, state_root=state_root)
+        == "https://example.com/home/dana"
+    )
+    assert relativize("run_0f3c", home=HOME, state_root=state_root) == "run_0f3c"
+
+
+def test_registered_secret_values_take_credentials_and_leave_urls_and_ids():
+    values = bundle_redaction.registered_secret_values(
+        {
+            "google": {
+                "refresh_token": REFRESH_TOKEN,
+                "email": "operator@example.com",
+                "scopes": ["https://www.googleapis.com/auth/gmail.readonly"],
+                "token_uri": "https://oauth2.googleapis.com/token",
+            },
+            "mcp-oauth:granola": {"access_token": ACCESS_TOKEN, "provider": "granola"},
+        }
+    )
+    assert REFRESH_TOKEN in values
+    assert ACCESS_TOKEN in values
+    assert "operator@example.com" not in values
+    assert "https://oauth2.googleapis.com/token" not in values
+    assert "granola" not in values
+
+
+@pytest.mark.parametrize(
+    "text, category",
+    [
+        (API_KEY, "issued_credential"),
+        (ACCESS_TOKEN, "issued_credential"),
+        (FORGE_TOKEN, "issued_credential"),
+        (AWS_KEY, "issued_credential"),
+        (WEB_TOKEN, "json_web_token"),
+        (PRIVATE_KEY, "private_key"),
+        (AUTH_HEADER, "authorization_header"),
+        (ASSIGNMENT, "credential_assignment"),
+        (HOME_PATH, "home_path"),
+    ],
+)
+def test_the_scan_names_every_credential_shape(text, category):
+    matches = bundle_redaction.scan(
+        {"field": text},
+        registered=frozenset(),
+        home=HOME,
+        state_root=HOME / ".config" / "club",
+    )
+    assert category in {match.category for match in matches}
+    assert {match.category for match in matches} <= bundle_redaction.SCAN_CATEGORIES
+    assert all(MARK not in repr(match) for match in matches)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "run_0f3c9a1b2c3d4e5f60718293a4b5c6d7",
+        "per_0f3c9a1b2c3d4e5f60718293a4b5c6d7",
+        "2026-08-27T16:45:00.123456+00:00",
+        "gpt-5",
+        "claude-opus-4-1-20250805",
+        "<state>/club.db",
+        "weekly_sourcing_review",
+        "a" * 64,
+        # A refusal on prose would refuse every export, not the leaking one.
+        "Basic authentication is required by this connector",
+        "context_window_tokens: 200000",
+        "input_tokens=4120",
+        "<state>/secrets.json is group readable",
+        "https://www.googleapis.com/auth/gmail.readonly",
+    ],
+)
+def test_the_scan_leaves_sourcecado_identifiers_alone(text):
+    assert (
+        bundle_redaction.scan(
+            {"field": text},
+            registered=frozenset(),
+            home=HOME,
+            state_root=HOME / ".config" / "club",
+        )
+        == ()
+    )
+
+
+def test_the_archive_is_byte_stable_for_one_document(tmp_path):
+    harness = Harness(tmp_path)
+    document = build_document(harness.subject(), harness.sources())
+    one = archive_bytes(document, bundle_id="abc123", generated_at=EPOCH.isoformat())
+    two = archive_bytes(document, bundle_id="abc123", generated_at=EPOCH.isoformat())
+    assert one == two
+
+
+# --- the HTTP surface -----------------------------------------------------
+
+
+API_TOKEN = "diagnostic-bundle-token"
+
+
+def _client(harness: Harness):
+    from fastapi.testclient import TestClient
+
+    from coworker.server import TOKEN_HEADER, create_app
+
+    app = create_app(token=API_TOKEN, state=harness.root, provider=None)
+    return TestClient(app), {TOKEN_HEADER: API_TOKEN}, app
+
+
+def test_the_route_previews_before_anything_is_written_and_saves_only_when_asked(
+    tmp_path,
+):
+    harness = Harness(tmp_path)
+    client, headers, _ = _client(harness)
+    diagnostics = harness.root / "diagnostics"
+
+    preview = client.post(
+        "/v1/diagnostics/bundle/preview",
+        json={"run_id": harness.run_id},
+        headers=headers,
+    )
+    assert preview.status_code == 200
+    body = preview.json()["preview"]
+    assert body["subject"] == {"kind": "run", "run_id": harness.run_id}
+    assert len(body["evidence_categories"]) == len(EVIDENCE_CATEGORIES)
+    assert body["excluded"]
+    assert not diagnostics.exists(), "a preview must not write a bundle"
+
+    saved = client.post(
+        "/v1/diagnostics/bundle/export",
+        json={"run_id": harness.run_id},
+        headers=headers,
+    )
+    assert saved.status_code == 200
+    written = saved.json()["bundle"]
+    archive = Path(written["path"])
+    assert archive.parent == diagnostics
+    assert archive.is_file()
+    assert inspect_archive(archive)["ok"] is True
+    assert MARK not in _archive_text(archive)
+
+
+def test_the_route_can_start_from_a_state_finding(tmp_path):
+    harness = Harness(tmp_path)
+    client, headers, _ = _client(harness)
+
+    response = client.post(
+        "/v1/diagnostics/bundle/preview",
+        json={"check": "permissions", "store_id": "state_root"},
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["preview"]["subject"]["check"] == "permissions"
+    assert response.json()["preview"]["run"] is None
+
+
+def test_the_route_refuses_an_unknown_run_and_an_empty_start(tmp_path):
+    harness = Harness(tmp_path)
+    client, headers, _ = _client(harness)
+
+    missing = client.post(
+        "/v1/diagnostics/bundle/export", json={"run_id": "run-nope"}, headers=headers
+    )
+    assert missing.status_code == 404
+
+    empty = client.post("/v1/diagnostics/bundle/export", json={}, headers=headers)
+    assert empty.status_code == 400
+
+
+def test_the_route_fails_closed_when_a_registered_secret_reaches_the_bundle(tmp_path):
+    """End to end: a value the operator registered can never ride out.
+
+    Registering the run's own id as a credential is artificial, but it is the
+    only way to force a registered value into a bundle that is otherwise clean,
+    and it proves the refusal reaches the caller rather than being swallowed.
+    """
+    harness = Harness(tmp_path)
+    client, headers, app = _client(harness)
+    app.state.secrets.put("canary", {"access_token": harness.run_id})
+
+    refused = client.post(
+        "/v1/diagnostics/bundle/export",
+        json={"run_id": harness.run_id},
+        headers=headers,
+    )
+    assert refused.status_code == 409
+    body = refused.json()
+    assert body["error"] == "scan_refused"
+    assert {match["category"] for match in body["matches"]} == {"registered_secret"}
+    assert all(harness.run_id not in match["location"] for match in body["matches"])
+    assert not (harness.root / "diagnostics").exists()
+
+    blocked = client.post(
+        "/v1/diagnostics/bundle/preview",
+        json={"run_id": harness.run_id},
+        headers=headers,
+    )
+    assert blocked.status_code == 409


### PR DESCRIPTION
Closes #75.

## Domain words

- **Bundle** — one local ZIP describing one failed run or one state finding.
- **Subject** — the exact run id, or the exact Doctor finding, an export started from. Every bundle names one.
- **Member** — one file inside the archive.
- **Scan** — the pre-export check that refuses to build a bundle at all.
- **Fail closed** — a matched scan produces nothing. Not a redacted bundle, not a warning file, not an empty folder.

## Why this is a security change, not a diagnostics change

A diagnostic bundle aggregates everything about a failed run into one file whose entire purpose is to be handed to someone else. Every other safety property in Sourcecado is undone if a secret rides out in here.

So the deliverable is the redaction layering and the fail-closed path. The packaging is the easy part.

## Three independent redaction layers

| Layer | Source | Independent because |
|---|---|---|
| 1 | The run receipt's closed field allowlist, from #74 | Already merged; the bundle consumes receipts rather than raw checkpoints |
| 2 | Doctor's bounded redacted output contract, from #73 | Already merged; reused rather than reimplemented |
| 3 | The bundle's own pre-export scan | **Imports neither of the first two** |

The third layer's independence is the point. A scan that trusts the layers above it keeps passing after one of them changes — which is how a leak appears months later, in a build nobody thought they had altered.

Two tests hold that line:

- `test_the_scan_still_catches_a_secret_when_the_upstream_layers_are_disabled` — the scan is exercised with layers 1 and 2 turned off, and still catches the secret.
- `test_the_third_layer_imports_neither_of_the_first_two` — structural, so the independence cannot be quietly undone by an import.

## Fail closed means produce nothing

A matched scan aborts the export. There is no redacted-and-continue path.

The reasoning: a scan that matched is evidence that something reached the bundle by a route nobody modeled. Producing a "cleaned" bundle from a state you have just proved you do not understand is worse than producing nothing.

`test_a_scan_failure_names_a_category_and_a_location_but_never_the_value` — the operator is told what category and where, never the matched value. An error message is not a safe place to print a secret.

Both pattern-based and registered-secret scans run. `test_a_registered_secret_reaching_the_bundle_fails_the_export_closed` and `test_a_credential_pattern_reaching_the_bundle_fails_the_export_closed`.

## No partial artifact, ever

Assembly happens in a temporary location and moves into place only after every scan passes.

- `test_a_failed_scan_leaves_no_file_and_no_temporary`
- `test_a_crash_while_assembling_leaves_no_file_and_no_temporary` — forces a mid-build exception and asserts nothing readable remains anywhere.

A successful export writes one file at mode 0600: `test_a_successful_export_writes_one_owner_only_file`.

## Planted secrets, proven non-vacuously

Every category the issue names is planted: logs, errors, connector payloads, paths, and approval data.

The non-vacuity guard is a separate test that runs first: `test_every_planted_category_is_carried_by_the_bundle_before_any_leak_check` asserts the bundle actually carries evidence for each category. Only then does `test_no_planted_secret_survives_into_any_member` assert absence. Without the first, the second would pass when a category produced no output at all — and would keep passing after the redaction broke.

Raw home paths are covered specifically, since `/Users/<name>/…` in a traceback identifies a real person: `test_a_home_path_in_carried_text_becomes_the_home_placeholder` and `test_a_raw_home_path_never_survives`.

`test_prompts_and_message_bodies_have_no_field_to_land_in` — the exclusion is structural, not a filter.

## Reused vocabulary rather than a parallel one

The bundle expresses "we do not know" using `run_evidence.py`'s existing closed vocabulary — `present`, `absent`, `partial`, `missing`, `ambiguous`, `unsupported`, `expired` — rather than coining its own. `test_the_bundle_reuses_the_merged_evidence_vocabulary` and `test_absent_and_missing_stay_different_through_the_projection`.

Two vocabularies for the same distinction drift apart, and this one had already been thought through in #74.

## Never uploads

`coworker/diagnostic_bundle.py` opens no network client and imports nothing that could. `test_the_bundle_module_opens_no_network_client` holds it.

The operator surface is Settings → Diagnostic bundle, deliberately two separate steps: **Review bundle** assembles, scans, and shows a bounded preview with every category and what is left out, writing nothing; **Save bundle to this Mac** repeats the work and writes one file, reporting path, size, and SHA-256.

## Determinism

`test_two_exports_from_identical_state_differ_only_in_package_identity`, and `test_the_document_builder_has_no_clock_and_no_randomness` — the builder cannot introduce nondeterminism because it has no access to either.

## Measurements

```
1107 passed, 3 skipped, 1 warning in 43.48s
 Test Files  46 passed (46)
      Tests  419 passed (419)
tsc --noEmit && vite build   clean
```

All re-run independently by the reviewing session on the pushed commit. 35 tests in `test_diagnostic_bundle.py`.

## Boundary

Reads Doctor and ledger output; modifies neither. No file under `agent_run*`, `run_ledger`/`run_receipt`/`run_evidence`, `migrations.py`, `doctor.py`, `turn.py`, `store.py`, `people.py`, `permissions.py`, or `provider.py` was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjAD6SVox1gvF4sV3jTnJy
