### PR TITLE
feat(desktop): detect stale run owners and impossible run history in Doctor

### DIFF
--- a/desktop/coworker/doctor.py
+++ b/desktop/coworker/doctor.py
@@ -10,6 +10,12 @@ left at the end of an append-only log, and applying a registered migration. A
 corrupt row, an orphaned link, an interrupted approval, or anything touching a
 person file or an external outcome is reported for review and left alone.
 
+Agent Run ownership is report-only, without exception, and one rule governs it:
+an owner is called dead only on kernel-backed proof that its process has exited.
+Another host, a missing marker, or a platform without file locking are unknown,
+and unknown is reported as unknown. Rounding unknown up to dead would invite an
+operator to take a run away from a process that is still working it.
+
 Output is bounded and redacted. Doctor reports store ids, versions, check names,
 and counts. It never prints a row, a message body, a token, an authorization
 header, or a path outside the state directory.
@@ -31,15 +37,28 @@ from pathlib import Path
 from typing import Any
 
 from coworker import migrations
+from coworker.agent_run_owner import OWNERS_DIR_NAME, Liveness, OwnerRegistry
+from coworker.agent_run_repository import DB_NAME as AGENT_RUNS_DB
+from coworker.agent_run_repository import SCHEMA_VERSION as AGENT_RUNS_VERSION
+from coworker.agent_run_state import (
+    AgentRunTransitionError,
+    is_leasable,
+    is_terminal,
+    validate_transition,
+)
+from coworker.agent_runs import json_list
 from coworker.migrations import (
     BackupFailed,
     StoreKind,
     StoreStatus,
+    VersionChannel,
     open_readonly,
     state_root,
     store_path,
     store_present,
 )
+from coworker.run_evidence import analyze_record
+from coworker.run_receipt import parse_moment
 
 MAX_DETAIL_ROWS = 8
 MAX_DETAIL_CHARS = 200
@@ -56,6 +75,28 @@ OPTIONAL_DEPENDENCIES = ("mcp", "pypdf")
 # the runs table without importing the scheduler, which pulls in the agent loop.
 KNOWN_RUN_STATUSES = frozenset(
     {"running", "success", "failed", "waiting_approval", "partial", "interrupted"}
+)
+
+# A read-only descriptor for the Agent Run store, so the integrity and JSON
+# column checks already written here cover it too. It is not a registry entry:
+# `agent_runs.db` has one schema version and no upgrade path yet, and adding it
+# to the registry belongs in `coworker/migrations.py`, which this does not touch.
+AGENT_RUNS_STORE_ID = "agent_runs_db"
+_AGENT_RUNS = migrations.StoreSpec(
+    store_id=AGENT_RUNS_STORE_ID,
+    kind=StoreKind.SQLITE,
+    relative_path=AGENT_RUNS_DB,
+    current_version=AGENT_RUNS_VERSION,
+    version_channel=VersionChannel.SQLITE_USER_VERSION,
+    description="Durable Agent Run identity, leases, and checkpoints",
+    json_columns=(
+        ("agent_runs", "approval_ids"),
+        ("agent_runs", "source_refs"),
+        ("agent_runs", "artifact_refs"),
+        ("agent_runs", "usage"),
+        ("agent_runs", "terminal_result"),
+        ("agent_run_checkpoints", "payload"),
+    ),
 )
 
 _SECRET_ASSIGNMENT = re.compile(
@@ -616,9 +657,8 @@ def _is_timestamp(value: object) -> bool:
 def _check_schedule(collector: _Collector, root: Path, spec) -> None:
     """Read-only consistency checks over jobs and runs.
 
-    Nothing here needs a canonical Agent Run identity. Checks that do — a stale
-    run owner, a dead lease, an impossible checkpoint transition — belong in
-    `_check_run_ownership`, which stays empty until issue #63 lands that identity.
+    These are the scheduler's own jobs and runs in `club.db`, which are not
+    Agent Runs. The durable Agent Run store is checked in `_check_run_ownership`.
     """
     conn = open_readonly(store_path(root, spec))
     try:
@@ -698,15 +738,455 @@ def _check_schedule(collector: _Collector, root: Path, spec) -> None:
         conn.close()
 
 
-def _check_run_ownership(collector: _Collector, root: Path, spec) -> None:
-    """Extension point for issue #63.
+def _check_run_ownership(collector: _Collector, root: Path, *, cross_store: bool) -> None:
+    """The Agent Run store: who owns a run, how it got here, and what it names.
 
-    Stale run owner, dead lease, and impossible checkpoint transition checks all
-    need the canonical Agent Run identity that #63 introduces. There is nothing
-    on disk today that can distinguish an abandoned owner from a live one, so
-    this deliberately reports nothing rather than guessing.
+    Three questions, in the order that keeps each honest. Is the run store
+    readable at all? Does its history describe a run that could have happened?
+    Do its references still resolve?
+
+    The one rule that outranks the rest: an owner is reported dead only when the
+    kernel says so. `OwnerRegistry` proves death by taking the exclusive `flock`
+    the owner held for the life of its process. Everything else -- another host,
+    a missing marker, a platform without `flock` -- is unknown. Unknown is
+    reported as unknown, because a check that quietly rounds it up to dead would
+    invite an operator to take a run away from a process that is still working
+    it. An unknown owner needs no rescue: its lease still expires, and expiry
+    reclaim is fenced by version.
     """
-    return
+    if not store_present(root, _AGENT_RUNS):
+        return
+    try:
+        version = migrations.read_version(root, _AGENT_RUNS)
+    except migrations.StoreUnreadable:
+        version = None
+    if version is not None and version > AGENT_RUNS_VERSION:
+        collector.add(
+            "agent_run.version_ahead",
+            AGENT_RUNS_STORE_ID,
+            Severity.ERROR,
+            Repair.NONE,
+            f"The Agent Run store was written by a newer Sourcecado "
+            f"(version {version}, this build knows {AGENT_RUNS_VERSION}). "
+            "Doctor will not read its runs.",
+            blocking=True,
+        )
+        return
+    if not _check_sqlite_integrity(collector, root, _AGENT_RUNS):
+        return
+    _check_json_columns(collector, root, _AGENT_RUNS)
+
+    conn = open_readonly(store_path(root, _AGENT_RUNS))
+    try:
+        if not {"agent_runs", "agent_run_checkpoints"} <= migrations.table_names(conn):
+            return
+        runs = [
+            dict(row)
+            for row in conn.execute(
+                "SELECT * FROM agent_runs ORDER BY created_at, rowid"
+            )
+        ]
+        history: dict[str, list[dict[str, Any]]] = {}
+        for row in conn.execute(
+            "SELECT run_id, sequence, kind, state FROM agent_run_checkpoints "
+            "ORDER BY run_id, sequence"
+        ):
+            history.setdefault(str(row["run_id"]), []).append(dict(row))
+    finally:
+        conn.close()
+
+    _check_run_leases(collector, root, runs)
+    _check_run_history(collector, runs, history)
+    if cross_store:
+        _check_run_links(collector, root, runs, history)
+
+
+def _unprovable(owner_id: str | None, host: str | None) -> Liveness:
+    """No proof is available. Absence of proof is never proof of death."""
+    return Liveness.UNKNOWN
+
+
+def _liveness_probe(collector: _Collector, root: Path):
+    """The one source of proof, or `unknown` when there is no proof to read.
+
+    Two conditions have to hold before Doctor will ask the kernel anything.
+
+    The marker directory has to already exist. Doctor never creates it, and a
+    run store restored without its markers proves nothing about who is alive --
+    the same verdict `OwnerRegistry` gives for a marker that is simply gone.
+
+    It also has to already be owner-only, because `OwnerRegistry`'s constructor
+    restores that mode, and a check that changed a permission while only
+    diagnosing would break the promise that a check writes nothing. A loosened
+    directory is reported instead, and every owner in it stays unknown. That
+    costs a proof of death, which is the safe direction to lose one in: unknown
+    is never reported as dead.
+    """
+    markers = root / OWNERS_DIR_NAME
+    if not markers.is_dir():
+        return _unprovable
+    mode = markers.stat().st_mode & 0o777
+    if mode != migrations.DIR_MODE:
+        collector.add(
+            "agent_run.owner_markers_permissive",
+            AGENT_RUNS_STORE_ID,
+            Severity.WARN,
+            Repair.REVIEW_REQUIRED,
+            f"The Agent Run owner markers are {oct(mode)}, expected "
+            f"{oct(migrations.DIR_MODE)}. Reading them would restore the mode, "
+            "and a check may not change state, so owner liveness is left "
+            "unknown until the permissions are put back.",
+            count=1,
+            detail=[_relative(markers, root)],
+        )
+        return _unprovable
+    return OwnerRegistry(root).liveness_of
+
+
+def _check_run_leases(collector: _Collector, root: Path, runs: list[dict[str, Any]]) -> None:
+    now = datetime.now(UTC)
+    probe = _liveness_probe(collector, root)
+    verdicts: dict[str, Liveness] = {}
+    alive: list[str] = []
+    dead: list[str] = []
+    unknown: list[str] = []
+    expired: list[str] = []
+    unowned: list[str] = []
+    for run in runs:
+        run_id = str(run.get("run_id"))
+        owner = run.get("lease_owner")
+        if owner is None:
+            # A run is created already owned, so this can only follow a crash
+            # between creating a run and taking its lease.
+            if str(run.get("current_state")) == "running":
+                unowned.append(f"run {run_id}")
+            continue
+        owner = str(owner)
+        # Expiry is checked first and on its own. An expired lease is already
+        # reclaimable and already fenced, so whether its owner still breathes
+        # changes nothing -- and asking would risk answering the wrong question.
+        expires = parse_moment(run.get("lease_expires_at"))
+        if expires is None or expires <= now:
+            expired.append(f"run {run_id}")
+            continue
+        if owner not in verdicts:
+            verdicts[owner] = probe(owner, run.get("lease_owner_host"))
+        verdict = verdicts[owner]
+        # The run id is what an operator acts on. The owner id is not printed:
+        # it is built from the machine's host name, and Doctor keeps the host
+        # out of its report the same way it keeps absolute paths out.
+        if verdict is Liveness.ALIVE:
+            alive.append(f"run {run_id}")
+        elif verdict is Liveness.DEAD:
+            dead.append(f"run {run_id}")
+        else:
+            unknown.append(f"run {run_id}")
+    if alive:
+        collector.add(
+            "agent_run.owned_by_live_process",
+            AGENT_RUNS_STORE_ID,
+            Severity.INFO,
+            Repair.NONE,
+            "Runs are held by an owner whose process is proven alive. They are "
+            "being worked right now and nothing here is stale.",
+            count=len(alive),
+            detail=alive,
+        )
+    if dead:
+        collector.add(
+            "agent_run.dead_owner",
+            AGENT_RUNS_STORE_ID,
+            Severity.WARN,
+            Repair.REVIEW_REQUIRED,
+            "Runs hold an unexpired lease whose owner process the kernel "
+            "confirms has exited. Starting the sidecar reclaims them under a "
+            "lease; Doctor will not write to a run store it does not own.",
+            count=len(dead),
+            detail=dead,
+        )
+    if unknown:
+        collector.add(
+            "agent_run.unknown_owner",
+            AGENT_RUNS_STORE_ID,
+            Severity.INFO,
+            Repair.NONE,
+            "Runs are held by an owner whose liveness is unknown: another host, "
+            "a marker that is gone, or a platform without file locking. Unknown "
+            "is not dead. The lease still expires and reclaiming an expired "
+            "lease is fenced, so nothing is stranded.",
+            count=len(unknown),
+            detail=unknown,
+        )
+    if expired:
+        collector.add(
+            "agent_run.expired_lease",
+            AGENT_RUNS_STORE_ID,
+            Severity.WARN,
+            Repair.REVIEW_REQUIRED,
+            "Runs hold a lease that has run out of time. Anyone may reclaim it "
+            "and the version fence stops a late writer, so starting the sidecar "
+            "clears this. Doctor reports it and changes nothing.",
+            count=len(expired),
+            detail=expired,
+        )
+    if unowned:
+        collector.add(
+            "agent_run.unowned_running",
+            AGENT_RUNS_STORE_ID,
+            Severity.WARN,
+            Repair.REVIEW_REQUIRED,
+            "Runs are marked running with no lease at all. A run is created "
+            "already owned, so this follows a crash between creating the run "
+            "and owning it. Startup reclaim classifies these as interrupted.",
+            count=len(unowned),
+            detail=unowned,
+        )
+
+
+def _check_run_history(
+    collector: _Collector,
+    runs: list[dict[str, Any]],
+    history: dict[str, list[dict[str, Any]]],
+) -> None:
+    """Records that no correct run could have produced.
+
+    Which edges are legal is not restated here. `coworker/agent_run_state.py`
+    holds the one table the store validates writes against, and this walks the
+    stored checkpoints back through the same `validate_transition`, so a check
+    cannot drift away from the rule it is checking.
+
+    What the record can support comes from `run_evidence.analyze_record`, which
+    already separates a checkpoint prefix retention deleted on purpose from a
+    sequence that is genuinely torn.
+    """
+    unsupported: list[str] = []
+    gaps: list[str] = []
+    after_terminal: list[str] = []
+    illegal: list[str] = []
+    mismatched: list[str] = []
+    leased: list[str] = []
+    for run in runs:
+        run_id = str(run.get("run_id"))
+        checkpoints = history.get(run_id, [])
+        record = analyze_record(run, checkpoints)
+        if record["unsupported"]:
+            # Fail closed. A record this build cannot read is not a record this
+            # build may call wrong, so no transition verdict is reached here.
+            unsupported.append(f"run {run_id}: {', '.join(record['unsupported'][:4])}")
+            continue
+        state = str(run.get("current_state"))
+        if run.get("lease_owner") is not None and not is_leasable(state):
+            leased.append(f"run {run_id} holds a lease in state {state}")
+        if record["damaged"]:
+            gaps.append(
+                f"run {run_id} stores {record['stored']} checkpoints of "
+                f"{record['expected']}, and not as a dense tail"
+            )
+            continue
+        previous: str | None = "running" if record["pruned_through"] == 0 else None
+        for item in checkpoints:
+            kind = str(item["kind"])
+            landed = str(item["state"])
+            if previous is None:
+                # Retention removed what came before, so this checkpoint's
+                # incoming edge cannot be judged. Its outgoing edges still can.
+                previous = landed
+                continue
+            if int(item["sequence"]) == 1 and kind != "run_started":
+                illegal.append(
+                    f"run {run_id} opens with {kind}; every run opens with run_started"
+                )
+            elif is_terminal(previous):
+                after_terminal.append(
+                    f"run {run_id} checkpoint {item['sequence']} is {kind} "
+                    f"after the run reached {previous}"
+                )
+            else:
+                try:
+                    validate_transition(kind, previous, landed)
+                except AgentRunTransitionError as exc:
+                    illegal.append(f"run {run_id} checkpoint {item['sequence']}: {exc}")
+            previous = landed
+        if (
+            checkpoints
+            and int(checkpoints[-1]["sequence"]) == record["expected"]
+            and str(checkpoints[-1]["state"]) != state
+        ):
+            mismatched.append(
+                f"run {run_id} row says {state}, its last checkpoint says "
+                f"{checkpoints[-1]['state']}"
+            )
+    if unsupported:
+        collector.add(
+            "agent_run.unsupported_record",
+            AGENT_RUNS_STORE_ID,
+            Severity.WARN,
+            Repair.REVIEW_REQUIRED,
+            "Runs carry a state, trigger, or checkpoint kind this build does "
+            "not know. Doctor reads no further into them rather than calling "
+            "something it cannot express a defect.",
+            count=len(unsupported),
+            detail=unsupported,
+        )
+    if gaps:
+        collector.add(
+            "agent_run.checkpoint_gap",
+            AGENT_RUNS_STORE_ID,
+            Severity.ERROR,
+            Repair.REVIEW_REQUIRED,
+            "Checkpoint sequences have holes. The sequence is dense by "
+            "construction, and retention only ever drops a leading run of it, "
+            "so this is damage rather than pruning. What the missing steps "
+            "recorded cannot be reconstructed.",
+            count=len(gaps),
+            detail=gaps,
+        )
+    if after_terminal:
+        collector.add(
+            "agent_run.checkpoint_after_terminal",
+            AGENT_RUNS_STORE_ID,
+            Severity.ERROR,
+            Repair.REVIEW_REQUIRED,
+            "Runs checkpointed after they had already finished. A terminal run "
+            "releases its lease and never moves again, so these rows were not "
+            "written by a correct run.",
+            count=len(after_terminal),
+            detail=after_terminal,
+        )
+    if illegal:
+        collector.add(
+            "agent_run.impossible_transition",
+            AGENT_RUNS_STORE_ID,
+            Severity.ERROR,
+            Repair.REVIEW_REQUIRED,
+            "Checkpoints record an edge the Agent Run state machine forbids.",
+            count=len(illegal),
+            detail=illegal,
+        )
+    if mismatched:
+        collector.add(
+            "agent_run.state_mismatch",
+            AGENT_RUNS_STORE_ID,
+            Severity.ERROR,
+            Repair.REVIEW_REQUIRED,
+            "Run rows disagree with their own last checkpoint. Both are written "
+            "in one transaction, so the record contradicts itself.",
+            count=len(mismatched),
+            detail=mismatched,
+        )
+    if leased:
+        collector.add(
+            "agent_run.lease_on_unleasable_state",
+            AGENT_RUNS_STORE_ID,
+            Severity.WARN,
+            Repair.REVIEW_REQUIRED,
+            "Runs hold a lease in a state that holds no lease. Parking or "
+            "finishing a run releases its lease in the same transaction as the "
+            "state change, so this pair cannot both be true.",
+            count=len(leased),
+            detail=leased,
+        )
+
+
+def _known_keys(root: Path, store_id: str, sql: str) -> set[str] | None:
+    """The ids one store holds, or None when that store cannot answer.
+
+    A store that is absent or unreadable gives no answer, and no answer is not
+    the same as "the target is gone". Doctor stays quiet rather than reporting
+    an orphan it cannot support.
+    """
+    spec = migrations.spec_for(store_id)
+    if not store_present(root, spec):
+        return None
+    try:
+        conn = open_readonly(store_path(root, spec))
+    except sqlite3.Error:
+        return None
+    try:
+        return {str(row[0]) for row in conn.execute(sql)}
+    except sqlite3.DatabaseError:
+        return None
+    finally:
+        conn.close()
+
+
+def _check_run_links(
+    collector: _Collector,
+    root: Path,
+    runs: list[dict[str, Any]],
+    history: dict[str, list[dict[str, Any]]],
+) -> None:
+    """References keyed by the canonical run identity, in both directions.
+
+    Orphaned is not pruned. Retention deletes checkpoint rows for a run whose
+    row stays, so it can leave a run with no steps but never a step with no
+    run. Approvals are never deleted by anything, so an approval id a run names
+    and the inbox does not hold is genuinely dangling.
+
+    Queue items are not covered because nothing links them by run identity:
+    `chat_queue` carries no run id and a run row carries no queue item id. The
+    only queue link a run has is the session it belongs to, which is checked.
+    """
+    known_runs = {str(run.get("run_id")) for run in runs}
+    sessions = _known_keys(root, "conversation_db", "SELECT session_id FROM sessions")
+    if sessions is not None:
+        transcripts = root / "conversations"
+        if transcripts.is_dir():
+            sessions |= {path.stem for path in transcripts.glob("*.jsonl")}
+    approvals = _known_keys(root, "conversation_db", "SELECT id FROM inbox")
+    people = _known_keys(root, "people_db", "SELECT person_id FROM people")
+
+    dangling_parents: list[str] = []
+    dangling_sessions: list[str] = []
+    dangling_people: list[str] = []
+    dangling_approvals: list[str] = []
+    for run in runs:
+        run_id = str(run.get("run_id"))
+        parent = run.get("parent_run_id")
+        if parent is not None and str(parent) not in known_runs:
+            dangling_parents.append(f"run {run_id} names parent {str(parent)[:48]}")
+        session = str(run.get("session_id") or "")
+        if sessions is not None and session not in sessions:
+            dangling_sessions.append(f"run {run_id} names session {session[:48]}")
+        person = run.get("person_id")
+        if people is not None and person is not None and str(person) not in people:
+            dangling_people.append(f"run {run_id} names person {str(person)[:48]}")
+        if approvals is not None:
+            for approval in json_list(run.get("approval_ids")):
+                if str(approval) not in approvals:
+                    dangling_approvals.append(
+                        f"run {run_id} names approval {str(approval)[:48]}"
+                    )
+    orphaned_checkpoints = sorted(set(history) - known_runs)
+
+    for check, entries, subject in (
+        ("agent_run.orphaned_parent", dangling_parents, "a parent run"),
+        ("agent_run.orphaned_session", dangling_sessions, "a session"),
+        ("agent_run.orphaned_person", dangling_people, "a person file"),
+        ("agent_run.orphaned_approval", dangling_approvals, "an approval"),
+    ):
+        if entries:
+            collector.add(
+                check,
+                AGENT_RUNS_STORE_ID,
+                Severity.WARN,
+                Repair.REVIEW_REQUIRED,
+                f"Runs name {subject} that no longer exists. A run is a record "
+                "of work that happened, so Doctor never edits or drops one.",
+                count=len(entries),
+                detail=entries,
+            )
+    if orphaned_checkpoints:
+        collector.add(
+            "agent_run.orphaned_checkpoint",
+            AGENT_RUNS_STORE_ID,
+            Severity.ERROR,
+            Repair.REVIEW_REQUIRED,
+            "Checkpoints belong to a run this store does not hold. Retention "
+            "deletes steps and keeps the run row, so it never produces this.",
+            count=len(orphaned_checkpoints),
+            detail=[f"checkpoints for run {item[:48]}" for item in orphaned_checkpoints],
+        )
 
 
 def _check_links(collector: _Collector, root: Path) -> None:
@@ -896,11 +1376,14 @@ def _scan(root: Path) -> _Scan:
                 _check_json_columns(collector, root, spec)
                 if spec.store_id == "conversation_db":
                     _check_schedule(collector, root, spec)
-                    _check_run_ownership(collector, root, spec)
         elif spec.kind in (StoreKind.JSONL_DIR, StoreKind.JSONL_LOG):
             torn_tails.extend(_check_jsonl(collector, root, spec))
     if not unreadable:
         _check_links(collector, root)
+    # The run store is its own database and is not in the registry, so it is
+    # checked here rather than inside the registry loop. Its own checks stand
+    # alone; only its cross-store references need the other stores readable.
+    _check_run_ownership(collector, root, cross_store=not unreadable)
     drift = _check_permissions(collector, root)
     dependencies = _check_dependencies(collector)
 

--- a/desktop/docs/doctor.md
+++ b/desktop/docs/doctor.md
@@ -83,6 +83,20 @@ process and fails if the model or connector modules appear in `sys.modules`, and
 | `workspace_trash` | `workspace_trash/` | Directory | not versioned |
 | `dotenv` | `.env` | Opaque file | not versioned |
 
+One more SQLite database is checked but is **not** in the registry:
+
+| Store id | Path | Kind | Where its version lives |
+| --- | --- | --- | --- |
+| `agent_runs_db` | `agent_runs.db` | SQLite | `PRAGMA user_version` |
+
+The Agent Run store has one schema version and no upgrade path yet, so there is
+nothing for the registry to migrate. Doctor reads its version directly from
+`coworker/agent_run_repository.SCHEMA_VERSION` and fails closed the same way: a
+run store from a newer build is reported, blocks every repair, and is not read.
+Because it is not registered, it does not appear in the `stores` table of the
+report and its permissions are not covered by the drift check. Registering it
+belongs in `coworker/migrations.py`.
+
 The version lives with the data wherever the format can carry it. SQLite has
 `PRAGMA user_version`, which needs no table of ours and commits inside the same
 transaction as the migration. The workspace JSON documents already write a
@@ -132,6 +146,14 @@ the contract. Removing those blocks is a follow-up, not part of this change.
   in a final status with no finish time.
 - **Orphaned links** — queued messages, approvals, retry chains, person session
   bindings, and ledger events pointing at something that no longer exists.
+- **Agent Run owners and leases** — leases that have expired, owners the kernel
+  confirms have exited, and owners whose liveness cannot be proven. See below.
+- **Agent Run history** — checkpoints recording a transition the state machine
+  forbids, a run that checkpointed after it finished, a hole in a sequence that
+  is dense by construction, a run row that disagrees with its own last
+  checkpoint, and a lease held in a state that holds no lease.
+- **Agent Run links** — the approvals, sessions, person files, and parent runs a
+  run names, and checkpoints naming a run the store does not hold.
 - **Interrupted approvals** — approvals that were authorised but never reported
   an outcome.
 - **Permission drift** — anything under the state directory that group or other
@@ -291,10 +313,132 @@ rerun sees it as still pending and tries again. Stores that already migrated in
 that run keep their new version and a rerun treats them as current. Migrations
 are idempotent: running Doctor twice does the work once.
 
-## Not covered yet
+## Agent Runs
 
-Doctor does not detect a stale run owner, a dead lease, or an impossible
-checkpoint transition. All three need the canonical Agent Run identity that
-issue #63 introduces; nothing on disk today can tell an abandoned owner from a
-live one. The place they belong is `_check_run_ownership` in
-`coworker/doctor.py`, which deliberately reports nothing rather than guessing.
+An **Agent Run** is one durable unit of assistant work with one identity, stored
+in `agent_runs.db`. A **lease** names the one process allowed to write to a run
+and the moment that right runs out. An **owner** is that process.
+`desktop/docs/agent-runs.md` is the design record.
+
+### How Doctor decides an owner is dead
+
+Only when the kernel says so. Nothing else counts.
+
+Every owner process holds an exclusive `flock` on its own marker file under
+`agent_run_owners/` for as long as it runs. The kernel releases that lock when
+the process exits, by any means, and never a moment sooner. Doctor asks
+`OwnerRegistry.liveness_of` — the same function the run store's own startup
+recovery asks — and gets one of three answers:
+
+| Answer | What Doctor reports |
+| --- | --- |
+| The marker locks against Doctor | `agent_run.owned_by_live_process`, severity info |
+| The marker is free | `agent_run.dead_owner`, severity warn |
+| Anything else | `agent_run.unknown_owner`, severity info |
+
+"Anything else" means the lease belongs to another host, the marker file is
+gone, the marker directory is gone, or the platform has no file locking. All of
+those are **unknown**, and unknown is reported as unknown.
+
+This distinction is the whole point. Reporting an unknown owner as dead would
+invite an operator to take a run away from a process that is still working it,
+which is exactly what the `flock` design exists to prevent. An unknown owner
+does not need rescuing: its lease still expires, and reclaiming an expired lease
+is fenced by version, so a superseded owner writes nothing rather than writing
+second.
+
+An **expired lease is a separate finding** and is decided before liveness is
+consulted at all. Once a lease has run out, whether its owner is alive changes
+nothing — that owner cannot renew and cannot commit. So a live process holding
+an expired lease is reported as `agent_run.expired_lease` and never as a dead
+owner.
+
+`test_a_live_run_owner_is_never_reported_as_stale` is the test that holds this
+line. It starts a real second process that takes a real lease and holds its
+marker, then asserts Doctor reports it alive, reports no dead owner, no expired
+lease, and no stale run, and calls the install healthy. Two more tests cover the
+unknown cases: a deleted marker file and a lease recorded against another host.
+
+Doctor also never touches the marker directory. It will not create one, and it
+will not read markers through a directory whose permissions have been loosened,
+because `OwnerRegistry`'s constructor would restore the mode and a check may not
+change state. A loosened directory is reported as
+`agent_run.owner_markers_permissive` and its owners stay unknown. Losing a proof
+of death is the safe direction to lose one in.
+
+### Which transitions are impossible
+
+Doctor does not carry its own copy of the rules. `coworker/agent_run_state.py`
+holds one table naming, for each checkpoint kind, the states it may be appended
+from and the states it may leave behind. The run store validates every write
+against that table, and Doctor walks the stored checkpoints back through the
+same `validate_transition`. A check cannot drift away from the rule it checks.
+
+What is reported:
+
+| Finding | What it means |
+| --- | --- |
+| `agent_run.checkpoint_after_terminal` | A run checkpointed after it finished. A terminal run releases its lease and never moves again. |
+| `agent_run.impossible_transition` | An edge the table forbids, or a run that opens with something other than `run_started`. |
+| `agent_run.checkpoint_gap` | The sequence has a hole. See below. |
+| `agent_run.state_mismatch` | The run row and its own last checkpoint disagree, though both are written in one transaction. |
+| `agent_run.lease_on_unleasable_state` | A lease is held on a waiting or terminal run. Parking or finishing releases the lease in the same transaction as the state change. |
+| `agent_run.unsupported_record` | A state, trigger, or checkpoint kind this build does not know. |
+
+`agent_run.unsupported_record` fails closed and stops there. A record Doctor
+cannot read is not a record Doctor may call wrong, so no transition verdict is
+reached for that run. "This build cannot express it" and "this is broken" are
+different reports and one must not decay into the other.
+
+### Orphaned is not pruned
+
+Retention drops step detail for long-finished runs on purpose
+(`RunLedger.prune_checkpoints`, 30 days). Pruned is not orphaned, and Doctor
+tells them apart three ways.
+
+**By shape.** A checkpoint sequence is dense from 1 to the run's
+`checkpoint_sequence`, and retention only ever removes a leading run of it. So a
+dense tail that reaches the expected sequence is pruned evidence, and anything
+else is damage. Doctor does not reimplement that rule: it uses
+`run_evidence.analyze_record`, the same function the run receipt uses, and reads
+its `pruned_through` and `damaged` fields. A fully pruned run reports nothing.
+
+**By direction.** Pruning deletes checkpoint rows and never touches the run row.
+It can leave a run with no steps; it can never leave a step with no run. So
+`agent_run.orphaned_checkpoint` is always damage.
+
+**By store.** Approvals are never deleted by anything in Sourcecado, so an
+approval id a run names that the inbox does not hold is genuinely dangling and
+not aged out.
+
+A fourth rule keeps the check honest in the other direction: **no answer is not
+an orphan.** If `club.db` or `people.db` is missing or unreadable, Doctor cannot
+tell whether a session, approval, or person file still exists, so it reports
+nothing for those links rather than calling them broken.
+
+### What Doctor will not do to a run
+
+Nothing. Every Agent Run finding is report-only. There is no repair, no proposed
+repair, and no write of any kind to `agent_runs.db`.
+
+That is deliberate. The two repairs an "obvious" fix would reach for — releasing
+a stale lease and marking an abandoned run interrupted — are exactly the two the
+run store already does correctly at startup, under a lease, fenced by version,
+in one transaction with the checkpoint that records it. Doctor holds no lease
+and cannot acquire one. A Doctor that wrote the same rows would be a second
+writer racing an owner it may not be able to prove is gone, which is the failure
+the whole design exists to prevent. Starting the sidecar is the repair.
+
+### Not covered yet
+
+- **Queue items are not linked to runs.** `chat_queue` carries no run id and a
+  run row carries no queue item id, so there is no link to check. The only queue
+  link a run has is the session it belongs to, which is checked.
+- **`inbox.run_id` is not checked against the run store.** That column holds
+  turn-loop identities (`run_<hex>`), which are a different namespace from Agent
+  Run identities (`run-<hex>`), and nothing writes the latter into it yet.
+  Checking it today would report every approval on every install as orphaned.
+- **`agent_runs.db` is not in the migration registry**, so it is absent from the
+  report's store table and from the permission drift check.
+- **The scan is unbounded in memory.** Every run row and every checkpoint is
+  read at once. Output is bounded; the read is not.

--- a/desktop/tests/test_doctor.py
+++ b/desktop/tests/test_doctor.py
@@ -28,7 +28,9 @@ def _tree_digest(root: Path) -> dict[str, tuple[str, str]]:
             oct(path.stat().st_mode & 0o777),
         )
         for path in sorted(root.rglob("*"))
-        if path.is_file()
+        # SQLite creates a -wal/-shm pair for any open of a WAL database, a
+        # read-only open included. They hold no Sourcecado state of their own.
+        if path.is_file() and path.suffix not in (".db-wal", ".db-shm")
     }
 
 
@@ -1054,3 +1056,589 @@ def test_cli_uses_the_same_state_directory_as_the_sidecar(monkeypatch, tmp_path)
     assert doctor.state_root() == state_dir()
     monkeypatch.delenv("CLUB_STATE_DIR")
     assert doctor.state_root() == state_dir()
+
+
+# --- Agent Run ownership, history, and links ----------------------------
+
+# A second process that takes a real lease and either holds its kernel marker
+# or dies. Only a process that genuinely holds an exclusive `flock` can prove
+# it is alive, so liveness cannot be faked from inside the test process.
+AGENT_RUN_CHILD = """
+import json, os, sys, time
+sys.path.insert(0, sys.argv[1])
+from coworker.agent_run_repository import AgentRunRepository
+
+repo = AgentRunRepository(sys.argv[2])
+owner = repo.registry.register()
+started = repo.create_run(
+    session_id="main", trigger="chat", goal="find leads at Rippling",
+    owner=owner, lease_seconds=3600,
+)
+print(json.dumps({"run_id": started.run["run_id"], "owner_id": owner.owner_id}))
+sys.stdout.flush()
+if sys.argv[3] == "hold":
+    time.sleep(300)
+os._exit(0)
+"""
+
+
+def _spawn_run_owner(root: Path, mode: str):
+    proc = subprocess.Popen(
+        [sys.executable, "-c", AGENT_RUN_CHILD, str(DESKTOP), str(root), mode],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    line = proc.stdout.readline()
+    assert line, "child never created an Agent Run"
+    return proc, json.loads(line)
+
+
+def _run_store(root: Path):
+    from coworker.agent_run_repository import AgentRunRepository
+
+    return AgentRunRepository(root)
+
+
+def _seed_run(root: Path, *, session_id: str = "main", **kwargs):
+    """One real run created through the store, then handed back unowned."""
+    repo = _run_store(root)
+    owner = repo.registry.register()
+    started = repo.create_run(
+        session_id=session_id, trigger="chat", goal="find leads", owner=owner, **kwargs
+    )
+    return repo, owner, started
+
+
+def _write_checkpoints(root: Path, run_id: str, rows):
+    """Plant checkpoint history the store itself would refuse to write."""
+    conn = _connect(root, "agent_runs.db")
+    conn.execute("DELETE FROM agent_run_checkpoints WHERE run_id = ?", (run_id,))
+    for sequence, kind, state in rows:
+        conn.execute(
+            "INSERT INTO agent_run_checkpoints "
+            "(run_id, sequence, kind, state, payload, created_at) "
+            "VALUES (?, ?, ?, ?, '{}', '2026-08-27T10:00:00.000000+00:00')",
+            (run_id, sequence, kind, state),
+        )
+    conn.execute(
+        "UPDATE agent_runs SET checkpoint_sequence = ?, current_state = ? "
+        "WHERE run_id = ?",
+        (rows[-1][0], rows[-1][2], run_id),
+    )
+    conn.commit()
+    conn.close()
+
+
+# --- check 1: stale run owner and lease ---------------------------------
+
+
+def test_a_live_run_owner_is_never_reported_as_stale(tmp_path):
+    """The regression that would matter most: Doctor calling a live owner dead.
+
+    The child process holds an exclusive flock on its owner marker for as long
+    as it runs. The kernel is the only thing that can release it.
+    """
+    root = build_current_state(tmp_path / "state")
+    migrations.apply_migrations(root)
+    proc, claim = _spawn_run_owner(root, "hold")
+    try:
+        report = doctor.diagnose(root)
+    finally:
+        proc.kill()
+        proc.wait()
+
+    live = _finding(report, "agent_run.owned_by_live_process")
+    assert live.record_count == 1
+    assert live.severity is Severity.INFO
+    assert live.repair is Repair.NONE
+    assert "agent_run.dead_owner" not in _checks(report)
+    assert "agent_run.expired_lease" not in _checks(report)
+    assert "agent_run.unowned_running" not in _checks(report)
+    assert claim["run_id"] in " ".join(live.detail)
+    # A live owner is not a defect, so it must not make the install unhealthy.
+    assert report.healthy is True
+    assert all(item.store_id != "agent_runs_db" for item in report.proposed_repairs)
+
+
+def test_a_dead_owner_is_reported_only_on_kernel_proof(tmp_path):
+    root = build_current_state(tmp_path / "state")
+    proc, claim = _spawn_run_owner(root, "exit")
+    assert proc.wait(timeout=30) == 0
+
+    report = doctor.diagnose(root)
+
+    dead = _finding(report, "agent_run.dead_owner")
+    assert dead.record_count == 1
+    assert dead.repair is Repair.REVIEW_REQUIRED
+    assert claim["run_id"] in " ".join(dead.detail)
+    assert "agent_run.owned_by_live_process" not in _checks(report)
+    assert all(item.store_id != "agent_runs_db" for item in report.proposed_repairs)
+
+
+def test_a_missing_owner_marker_is_unknown_and_never_dead(tmp_path):
+    from coworker.agent_run_owner import OWNERS_DIR_NAME
+
+    root = build_current_state(tmp_path / "state")
+    repo, owner, started = _seed_run(root, lease_seconds=3600)
+    repo.close()
+    (root / OWNERS_DIR_NAME / f"{owner.owner_id}.owner").unlink()
+
+    report = doctor.diagnose(root)
+
+    unknown = _finding(report, "agent_run.unknown_owner")
+    assert unknown.record_count == 1
+    assert unknown.severity is Severity.INFO
+    assert unknown.repair is Repair.NONE
+    assert "Unknown is not dead" in unknown.summary
+    assert "agent_run.dead_owner" not in _checks(report)
+
+
+def test_an_owner_on_another_host_is_unknown_and_never_dead(tmp_path):
+    root = build_current_state(tmp_path / "state")
+    repo, owner, started = _seed_run(root, lease_seconds=3600)
+    repo.close()
+    conn = _connect(root, "agent_runs.db")
+    conn.execute("UPDATE agent_runs SET lease_owner_host = 'another-laptop'")
+    conn.commit()
+    conn.close()
+
+    report = doctor.diagnose(root)
+
+    assert _finding(report, "agent_run.unknown_owner").record_count == 1
+    assert "agent_run.dead_owner" not in _checks(report)
+
+
+def test_a_run_store_with_no_owner_directory_reports_unknown_not_dead(tmp_path):
+    """A restored database without its markers proves nothing about liveness."""
+    import shutil
+
+    from coworker.agent_run_owner import OWNERS_DIR_NAME
+
+    root = build_current_state(tmp_path / "state")
+    repo, owner, started = _seed_run(root, lease_seconds=3600)
+    repo.close()
+    shutil.rmtree(root / OWNERS_DIR_NAME)
+
+    report = doctor.diagnose(root)
+
+    assert _finding(report, "agent_run.unknown_owner").record_count == 1
+    assert "agent_run.dead_owner" not in _checks(report)
+    # Doctor must not put the marker directory back while only diagnosing.
+    assert not (root / OWNERS_DIR_NAME).exists()
+
+
+def test_an_expired_lease_is_reported_apart_from_a_dead_owner(tmp_path):
+    root = build_current_state(tmp_path / "state")
+    proc, claim = _spawn_run_owner(root, "hold")
+    try:
+        conn = _connect(root, "agent_runs.db")
+        conn.execute(
+            "UPDATE agent_runs SET lease_expires_at = '2020-01-01T00:00:00.000000+00:00'"
+        )
+        conn.commit()
+        conn.close()
+        report = doctor.diagnose(root)
+    finally:
+        proc.kill()
+        proc.wait()
+
+    expired = _finding(report, "agent_run.expired_lease")
+    assert expired.record_count == 1
+    assert expired.repair is Repair.REVIEW_REQUIRED
+    # The owner is genuinely alive. An expired lease is a separate fact and
+    # must never be reported as a dead owner.
+    assert "agent_run.dead_owner" not in _checks(report)
+
+
+def test_a_running_run_with_no_lease_is_reported(tmp_path):
+    root = build_current_state(tmp_path / "state")
+    repo, owner, started = _seed_run(root)
+    repo.release_lease(started.lease)
+    repo.close()
+
+    report = doctor.diagnose(root)
+
+    unowned = _finding(report, "agent_run.unowned_running")
+    assert unowned.record_count == 1
+    assert unowned.repair is Repair.REVIEW_REQUIRED
+
+
+# --- check 2: impossible checkpoint transitions -------------------------
+
+
+def test_a_checkpoint_after_a_terminal_state_is_impossible(tmp_path):
+    root = build_current_state(tmp_path / "state")
+    repo, owner, started = _seed_run(root)
+    repo.release_lease(started.lease)
+    repo.close()
+    _write_checkpoints(
+        root,
+        started.run["run_id"],
+        [(1, "run_started", "running"), (2, "terminal", "complete"), (3, "model_completed", "running")],
+    )
+
+    report = doctor.diagnose(root)
+
+    finding = _finding(report, "agent_run.checkpoint_after_terminal")
+    assert finding.record_count == 1
+    assert finding.severity is Severity.ERROR
+    assert finding.repair is Repair.REVIEW_REQUIRED
+
+
+def test_a_transition_the_state_machine_forbids_is_detected(tmp_path):
+    root = build_current_state(tmp_path / "state")
+    repo, owner, started = _seed_run(root)
+    repo.release_lease(started.lease)
+    repo.close()
+    # `model_completed` may only be appended from `running`.
+    _write_checkpoints(
+        root,
+        started.run["run_id"],
+        [
+            (1, "run_started", "running"),
+            (2, "waiting_approval", "waiting_approval"),
+            (3, "model_completed", "running"),
+        ],
+    )
+
+    report = doctor.diagnose(root)
+
+    assert _finding(report, "agent_run.impossible_transition").record_count == 1
+
+
+def test_a_first_checkpoint_that_is_not_run_started_is_impossible(tmp_path):
+    root = build_current_state(tmp_path / "state")
+    repo, owner, started = _seed_run(root)
+    repo.release_lease(started.lease)
+    repo.close()
+    _write_checkpoints(
+        root,
+        started.run["run_id"],
+        [(1, "model_pending", "running"), (2, "model_completed", "running")],
+    )
+
+    report = doctor.diagnose(root)
+
+    assert _finding(report, "agent_run.impossible_transition").record_count == 1
+
+
+def test_a_gap_in_the_checkpoint_sequence_is_detected(tmp_path):
+    root = build_current_state(tmp_path / "state")
+    repo, owner, started = _seed_run(root)
+    repo.release_lease(started.lease)
+    repo.close()
+    _write_checkpoints(
+        root,
+        started.run["run_id"],
+        [(1, "run_started", "running"), (4, "model_completed", "running")],
+    )
+
+    report = doctor.diagnose(root)
+
+    gap = _finding(report, "agent_run.checkpoint_gap")
+    assert gap.record_count == 1
+    assert gap.severity is Severity.ERROR
+
+
+def test_checkpoints_removed_by_retention_are_not_reported_as_a_gap(tmp_path):
+    """Retention drops step detail on purpose. Pruned is not orphaned."""
+    from datetime import UTC, datetime, timedelta
+
+    root = build_current_state(tmp_path / "state")
+    migrations.apply_migrations(root)
+    repo, owner, started = _seed_run(root)
+    run_id = started.run["run_id"]
+    repo.checkpoint(started.lease, kind="terminal", state="complete")
+    pruned = repo.prune_checkpoints(finished_before=datetime.now(UTC) + timedelta(days=1))
+    assert pruned == [run_id]
+    assert repo.list_checkpoints(run_id) == []
+    repo.close()
+
+    report = doctor.diagnose(root)
+
+    assert "agent_run.checkpoint_gap" not in _checks(report)
+    assert "agent_run.impossible_transition" not in _checks(report)
+    assert "agent_run.state_mismatch" not in _checks(report)
+    assert report.healthy is True
+
+
+def test_a_lease_held_in_a_state_that_holds_no_lease_is_detected(tmp_path):
+    root = build_current_state(tmp_path / "state")
+    repo, owner, started = _seed_run(root, lease_seconds=3600)
+    repo.close()
+    conn = _connect(root, "agent_runs.db")
+    conn.execute("UPDATE agent_runs SET current_state = 'waiting_approval'")
+    conn.execute(
+        "UPDATE agent_run_checkpoints SET state = 'waiting_approval', "
+        "kind = 'waiting_approval' WHERE sequence = 1"
+    )
+    conn.commit()
+    conn.close()
+
+    report = doctor.diagnose(root)
+
+    finding = _finding(report, "agent_run.lease_on_unleasable_state")
+    assert finding.record_count == 1
+    assert finding.repair is Repair.REVIEW_REQUIRED
+
+
+def test_a_row_that_disagrees_with_its_last_checkpoint_is_detected(tmp_path):
+    root = build_current_state(tmp_path / "state")
+    repo, owner, started = _seed_run(root)
+    repo.release_lease(started.lease)
+    repo.close()
+    conn = _connect(root, "agent_runs.db")
+    conn.execute("UPDATE agent_runs SET current_state = 'complete', finished_at = '2026-08-27'")
+    conn.commit()
+    conn.close()
+
+    report = doctor.diagnose(root)
+
+    assert _finding(report, "agent_run.state_mismatch").record_count == 1
+
+
+def test_a_record_this_build_cannot_read_is_unsupported_not_a_bad_transition(tmp_path):
+    """Fail closed. "Doctor cannot read this" must never render as "this is wrong"."""
+    root = build_current_state(tmp_path / "state")
+    repo, owner, started = _seed_run(root)
+    repo.release_lease(started.lease)
+    repo.close()
+    conn = _connect(root, "agent_runs.db")
+    conn.execute("UPDATE agent_run_checkpoints SET kind = 'future_kind_from_a_newer_build'")
+    conn.commit()
+    conn.close()
+
+    report = doctor.diagnose(root)
+
+    finding = _finding(report, "agent_run.unsupported_record")
+    assert finding.record_count == 1
+    assert finding.repair is Repair.REVIEW_REQUIRED
+    assert "agent_run.impossible_transition" not in _checks(report)
+    assert "agent_run.checkpoint_after_terminal" not in _checks(report)
+
+
+def test_a_run_store_from_a_newer_build_fails_closed(tmp_path):
+    from coworker.agent_run_repository import SCHEMA_VERSION
+
+    root = build_legacy_state(tmp_path / "state")
+    repo, owner, started = _seed_run(root)
+    repo.close()
+    conn = _connect(root, "agent_runs.db")
+    conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION + 5}")
+    conn.commit()
+    conn.close()
+    before = _tree_digest(root)
+
+    report = doctor.diagnose(root)
+
+    finding = _finding(report, "agent_run.version_ahead")
+    assert finding.blocking is True
+    assert report.blocked is True
+    assert report.proposed_repairs == ()
+    assert doctor.repair(root).blocked is True
+    assert _tree_digest(root) == before
+
+
+# --- check 3: orphaned links keyed by run identity ----------------------
+
+
+def test_orphaned_run_links_are_detected(tmp_path):
+    root = build_current_state(tmp_path / "state")
+    repo, owner, started = _seed_run(root, session_id="ghost")
+    run_id = started.run["run_id"]
+    repo.checkpoint(
+        started.lease,
+        kind="waiting_approval",
+        state="waiting_approval",
+        approval_ids=["call_that_never_existed"],
+        person_id="per_missing_from_the_person_store",
+    )
+    repo.close()
+    conn = _connect(root, "agent_runs.db")
+    conn.execute("UPDATE agent_runs SET parent_run_id = 'run-gone' WHERE run_id = ?", (run_id,))
+    conn.execute(
+        "INSERT INTO agent_run_checkpoints "
+        "(run_id, sequence, kind, state, payload, created_at) "
+        "VALUES ('run-not-in-this-store', 1, 'run_started', 'running', '{}', '2026-08-27')"
+    )
+    conn.commit()
+    conn.close()
+
+    report = doctor.diagnose(root)
+
+    assert _finding(report, "agent_run.orphaned_approval").record_count == 1
+    assert _finding(report, "agent_run.orphaned_parent").record_count == 1
+    assert _finding(report, "agent_run.orphaned_session").record_count == 1
+    assert _finding(report, "agent_run.orphaned_person").record_count == 1
+    assert _finding(report, "agent_run.orphaned_checkpoint").record_count == 1
+    assert all(
+        item.repair is Repair.REVIEW_REQUIRED
+        for item in report.findings
+        if item.check.startswith("agent_run.orphaned_")
+    )
+    assert all(item.store_id != "agent_runs_db" for item in report.proposed_repairs)
+
+
+def test_links_that_resolve_are_not_reported_as_orphans(tmp_path):
+    root = build_current_state(tmp_path / "state")
+    migrations.apply_migrations(root)
+    people = _connect(root, "people.db")
+    person_id = str(people.execute("SELECT person_id FROM people LIMIT 1").fetchone()[0])
+    people.close()
+    repo, owner, started = _seed_run(root, session_id="main")
+    repo.checkpoint(
+        started.lease,
+        kind="waiting_approval",
+        state="waiting_approval",
+        approval_ids=["call_gmail_send_1"],
+        person_id=person_id,
+    )
+    repo.close()
+
+    report = doctor.diagnose(root)
+
+    assert not [item for item in report.findings if item.check.startswith("agent_run.orphaned_")]
+    assert report.healthy is True
+
+
+def test_a_run_link_is_unverifiable_rather_than_orphaned_without_its_store(tmp_path):
+    """No conversation store means no answer, and no answer is not an orphan."""
+    root = tmp_path / "state"
+    root.mkdir(parents=True)
+    repo, owner, started = _seed_run(root, session_id="main")
+    repo.checkpoint(
+        started.lease,
+        kind="waiting_approval",
+        state="waiting_approval",
+        approval_ids=["call_gmail_send_1"],
+    )
+    repo.close()
+    conn = _connect(root, "agent_runs.db")
+    conn.execute("UPDATE agent_runs SET parent_run_id = 'run-gone'")
+    conn.commit()
+    conn.close()
+
+    report = doctor.diagnose(root)
+
+    # Non-vacuous: the link check ran and found the one gap it could verify.
+    assert _finding(report, "agent_run.orphaned_parent").record_count == 1
+    assert "agent_run.orphaned_approval" not in _checks(report)
+    assert "agent_run.orphaned_session" not in _checks(report)
+
+
+# --- redaction of the new checks ----------------------------------------
+
+
+def test_no_planted_secret_survives_the_agent_run_checks(tmp_path):
+    """A credential in a run identifier field must not reach the report.
+
+    The run store redacts on write, so this plants the canary the only way it
+    could arrive: a row written by something other than the store.
+    """
+    root = build_current_state(tmp_path / "state", plant_secrets=True)
+    repo, owner, started = _seed_run(root, lease_seconds=3600)
+    run_id = started.run["run_id"]
+    repo.close()
+    conn = _connect(root, "agent_runs.db")
+    conn.execute(
+        "UPDATE agent_runs SET session_id = ?, lease_owner = ?, person_id = ?, "
+        "parent_run_id = ?, approval_ids = ? WHERE run_id = ?",
+        (
+            f"session-{PLANTED_API_KEY}",
+            f"owner-{PLANTED_BEARER}",
+            f"per_{PLANTED_API_KEY}",
+            f"run-{PLANTED_BEARER}",
+            json.dumps([f"call_{PLANTED_API_KEY}"]),
+            run_id,
+        ),
+    )
+    conn.execute(
+        "UPDATE agent_run_checkpoints SET kind = ? WHERE run_id = ?",
+        (f"kind_{PLANTED_API_KEY}", run_id),
+    )
+    conn.commit()
+    conn.close()
+
+    report = doctor.diagnose(root)
+    rendered = report.render()
+    serialized = json.dumps(report.to_dict())
+
+    # Non-vacuous: every field carrying a canary drove a real finding first.
+    for check in (
+        "agent_run.unsupported_record",
+        "agent_run.orphaned_approval",
+        "agent_run.orphaned_parent",
+        "agent_run.orphaned_session",
+        "agent_run.orphaned_person",
+        "agent_run.unknown_owner",
+    ):
+        finding = _finding(report, check)
+        assert finding.store_id == "agent_runs_db"
+        assert finding.record_count >= 1
+    _assert_no_canary([rendered, serialized], "agent runs")
+    assert str(root) not in rendered and str(root) not in serialized
+
+
+def test_agent_run_output_stays_bounded_with_many_broken_runs(tmp_path):
+    root = build_current_state(tmp_path / "state")
+    migrations.apply_migrations(root)
+    _run_store(root).close()
+    conn = _connect(root, "agent_runs.db")
+    for index in range(300):
+        conn.execute(
+            "INSERT INTO agent_runs (run_id, session_id, trigger, goal_fingerprint, "
+            "current_state, version, checkpoint_sequence, created_at, updated_at) "
+            "VALUES (?, 'ghost', 'chat', 'f', 'running', 1, 4, 'x', 'x')",
+            (f"run-broken-{index:04d}",),
+        )
+        conn.execute(
+            "INSERT INTO agent_run_checkpoints "
+            "(run_id, sequence, kind, state, payload, created_at) "
+            "VALUES (?, 1, 'run_started', 'running', '{}', 'x')",
+            (f"run-broken-{index:04d}",),
+        )
+    conn.commit()
+    conn.close()
+
+    report = doctor.diagnose(root)
+    rendered = report.render()
+
+    gap = _finding(report, "agent_run.checkpoint_gap")
+    assert gap.record_count == 300
+    assert len(gap.detail) <= doctor.MAX_DETAIL_ROWS
+    assert _finding(report, "agent_run.unowned_running").record_count == 300
+    assert len(report.findings) <= doctor.MAX_FINDINGS
+    for finding in report.findings:
+        assert len(finding.detail) <= doctor.MAX_DETAIL_ROWS
+        for line in finding.detail:
+            assert len(line) <= doctor.MAX_DETAIL_CHARS
+    assert len(rendered) <= doctor.MAX_REPORT_CHARS
+    assert "300" in rendered
+
+
+def test_diagnose_never_changes_the_owner_marker_permissions(tmp_path):
+    """Reading the markers through OwnerRegistry would restore their mode.
+
+    Doctor reports the drift instead. Losing a proof of death is safe; a check
+    that quietly writes during a dry run is not.
+    """
+    from coworker.agent_run_owner import OWNERS_DIR_NAME
+
+    root = build_current_state(tmp_path / "state")
+    migrations.apply_migrations(root)
+    proc, claim = _spawn_run_owner(root, "hold")
+    try:
+        markers = root / OWNERS_DIR_NAME
+        os.chmod(markers, 0o755)
+        report = doctor.diagnose(root)
+    finally:
+        proc.kill()
+        proc.wait()
+
+    assert markers.stat().st_mode & 0o777 == 0o755
+    finding = _finding(report, "agent_run.owner_markers_permissive")
+    assert finding.repair is Repair.REVIEW_REQUIRED
+    # The owner really is alive, and Doctor still refuses to call it dead.
+    assert _finding(report, "agent_run.unknown_owner").record_count == 1
+    assert "agent_run.dead_owner" not in _checks(report)
+    assert "agent_run.owned_by_live_process" not in _checks(report)


### PR DESCRIPTION
Completes #73. PR #103 landed the migration registry, integrity checks, backup, repair, and the redacted report, and deliberately deferred three checks that needed a canonical Agent Run identity. #105 merged that identity. This closes them.

## Domain words

- **Owner** — the process currently driving an Agent Run. Holds an exclusive `flock` on a marker file for its whole life.
- **Lease** — an owner's time-bounded claim on a run.
- **Liveness** — the three-state answer to "is that owner still alive": `ALIVE`, `DEAD`, `UNKNOWN`.
- **Kernel proof** — the only acceptable evidence that an owner is dead: the kernel released its `flock`, which happens on process exit by any means and never before.

## The three deferred checks

1. **Stale run owner and lease detection** — `agent_run.dead_owner`, `agent_run.expired_lease`, `agent_run.unknown_owner`, `agent_run.owned_by_live_process`, `agent_run.unowned_running`.
2. **Impossible checkpoint transition detection.**
3. **Orphaned queue and approval links** keyed by canonical run identity.

## The rule that governs all of it

**Doctor may report an owner as dead only on kernel proof. Never on a heuristic, never on a timestamp, never on a process id missing from `ps`.**

Collapsing `UNKNOWN` into `DEAD` is the failure that matters here. It would let Doctor recommend reclaiming a run whose owner is alive and working — which is precisely what the `flock` design in #105 exists to prevent. Two writers on one run is exactly the corruption the whole ownership model was built to make impossible.

An unknown owner does not need rescuing. Its lease still expires, and an expired lease is version-fenced, so reclaiming it later still cannot produce two writers. Doctor's job here is to report, not to rescue.

The distinction is carried into the operator-facing text, not just the code: the unknown finding's summary contains **"Unknown is not dead"**.

## The tests that hold it

These use real processes and real kernel behavior, not mocks.

`test_a_live_run_owner_is_never_reported_as_stale` spawns a child that holds an exclusive `flock` on its owner marker, runs Doctor while it is genuinely alive, and asserts:

- the run is reported as `owned_by_live_process`, severity `INFO`, repair `NONE`
- `dead_owner`, `expired_lease`, and `unowned_running` are all **absent**
- `report.healthy is True` — a live owner is not a defect
- no repair is proposed against `agent_runs_db`

`test_a_dead_owner_is_reported_only_on_kernel_proof` spawns a child that exits, so the kernel releases the lock, then asserts the dead finding appears with repair `REVIEW_REQUIRED`.

Three separate unknown cases, each asserting `dead_owner` is absent:

| Test | Situation |
|---|---|
| `test_a_missing_owner_marker_is_unknown_and_never_dead` | Marker file gone |
| `test_an_owner_on_another_host_is_unknown_and_never_dead` | Different host |
| `test_a_run_store_with_no_owner_directory_reports_unknown_not_dead` | No owner directory at all |

And `test_an_expired_lease_is_reported_apart_from_a_dead_owner` keeps those two situations distinct, because they call for different operator responses.

## Repairs

Every new finding is report-only or `REVIEW_REQUIRED`. None is automatic.

Run ownership is the domain where an "obvious" automatic repair does real damage, and no repair here is provably safe against a live owner. Doctor stays diagnostic, which is the contract PR #103 established.

## Measurements

```
1070 passed, 3 skipped, 1 warning in 43.14s
```

Re-run independently by the reviewing session on the pushed commit.

## Boundary

Three files: `doctor.py`, `test_doctor.py`, `doctor.md`. The `agent_run*` modules are read, never modified — they are merged, reviewed correctness from #105 and #63.

With this, #73 is complete as originally specified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjAD6SVox1gvF4sV3jTnJy
