### PR TITLE
feat(desktop): fence ambiguous external effects and classify restart

### DIFF
--- a/desktop/coworker/agent_run_approval.py
+++ b/desktop/coworker/agent_run_approval.py
@@ -189,63 +189,85 @@ def _quoted(values: Iterable[str]) -> str:
 # below is also enforced in `AgentRunRepository`; it is repeated here because a
 # raw SQL edit, a future method, or a bug in one of those paths must still hit
 # a wall rather than turn "we do not know" into "it worked".
-EFFECT_SCHEMA = f"""
-CREATE TABLE IF NOT EXISTS agent_run_effects (
-    effect_id TEXT PRIMARY KEY,
-    run_id TEXT NOT NULL,
-    tool_name TEXT NOT NULL,
-    tool_call_id TEXT,
-    approval_id TEXT,
-    replay_class TEXT NOT NULL,
-    arguments_fingerprint TEXT NOT NULL,
-    status TEXT NOT NULL,
-    dispatched_by TEXT NOT NULL,
-    dispatched_at TEXT NOT NULL,
-    settled_at TEXT,
-    outcome_ref TEXT,
-    reason TEXT,
-    resolved_by TEXT,
-    resolved_note TEXT,
-    resolved_at TEXT,
-    FOREIGN KEY (run_id) REFERENCES agent_runs(run_id),
-    CHECK (status IN ({_quoted(EFFECT_STATUSES)})),
-    CHECK (replay_class IN ({_quoted(ReplayClass)})),
-    -- A person's verdict cannot exist in this table without the person.
-    CHECK ((status IN ({_quoted(OPERATOR_OUTCOMES)})) = (resolved_by IS NOT NULL))
-);
-CREATE INDEX IF NOT EXISTS agent_run_effects_by_run
-    ON agent_run_effects(run_id, status);
-CREATE INDEX IF NOT EXISTS agent_run_effects_open
-    ON agent_run_effects(status, dispatched_at);
+#
+# Separate statements, not one script, and that is load-bearing.
+# `sqlite3.Connection.executescript` issues a COMMIT before it runs. Calling it
+# inside a migration's transaction would end that transaction, and the
+# registry's rollback would then have nothing left to roll back -- silently.
+# The migration in `coworker/migrations.py` executes these one at a time for
+# exactly that reason. `EFFECT_SCHEMA` below is only for creating a database
+# from nothing, where no transaction is open.
+EFFECT_STATEMENTS: tuple[str, ...] = (
+    f"""
+    CREATE TABLE IF NOT EXISTS agent_run_effects (
+        effect_id TEXT PRIMARY KEY,
+        run_id TEXT NOT NULL,
+        tool_name TEXT NOT NULL,
+        tool_call_id TEXT,
+        approval_id TEXT,
+        replay_class TEXT NOT NULL,
+        arguments_fingerprint TEXT NOT NULL,
+        status TEXT NOT NULL,
+        dispatched_by TEXT NOT NULL,
+        dispatched_at TEXT NOT NULL,
+        settled_at TEXT,
+        outcome_ref TEXT,
+        reason TEXT,
+        resolved_by TEXT,
+        resolved_note TEXT,
+        resolved_at TEXT,
+        FOREIGN KEY (run_id) REFERENCES agent_runs(run_id),
+        CHECK (status IN ({_quoted(EFFECT_STATUSES)})),
+        CHECK (replay_class IN ({_quoted(ReplayClass)})),
+        -- A person's verdict cannot exist in this table without the person.
+        CHECK ((status IN ({_quoted(OPERATOR_OUTCOMES)})) = (resolved_by IS NOT NULL))
+    )
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS agent_run_effects_by_run
+        ON agent_run_effects(run_id, status)
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS agent_run_effects_open
+        ON agent_run_effects(status, dispatched_at)
+    """,
+    f"""
+    CREATE TRIGGER IF NOT EXISTS agent_run_effects_open_as_dispatched
+    BEFORE INSERT ON agent_run_effects
+    WHEN NEW.status <> '{EffectStatus.DISPATCHED}'
+    BEGIN
+        SELECT RAISE(ABORT, 'an external effect record opens as dispatched');
+    END
+    """,
+    f"""
+    CREATE TRIGGER IF NOT EXISTS agent_run_effects_quarantine_is_operator_only
+    BEFORE UPDATE OF status ON agent_run_effects
+    WHEN OLD.status = '{EffectStatus.AMBIGUOUS}'
+     AND NEW.status NOT IN ({_quoted({EffectStatus.AMBIGUOUS, *OPERATOR_OUTCOMES})})
+    BEGIN
+        SELECT RAISE(ABORT,
+            'a quarantined external effect is settled by a person, never by code');
+    END
+    """,
+    f"""
+    CREATE TRIGGER IF NOT EXISTS agent_run_effects_settled_is_final
+    BEFORE UPDATE OF status ON agent_run_effects
+    WHEN OLD.status IN ({_quoted(SETTLED_EFFECT_STATUSES)})
+     AND NEW.status <> OLD.status
+    BEGIN
+        SELECT RAISE(ABORT, 'a settled external effect never changes outcome');
+    END
+    """,
+    """
+    CREATE TRIGGER IF NOT EXISTS agent_run_effects_are_never_deleted
+    BEFORE DELETE ON agent_run_effects
+    BEGIN
+        SELECT RAISE(ABORT,
+            'an external effect record is evidence that something left the machine');
+    END
+    """,
+)
 
-CREATE TRIGGER IF NOT EXISTS agent_run_effects_open_as_dispatched
-BEFORE INSERT ON agent_run_effects
-WHEN NEW.status <> '{EffectStatus.DISPATCHED}'
-BEGIN
-    SELECT RAISE(ABORT, 'an external effect record opens as dispatched');
-END;
-
-CREATE TRIGGER IF NOT EXISTS agent_run_effects_quarantine_is_operator_only
-BEFORE UPDATE OF status ON agent_run_effects
-WHEN OLD.status = '{EffectStatus.AMBIGUOUS}'
- AND NEW.status NOT IN ({_quoted({EffectStatus.AMBIGUOUS, *OPERATOR_OUTCOMES})})
-BEGIN
-    SELECT RAISE(ABORT,
-        'a quarantined external effect is settled by a person, never by code');
-END;
-
-CREATE TRIGGER IF NOT EXISTS agent_run_effects_settled_is_final
-BEFORE UPDATE OF status ON agent_run_effects
-WHEN OLD.status IN ({_quoted(SETTLED_EFFECT_STATUSES)})
- AND NEW.status <> OLD.status
-BEGIN
-    SELECT RAISE(ABORT, 'a settled external effect never changes outcome');
-END;
-
-CREATE TRIGGER IF NOT EXISTS agent_run_effects_are_never_deleted
-BEFORE DELETE ON agent_run_effects
-BEGIN
-    SELECT RAISE(ABORT,
-        'an external effect record is evidence that something left the machine');
-END;
-"""
+# The same DDL as one script, for creating a database from nothing. Safe there
+# because no transaction is open. Never use this inside a migration.
+EFFECT_SCHEMA = "\n".join(f"{statement.strip()};" for statement in EFFECT_STATEMENTS)

--- a/desktop/coworker/agent_run_approval.py
+++ b/desktop/coworker/agent_run_approval.py
@@ -1,0 +1,251 @@
+"""The fence between an approved external effect and a second attempt at it.
+
+Some effects reach a real person and cost real money. `gmail_send` is the case
+this module exists for. Between dispatching one and recording what happened
+there is a window, and a process that dies inside it leaves behind a fact
+nobody holds: the mail may have gone out, or it may not have. That is not
+"failed" and it is not "succeeded". Calling it either is the mistake with no
+undo, so the store refuses to.
+
+An effect with a dispatch and no outcome is `ambiguous`: quarantined until a
+person settles it. Nothing automatic moves it out. A retry, a resume, a second
+owner, and a later restart all read the same row and all stop there.
+
+Two vocabularies, deliberately disjoint.
+
+- `succeeded` and `failed` are what the dispatching process observed. Only that
+  process may write them, and only from `dispatched`.
+- `resolved_succeeded`, `resolved_failed`, and `abandoned` are what a person
+  decided. The row cannot hold one of them without naming who decided it.
+
+No value belongs to both sets, so a machine observation and a human judgement
+can never be confused when the record is read back. The database enforces the
+separation itself: `EFFECT_SCHEMA` carries triggers that abort an update
+crossing from `ambiguous` into a machine outcome, an update that changes a
+settled outcome, an insert that opens anywhere but `dispatched`, and any delete
+at all. A code path that gets this wrong fails loudly rather than quietly.
+
+Which tools need the fence is not decided here. `permissions.RETRY_SAFE` is the
+one list of tools that can re-run without producing a second external effect,
+and this module reads it. Everything outside it is consequential, so a tool the
+permission module has never heard of is fenced rather than replayed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from enum import StrEnum
+from typing import Any, Iterable
+
+from coworker.agent_runs import redact_secrets
+from coworker.permissions import RETRY_SAFE
+from coworker.run_evidence import Evidence
+
+
+class ReplayClass(StrEnum):
+    """Whether attempting this tool again can produce a second external effect."""
+
+    SAFE = "safe"
+    CONSEQUENTIAL = "consequential"
+
+
+class EffectStatus(StrEnum):
+    DISPATCHED = "dispatched"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    # The dispatch was recorded and no outcome ever was. Quarantined.
+    AMBIGUOUS = "ambiguous"
+    RESOLVED_SUCCEEDED = "resolved_succeeded"
+    RESOLVED_FAILED = "resolved_failed"
+    ABANDONED = "abandoned"
+
+
+# What the dispatching process saw. Reachable only from `dispatched`.
+MACHINE_OUTCOMES = frozenset({EffectStatus.SUCCEEDED, EffectStatus.FAILED})
+# What a person decided. Reachable only from `ambiguous`, and never without a name.
+OPERATOR_OUTCOMES = frozenset(
+    {
+        EffectStatus.RESOLVED_SUCCEEDED,
+        EffectStatus.RESOLVED_FAILED,
+        EffectStatus.ABANDONED,
+    }
+)
+SETTLED_EFFECT_STATUSES = MACHINE_OUTCOMES | OPERATOR_OUTCOMES
+OPEN_EFFECT_STATUSES = frozenset({EffectStatus.DISPATCHED, EffectStatus.AMBIGUOUS})
+EFFECT_STATUSES = SETTLED_EFFECT_STATUSES | OPEN_EFFECT_STATUSES
+
+# The whole point of the module in one line: an outcome a machine may write and
+# an outcome a person may write are never the same value.
+assert MACHINE_OUTCOMES.isdisjoint(OPERATOR_OUTCOMES)
+assert set(EffectStatus) == EFFECT_STATUSES
+
+_MAX_NOTE = 512
+_MAX_ID = 256
+
+
+class AgentRunEffectFenced(RuntimeError):
+    """A write would have moved an external effect along an edge that is closed."""
+
+
+def replay_class(tool_name: str) -> ReplayClass:
+    """Read `permissions.RETRY_SAFE`; treat everything else as consequential.
+
+    Fail closed on purpose. A tool the permission module does not list is not a
+    tool this module gets to guess about.
+    """
+    return (
+        ReplayClass.SAFE if str(tool_name) in RETRY_SAFE else ReplayClass.CONSEQUENTIAL
+    )
+
+
+def is_replay_safe(tool_name: str) -> bool:
+    return replay_class(tool_name) is ReplayClass.SAFE
+
+
+def effect_fingerprint(tool_name: str, arguments: Any) -> str:
+    """Identify one external effect without keeping what it said.
+
+    A recipient, a subject, and a body are the operator's content and stay in
+    the transcript and the approval record. What the run store needs is only
+    whether a call it is about to make is the call it already dispatched, and a
+    digest answers that.
+    """
+    canonical = json.dumps(
+        arguments if arguments is not None else {},
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+    return hashlib.sha256(f"{tool_name}\n{canonical}".encode("utf-8")).hexdigest()
+
+
+def is_quarantined(effect: dict[str, Any]) -> bool:
+    return str(effect.get("status")) == EffectStatus.AMBIGUOUS
+
+
+def unreported(effects: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Dispatched, never reported. These are what a restart must quarantine."""
+    return [
+        effect
+        for effect in effects
+        if str(effect.get("status")) == EffectStatus.DISPATCHED
+    ]
+
+
+def quarantined(effects: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [effect for effect in effects if is_quarantined(effect)]
+
+
+def external_effect_evidence(effects: Iterable[dict[str, Any]]) -> Evidence | None:
+    """The evidence value an unsettled effect forces, or None if none does.
+
+    Only the direction this module can decide alone. Whether silence about
+    external effects means `absent`, `missing`, or `expired` depends on the
+    whole record, and `run_evidence.absence_evidence` already owns that call.
+    """
+    items = list(effects)
+    if any(is_quarantined(effect) for effect in items):
+        return Evidence.AMBIGUOUS
+    if unreported(items):
+        return Evidence.MISSING
+    return None
+
+
+def operator_decision(decision: str) -> EffectStatus:
+    """Map a person's verdict onto the operator half of the vocabulary."""
+    try:
+        status = EffectStatus(str(decision))
+    except ValueError as exc:
+        raise ValueError(f"unknown operator decision {decision!r}") from exc
+    if status not in OPERATOR_OUTCOMES:
+        raise ValueError(
+            f"{decision!r} is a machine outcome; a person settles a quarantined "
+            "effect with one of "
+            f"{sorted(str(value) for value in OPERATOR_OUTCOMES)}"
+        )
+    return status
+
+
+def bounded_note(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = redact_secrets(str(value))[:_MAX_NOTE].strip()
+    return text or None
+
+
+def bounded_actor(value: Any) -> str:
+    text = redact_secrets(str(value or "")).strip()[:_MAX_ID]
+    if not text or "\n" in text:
+        raise ValueError("an operator decision must name who made it")
+    return text
+
+
+def _quoted(values: Iterable[str]) -> str:
+    return ",".join(f"'{value}'" for value in sorted(str(item) for item in values))
+
+
+# The fence, expressed where no Python path can route around it. Every rule
+# below is also enforced in `AgentRunRepository`; it is repeated here because a
+# raw SQL edit, a future method, or a bug in one of those paths must still hit
+# a wall rather than turn "we do not know" into "it worked".
+EFFECT_SCHEMA = f"""
+CREATE TABLE IF NOT EXISTS agent_run_effects (
+    effect_id TEXT PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    tool_name TEXT NOT NULL,
+    tool_call_id TEXT,
+    approval_id TEXT,
+    replay_class TEXT NOT NULL,
+    arguments_fingerprint TEXT NOT NULL,
+    status TEXT NOT NULL,
+    dispatched_by TEXT NOT NULL,
+    dispatched_at TEXT NOT NULL,
+    settled_at TEXT,
+    outcome_ref TEXT,
+    reason TEXT,
+    resolved_by TEXT,
+    resolved_note TEXT,
+    resolved_at TEXT,
+    FOREIGN KEY (run_id) REFERENCES agent_runs(run_id),
+    CHECK (status IN ({_quoted(EFFECT_STATUSES)})),
+    CHECK (replay_class IN ({_quoted(ReplayClass)})),
+    -- A person's verdict cannot exist in this table without the person.
+    CHECK ((status IN ({_quoted(OPERATOR_OUTCOMES)})) = (resolved_by IS NOT NULL))
+);
+CREATE INDEX IF NOT EXISTS agent_run_effects_by_run
+    ON agent_run_effects(run_id, status);
+CREATE INDEX IF NOT EXISTS agent_run_effects_open
+    ON agent_run_effects(status, dispatched_at);
+
+CREATE TRIGGER IF NOT EXISTS agent_run_effects_open_as_dispatched
+BEFORE INSERT ON agent_run_effects
+WHEN NEW.status <> '{EffectStatus.DISPATCHED}'
+BEGIN
+    SELECT RAISE(ABORT, 'an external effect record opens as dispatched');
+END;
+
+CREATE TRIGGER IF NOT EXISTS agent_run_effects_quarantine_is_operator_only
+BEFORE UPDATE OF status ON agent_run_effects
+WHEN OLD.status = '{EffectStatus.AMBIGUOUS}'
+ AND NEW.status NOT IN ({_quoted({EffectStatus.AMBIGUOUS, *OPERATOR_OUTCOMES})})
+BEGIN
+    SELECT RAISE(ABORT,
+        'a quarantined external effect is settled by a person, never by code');
+END;
+
+CREATE TRIGGER IF NOT EXISTS agent_run_effects_settled_is_final
+BEFORE UPDATE OF status ON agent_run_effects
+WHEN OLD.status IN ({_quoted(SETTLED_EFFECT_STATUSES)})
+ AND NEW.status <> OLD.status
+BEGIN
+    SELECT RAISE(ABORT, 'a settled external effect never changes outcome');
+END;
+
+CREATE TRIGGER IF NOT EXISTS agent_run_effects_are_never_deleted
+BEFORE DELETE ON agent_run_effects
+BEGIN
+    SELECT RAISE(ABORT,
+        'an external effect record is evidence that something left the machine');
+END;
+"""

--- a/desktop/coworker/agent_run_repository.py
+++ b/desktop/coworker/agent_run_repository.py
@@ -1137,6 +1137,18 @@ class AgentRunRepository:
         raise AgentRunLeaseLost(lease.run_id)
 
     def _initialize_schema(self) -> None:
+        """Create what is missing. Record a version only for a new database.
+
+        Creating a database at the current version is not a migration. Changing
+        an existing database's version is, and that belongs to
+        `coworker/migrations.py`, which is the only other writer of
+        `PRAGMA user_version` anywhere in the codebase. Every registered store
+        works this way: the store owns its DDL, the registry owns its version.
+
+        So an existing store keeps whatever version the registry last recorded,
+        and starting the application never silently upgrades one. Doctor reports
+        it as behind and migrates it deliberately, with a backup first.
+        """
         with self._lock:
             version = int(self._conn.execute("PRAGMA user_version").fetchone()[0])
             if version > SCHEMA_VERSION:
@@ -1145,6 +1157,10 @@ class AgentRunRepository:
                     f"{DB_NAME} is at schema {version}, newer than this build's "
                     f"{SCHEMA_VERSION}"
                 )
+            fresh = version == 0 and not self._conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+                "AND name = 'agent_runs'"
+            ).fetchone()
             self._conn.executescript(
                 """
                 CREATE TABLE IF NOT EXISTS agent_runs (
@@ -1188,7 +1204,8 @@ class AgentRunRepository:
                 """
                 + EFFECT_SCHEMA
             )
-            self._conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+            if fresh:
+                self._conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
 
 
 def _stamp(value: datetime | None = None) -> str:

--- a/desktop/coworker/agent_run_repository.py
+++ b/desktop/coworker/agent_run_repository.py
@@ -24,6 +24,16 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Iterable, Iterator
 
+from coworker.agent_run_approval import (
+    EFFECT_SCHEMA,
+    AgentRunEffectFenced,
+    EffectStatus,
+    bounded_actor,
+    bounded_note,
+    effect_fingerprint,
+    operator_decision,
+    replay_class,
+)
 from coworker.agent_run_owner import Liveness, OwnerRegistry, RunOwner
 from coworker.agent_run_state import (
     is_leasable,
@@ -48,7 +58,10 @@ from coworker.agent_runs import (
     project_terminal_result,
 )
 
-SCHEMA_VERSION = 1
+# 2 adds `agent_run_effects`: the external-effect fence. The table is created
+# by the same idempotent script that creates the run tables, so a version 1
+# store gains it on open and nothing has to be migrated.
+SCHEMA_VERSION = 2
 DB_NAME = "agent_runs.db"
 # Long enough for a slow provider call, short enough that crashed work is not
 # stranded for an operator's whole afternoon.
@@ -88,6 +101,17 @@ class CheckpointCommit:
     run: dict[str, Any]
     checkpoint: dict[str, Any]
     # None once the run parked or finished: nobody holds authority over it.
+    lease: AgentRunLease | None
+
+
+@dataclass(frozen=True)
+class EffectCommit:
+    """One external-effect write: run row, checkpoint, and effect row together."""
+
+    run: dict[str, Any]
+    checkpoint: dict[str, Any]
+    effect: dict[str, Any]
+    # None once the quarantine parked the run: nobody holds authority over it.
     lease: AgentRunLease | None
 
 
@@ -425,6 +449,383 @@ class AgentRunRepository:
             ),
         )
 
+    # --- approval fencing ------------------------------------------------
+
+    def resume_from_approval(
+        self,
+        run_id: str,
+        owner: RunOwner,
+        *,
+        approval_id: str,
+        decision: str,
+        lease_seconds: int | float = DEFAULT_LEASE_SECONDS,
+        now: datetime | None = None,
+    ) -> CheckpointCommit | None:
+        """Give a parked run back to a process, against a named resolution.
+
+        `acquire_lease` refuses waiting states on purpose: a parked run belongs
+        to a person, and a process that wants it back has to say which decision
+        released it. This is that door and it is deliberately narrow.
+
+        The lease and the move to `running` commit together. A run must never
+        rest in a waiting state while holding a lease -- waiting states hold no
+        lease, and Doctor reports the pair as a record contradicting itself.
+
+        A run parked in `waiting_external` is not opened here at all. Its effect
+        is quarantined, and an approval decision says nothing about whether a
+        send already went out. Only `resolve_quarantined_effect` settles that.
+        """
+        if decision not in {"allow", "deny"}:
+            raise ValueError(f"an approval resolves to allow or deny, not {decision!r}")
+        named = _bounded_id(approval_id, "approval_id")
+        seconds = _lease_seconds(lease_seconds)
+        stamp = _stamp(now)
+        expires_at = _stamp(_parse(stamp) + timedelta(seconds=seconds))
+        with self._write():
+            row = self._row(run_id)
+            if row is None:
+                raise KeyError(run_id)
+            state = str(row["current_state"])
+            if state == "waiting_external":
+                raise AgentRunEffectFenced(
+                    f"run {run_id} is parked on an external effect whose outcome "
+                    "is unknown; an approval decision does not settle that"
+                )
+            if not is_waiting(state):
+                return None
+            if named not in json_list(row["approval_ids"]):
+                raise ValueError(f"run {run_id} never raised approval {named!r}")
+            version = int(row["version"])
+            sequence = int(row["checkpoint_sequence"]) + 1
+            validate_transition("approval_resolved", state, "running")
+            changed = self._conn.execute(
+                """
+                UPDATE agent_runs SET
+                    current_state = 'running', checkpoint_sequence = ?,
+                    version = version + 1, updated_at = ?,
+                    lease_owner = ?, lease_owner_host = ?, lease_owner_pid = ?,
+                    lease_expires_at = ?
+                WHERE run_id = ? AND version = ? AND lease_owner IS NULL
+                """,
+                (
+                    sequence,
+                    stamp,
+                    owner.owner_id,
+                    owner.host,
+                    int(owner.pid),
+                    expires_at,
+                    str(run_id),
+                    version,
+                ),
+            ).rowcount
+            if changed != 1:
+                return None
+            checkpoint = self._append_checkpoint(
+                str(run_id),
+                sequence,
+                "approval_resolved",
+                "running",
+                {"approval_id": named, "status": decision},
+                stamp,
+            )
+            run = _run_row(self._row(run_id))
+        return CheckpointCommit(
+            run=run,
+            checkpoint=checkpoint,
+            lease=AgentRunLease(str(run_id), owner.owner_id, version + 1, expires_at),
+        )
+
+    # --- external effects ------------------------------------------------
+    #
+    # Three writes with one shape: compare-and-swap the run row against the
+    # lease, append the checkpoint, and move the effect row, all in one
+    # transaction. The run store is the fence of record for external effects
+    # precisely because these three facts commit together or not at all.
+    #
+    # The ordering that makes the window recoverable is the caller's job and is
+    # not negotiable: `dispatch_effect` commits *before* the external call, and
+    # `record_effect_outcome` commits *after* it. A process that dies before the
+    # dispatch commit made no call. A process that dies after it may or may not
+    # have, and that is exactly what `quarantine_effect` records.
+
+    def dispatch_effect(
+        self,
+        lease: AgentRunLease,
+        *,
+        tool_name: str,
+        arguments: Any = None,
+        effect_id: str | None = None,
+        tool_call_id: str | None = None,
+        approval_id: str | None = None,
+        step: int | None = None,
+        now: datetime | None = None,
+    ) -> EffectCommit:
+        """Record that an external effect is about to be attempted, before it is.
+
+        The arguments are fingerprinted, never stored. A recipient, a subject,
+        and a body belong to the transcript and the approval record; what this
+        store needs is only whether a call it is about to make is the call it
+        already dispatched.
+        """
+        identity = _bounded_id(effect_id or f"effect-{uuid.uuid4().hex}", "effect_id")
+        name = _bounded_id(tool_name, "tool_name")
+        stamp = _stamp(now)
+        payload = {
+            "attempt_id": identity,
+            "tool_name": name,
+            "tool_call_id": tool_call_id,
+            "approval_id": approval_id,
+            "step": step,
+            "status": str(EffectStatus.DISPATCHED),
+        }
+        with self._write():
+            row = self._effect_checkpoint(
+                lease, "tool_pending", "running", payload, stamp, release=False
+            )
+            try:
+                self._conn.execute(
+                    """
+                    INSERT INTO agent_run_effects (
+                        effect_id, run_id, tool_name, tool_call_id, approval_id,
+                        replay_class, arguments_fingerprint, status,
+                        dispatched_by, dispatched_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        identity,
+                        lease.run_id,
+                        name,
+                        _optional_id(tool_call_id),
+                        _optional_id(approval_id),
+                        str(replay_class(name)),
+                        effect_fingerprint(name, arguments),
+                        str(EffectStatus.DISPATCHED),
+                        lease.owner_id,
+                        stamp,
+                    ),
+                )
+            except sqlite3.IntegrityError as exc:
+                raise AgentRunEffectFenced(
+                    f"effect {identity} is already on record"
+                ) from exc
+            effect = self._effect_row(identity)
+        return EffectCommit(
+            run=row["run"],
+            checkpoint=row["checkpoint"],
+            effect=effect,
+            lease=row["lease"],
+        )
+
+    def record_effect_outcome(
+        self,
+        lease: AgentRunLease,
+        effect_id: str,
+        *,
+        ok: bool,
+        outcome_ref: str | None = None,
+        error_class: str | None = None,
+        error_summary: str | None = None,
+        duration_ms: int | None = None,
+        now: datetime | None = None,
+    ) -> EffectCommit:
+        """Close the window. Only the process that dispatched may say what happened.
+
+        The owner check is not politeness. A second owner did not make the call,
+        so it has nothing to report, and letting it write an outcome is how an
+        unknown quietly becomes a certainty.
+        """
+        status = EffectStatus.SUCCEEDED if ok else EffectStatus.FAILED
+        stamp = _stamp(now)
+        payload = {
+            "attempt_id": str(effect_id),
+            "status": str(status),
+            "error_class": error_class,
+            "error_summary": error_summary,
+            "duration_ms": duration_ms,
+        }
+        with self._write():
+            # The effect fence is checked before the run's own state machine so
+            # that "this effect is already quarantined" is what the caller hears,
+            # whatever shape the run happens to be in. Both layers refuse; this
+            # one has the answer an operator needs.
+            existing = self._require_dispatched(
+                effect_id, lease.run_id, owner_id=lease.owner_id
+            )
+            payload["tool_name"] = existing["tool_name"]
+            row = self._effect_checkpoint(
+                lease, "tool_completed", "running", payload, stamp, release=False
+            )
+            changed = self._conn.execute(
+                """
+                UPDATE agent_run_effects SET
+                    status = ?, settled_at = ?, outcome_ref = COALESCE(?, outcome_ref)
+                WHERE effect_id = ? AND run_id = ? AND status = ?
+                  AND dispatched_by = ?
+                """,
+                (
+                    str(status),
+                    stamp,
+                    _optional_id(outcome_ref),
+                    str(effect_id),
+                    lease.run_id,
+                    str(EffectStatus.DISPATCHED),
+                    lease.owner_id,
+                ),
+            ).rowcount
+            if changed != 1:
+                raise AgentRunEffectFenced(
+                    f"effect {effect_id} is {existing['status']}, and only its "
+                    "dispatching owner may report an outcome, and only once"
+                )
+            effect = self._effect_row(effect_id)
+        return EffectCommit(
+            run=row["run"],
+            checkpoint=row["checkpoint"],
+            effect=effect,
+            lease=row["lease"],
+        )
+
+    def quarantine_effect(
+        self,
+        lease: AgentRunLease,
+        effect_id: str,
+        *,
+        reason: str,
+        state: str = "interrupted",
+        now: datetime | None = None,
+    ) -> EffectCommit:
+        """Move an effect that never reported back into review, and park the run.
+
+        Any owner may do this, including one that did not dispatch, because
+        quarantining claims nothing about the world. It records that nobody
+        knows, which is true for every process that reads the row.
+
+        The run comes to rest holding no lease. `interrupted` is the resting
+        place after a crash: the work needs classification, and a person now
+        owns that. `waiting_external` is the resting place when the owner is
+        still alive and its call simply never answered.
+        """
+        kinds = {
+            "interrupted": "tool_outcome_unknown",
+            "waiting_external": "waiting_external",
+        }
+        if state not in kinds:
+            raise ValueError(
+                f"a quarantine leaves a run in {sorted(kinds)}, not {state!r}"
+            )
+        stamp = _stamp(now)
+        with self._write():
+            existing = self._require_dispatched(effect_id, lease.run_id)
+            payload = {
+                "attempt_id": str(effect_id),
+                "tool_name": existing["tool_name"],
+                "tool_call_id": existing["tool_call_id"],
+                "approval_id": existing["approval_id"],
+                "status": str(EffectStatus.AMBIGUOUS),
+                "reason": reason,
+            }
+            row = self._effect_checkpoint(
+                lease, kinds[state], state, payload, stamp, release=True
+            )
+            changed = self._conn.execute(
+                """
+                UPDATE agent_run_effects SET
+                    status = ?, settled_at = ?, reason = ?
+                WHERE effect_id = ? AND run_id = ? AND status = ?
+                """,
+                (
+                    str(EffectStatus.AMBIGUOUS),
+                    stamp,
+                    bounded_note(reason),
+                    str(effect_id),
+                    lease.run_id,
+                    str(EffectStatus.DISPATCHED),
+                ),
+            ).rowcount
+            if changed != 1:
+                raise AgentRunEffectFenced(
+                    f"effect {effect_id} is {existing['status']}, which is already "
+                    "settled or already quarantined"
+                )
+            effect = self._effect_row(effect_id)
+        return EffectCommit(
+            run=row["run"],
+            checkpoint=row["checkpoint"],
+            effect=effect,
+            lease=row["lease"],
+        )
+
+    def resolve_quarantined_effect(
+        self,
+        effect_id: str,
+        *,
+        decision: str,
+        operator: str,
+        note: str | None = None,
+        outcome_ref: str | None = None,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        """A person settles what the machine could not.
+
+        This write takes no lease, and that is deliberate: a quarantined run is
+        parked and holds none. Like `prune_checkpoints` it is narrow on purpose.
+        It touches one row of `agent_run_effects` and `agent_runs` never, it
+        moves only out of `ambiguous`, and its target statuses are the three the
+        table refuses to hold without a named person.
+
+        Settling the effect does not restart the run. What to do with a run
+        whose send turned out to have gone through is the operator's next
+        decision, not a consequence of recording this one.
+        """
+        status = operator_decision(decision)
+        actor = bounded_actor(operator)
+        stamp = _stamp(now)
+        with self._write():
+            existing = self._effect_row(effect_id)
+            changed = self._conn.execute(
+                """
+                UPDATE agent_run_effects SET
+                    status = ?, resolved_by = ?, resolved_note = ?,
+                    resolved_at = ?, outcome_ref = COALESCE(?, outcome_ref)
+                WHERE effect_id = ? AND status = ?
+                """,
+                (
+                    str(status),
+                    actor,
+                    bounded_note(note),
+                    stamp,
+                    _optional_id(outcome_ref),
+                    str(effect_id),
+                    str(EffectStatus.AMBIGUOUS),
+                ),
+            ).rowcount
+            if changed != 1:
+                raise AgentRunEffectFenced(
+                    f"effect {effect_id} is {existing['status']}; only a "
+                    "quarantined effect is a person's to settle"
+                )
+            resolved = self._effect_row(effect_id)
+        return resolved
+
+    def list_effects(self, run_id: str) -> list[dict[str, Any]]:
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT * FROM agent_run_effects WHERE run_id = ? "
+                "ORDER BY dispatched_at, rowid",
+                (str(run_id),),
+            ).fetchall()
+        return [_effect_row(row) for row in rows]
+
+    def list_quarantined_effects(self, *, limit: int = 100) -> list[dict[str, Any]]:
+        """The review queue: every effect nobody knows the outcome of."""
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT * FROM agent_run_effects WHERE status = ? "
+                "ORDER BY dispatched_at, rowid LIMIT ?",
+                (str(EffectStatus.AMBIGUOUS), max(1, int(limit))),
+            ).fetchall()
+        return [_effect_row(row) for row in rows]
+
     # --- retention -------------------------------------------------------
 
     def prune_checkpoints(self, *, finished_before: datetime) -> list[str]:
@@ -606,6 +1007,109 @@ class AgentRunRepository:
             "created_at": stamp,
         }
 
+    def _effect_checkpoint(
+        self,
+        lease: AgentRunLease,
+        kind: str,
+        state: str,
+        payload: dict[str, Any],
+        stamp: str,
+        *,
+        release: bool,
+    ) -> dict[str, Any]:
+        """The run half of an external-effect write. Caller is inside `_write`.
+
+        Deliberately narrower than `checkpoint`: an effect write carries no
+        usage, no source or artifact references, and no terminal result, so it
+        merges none of them. It moves the state, appends the step, and drops the
+        lease when the run comes to rest.
+        """
+        row = self._row(lease.run_id)
+        if row is None:
+            raise KeyError(lease.run_id)
+        self._check_fence(row, lease, stamp)
+        current = str(row["current_state"])
+        validate_transition(kind, current, state)
+        sequence = int(row["checkpoint_sequence"]) + 1
+        changed = self._conn.execute(
+            """
+            UPDATE agent_runs SET
+                current_state = ?, checkpoint_sequence = ?, version = version + 1,
+                updated_at = ?,
+                lease_owner = CASE WHEN ? THEN NULL ELSE lease_owner END,
+                lease_owner_host = CASE WHEN ? THEN NULL ELSE lease_owner_host END,
+                lease_owner_pid = CASE WHEN ? THEN NULL ELSE lease_owner_pid END,
+                lease_expires_at = CASE WHEN ? THEN NULL ELSE lease_expires_at END
+            WHERE run_id = ? AND version = ? AND lease_owner = ?
+            """,
+            (
+                state,
+                sequence,
+                stamp,
+                release,
+                release,
+                release,
+                release,
+                lease.run_id,
+                lease.version,
+                lease.owner_id,
+            ),
+        ).rowcount
+        if changed != 1:
+            self._raise_fence_failure(lease, stamp)
+        checkpoint = self._append_checkpoint(
+            lease.run_id, sequence, kind, state, payload, stamp
+        )
+        return {
+            "run": _run_row(self._row(lease.run_id)),
+            "checkpoint": checkpoint,
+            "lease": (
+                None
+                if release
+                else AgentRunLease(
+                    lease.run_id, lease.owner_id, lease.version + 1, lease.expires_at
+                )
+            ),
+        }
+
+    def _require_dispatched(
+        self, effect_id: str, run_id: str, *, owner_id: str | None = None
+    ) -> dict[str, Any]:
+        """Refuse anything but an open effect, and say why. Caller is in `_write`.
+
+        The guarantee itself is the `WHERE status = 'dispatched'` on the update
+        that follows and the triggers under it. This is the sentence an operator
+        reads when the guarantee fires.
+        """
+        effect = self._effect_row(effect_id, run_id=run_id)
+        status = effect["status"]
+        if status != str(EffectStatus.DISPATCHED):
+            raise AgentRunEffectFenced(
+                f"effect {effect_id} is {status}: "
+                + (
+                    "a quarantined external effect is settled by a person, "
+                    "never by a retry, a resume, or a second owner"
+                    if status == str(EffectStatus.AMBIGUOUS)
+                    else "a settled external effect never changes outcome"
+                )
+            )
+        if owner_id is not None and effect["dispatched_by"] != owner_id:
+            raise AgentRunEffectFenced(
+                f"effect {effect_id} was dispatched by another process, which is "
+                "the only one that can say what its call did"
+            )
+        return effect
+
+    def _effect_row(
+        self, effect_id: str, run_id: str | None = None
+    ) -> dict[str, Any]:
+        row = self._conn.execute(
+            "SELECT * FROM agent_run_effects WHERE effect_id = ?", (str(effect_id),)
+        ).fetchone()
+        if row is None or (run_id is not None and str(row["run_id"]) != str(run_id)):
+            raise KeyError(effect_id)
+        return _effect_row(row)
+
     def _check_fence(
         self, row: sqlite3.Row, lease: AgentRunLease, stamp: str
     ) -> None:
@@ -682,6 +1186,7 @@ class AgentRunRepository:
                 CREATE INDEX IF NOT EXISTS agent_runs_live_lease
                     ON agent_runs(lease_expires_at) WHERE lease_owner IS NOT NULL;
                 """
+                + EFFECT_SCHEMA
             )
             self._conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
 
@@ -742,6 +1247,27 @@ def _run_row(row: sqlite3.Row) -> dict[str, Any]:
         "created_at": str(row["created_at"]),
         "updated_at": str(row["updated_at"]),
         "finished_at": row["finished_at"],
+    }
+
+
+def _effect_row(row: sqlite3.Row) -> dict[str, Any]:
+    return {
+        "effect_id": str(row["effect_id"]),
+        "run_id": str(row["run_id"]),
+        "tool_name": str(row["tool_name"]),
+        "tool_call_id": row["tool_call_id"],
+        "approval_id": row["approval_id"],
+        "replay_class": str(row["replay_class"]),
+        "arguments_fingerprint": str(row["arguments_fingerprint"]),
+        "status": str(row["status"]),
+        "dispatched_by": str(row["dispatched_by"]),
+        "dispatched_at": str(row["dispatched_at"]),
+        "settled_at": row["settled_at"],
+        "outcome_ref": row["outcome_ref"],
+        "reason": row["reason"],
+        "resolved_by": row["resolved_by"],
+        "resolved_note": row["resolved_note"],
+        "resolved_at": row["resolved_at"],
     }
 
 

--- a/desktop/coworker/agent_run_resume.py
+++ b/desktop/coworker/agent_run_resume.py
@@ -1,0 +1,275 @@
+"""What a restarting process may pick up, and what it must leave alone.
+
+Restart is two questions asked in order, and the order is the whole safety
+argument.
+
+First, which leases are free? `AgentRunRepository.reclaim_dead_owner_leases`
+already answers that, and it answers it from kernel facts: a lease is taken
+back when it has expired, or when the `flock` its owner held for the life of
+its process has been released. A live owner is never stolen from, and an owner
+whose liveness cannot be proven is left alone rather than guessed at.
+
+Second, of the work that is now free, which is safe to continue? That is this
+module. It reads the run's own record and reaches one of five verdicts, and it
+never runs anything. Deciding is separated from doing so that the decision can
+be tested, logged, and shown to an operator on its own.
+
+The verdict that matters most is the one that refuses. An external effect that
+was dispatched and never reported back is not resumed and not retried: it is
+quarantined, because the send may already have reached a real person. See
+`coworker/agent_run_approval.py` for the fence that holds it there.
+
+Nothing here is wired into the running application. The process that starts the
+sidecar is where `restart()` belongs, and that wiring is later work.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from typing import Any, Iterable
+
+from coworker.agent_run_approval import (
+    is_replay_safe,
+    quarantined,
+    unreported,
+)
+from coworker.agent_run_owner import RunOwner
+from coworker.agent_run_state import is_terminal, is_waiting
+from coworker.agent_runs import AGENT_RUN_STATES, TERMINAL_AGENT_RUN_STATES
+
+# Every state a restart might have to think about. Terminal runs never move
+# again, so they are not among them.
+OPEN_AGENT_RUN_STATES = AGENT_RUN_STATES - TERMINAL_AGENT_RUN_STATES
+
+
+class ResumeAction(StrEnum):
+    """What a restarting process may do with one run."""
+
+    # Safe incomplete work. Continue under the same run identity.
+    RESUME = "resume"
+    # The final answer was generated and recorded but never delivered. Deliver
+    # what is on record; do not ask the model again.
+    DELIVER = "deliver"
+    # An external effect was dispatched and never reported. Move it into review.
+    QUARANTINE = "quarantine"
+    # Already quarantined, or too unclear to touch. A person owns this.
+    REVIEW = "review"
+    # Finished, parked on a person, or owned by a process that is still working.
+    NOTHING = "nothing"
+
+
+@dataclass(frozen=True)
+class ResumeVerdict:
+    run_id: str
+    action: ResumeAction
+    reason: str
+    effect_id: str | None = None
+    tool_name: str | None = None
+    step: int | None = None
+    cut_point: str | None = None
+
+
+@dataclass(frozen=True)
+class RestartOutcome:
+    """What one restart decided, and what it actually did about it.
+
+    `verdicts` is the plan as it stood before anything was quarantined, so a
+    run listed as `QUARANTINE` here appears in `quarantined` if the quarantine
+    committed. Reclassifying it would report `REVIEW` and lose the fact that
+    this restart is what noticed.
+    """
+
+    verdicts: tuple[ResumeVerdict, ...]
+    quarantined: tuple[dict[str, Any], ...]
+
+    @property
+    def resumable(self) -> tuple[ResumeVerdict, ...]:
+        return tuple(
+            verdict
+            for verdict in self.verdicts
+            if verdict.action in {ResumeAction.RESUME, ResumeAction.DELIVER}
+        )
+
+
+_RESUME_REASONS = {
+    "run_started": "no_work_was_recorded",
+    "model_pending": "model_never_completed",
+    "model_completed": "model_completed_before_the_next_step",
+    "tool_pending": "tool_never_completed",
+    "tool_completed": "tool_completed_before_the_next_step",
+    "approval_resolved": "approval_resolved_before_work_resumed",
+}
+
+
+def classify_resume(
+    run: dict[str, Any],
+    checkpoints: list[dict[str, Any]],
+    effects: Iterable[dict[str, Any]],
+) -> ResumeVerdict:
+    """Decide what may be done with one run. Runs nothing, writes nothing.
+
+    Call this after reclaim. Before reclaim a dead owner's lease is still on the
+    row and reads as held, so the verdict is `NOTHING` -- which errs toward
+    leaving work alone, the direction a mistake here has to err in.
+    """
+    run_id = str(run.get("run_id"))
+    state = str(run.get("current_state") or "")
+    items = list(effects)
+    cut = _cut_point(checkpoints)
+    kind = str(cut.get("kind")) if cut else None
+    payload = dict(cut.get("payload") or {}) if cut else {}
+    step = payload.get("step")
+
+    def verdict(action: ResumeAction, reason: str, **extra: Any) -> ResumeVerdict:
+        return ResumeVerdict(
+            run_id=run_id,
+            action=action,
+            reason=reason,
+            step=step if isinstance(step, int) else None,
+            cut_point=kind,
+            **extra,
+        )
+
+    if is_terminal(state):
+        return verdict(ResumeAction.NOTHING, "the run already finished")
+    # After reclaim, a lease still on the row belongs to a process that is
+    # either alive or not provably dead. Neither is ours to take.
+    if run.get("lease_owner") is not None:
+        return verdict(ResumeAction.NOTHING, "another process holds the lease")
+
+    # Effects outrank everything below, including the run's own state. What the
+    # run was doing matters less than whether something already left the machine.
+    held = quarantined(items)
+    if held:
+        return verdict(
+            ResumeAction.REVIEW,
+            "an external effect is quarantined and only a person settles it",
+            effect_id=str(held[0]["effect_id"]),
+            tool_name=str(held[0]["tool_name"]),
+        )
+    open_effects = unreported(items)
+    if open_effects:
+        return verdict(
+            ResumeAction.QUARANTINE,
+            "an external effect was dispatched and never reported back",
+            effect_id=str(open_effects[0]["effect_id"]),
+            tool_name=str(open_effects[0]["tool_name"]),
+        )
+
+    if is_waiting(state):
+        return verdict(ResumeAction.NOTHING, "the run is parked on a person")
+
+    # A consequential tool that never opened an effect record left no way to
+    # tell whether it ran. Fail closed: this is the same unknown, one level up.
+    if kind == "tool_pending":
+        tool_name = payload.get("tool_name")
+        if tool_name is not None and not is_replay_safe(str(tool_name)):
+            known = {str(effect["effect_id"]) for effect in items}
+            if str(payload.get("attempt_id") or "") not in known:
+                return verdict(
+                    ResumeAction.REVIEW,
+                    "a consequential tool was pending with no effect record, so "
+                    "whether it ran cannot be established",
+                    tool_name=str(tool_name),
+                )
+        if tool_name is not None:
+            return verdict(
+                ResumeAction.RESUME,
+                _RESUME_REASONS["tool_pending"],
+                tool_name=str(tool_name),
+            )
+
+    # The answer exists and was recorded; only its delivery is unaccounted for.
+    # Asking the model again would spend tokens to produce a different answer.
+    if run.get("terminal_result") is not None:
+        return verdict(
+            ResumeAction.DELIVER,
+            "the final result is on record and its delivery is not",
+        )
+
+    return verdict(
+        ResumeAction.RESUME,
+        _RESUME_REASONS.get(kind or "", f"{kind} left the run incomplete"),
+    )
+
+
+def plan_restart(
+    repo: Any, *, now: datetime | None = None, limit: int = 500
+) -> list[ResumeVerdict]:
+    """Reclaim what is provably free, then say what may be picked up.
+
+    Reclaim runs first because a dead owner's lease is still on its row until it
+    does. `reclaim_dead_owner_leases` never takes a lease from a live owner, so
+    whatever is still held afterwards is genuinely held.
+    """
+    repo.reclaim_dead_owner_leases(now)
+    return [
+        classify_resume(
+            run,
+            repo.list_checkpoints(run["run_id"]),
+            repo.list_effects(run["run_id"]),
+        )
+        for run in repo.list_runs(states=sorted(OPEN_AGENT_RUN_STATES), limit=limit)
+    ]
+
+
+def quarantine_unreported_effect(
+    repo: Any,
+    owner: RunOwner,
+    verdict: ResumeVerdict,
+    *,
+    now: datetime | None = None,
+) -> Any:
+    """Take the run just long enough to move its unreported effect into review.
+
+    Returns None when the lease could not be taken. Someone else is working that
+    run, and a restart never forces its way past a live owner.
+    """
+    if verdict.action is not ResumeAction.QUARANTINE or verdict.effect_id is None:
+        raise ValueError(f"{verdict.action} is not a quarantine verdict")
+    lease = repo.acquire_lease(verdict.run_id, owner, now=now)
+    if lease is None:
+        return None
+    return repo.quarantine_effect(
+        lease, verdict.effect_id, reason=verdict.reason, now=now
+    )
+
+
+def restart(
+    repo: Any,
+    owner: RunOwner,
+    *,
+    now: datetime | None = None,
+    limit: int = 500,
+) -> RestartOutcome:
+    """One startup pass: reclaim, classify, and quarantine what must not replay.
+
+    Quarantining is the only write this makes, because it is the only decision
+    that cannot wait. An effect nobody knows the outcome of has to stop being
+    mistakable for work in progress before anything else looks at the run.
+    Resuming and delivering are left to the caller.
+    """
+    verdicts = plan_restart(repo, now=now, limit=limit)
+    held: list[dict[str, Any]] = []
+    for verdict in verdicts:
+        if verdict.action is not ResumeAction.QUARANTINE:
+            continue
+        commit = quarantine_unreported_effect(repo, owner, verdict, now=now)
+        if commit is not None:
+            held.append(commit.effect)
+    return RestartOutcome(verdicts=tuple(verdicts), quarantined=tuple(held))
+
+
+def _cut_point(checkpoints: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """The last thing the run actually did.
+
+    Reclaim appends `process_interrupted` to say the owner is gone. That is a
+    record of the crash, not of the work, so the step to reason about is the
+    last one before it.
+    """
+    for item in reversed(checkpoints):
+        if str(item.get("kind")) != "process_interrupted":
+            return item
+    return None

--- a/desktop/coworker/doctor.py
+++ b/desktop/coworker/doctor.py
@@ -38,7 +38,6 @@ from typing import Any
 
 from coworker import migrations
 from coworker.agent_run_owner import OWNERS_DIR_NAME, Liveness, OwnerRegistry
-from coworker.agent_run_repository import DB_NAME as AGENT_RUNS_DB
 from coworker.agent_run_repository import SCHEMA_VERSION as AGENT_RUNS_VERSION
 from coworker.agent_run_state import (
     AgentRunTransitionError,
@@ -51,7 +50,6 @@ from coworker.migrations import (
     BackupFailed,
     StoreKind,
     StoreStatus,
-    VersionChannel,
     open_readonly,
     state_root,
     store_path,
@@ -77,27 +75,12 @@ KNOWN_RUN_STATUSES = frozenset(
     {"running", "success", "failed", "waiting_approval", "partial", "interrupted"}
 )
 
-# A read-only descriptor for the Agent Run store, so the integrity and JSON
-# column checks already written here cover it too. It is not a registry entry:
-# `agent_runs.db` has one schema version and no upgrade path yet, and adding it
-# to the registry belongs in `coworker/migrations.py`, which this does not touch.
+# The Agent Run store is a registry entry now, so its version, integrity, JSON
+# columns, permissions, and upgrade path are handled by the same machinery as
+# every other store. What stays here is the part only this file knows how to
+# ask: who owns a run, whether its history could have happened, and whether its
+# references still resolve.
 AGENT_RUNS_STORE_ID = "agent_runs_db"
-_AGENT_RUNS = migrations.StoreSpec(
-    store_id=AGENT_RUNS_STORE_ID,
-    kind=StoreKind.SQLITE,
-    relative_path=AGENT_RUNS_DB,
-    current_version=AGENT_RUNS_VERSION,
-    version_channel=VersionChannel.SQLITE_USER_VERSION,
-    description="Durable Agent Run identity, leases, and checkpoints",
-    json_columns=(
-        ("agent_runs", "approval_ids"),
-        ("agent_runs", "source_refs"),
-        ("agent_runs", "artifact_refs"),
-        ("agent_runs", "usage"),
-        ("agent_runs", "terminal_result"),
-        ("agent_run_checkpoints", "payload"),
-    ),
-)
 
 _SECRET_ASSIGNMENT = re.compile(
     r"(?i)(?P<key>(?:api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token"
@@ -754,13 +737,18 @@ def _check_run_ownership(collector: _Collector, root: Path, *, cross_store: bool
     it. An unknown owner needs no rescue: its lease still expires, and expiry
     reclaim is fenced by version.
     """
-    if not store_present(root, _AGENT_RUNS):
+    spec = migrations.spec_for(AGENT_RUNS_STORE_ID)
+    if not store_present(root, spec):
         return
     try:
-        version = migrations.read_version(root, _AGENT_RUNS)
+        version = migrations.read_version(root, spec)
     except migrations.StoreUnreadable:
         version = None
     if version is not None and version > AGENT_RUNS_VERSION:
+        # `_check_versions` already reported that the registry will not migrate
+        # this store. This says the separate thing an operator needs: the runs
+        # themselves are not being read, so every check below is absent rather
+        # than clean.
         collector.add(
             "agent_run.version_ahead",
             AGENT_RUNS_STORE_ID,
@@ -772,11 +760,8 @@ def _check_run_ownership(collector: _Collector, root: Path, *, cross_store: bool
             blocking=True,
         )
         return
-    if not _check_sqlite_integrity(collector, root, _AGENT_RUNS):
-        return
-    _check_json_columns(collector, root, _AGENT_RUNS)
-
-    conn = open_readonly(store_path(root, _AGENT_RUNS))
+    # Integrity and JSON columns are covered by the registry loop in `_scan`.
+    conn = open_readonly(store_path(root, spec))
     try:
         if not {"agent_runs", "agent_run_checkpoints"} <= migrations.table_names(conn):
             return

--- a/desktop/coworker/migrations.py
+++ b/desktop/coworker/migrations.py
@@ -36,6 +36,8 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
+from coworker.agent_run_approval import EFFECT_STATEMENTS
+from coworker.agent_run_repository import SCHEMA_VERSION as AGENT_RUNS_DB_VERSION
 from coworker.mcp import SCHEMA_VERSION as MCP_CONFIG_VERSION
 from coworker.people import SCHEMA_VERSION as PEOPLE_DB_VERSION
 from coworker.secrets import SCHEMA_VERSION as SECRETS_VERSION
@@ -650,6 +652,45 @@ _RECORDED_COUNTERS: dict[str, Callable[[MigrationContext], int]] = {
 }
 
 
+# The Agent Run store shipped in its own slice and recorded its own version
+# before the registry knew it existed. Adoption creates nothing: the repository
+# builds its tables on open, exactly as ConversationStore and PeopleStore do.
+# What was missing was a registered version and a path forward, which is what
+# these two steps add.
+
+
+def _count_agent_runs_db(context: MigrationContext) -> int:
+    conn = context.connection
+    assert conn is not None
+    return _row_count(conn, "agent_runs")
+
+
+def _adopt_agent_runs_db(context: MigrationContext) -> int:
+    return _count_agent_runs_db(context)
+
+
+def _count_agent_run_effects(context: MigrationContext) -> int:
+    """No row is read or written. The step adds an empty table and its rules."""
+    return 0
+
+
+def _add_agent_run_effects(context: MigrationContext) -> int:
+    """Add the external-effect fence to a version 1 Agent Run store.
+
+    Executed one statement at a time, never through `executescript`, which
+    issues a COMMIT before it runs. Inside the transaction `_apply_store` opens,
+    that COMMIT would end the transaction and leave the rollback below with
+    nothing to undo -- and it would do it silently. SQLite rolls DDL back like
+    any other statement, so this way a failed step really does leave the store
+    as it was.
+    """
+    conn = context.connection
+    assert conn is not None
+    for statement in EFFECT_STATEMENTS:
+        conn.execute(statement)
+    return 0
+
+
 def _adopt(description: str, count: Callable, apply: Callable) -> tuple[Migration, ...]:
     return (
         Migration(
@@ -665,6 +706,46 @@ def _adopt(description: str, count: Callable, apply: Callable) -> tuple[Migratio
 # --- the registry --------------------------------------------------------
 
 REGISTRY: tuple[StoreSpec, ...] = (
+    StoreSpec(
+        store_id="agent_runs_db",
+        kind=StoreKind.SQLITE,
+        relative_path="agent_runs.db",
+        current_version=AGENT_RUNS_DB_VERSION,
+        version_channel=VersionChannel.SQLITE_USER_VERSION,
+        description=(
+            "Durable Agent Run identity, leases, checkpoints, and the external-"
+            "effect fence."
+        ),
+        migrations=(
+            Migration(
+                from_version=0,
+                to_version=1,
+                description=(
+                    "Adopt the Agent Run store shipped before the registry knew it."
+                ),
+                count=_count_agent_runs_db,
+                apply=_adopt_agent_runs_db,
+            ),
+            Migration(
+                from_version=1,
+                to_version=2,
+                description=(
+                    "Add the external-effect fence, so a send whose outcome "
+                    "nobody knows is quarantined instead of retried."
+                ),
+                count=_count_agent_run_effects,
+                apply=_add_agent_run_effects,
+            ),
+        ),
+        json_columns=(
+            ("agent_runs", "approval_ids"),
+            ("agent_runs", "source_refs"),
+            ("agent_runs", "artifact_refs"),
+            ("agent_runs", "usage"),
+            ("agent_runs", "terminal_result"),
+            ("agent_run_checkpoints", "payload"),
+        ),
+    ),
     StoreSpec(
         store_id="conversation_db",
         kind=StoreKind.SQLITE,

--- a/desktop/docs/agent-runs.md
+++ b/desktop/docs/agent-runs.md
@@ -18,11 +18,40 @@ read, the artifacts it produced, the usage it spent, and how it ended.
 
 The run store is its own SQLite database, `agent_runs.db`, in the local state
 directory. It declares `SCHEMA_VERSION` in `coworker/agent_run_repository.py`
-and stamps it in `PRAGMA user_version`, which is the contract the migration
-registry reads. Version 2 adds `agent_run_effects`. The store is not in the
-migration registry, and the table is created by the same idempotent script that
-creates the run tables, so a version 1 store gains it on open with nothing to
-migrate.
+and stamps it in `PRAGMA user_version`. Version 2 adds `agent_run_effects`.
+
+### The versioning gap this store still has
+
+`agent_runs.db` is **not** in `coworker/migrations.py`'s `REGISTRY`. It was
+created outside it by the run store's own slice and has stayed outside it since.
+Doctor checks it through a private `StoreSpec` that `_check_run_ownership`
+builds by hand, reading `agent_run_repository.SCHEMA_VERSION` directly, so the
+fail-closed "written by a newer build" check does cover it -- but the registry's
+migration machinery does not. There is no recorded migration step, no backup
+before the upgrade, and no rollback.
+
+Issue #73 is explicit that ad hoc create-if-missing is not sufficient release
+versioning, and this store does not meet that contract. Two things are true at
+once and both belong in the record:
+
+- The version 1 to 2 upgrade is safe on its own terms, and that is asserted
+  rather than asserted-by-hand-waving. `EFFECT_SCHEMA` creates one table, two
+  indexes, and four triggers, and touches no existing table: no `ALTER TABLE`,
+  nothing named `agent_runs` or `agent_run_checkpoints`. That is what makes
+  `CREATE TABLE IF NOT EXISTS` sufficient here, and
+  `test_the_effect_schema_only_creates_objects_that_did_not_exist` fails the
+  moment it stops being true -- which is the exact latent corruption that
+  create-if-missing would otherwise hide.
+- It is still not the contract. Registering the store is the fix, it needs
+  `coworker/migrations.py`, and it has not been done here.
+
+Registering it needs, in `coworker/migrations.py`: an `AGENT_RUNS_DB_VERSION`
+constant, a `StoreSpec` for `agent_runs.db` on the
+`VersionChannel.SQLITE_USER_VERSION` channel carrying the `json_columns` Doctor
+already lists, an adoption `Migration` for stores created before the registry
+knew about this one, and a `1 -> 2` `Migration` whose `apply` runs
+`EFFECT_SCHEMA`. Doctor then drops its private spec for `spec_for` and the store
+joins the `stores` table and the permission drift check.
 
 ### States
 
@@ -234,6 +263,8 @@ The following are named seams, not implementations.
   person may already have acted on the quarantine -- but the observation is
   lost unless the caller logs it. There is no way to attach a late, non-binding
   observation to a quarantined effect.
+- The run store is outside the migration registry, so its upgrade has no
+  backup and no rollback. See the versioning gap above.
 - A quarantined run comes to rest `interrupted`. Settling its effect makes the
   run eligible to resume, but nothing decides whether resuming a turn whose send
   may already have gone out is what the operator wants. That is a person's next

--- a/desktop/docs/agent-runs.md
+++ b/desktop/docs/agent-runs.md
@@ -1,8 +1,9 @@
 # Durable Agent Runs: identity, leases, and checkpoints
 
-Status: active-stack engineering reference. Covers the run store and its
-ownership rules only. Approval fencing, restart resume, and the chat, queue,
-schedule, and UI wiring are separate later work and are not implemented here.
+Status: active-stack engineering reference. Covers the run store, its ownership
+rules, the external-effect fence, and restart classification. The chat, queue,
+schedule, server, and UI wiring are separate later work and are not implemented
+here: nothing in this document is called by the running application yet.
 
 ## What an Agent Run is
 
@@ -18,7 +19,10 @@ read, the artifacts it produced, the usage it spent, and how it ended.
 The run store is its own SQLite database, `agent_runs.db`, in the local state
 directory. It declares `SCHEMA_VERSION` in `coworker/agent_run_repository.py`
 and stamps it in `PRAGMA user_version`, which is the contract the migration
-registry reads.
+registry reads. Version 2 adds `agent_run_effects`. The store is not in the
+migration registry, and the table is created by the same idempotent script that
+creates the run tables, so a version 1 store gains it on open with nothing to
+migrate.
 
 ### States
 
@@ -94,23 +98,126 @@ it may leave behind. `coworker/agent_run_state.py` holds that one table, and
 state reachability is derived from it rather than restated, so the store, later
 resume paths, and Doctor cannot drift apart.
 
+## External effects
+
+Some effects reach a real person and cost real money. `gmail_send` is the case
+the fence exists for. Between dispatching one and recording what happened there
+is a window, and a process that dies inside it leaves a fact nobody holds: the
+mail may have gone out, or it may not have. That is not `failed` and it is not
+`succeeded`, and calling it either is the mistake with no undo.
+
+So the store records the dispatch **before** the call and the outcome **after**
+it. The ordering is the whole recovery argument. A process that dies before the
+dispatch commit made no call. A process that dies after it may or may not have,
+and an effect with a dispatch and no outcome is `ambiguous`: quarantined until a
+person settles it.
+
+`coworker/agent_run_approval.py` holds the vocabulary, and it is two disjoint
+halves.
+
+| Half | Values | Who may write it | From |
+| --- | --- | --- | --- |
+| Machine | `succeeded`, `failed` | only the process that dispatched | `dispatched` |
+| Operator | `resolved_succeeded`, `resolved_failed`, `abandoned` | a named person | `ambiguous` |
+
+No value belongs to both, so "the machine concluded this" and "a person
+concluded this" can never be confused when the record is read back. The
+database enforces the separation itself. `EFFECT_SCHEMA` carries a `CHECK` that
+refuses an operator status without a `resolved_by`, and triggers that abort an
+update crossing out of `ambiguous` into a machine outcome, an update that
+changes a settled outcome, an insert that opens anywhere but `dispatched`, and
+any delete at all. A retry, a resume, a second owner, and a raw SQL edit all hit
+the same wall.
+
+The effect row is content-free for the same reason a checkpoint is. It carries
+the tool name, the approval id, the call id, and a SHA-256 fingerprint of the
+arguments. The recipient, subject, and body stay in the transcript and the
+approval record; what the run store needs is only whether the call it is about
+to make is the call it already dispatched.
+
+An effect record is never deleted. `prune_checkpoints` drops step detail for old
+runs and touches `agent_run_effects` never, because the record that something
+left the machine is not step detail.
+
+### Which tools are fenced
+
+`coworker/permissions.py` already owns this decision and the fence does not
+restate it. `RETRY_SAFE` is the list of tools that can re-run without producing
+a second external effect, and `agent_run_approval.replay_class` reads it:
+anything outside that list is `consequential`. `gmail_send` is deliberately
+absent from `RETRY_SAFE`, which is what stops a provider retry replaying a send,
+and it is the same absence that makes the run store fence it. A tool the
+permission module has never heard of is consequential, so the fence fails
+closed rather than guessing.
+
+### The approval door
+
+`acquire_lease` refuses waiting states on purpose: a parked run belongs to a
+person. `resume_from_approval` is the one way back, and it is narrow. It needs
+the id of an approval the run actually raised, and it grants the lease and moves
+the run to `running` in a single transaction, so the run never rests parked and
+leased at once -- a pair Doctor reports as a record contradicting itself.
+
+A run parked in `waiting_external` is not opened by that door at all. Its effect
+is quarantined, and an approval decision says nothing about whether a send
+already went out.
+
+## Restart
+
+`coworker/agent_run_resume.py` decides and never runs. Restart asks two
+questions in order.
+
+Which leases are free? `reclaim_dead_owner_leases` answers that from expiry and
+from proven death, and it never takes a lease from a live owner. Whatever is
+still held after it runs is genuinely held.
+
+Of the work that is now free, which is safe to continue? `classify_resume`
+reaches one of five verdicts from the run row, its checkpoints, and its effects.
+
+| Verdict | When |
+| --- | --- |
+| `nothing` | Terminal, parked on a person, or still owned by another process. |
+| `quarantine` | An effect was dispatched and never reported back. |
+| `review` | Already quarantined, or a consequential tool with no effect record. |
+| `deliver` | A terminal result is on record and its delivery is not. |
+| `resume` | Safe incomplete work, under the same run identity. |
+
+Effects outrank the run's own state. What the run was doing matters less than
+whether something already left the machine.
+
+`deliver` exists so that a crash after the model produced the final answer does
+not buy that answer twice. The run row already carries the shape of the result
+-- status, message id, text length -- written in the same transaction as the
+checkpoint that recorded it, and the text itself is in the transcript. Asking
+the model again would spend tokens to produce a different answer.
+
+`restart()` performs exactly one kind of write: it quarantines. That is the only
+decision that cannot wait, because an effect nobody knows the outcome of must
+stop being mistakable for work in progress before anything else looks at the
+run. Resuming and delivering are left to the caller.
+
 ## Extension points
 
 The following are named seams, not implementations.
 
-- **Approval fencing.** `acquire_lease` refuses waiting states on purpose. A
-  resolution-gated acquire belongs beside it, so that only a resolved approval
-  can return a lease to a parked run.
-- **Restart and resume.** `reclaim_dead_owner_leases` classifies interrupted
-  work and stops. Deciding what is safe to replay is separate, and a tool whose
-  outcome is unknown must not be replayed by default.
 - **Heartbeat.** `renew_lease` is the seam a long provider call renews through.
   Losing renewal must abandon the work, not continue it.
-- **Wiring.** Nothing constructs an `AgentRunRepository` in the running
-  application yet. The process that starts the sidecar registers one owner with
-  `OwnerRegistry.register()` and calls `reclaim_dead_owner_leases()` once, at
-  startup. The repository deliberately does not reconcile in its constructor,
-  because opening a store is not the same event as starting a process.
+- **Wiring.** Nothing constructs an `AgentRunRepository` for run execution in
+  the running application yet. The process that starts the sidecar registers one
+  owner with `OwnerRegistry.register()` and calls `agent_run_resume.restart()`
+  once, at startup. The repository deliberately does not reconcile in its
+  constructor, because opening a store is not the same event as starting a
+  process.
+- **The two halves of at-most-once.** `store.decide_and_claim_inbox_execution`
+  makes an approved send dispatch at most once. This store makes the outcome of
+  that dispatch un-guessable after a crash. Joining them -- so that a quarantined
+  effect and an `interrupted` inbox row are one thing an operator sees -- is
+  wiring, and the run store is the fence of record when they disagree.
+- **The review queue.** `list_quarantined_effects` is what a surface renders.
+  Nothing renders it yet.
+- **Receipts.** `agent_run_approval.external_effect_evidence` maps an unsettled
+  effect onto the `Evidence` vocabulary `run_receipt` already reads. Wiring it
+  into a receipt section is later work.
 
 ## Known gaps
 
@@ -121,3 +228,13 @@ The following are named seams, not implementations.
 - Owner marker files are removed when their owner is proven dead and its work
   reclaimed, and when a process releases its own owner. A process killed with
   no runs to reclaim leaves a marker behind.
+- A process whose lease expired, whose effect was quarantined by someone else,
+  and which then wakes up genuinely knowing the send succeeded cannot write what
+  it knows. `record_effect_outcome` raises instead. That is deliberate -- a
+  person may already have acted on the quarantine -- but the observation is
+  lost unless the caller logs it. There is no way to attach a late, non-binding
+  observation to a quarantined effect.
+- A quarantined run comes to rest `interrupted`. Settling its effect makes the
+  run eligible to resume, but nothing decides whether resuming a turn whose send
+  may already have gone out is what the operator wants. That is a person's next
+  decision and no code makes it.

--- a/desktop/docs/agent-runs.md
+++ b/desktop/docs/agent-runs.md
@@ -20,53 +20,41 @@ The run store is its own SQLite database, `agent_runs.db`, in the local state
 directory. It declares `SCHEMA_VERSION` in `coworker/agent_run_repository.py`
 and stamps it in `PRAGMA user_version`. Version 2 adds `agent_run_effects`.
 
-### The versioning gap this store still has
+### Versioning
 
-`agent_runs.db` is **not** in `coworker/migrations.py`'s `REGISTRY`. It was
-created outside it by the run store's own slice and has stayed outside it since.
-Doctor checks it through a private `StoreSpec` that `_check_run_ownership`
-builds by hand, reading `agent_run_repository.SCHEMA_VERSION` directly, so the
-fail-closed "written by a newer build" check does cover it -- but the registry's
-migration machinery does not. There is no recorded migration step, no backup
-before the upgrade, and no rollback.
+`agent_runs.db` is registered in `coworker/migrations.py` as `agent_runs_db`,
+on the same `PRAGMA user_version` channel as every other SQLite store, with two
+steps: an adoption step for the store as it shipped before the registry knew it
+existed, and `1 -> 2`, which adds the external-effect fence.
 
-Issue #73 is explicit that ad hoc create-if-missing is not sufficient release
-versioning, and this store does not meet that contract. Two things are true at
-once and both belong in the record:
+The division of labour matters and is the same for every store in the registry.
+**The store owns its DDL. The registry owns its version.** `migrations.py` is
+the only writer of `PRAGMA user_version` in the codebase, with one narrow
+exception: `AgentRunRepository` stamps a database it creates from nothing,
+because creating a database at the current version is not a migration. Changing
+an existing database's version is, and only the registry does that.
 
-- The version 1 to 2 upgrade is safe on its own terms, and that is asserted
-  rather than asserted-by-hand-waving. `EFFECT_SCHEMA` creates one table, two
-  indexes, and four triggers, and touches no existing table: no `ALTER TABLE`,
-  nothing named `agent_runs` or `agent_run_checkpoints`. That is what makes
-  `CREATE TABLE IF NOT EXISTS` sufficient here, and
-  `test_the_effect_schema_only_creates_objects_that_did_not_exist` fails the
-  moment it stops being true -- which is the exact latent corruption that
-  create-if-missing would otherwise hide.
-- It is still not the contract. Registering the store is the fix, it needs
-  `coworker/migrations.py`, and it has not been done here.
+The consequence is the point. Starting the application never silently upgrades
+a store. An existing version 1 database gains the fence tables on open, because
+`CREATE TABLE IF NOT EXISTS` runs either way and a store waiting to be migrated
+should still be fenced rather than unprotected -- but it stays recorded as
+version 1 until Doctor migrates it deliberately, with a backup taken first and
+a rollback if the step fails. A user who rolls back to an older build after
+merely running the app still finds a version that build can open.
 
-Registering it needs, in `coworker/migrations.py`: an `AGENT_RUNS_DB_VERSION`
-constant, a `StoreSpec` for `agent_runs.db` on the
-`VersionChannel.SQLITE_USER_VERSION` channel carrying the `json_columns` Doctor
-already lists, an adoption `Migration` for stores created before the registry
-knew about this one, and a `1 -> 2` `Migration` whose `apply` runs
-`EFFECT_SCHEMA`. Doctor then drops its private spec for `spec_for` and the store
-joins the `stores` table and the permission drift check.
+`EFFECT_STATEMENTS` is a tuple of separate statements rather than one script for
+one reason: `sqlite3.Connection.executescript` issues a COMMIT before it runs.
+A migration step that used it would end the transaction `_apply_store` opened,
+and the rollback would then silently have nothing to undo. The step executes the
+statements one at a time, and SQLite rolls DDL back like anything else.
 
-### States
-
-| State | Meaning |
-| --- | --- |
-| `running` | A live process holds the lease and is working the run. |
-| `waiting_approval` | Parked on an operator decision. Nobody owns it. |
-| `waiting_input` | Parked on a question to the operator. Nobody owns it. |
-| `waiting_external` | Parked on an external effect whose outcome is unknown. |
-| `interrupted` | The owner died or ran out of lease. Needs classification. |
-| `complete`, `partial`, `stopped`, `failed` | Terminal. The run never moves again. |
-
-Waiting and terminal runs hold no lease. A lease means "a process is driving
-this run right now", so parking or finishing releases it in the same
-transaction as the state change.
+Two properties are asserted rather than argued.
+`test_the_effect_schema_only_creates_objects_that_did_not_exist` fails the
+moment the schema needs a column on an existing table, which is the case
+`CREATE TABLE IF NOT EXISTS` would silently skip.
+`test_the_fence_step_never_commits_the_transaction_it_runs_inside` fails if the
+step ever stops being rollback-safe, and proves it is not vacuous by showing
+`executescript` really does commit.
 
 ## Ownership
 
@@ -225,6 +213,25 @@ decision that cannot wait, because an effect nobody knows the outcome of must
 stop being mistakable for work in progress before anything else looks at the
 run. Resuming and delivering are left to the caller.
 
+## A trap for whoever wires this up
+
+A consequential tool **must** open an effect record before it is called.
+`dispatch_effect` commits before the call and `record_effect_outcome` commits
+after it, and that ordering is the entire recovery argument: a process that dies
+before the dispatch commit made no call, and one that dies after it may or may
+not have.
+
+Call a consequential tool without `dispatch_effect` and a crash mid-call leaves
+a `tool_pending` checkpoint with no effect record. `classify_resume` then returns
+`REVIEW` -- it will not resume that run and there is no effect row for a person
+to settle, so the run needs manual attention. That is the safe direction and it
+is deliberate, but it is a trap: the failure shows up only after a crash, on the
+one code path nobody exercises by hand.
+
+`agent_run_approval.replay_class` names which tools this applies to. It reads
+`permissions.RETRY_SAFE`, and everything outside that list is consequential,
+including a tool the permission module has never heard of.
+
 ## Extension points
 
 The following are named seams, not implementations.
@@ -263,8 +270,6 @@ The following are named seams, not implementations.
   person may already have acted on the quarantine -- but the observation is
   lost unless the caller logs it. There is no way to attach a late, non-binding
   observation to a quarantined effect.
-- The run store is outside the migration registry, so its upgrade has no
-  backup and no rollback. See the versioning gap above.
 - A quarantined run comes to rest `interrupted`. Settling its effect makes the
   run eligible to resume, but nothing decides whether resuming a turn whose send
   may already have gone out is what the operator wants. That is a person's next

--- a/desktop/tests/state_fixtures.py
+++ b/desktop/tests/state_fixtures.py
@@ -253,6 +253,15 @@ def build_current_state(root: Path, *, plant_secrets: bool = False) -> Path:
             f"# 99\n\nApollo key is {PLANTED_API_KEY}. {PLANTED_REASONING}\n",
         )
 
+    # The Agent Run store, created by the real repository. A fresh database is
+    # born at the current version, so the registry has nothing to migrate.
+    # Deliberately empty: a healthy state directory must contribute nothing to
+    # any ownership or history finding, so a test that plants a stale owner, a
+    # dead one, or an unreadable checkpoint measures exactly what it planted.
+    from coworker.agent_run_repository import AgentRunRepository
+
+    AgentRunRepository(root).close()
+
     return root
 
 
@@ -499,6 +508,52 @@ MEETING_EVIDENCE_DDL = """
 """
 
 
+# The Agent Run store as version 1 shipped it: identity, leases, and
+# checkpoints, and no external-effect fence. Written out in full rather than
+# imported so that a change to today's schema shows up as a migration to test,
+# not as a fixture that quietly moved with it.
+LEGACY_AGENT_RUNS_DDL = """
+    CREATE TABLE agent_runs (
+        run_id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        person_id TEXT,
+        parent_run_id TEXT,
+        trigger TEXT NOT NULL,
+        goal_fingerprint TEXT NOT NULL,
+        provider_model_id TEXT,
+        current_state TEXT NOT NULL,
+        version INTEGER NOT NULL DEFAULT 0,
+        checkpoint_sequence INTEGER NOT NULL DEFAULT 0,
+        approval_ids TEXT NOT NULL DEFAULT '[]',
+        source_refs TEXT NOT NULL DEFAULT '[]',
+        artifact_refs TEXT NOT NULL DEFAULT '[]',
+        usage TEXT NOT NULL DEFAULT '{}',
+        terminal_result TEXT,
+        lease_owner TEXT,
+        lease_owner_host TEXT,
+        lease_owner_pid INTEGER,
+        lease_expires_at TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        finished_at TEXT
+    );
+    CREATE TABLE agent_run_checkpoints (
+        run_id TEXT NOT NULL,
+        sequence INTEGER NOT NULL,
+        kind TEXT NOT NULL,
+        state TEXT NOT NULL,
+        payload TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (run_id, sequence),
+        FOREIGN KEY (run_id) REFERENCES agent_runs(run_id)
+    );
+    CREATE INDEX agent_runs_session_created
+        ON agent_runs(session_id, created_at);
+    CREATE INDEX agent_runs_live_lease
+        ON agent_runs(lease_expires_at) WHERE lease_owner IS NOT NULL;
+"""
+
+
 def build_legacy_state(root: Path, *, plant_secrets: bool = False) -> Path:
     """Write the pre-registry state directory, populated the way an install is."""
     root = Path(root)
@@ -694,6 +749,75 @@ def build_legacy_state(root: Path, *, plant_secrets: bool = False) -> Path:
             }
         ],
     )
+    # The Agent Run store as the build before the external-effect fence left it:
+    # version 1 tables, real rows, no `agent_run_effects`. This is the
+    # production-shaped fixture the 1 -> 2 migration is exercised against, so it
+    # goes through backup, apply, rollback, rerun, and restart with every other
+    # store in this directory.
+    runs_conn = sqlite3.connect(root / "agent_runs.db")
+    runs_conn.executescript(LEGACY_AGENT_RUNS_DDL)
+    # Both runs hold no lease: one parked on an operator, one finished. A
+    # migration fixture is about rows surviving an upgrade, and ownership states
+    # are planted by the tests that are about ownership.
+    runs_conn.execute(
+        "INSERT INTO agent_runs (run_id, session_id, trigger, goal_fingerprint, "
+        "current_state, version, checkpoint_sequence, approval_ids, created_at, "
+        "updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "run-legacy-1",
+            "main",
+            "chat",
+            "b" * 64,
+            "waiting_approval",
+            2,
+            2,
+            json.dumps(["call_gmail_send_1"]),
+            "2026-08-01T09:12:00.000000+00:00",
+            "2026-08-01T09:12:30.000000+00:00",
+        ),
+    )
+    runs_conn.execute(
+        "INSERT INTO agent_runs (run_id, session_id, trigger, goal_fingerprint, "
+        "current_state, version, checkpoint_sequence, terminal_result, "
+        "created_at, updated_at, finished_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "run-legacy-2",
+            "sched-1",
+            "scheduled",
+            "c" * 64,
+            "complete",
+            3,
+            2,
+            json.dumps({"status": "ok", "text_length": 214}),
+            "2026-08-03T16:00:00.000000+00:00",
+            "2026-08-03T16:04:00.000000+00:00",
+            "2026-08-03T16:04:00.000000+00:00",
+        ),
+    )
+    for legacy_run, sequence, kind, state in (
+        ("run-legacy-1", 1, "run_started", "running"),
+        ("run-legacy-1", 2, "waiting_approval", "waiting_approval"),
+        ("run-legacy-2", 1, "run_started", "running"),
+        ("run-legacy-2", 2, "terminal", "complete"),
+    ):
+        runs_conn.execute(
+            "INSERT INTO agent_run_checkpoints (run_id, sequence, kind, state, "
+            "payload, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                legacy_run,
+                sequence,
+                kind,
+                state,
+                "{}",
+                "2026-08-01T09:12:00.000000+00:00",
+            ),
+        )
+    runs_conn.execute("PRAGMA user_version = 1")
+    runs_conn.commit()
+    runs_conn.close()
+    os.chmod(root / "agent_runs.db", 0o600)
+
     return root
 
 

--- a/desktop/tests/test_agent_run_effect_fence.py
+++ b/desktop/tests/test_agent_run_effect_fence.py
@@ -893,8 +893,18 @@ def test_the_effect_schema_only_creates_objects_that_did_not_exist(tmp_path):
     assert " ON agent_runs " not in EFFECT_SCHEMA
 
 
-def test_a_version_one_store_upgrades_without_losing_or_changing_a_row(tmp_path):
-    """A production-shaped upgrade fixture: v1 on disk, opened by this build."""
+def test_a_version_one_store_gains_the_fence_on_open_but_not_a_new_version(tmp_path):
+    """Opening a store creates what is missing. It does not migrate it.
+
+    The version belongs to `coworker/migrations.py`, which is the only other
+    writer of `PRAGMA user_version` in the codebase. Every registered store
+    works this way: the store owns its DDL, the registry owns its version. So
+    starting the application never silently upgrades an existing database, and
+    a rollback to an older build still finds a version it can open.
+
+    The upgrade itself -- with a backup, a rollback, and a rerun -- is the
+    registry's, and is tested in `tests/test_migrations.py`.
+    """
     before, checkpoints = _version_one_store(tmp_path)
     objects_before = _objects(tmp_path)
 
@@ -902,11 +912,11 @@ def test_a_version_one_store_upgrades_without_losing_or_changing_a_row(tmp_path)
 
     conn = _raw(tmp_path)
     try:
-        assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 2
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 1
         assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
     finally:
         conn.close()
-    # Exactly the new objects appeared. Nothing existing was replaced.
+    # Exactly the fence appeared. Nothing existing was removed or replaced.
     added = _objects(tmp_path) - objects_before
     assert objects_before - _objects(tmp_path) == set()
     assert {name for _, name in added} == {
@@ -920,12 +930,13 @@ def test_a_version_one_store_upgrades_without_losing_or_changing_a_row(tmp_path)
         "agent_run_effects_settled_is_final",
         "agent_run_effects_are_never_deleted",
     }
-    # Every version 1 row survives byte for byte, including its lease and version.
+    # Every version 1 row survives, including its lease and its version.
     for run_id, run in before.items():
         assert reopened.get_run(run_id) == run
         assert reopened.list_checkpoints(run_id) == checkpoints[run_id]
         assert reopened.list_effects(run_id) == []
-    # The upgraded store works: a fence write lands on a run created before it.
+    # The fence works immediately, so a store waiting to be migrated is fenced
+    # rather than unprotected.
     live = next(
         run_id for run_id, run in before.items() if run["current_state"] == "running"
     )
@@ -937,7 +948,18 @@ def test_a_version_one_store_upgrades_without_losing_or_changing_a_row(tmp_path)
     ).effect["status"] == EffectStatus.DISPATCHED
 
 
-def test_the_upgrade_is_idempotent_across_reruns_and_a_restart(tmp_path):
+def test_a_brand_new_database_is_born_at_the_current_version(tmp_path):
+    """Creating a database at the current version is not a migration."""
+    repo = AgentRunRepository(tmp_path)
+    conn = _raw(tmp_path)
+    try:
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION
+    finally:
+        conn.close()
+    repo.close()
+
+
+def test_opening_an_unmigrated_store_repeatedly_changes_nothing_further(tmp_path):
     before, checkpoints = _version_one_store(tmp_path)
 
     first = AgentRunRepository(tmp_path)
@@ -952,7 +974,7 @@ def test_the_upgrade_is_idempotent_across_reruns_and_a_restart(tmp_path):
     assert _objects(tmp_path) == settled
     conn = _raw(tmp_path)
     try:
-        assert conn.execute("PRAGMA user_version").fetchone()[0] == 2
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 1
     finally:
         conn.close()
     for run_id, run in before.items():

--- a/desktop/tests/test_agent_run_effect_fence.py
+++ b/desktop/tests/test_agent_run_effect_fence.py
@@ -1,0 +1,997 @@
+"""Slice 3: the fence around an external effect that may already have happened.
+
+The property under test is that an effect with a dispatch and no outcome never
+becomes `succeeded` or `failed` by any route. Not a retry, not a resume, not a
+second owner, not a raw SQL edit. It becomes `ambiguous`, and only a named
+person moves it from there.
+"""
+
+import sqlite3
+import threading
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from coworker.agent_run_approval import (
+    EFFECT_STATUSES,
+    MACHINE_OUTCOMES,
+    OPERATOR_OUTCOMES,
+    AgentRunEffectFenced,
+    EffectStatus,
+    ReplayClass,
+    effect_fingerprint,
+    external_effect_evidence,
+    replay_class,
+)
+from coworker.agent_run_owner import OwnerRegistry
+from coworker.agent_run_repository import (
+    DB_NAME,
+    AgentRunLeaseLost,
+    AgentRunRepository,
+)
+from coworker.agent_run_state import AgentRunTransitionError
+from coworker.permissions import ASK, AUTO, RETRY_SAFE
+from coworker.run_evidence import Evidence
+
+NOW = datetime(2026, 8, 27, 10, 0, 0, tzinfo=UTC)
+SEND_ARGS = {"to": "dana@ramp.test", "subject": "Intro", "body": "Hello Dana."}
+
+
+def _repo(tmp_path):
+    repo = AgentRunRepository(tmp_path)
+    return repo, repo.registry.register()
+
+
+def _start(repo, owner, **kwargs):
+    return repo.create_run(
+        session_id=kwargs.pop("session_id", "sess-1"),
+        trigger="chat",
+        goal="reach out to Dana",
+        owner=owner,
+        lease_seconds=kwargs.pop("lease_seconds", 600),
+        now=kwargs.pop("now", NOW),
+    )
+
+
+def _stored_bytes(tmp_path) -> bytes:
+    blob = b""
+    for suffix in ("", "-wal", "-shm"):
+        path = tmp_path / f"{DB_NAME}{suffix}"
+        if path.exists():
+            blob += path.read_bytes()
+    return blob
+
+
+def _raw(tmp_path):
+    """A connection that knows nothing about the repository's method contracts."""
+    conn = sqlite3.connect(tmp_path / DB_NAME)
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+# --- the fence agrees with permissions rather than restating it ----------
+
+
+def test_replay_class_is_derived_from_permissions_retry_safe():
+    """One list decides this. The fence reads it; it does not keep its own."""
+    assert RETRY_SAFE, "the permission module must still publish a retry allowlist"
+    for name in RETRY_SAFE:
+        assert replay_class(name) is ReplayClass.SAFE, name
+    for name in ASK:
+        assert replay_class(name) is ReplayClass.CONSEQUENTIAL, name
+    # Exactly the retry allowlist is safe: nothing the fence adds, nothing it drops.
+    known = AUTO | ASK
+    assert {name for name in known if replay_class(name) is ReplayClass.SAFE} == set(
+        RETRY_SAFE
+    )
+    # gmail_send is the case the fence exists for, and it is fenced.
+    assert "gmail_send" not in RETRY_SAFE
+    assert replay_class("gmail_send") is ReplayClass.CONSEQUENTIAL
+    # A tool nobody has classified is fenced, never replayed.
+    assert replay_class("a_tool_from_a_later_build") is ReplayClass.CONSEQUENTIAL
+
+
+def test_machine_and_operator_outcomes_share_no_value():
+    assert MACHINE_OUTCOMES.isdisjoint(OPERATOR_OUTCOMES)
+    assert MACHINE_OUTCOMES | OPERATOR_OUTCOMES <= EFFECT_STATUSES
+    assert EffectStatus.AMBIGUOUS not in MACHINE_OUTCOMES | OPERATOR_OUTCOMES
+
+
+def test_an_ambiguous_effect_is_reported_with_the_existing_evidence_word():
+    """`run_evidence` already had the word. The fence reuses it."""
+    assert external_effect_evidence([]) is None
+    assert (
+        external_effect_evidence([{"status": EffectStatus.SUCCEEDED}]) is None
+    )
+    assert (
+        external_effect_evidence([{"status": EffectStatus.DISPATCHED}])
+        is Evidence.MISSING
+    )
+    assert (
+        external_effect_evidence(
+            [{"status": EffectStatus.SUCCEEDED}, {"status": EffectStatus.AMBIGUOUS}]
+        )
+        is Evidence.AMBIGUOUS
+    )
+
+
+# --- the happy path still works -----------------------------------------
+
+
+def test_a_dispatched_effect_is_recorded_before_the_call_and_settled_after(tmp_path):
+    repo, owner = _repo(tmp_path)
+    started = _start(repo, owner)
+    run_id = started.run["run_id"]
+
+    dispatch = repo.dispatch_effect(
+        started.lease,
+        tool_name="gmail_send",
+        arguments=SEND_ARGS,
+        tool_call_id="call-1",
+        approval_id="inbox-1",
+        step=3,
+        now=NOW,
+    )
+    effect_id = dispatch.effect["effect_id"]
+    assert dispatch.effect["status"] == EffectStatus.DISPATCHED
+    assert dispatch.effect["replay_class"] == ReplayClass.CONSEQUENTIAL
+    assert dispatch.effect["arguments_fingerprint"] == effect_fingerprint(
+        "gmail_send", SEND_ARGS
+    )
+    assert dispatch.run["current_state"] == "running"
+    assert dispatch.lease is not None and dispatch.lease.version == started.lease.version + 1
+    assert dispatch.checkpoint["kind"] == "tool_pending"
+    assert dispatch.checkpoint["payload"]["attempt_id"] == effect_id
+
+    settled = repo.record_effect_outcome(
+        dispatch.lease, effect_id, ok=True, outcome_ref="gmail-msg-77", now=NOW
+    )
+    assert settled.effect["status"] == EffectStatus.SUCCEEDED
+    assert settled.effect["outcome_ref"] == "gmail-msg-77"
+    assert settled.checkpoint["kind"] == "tool_completed"
+    assert repo.get_run(run_id)["current_state"] == "running"
+    assert repo.list_effects(run_id) == [settled.effect]
+
+
+def test_a_failure_the_process_actually_observed_is_recorded_as_failed(tmp_path):
+    repo, owner = _repo(tmp_path)
+    started = _start(repo, owner)
+    dispatch = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+
+    settled = repo.record_effect_outcome(
+        dispatch.lease,
+        dispatch.effect["effect_id"],
+        ok=False,
+        error_class="SMTPRecipientsRefused",
+        error_summary="the recipient address was refused",
+        now=NOW,
+    )
+
+    assert settled.effect["status"] == EffectStatus.FAILED
+    assert settled.checkpoint["payload"]["error_class"] == "SMTPRecipientsRefused"
+    # `failed` is a machine outcome, so it needed no person and names none.
+    assert settled.effect["resolved_by"] is None
+
+
+# --- the quarantine ------------------------------------------------------
+
+
+def test_an_unreported_effect_is_quarantined_and_the_run_stops(tmp_path):
+    repo, owner = _repo(tmp_path)
+    started = _start(repo, owner)
+    run_id = started.run["run_id"]
+    dispatch = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+
+    quarantine = repo.quarantine_effect(
+        dispatch.lease,
+        dispatch.effect["effect_id"],
+        reason="owner_process_dead",
+        now=NOW,
+    )
+
+    assert quarantine.effect["status"] == EffectStatus.AMBIGUOUS
+    assert quarantine.effect["reason"] == "owner_process_dead"
+    assert quarantine.checkpoint["kind"] == "tool_outcome_unknown"
+    assert quarantine.run["current_state"] == "interrupted"
+    # Nobody owns a quarantined run. A person does.
+    assert quarantine.lease is None
+    assert quarantine.run["lease_owner"] is None
+    assert repo.get_run(run_id)["lease_owner"] is None
+    assert [item["run_id"] for item in repo.list_quarantined_effects()] == [run_id]
+
+
+def test_a_live_owner_may_park_on_an_effect_that_never_answered(tmp_path):
+    """The same ambiguity without a crash: the call timed out and we are alive."""
+    repo, owner = _repo(tmp_path)
+    started = _start(repo, owner)
+    dispatch = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+
+    parked = repo.quarantine_effect(
+        dispatch.lease,
+        dispatch.effect["effect_id"],
+        reason="send_never_answered",
+        state="waiting_external",
+        now=NOW,
+    )
+
+    assert parked.run["current_state"] == "waiting_external"
+    assert parked.effect["status"] == EffectStatus.AMBIGUOUS
+    assert parked.lease is None and parked.run["lease_owner"] is None
+    assert parked.checkpoint["kind"] == "waiting_external"
+
+
+def test_quarantine_refuses_a_state_the_run_machine_does_not_allow(tmp_path):
+    repo, owner = _repo(tmp_path)
+    started = _start(repo, owner)
+    dispatch = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+
+    with pytest.raises(ValueError):
+        repo.quarantine_effect(
+            dispatch.lease, dispatch.effect["effect_id"], reason="x", state="complete"
+        )
+
+
+# --- the fence proper: nothing automatic leaves `ambiguous` --------------
+
+
+def test_a_retry_cannot_report_an_outcome_for_a_quarantined_effect(tmp_path):
+    repo, owner = _repo(tmp_path)
+    started = _start(repo, owner)
+    dispatch = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+    effect_id = dispatch.effect["effect_id"]
+    repo.quarantine_effect(dispatch.lease, effect_id, reason="cut", now=NOW)
+
+    # The dispatching owner comes back with a result. It is too late.
+    retaken = repo.acquire_lease(started.run["run_id"], owner, 600, now=NOW)
+    assert retaken is not None
+    for ok in (True, False):
+        with pytest.raises(AgentRunEffectFenced):
+            repo.record_effect_outcome(retaken, effect_id, ok=ok, now=NOW)
+    assert repo.list_effects(started.run["run_id"])[0]["status"] == (
+        EffectStatus.AMBIGUOUS
+    )
+
+
+def test_a_second_owner_cannot_report_an_outcome_it_never_dispatched(tmp_path):
+    """Only the process that made the call may say what the call did."""
+    repo, owner = _repo(tmp_path)
+    successor = OwnerRegistry(tmp_path).register()
+    started = _start(repo, owner, lease_seconds=60)
+    dispatch = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+    effect_id = dispatch.effect["effect_id"]
+
+    later = NOW + timedelta(seconds=120)
+    repo.reconcile_expired_leases(now=later)
+    taken = repo.acquire_lease(started.run["run_id"], successor, 600, now=later)
+    assert taken is not None
+
+    with pytest.raises(AgentRunEffectFenced):
+        repo.record_effect_outcome(taken, effect_id, ok=True, now=later)
+    assert repo.list_effects(started.run["run_id"])[0]["status"] == (
+        EffectStatus.DISPATCHED
+    )
+    # The successor may quarantine it, because that claims nothing about the world.
+    quarantine = repo.quarantine_effect(taken, effect_id, reason="cut", now=later)
+    assert quarantine.effect["status"] == EffectStatus.AMBIGUOUS
+
+
+def test_a_superseded_lease_writes_no_effect_at_all(tmp_path):
+    repo, owner = _repo(tmp_path)
+    successor = OwnerRegistry(tmp_path).register()
+    started = _start(repo, owner, lease_seconds=60)
+    later = NOW + timedelta(seconds=120)
+    repo.reconcile_expired_leases(now=later)
+    assert repo.acquire_lease(started.run["run_id"], successor, 600, now=later)
+
+    before = repo.get_run(started.run["run_id"])
+    with pytest.raises(AgentRunLeaseLost):
+        repo.dispatch_effect(
+            started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=later
+        )
+    assert repo.get_run(started.run["run_id"]) == before
+    assert repo.list_effects(started.run["run_id"]) == []
+
+
+def test_raw_sql_cannot_launder_a_quarantined_effect_into_a_success(tmp_path):
+    """The rule lives in the database, not only in the methods above it."""
+    repo, owner = _repo(tmp_path)
+    started = _start(repo, owner)
+    dispatch = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+    effect_id = dispatch.effect["effect_id"]
+    repo.quarantine_effect(dispatch.lease, effect_id, reason="cut", now=NOW)
+
+    conn = _raw(tmp_path)
+    try:
+        for target in ("succeeded", "failed", "dispatched"):
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "UPDATE agent_run_effects SET status = ? WHERE effect_id = ?",
+                    (target, effect_id),
+                )
+        # Nor by deleting the evidence and writing a clean row in its place.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "DELETE FROM agent_run_effects WHERE effect_id = ?", (effect_id,)
+            )
+        # Nor by opening a fresh record already claiming success.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO agent_run_effects (effect_id, run_id, tool_name, "
+                "replay_class, arguments_fingerprint, status, dispatched_by, "
+                "dispatched_at) VALUES ('e2', ?, 'gmail_send', 'consequential', "
+                "'f', 'succeeded', 'o', ?)",
+                (started.run["run_id"], NOW.isoformat()),
+            )
+        # Nor by claiming a person settled it without naming one.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "UPDATE agent_run_effects SET status = 'resolved_succeeded' "
+                "WHERE effect_id = ?",
+                (effect_id,),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+    assert repo.list_effects(started.run["run_id"])[0]["status"] == (
+        EffectStatus.AMBIGUOUS
+    )
+
+
+def test_a_settled_effect_never_changes_its_outcome(tmp_path):
+    repo, owner = _repo(tmp_path)
+    started = _start(repo, owner)
+    dispatch = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+    effect_id = dispatch.effect["effect_id"]
+    settled = repo.record_effect_outcome(dispatch.lease, effect_id, ok=True, now=NOW)
+
+    with pytest.raises(AgentRunEffectFenced):
+        repo.record_effect_outcome(settled.lease, effect_id, ok=False, now=NOW)
+    with pytest.raises(AgentRunEffectFenced):
+        repo.quarantine_effect(
+            settled.lease, effect_id, reason="second thoughts", now=NOW
+        )
+    with pytest.raises(AgentRunEffectFenced):
+        repo.resolve_quarantined_effect(
+            effect_id, decision="abandoned", operator="fisher"
+        )
+    conn = _raw(tmp_path)
+    try:
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "UPDATE agent_run_effects SET status = 'failed' WHERE effect_id = ?",
+                (effect_id,),
+            )
+    finally:
+        conn.close()
+    assert repo.list_effects(started.run["run_id"])[0]["status"] == (
+        EffectStatus.SUCCEEDED
+    )
+
+
+# --- only a named person settles a quarantine ---------------------------
+
+
+def test_a_person_settles_a_quarantine_and_is_recorded_as_having_done_so(tmp_path):
+    repo, owner = _repo(tmp_path)
+    started = _start(repo, owner)
+    dispatch = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+    effect_id = dispatch.effect["effect_id"]
+    repo.quarantine_effect(dispatch.lease, effect_id, reason="cut", now=NOW)
+
+    resolved = repo.resolve_quarantined_effect(
+        effect_id,
+        decision="resolved_succeeded",
+        operator="fisher",
+        note="Dana replied, so it went out.",
+        outcome_ref="gmail-msg-77",
+        now=NOW,
+    )
+
+    assert resolved["status"] == EffectStatus.RESOLVED_SUCCEEDED
+    assert resolved["resolved_by"] == "fisher"
+    assert resolved["resolved_note"] == "Dana replied, so it went out."
+    assert resolved["outcome_ref"] == "gmail-msg-77"
+    # A resolved effect is not a machine outcome, and never reads as one.
+    assert resolved["status"] not in MACHINE_OUTCOMES
+    assert repo.list_quarantined_effects() == []
+
+
+def test_a_resolution_without_a_person_is_refused(tmp_path):
+    repo, owner = _repo(tmp_path)
+    started = _start(repo, owner)
+    dispatch = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+    effect_id = dispatch.effect["effect_id"]
+    repo.quarantine_effect(dispatch.lease, effect_id, reason="cut", now=NOW)
+
+    for operator in ("", "   ", None):
+        with pytest.raises(ValueError):
+            repo.resolve_quarantined_effect(
+                effect_id, decision="abandoned", operator=operator
+            )
+    # A person cannot borrow the machine's words either.
+    for decision in ("succeeded", "failed", "dispatched", "ambiguous", "nonsense"):
+        with pytest.raises(ValueError):
+            repo.resolve_quarantined_effect(
+                effect_id, decision=decision, operator="fisher"
+            )
+    assert repo.list_effects(started.run["run_id"])[0]["status"] == (
+        EffectStatus.AMBIGUOUS
+    )
+
+
+def test_only_a_quarantined_effect_can_be_resolved(tmp_path):
+    repo, owner = _repo(tmp_path)
+    started = _start(repo, owner)
+    dispatch = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+
+    with pytest.raises(AgentRunEffectFenced):
+        repo.resolve_quarantined_effect(
+            dispatch.effect["effect_id"], decision="abandoned", operator="fisher"
+        )
+    with pytest.raises(KeyError):
+        repo.resolve_quarantined_effect(
+            "no-such-effect", decision="abandoned", operator="fisher"
+        )
+
+
+# --- redaction -----------------------------------------------------------
+
+
+def test_planted_secrets_never_reach_the_persisted_effect_record(tmp_path):
+    """Non-vacuous: the effect row must exist and carry its fields first."""
+    repo, owner = _repo(tmp_path)
+    started = _start(repo, owner)
+    token = "sk-" + "proj-" + "Z" * 28
+    header = "Bearer " + "Q" * 24
+    planted = {
+        "to": "dana@ramp.test",
+        "subject": "Following up on the Codeology intro",
+        "body": "Dana, here is the private thing I wrote for you.",
+        "api_key": token,
+        "authorization": header,
+    }
+
+    dispatch = repo.dispatch_effect(
+        started.lease,
+        tool_name="gmail_send",
+        arguments=planted,
+        tool_call_id="call-9",
+        approval_id="inbox-9",
+        now=NOW,
+    )
+    effect_id = dispatch.effect["effect_id"]
+    quarantined = repo.quarantine_effect(
+        dispatch.lease,
+        effect_id,
+        reason=f"dispatch failed with api_key={token}",
+        now=NOW,
+    )
+    repo.resolve_quarantined_effect(
+        effect_id,
+        decision="resolved_failed",
+        operator="fisher",
+        note=f"checked the mailbox, nothing sent, authorization: {header}",
+        now=NOW,
+    )
+
+    stored = repo.list_effects(started.run["run_id"])[0]
+    assert stored["effect_id"] == effect_id
+    assert stored["tool_name"] == "gmail_send"
+    assert stored["tool_call_id"] == "call-9"
+    assert stored["approval_id"] == "inbox-9"
+    assert stored["arguments_fingerprint"] == effect_fingerprint("gmail_send", planted)
+    assert stored["status"] == EffectStatus.RESOLVED_FAILED
+    assert stored["resolved_by"] == "fisher"
+    assert stored["reason"].startswith("dispatch failed with api_key=")
+    assert stored["resolved_note"].startswith("checked the mailbox, nothing sent")
+    assert quarantined.checkpoint["payload"], "the checkpoint must not be empty"
+    assert quarantined.checkpoint["payload"]["tool_name"] == "gmail_send"
+
+    blob = _stored_bytes(tmp_path)
+    assert b"gmail_send" in blob, "the effect record must really be on disk"
+    assert stored["arguments_fingerprint"].encode() in blob
+    for secret in (
+        token,
+        header,
+        planted["body"],
+        planted["subject"],
+        planted["to"],
+    ):
+        assert secret.encode() not in blob, secret
+
+
+def test_the_effect_fingerprint_separates_two_different_sends(tmp_path):
+    other = {**SEND_ARGS, "to": "someone.else@ramp.test"}
+    assert effect_fingerprint("gmail_send", SEND_ARGS) != effect_fingerprint(
+        "gmail_send", other
+    )
+    assert effect_fingerprint("gmail_send", SEND_ARGS) == effect_fingerprint(
+        "gmail_send", dict(reversed(list(SEND_ARGS.items())))
+    )
+    assert effect_fingerprint("gmail_send", SEND_ARGS) != effect_fingerprint(
+        "gmail_draft", SEND_ARGS
+    )
+
+
+# --- the store's own rules still hold ------------------------------------
+
+
+def test_an_effect_cannot_be_dispatched_from_a_parked_run(tmp_path):
+    repo, owner = _repo(tmp_path)
+    started = _start(repo, owner)
+    parked = repo.checkpoint(
+        started.lease, kind="waiting_approval", state="waiting_approval", now=NOW
+    )
+    assert parked.lease is None
+
+    with pytest.raises(AgentRunLeaseLost):
+        repo.dispatch_effect(
+            started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+        )
+
+
+def test_an_effect_record_survives_checkpoint_retention(tmp_path):
+    """Retention drops step detail. It never drops the record of a real effect."""
+    repo, owner = _repo(tmp_path)
+    started = _start(repo, owner)
+    dispatch = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+    settled = repo.record_effect_outcome(
+        dispatch.lease, dispatch.effect["effect_id"], ok=True, now=NOW
+    )
+    repo.checkpoint(
+        settled.lease,
+        kind="terminal",
+        state="complete",
+        terminal_result={"status": "ok"},
+        now=NOW,
+    )
+
+    assert repo.prune_checkpoints(finished_before=NOW + timedelta(days=1)) == [
+        started.run["run_id"]
+    ]
+    assert repo.list_checkpoints(started.run["run_id"]) == []
+    assert repo.list_effects(started.run["run_id"])[0]["status"] == (
+        EffectStatus.SUCCEEDED
+    )
+
+
+def test_a_quarantined_run_is_never_pruned_because_its_hole_is_marked(tmp_path):
+    repo, owner = _repo(tmp_path)
+    started = _start(repo, owner)
+    dispatch = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+    quarantine = repo.quarantine_effect(
+        dispatch.lease, dispatch.effect["effect_id"], reason="cut", now=NOW
+    )
+    assert quarantine.run["current_state"] == "interrupted"
+
+    # Force a finish time so retention would otherwise consider it.
+    conn = _raw(tmp_path)
+    try:
+        conn.execute(
+            "UPDATE agent_runs SET finished_at = ? WHERE run_id = ?",
+            (NOW.isoformat(), started.run["run_id"]),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert repo.prune_checkpoints(finished_before=NOW + timedelta(days=1)) == []
+    kinds = [item["kind"] for item in repo.list_checkpoints(started.run["run_id"])]
+    assert "tool_outcome_unknown" in kinds
+
+
+def test_dispatching_the_same_effect_id_twice_is_refused(tmp_path):
+    repo, owner = _repo(tmp_path)
+    started = _start(repo, owner)
+    first = repo.dispatch_effect(
+        started.lease,
+        tool_name="gmail_send",
+        arguments=SEND_ARGS,
+        effect_id="effect-fixed",
+        now=NOW,
+    )
+
+    with pytest.raises(AgentRunEffectFenced):
+        repo.dispatch_effect(
+            first.lease,
+            tool_name="gmail_send",
+            arguments=SEND_ARGS,
+            effect_id="effect-fixed",
+            now=NOW,
+        )
+    assert len(repo.list_effects(started.run["run_id"])) == 1
+
+
+def test_the_quarantine_checkpoint_is_a_legal_edge_of_the_run_machine(tmp_path):
+    """Doctor walks stored checkpoints back through `validate_transition`."""
+    from coworker.agent_run_state import validate_transition
+
+    validate_transition("tool_pending", "running", "running")
+    validate_transition("tool_completed", "running", "running")
+    validate_transition("tool_outcome_unknown", "running", "interrupted")
+    validate_transition("tool_outcome_unknown", "interrupted", "interrupted")
+    validate_transition("waiting_external", "running", "waiting_external")
+    with pytest.raises(AgentRunTransitionError):
+        validate_transition("waiting_external", "interrupted", "waiting_external")
+    # Defence in depth. Even if the effect fence were removed, a quarantined
+    # run rests in `interrupted`, and no tool may report a result from there.
+    with pytest.raises(AgentRunTransitionError):
+        validate_transition("tool_completed", "interrupted", "running")
+
+
+# --- the approval door ---------------------------------------------------
+
+
+def _parked(repo, owner, *, approval_id="inbox-7"):
+    started = _start(repo, owner)
+    repo.checkpoint(
+        started.lease,
+        kind="waiting_approval",
+        state="waiting_approval",
+        payload={"approval_id": approval_id, "tool_name": "gmail_send"},
+        approval_ids=[approval_id],
+        now=NOW,
+    )
+    return started.run["run_id"]
+
+
+def test_a_parked_run_comes_back_only_against_a_named_resolution(tmp_path):
+    repo, owner = _repo(tmp_path)
+    run_id = _parked(repo, owner)
+
+    # The ordinary door stays shut: a parked run is a person's.
+    assert repo.acquire_lease(run_id, owner, 600, now=NOW) is None
+
+    commit = repo.resume_from_approval(
+        run_id, owner, approval_id="inbox-7", decision="allow", now=NOW
+    )
+
+    assert commit is not None
+    assert commit.run["current_state"] == "running"
+    assert commit.run["lease_owner"] == owner.owner_id
+    assert commit.checkpoint["kind"] == "approval_resolved"
+    assert commit.checkpoint["payload"] == {
+        "approval_id": "inbox-7",
+        "status": "allow",
+    }
+    assert commit.lease is not None
+    # The run is running again, so an effect may now be dispatched against it.
+    assert repo.dispatch_effect(
+        commit.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+
+
+def test_the_lease_and_the_unparking_commit_together(tmp_path):
+    """Doctor calls a lease in a waiting state a record contradicting itself.
+
+    One version bump and one new checkpoint prove one write, so there is no
+    committed instant in which the run is parked and leased at the same time.
+    A two-step version -- take the lease, then move the state -- would leave
+    that pair visible to any other reader between the two commits.
+    """
+    repo, owner = _repo(tmp_path)
+    run_id = _parked(repo, owner)
+    before = repo.get_run(run_id)
+
+    commit = repo.resume_from_approval(
+        run_id, owner, approval_id="inbox-7", decision="deny", now=NOW
+    )
+
+    assert commit.run["version"] == before["version"] + 1
+    assert commit.run["checkpoint_sequence"] == before["checkpoint_sequence"] + 1
+    assert commit.lease.version == commit.run["version"]
+    assert commit.run["current_state"] == "running"
+    assert commit.run["lease_owner"] == owner.owner_id
+    conn = _raw(tmp_path)
+    try:
+        row = conn.execute(
+            "SELECT current_state, lease_owner, version FROM agent_runs "
+            "WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row == ("running", owner.owner_id, before["version"] + 1)
+
+
+def test_an_approval_the_run_never_raised_opens_nothing(tmp_path):
+    repo, owner = _repo(tmp_path)
+    run_id = _parked(repo, owner)
+
+    with pytest.raises(ValueError):
+        repo.resume_from_approval(
+            run_id, owner, approval_id="inbox-somebody-elses", decision="allow",
+            now=NOW,
+        )
+    with pytest.raises(ValueError):
+        repo.resume_from_approval(
+            run_id, owner, approval_id="inbox-7", decision="maybe", now=NOW
+        )
+    with pytest.raises(KeyError):
+        repo.resume_from_approval(
+            "no-such-run", owner, approval_id="inbox-7", decision="allow", now=NOW
+        )
+    run = repo.get_run(run_id)
+    assert run["current_state"] == "waiting_approval"
+    assert run["lease_owner"] is None
+
+
+def test_a_running_run_is_not_reopened_by_the_approval_door(tmp_path):
+    repo, owner = _repo(tmp_path)
+    started = _start(repo, owner)
+
+    assert (
+        repo.resume_from_approval(
+            started.run["run_id"],
+            owner,
+            approval_id="inbox-7",
+            decision="allow",
+            now=NOW,
+        )
+        is None
+    )
+    assert repo.get_run(started.run["run_id"])["version"] == started.run["version"]
+
+
+def test_an_approval_never_unparks_a_run_whose_effect_is_quarantined(tmp_path):
+    """An Allow says nothing about whether the last send already went out."""
+    repo, owner = _repo(tmp_path)
+    started = _start(repo, owner)
+    dispatch = repo.dispatch_effect(
+        started.lease,
+        tool_name="gmail_send",
+        arguments=SEND_ARGS,
+        approval_id="inbox-7",
+        now=NOW,
+    )
+    parked = repo.quarantine_effect(
+        dispatch.lease,
+        dispatch.effect["effect_id"],
+        reason="send_never_answered",
+        state="waiting_external",
+        now=NOW,
+    )
+    assert parked.run["current_state"] == "waiting_external"
+
+    with pytest.raises(AgentRunEffectFenced):
+        repo.resume_from_approval(
+            started.run["run_id"],
+            owner,
+            approval_id="inbox-7",
+            decision="allow",
+            now=NOW,
+        )
+    run = repo.get_run(started.run["run_id"])
+    assert run["current_state"] == "waiting_external"
+    assert run["lease_owner"] is None
+    assert repo.list_effects(run["run_id"])[0]["status"] == EffectStatus.AMBIGUOUS
+
+
+# --- what the store looks like to a reader that did not write it ---------
+
+
+def test_a_version_one_store_gains_the_effect_table_on_open(tmp_path):
+    """The table is created by the same idempotent script. Nothing migrates."""
+    repo, owner = _repo(tmp_path)
+    started = _start(repo, owner)
+    repo.close()
+    conn = _raw(tmp_path)
+    try:
+        conn.execute("DROP TABLE agent_run_effects")
+        conn.execute("PRAGMA user_version = 1")
+        conn.commit()
+    finally:
+        conn.close()
+
+    reopened = AgentRunRepository(tmp_path)
+
+    conn = _raw(tmp_path)
+    try:
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 2
+        tables = {
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+    finally:
+        conn.close()
+    assert "agent_run_effects" in tables
+    # The runs written before the bump are untouched and still readable.
+    assert reopened.get_run(started.run["run_id"])["current_state"] == "running"
+    assert reopened.list_effects(started.run["run_id"]) == []
+
+
+def test_the_record_a_fenced_run_leaves_behind_passes_doctors_history_rules(tmp_path):
+    """Doctor walks stored checkpoints back through `validate_transition`.
+
+    This reproduces the walk PR #111 added, over a run driven through every
+    path this slice introduces, so the new writes cannot quietly produce a
+    history Doctor would call impossible.
+    """
+    from coworker.agent_run_state import is_leasable, is_terminal, validate_transition
+    from coworker.run_evidence import analyze_record
+
+    repo, owner = _repo(tmp_path)
+    started = _start(repo, owner)
+    run_id = started.run["run_id"]
+    # A completed send, then a parked approval, then a resolved one, then a
+    # dispatch that never reported, quarantined.
+    first = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+    done = repo.record_effect_outcome(
+        first.lease, first.effect["effect_id"], ok=True, now=NOW
+    )
+    parked = repo.checkpoint(
+        done.lease,
+        kind="waiting_approval",
+        state="waiting_approval",
+        approval_ids=["inbox-7"],
+        payload={"approval_id": "inbox-7"},
+        now=NOW,
+    )
+    assert parked.lease is None
+    reopened = repo.resume_from_approval(
+        run_id, owner, approval_id="inbox-7", decision="allow", now=NOW
+    )
+    second = repo.dispatch_effect(
+        reopened.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+    repo.quarantine_effect(
+        second.lease, second.effect["effect_id"], reason="cut", now=NOW
+    )
+
+    run = repo.get_run(run_id)
+    checkpoints = repo.list_checkpoints(run_id)
+    record = analyze_record(run, checkpoints)
+
+    # Doctor reads no further into a record it cannot express. It must be able
+    # to express everything this slice writes.
+    assert record["unsupported"] == ()
+    assert not record["damaged"]
+    assert [item["sequence"] for item in checkpoints] == list(
+        range(1, record["expected"] + 1)
+    )
+    # No impossible transition, and nothing after a terminal state.
+    previous = "running"
+    for item in checkpoints:
+        assert not is_terminal(previous), item
+        if item["sequence"] == 1:
+            assert item["kind"] == "run_started"
+        else:
+            validate_transition(item["kind"], previous, item["state"])
+        previous = item["state"]
+    # The row agrees with its own last checkpoint, and holds no illegal lease.
+    assert checkpoints[-1]["state"] == run["current_state"]
+    assert run["lease_owner"] is None
+    assert not is_leasable(run["current_state"]) or run["lease_owner"] is None
+    # The hole is marked, so retention and the receipt both know it is there.
+    assert "tool_outcome_unknown" in [item["kind"] for item in checkpoints]
+
+
+# --- trying to break it --------------------------------------------------
+
+
+def test_two_owners_racing_to_quarantine_one_effect_quarantine_it_once(tmp_path):
+    repo, owner = _repo(tmp_path)
+    started = _start(repo, owner, now=None)
+    dispatch = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS
+    )
+    run_id = started.run["run_id"]
+    effect_id = dispatch.effect["effect_id"]
+
+    barrier = threading.Barrier(2)
+    outcomes: list[object] = []
+    guard = threading.Lock()
+
+    def contend():
+        worker = AgentRunRepository(tmp_path)
+        barrier.wait()
+        try:
+            result = worker.quarantine_effect(
+                dispatch.lease, effect_id, reason="racing cut"
+            )
+        except Exception as exc:
+            result = exc
+        with guard:
+            outcomes.append(result)
+
+    threads = [threading.Thread(target=contend) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    committed = [item for item in outcomes if not isinstance(item, Exception)]
+    refused = [item for item in outcomes if isinstance(item, Exception)]
+    assert len(committed) == 1 and len(refused) == 1
+    assert repo.list_effects(run_id)[0]["status"] == EffectStatus.AMBIGUOUS
+    kinds = [item["kind"] for item in repo.list_checkpoints(run_id)]
+    assert kinds.count("tool_outcome_unknown") == 1
+
+
+def test_the_dispatching_owner_waking_up_with_a_result_still_cannot_write_it(tmp_path):
+    """The worst case for the fence: the zombie genuinely knows the answer.
+
+    Its lease expired, a recovering process quarantined the send, and only then
+    does the original process come back holding a real success. It still may not
+    write it. A person may already have acted on the quarantine, and letting a
+    process that lost its authority overwrite that is worse than losing what it
+    saw. The attempt raises with a message a caller can log for the operator.
+    """
+    repo, owner = _repo(tmp_path)
+    successor = OwnerRegistry(tmp_path).register()
+    started = _start(repo, owner, lease_seconds=60)
+    dispatch = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+    effect_id = dispatch.effect["effect_id"]
+
+    later = NOW + timedelta(seconds=120)
+    repo.reconcile_expired_leases(now=later)
+    taken = repo.acquire_lease(started.run["run_id"], successor, 600, now=later)
+    repo.quarantine_effect(taken, effect_id, reason="owner_lease_expired", now=later)
+
+    with pytest.raises(AgentRunEffectFenced) as caught:
+        repo.record_effect_outcome(
+            dispatch.lease, effect_id, ok=True, outcome_ref="gmail-msg-77", now=later
+        )
+    assert "settled by a person" in str(caught.value)
+    effect = repo.list_effects(started.run["run_id"])[0]
+    assert effect["status"] == EffectStatus.AMBIGUOUS
+    # And the observation it carried did not leak onto the row either.
+    assert effect["outcome_ref"] is None
+
+
+def test_a_refused_dispatch_leaves_the_run_exactly_where_it_was(tmp_path):
+    repo, owner = _repo(tmp_path)
+    started = _start(repo, owner)
+    first = repo.dispatch_effect(
+        started.lease,
+        tool_name="gmail_send",
+        arguments=SEND_ARGS,
+        effect_id="effect-fixed",
+        now=NOW,
+    )
+    before = repo.get_run(started.run["run_id"])
+
+    with pytest.raises(AgentRunEffectFenced):
+        repo.dispatch_effect(
+            first.lease,
+            tool_name="gmail_send",
+            arguments=SEND_ARGS,
+            effect_id="effect-fixed",
+            now=NOW,
+        )
+
+    # The rolled-back transaction left no half-written checkpoint behind.
+    assert repo.get_run(started.run["run_id"]) == before
+    assert len(repo.list_checkpoints(started.run["run_id"])) == before[
+        "checkpoint_sequence"
+    ]

--- a/desktop/tests/test_agent_run_effect_fence.py
+++ b/desktop/tests/test_agent_run_effect_fence.py
@@ -6,6 +6,7 @@ second owner, not a raw SQL edit. It becomes `ambiguous`, and only a named
 person moves it from there.
 """
 
+import re
 import sqlite3
 import threading
 from datetime import UTC, datetime, timedelta
@@ -13,6 +14,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from coworker.agent_run_approval import (
+    EFFECT_SCHEMA,
     EFFECT_STATUSES,
     MACHINE_OUTCOMES,
     OPERATOR_OUTCOMES,
@@ -26,6 +28,7 @@ from coworker.agent_run_approval import (
 from coworker.agent_run_owner import OwnerRegistry
 from coworker.agent_run_repository import (
     DB_NAME,
+    SCHEMA_VERSION,
     AgentRunLeaseLost,
     AgentRunRepository,
 )
@@ -796,34 +799,199 @@ def test_an_approval_never_unparks_a_run_whose_effect_is_quarantined(tmp_path):
 # --- what the store looks like to a reader that did not write it ---------
 
 
-def test_a_version_one_store_gains_the_effect_table_on_open(tmp_path):
-    """The table is created by the same idempotent script. Nothing migrates."""
+def _version_one_store(tmp_path):
+    """A production-shaped version 1 store: real rows in both v1 tables.
+
+    Built by the real repository, then wound back to exactly what a build
+    without the effect fence would have left on disk.
+    """
     repo, owner = _repo(tmp_path)
-    started = _start(repo, owner)
+    first = _start(repo, owner, session_id="sess-old-a")
+    repo.checkpoint(first.lease, kind="model_pending", payload={"step": 1}, now=NOW)
+    second = _start(repo, owner, session_id="sess-old-b")
+    repo.checkpoint(
+        second.lease,
+        kind="terminal",
+        state="complete",
+        terminal_result={"status": "ok", "text_length": 12},
+        source_refs=[{"id": "src-1", "title": "Ramp"}],
+        now=NOW,
+    )
+    parked = _start(repo, owner, session_id="sess-old-c")
+    repo.checkpoint(
+        parked.lease,
+        kind="waiting_approval",
+        state="waiting_approval",
+        approval_ids=["inbox-1"],
+        now=NOW,
+    )
+    before = {
+        run["run_id"]: run
+        for run in (
+            repo.get_run(first.run["run_id"]),
+            repo.get_run(second.run["run_id"]),
+            repo.get_run(parked.run["run_id"]),
+        )
+    }
+    checkpoints = {
+        run_id: repo.list_checkpoints(run_id) for run_id in before
+    }
     repo.close()
     conn = _raw(tmp_path)
     try:
-        conn.execute("DROP TABLE agent_run_effects")
-        conn.execute("PRAGMA user_version = 1")
+        conn.executescript(
+            "DROP TRIGGER IF EXISTS agent_run_effects_open_as_dispatched;"
+            "DROP TRIGGER IF EXISTS agent_run_effects_quarantine_is_operator_only;"
+            "DROP TRIGGER IF EXISTS agent_run_effects_settled_is_final;"
+            "DROP TRIGGER IF EXISTS agent_run_effects_are_never_deleted;"
+            "DROP TABLE IF EXISTS agent_run_effects;"
+            "PRAGMA user_version = 1;"
+        )
         conn.commit()
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 1
     finally:
         conn.close()
+    return before, checkpoints
+
+
+def _objects(tmp_path):
+    conn = _raw(tmp_path)
+    try:
+        return {
+            (row[0], row[1])
+            for row in conn.execute("SELECT type, name FROM sqlite_master")
+        }
+    finally:
+        conn.close()
+
+
+def test_the_effect_schema_only_creates_objects_that_did_not_exist(tmp_path):
+    """The whole reason create-if-missing is enough here, asserted.
+
+    `CREATE TABLE IF NOT EXISTS` silently does nothing on a table that already
+    exists. That is safe only while the schema adds no column to an existing
+    table. If someone later adds one to `agent_runs`, this fails and says so,
+    rather than leaving a version 1 database stamped 2 with a missing column.
+    """
+    assert not re.search(r"\bALTER\s+TABLE\b", EFFECT_SCHEMA, re.I)
+    # Every object it creates is new. It never names a version 1 table.
+    created = set(
+        re.findall(
+            r"CREATE\s+(?:TABLE|INDEX|TRIGGER)\s+IF\s+NOT\s+EXISTS\s+(\w+)",
+            EFFECT_SCHEMA,
+            re.I,
+        )
+    )
+    assert created, "the effect schema must create something"
+    assert all(name.startswith("agent_run_effects") for name in created), created
+    for legacy in ("agent_runs", "agent_run_checkpoints"):
+        assert not re.search(
+            rf"\b(?:ALTER|DROP)\b[^;]*\b{legacy}\b(?!_)", EFFECT_SCHEMA, re.I
+        )
+    # And the trigger bodies only ever touch the new table.
+    assert "ON agent_run_effects" in EFFECT_SCHEMA
+    assert " ON agent_runs " not in EFFECT_SCHEMA
+
+
+def test_a_version_one_store_upgrades_without_losing_or_changing_a_row(tmp_path):
+    """A production-shaped upgrade fixture: v1 on disk, opened by this build."""
+    before, checkpoints = _version_one_store(tmp_path)
+    objects_before = _objects(tmp_path)
 
     reopened = AgentRunRepository(tmp_path)
 
     conn = _raw(tmp_path)
     try:
-        assert conn.execute("PRAGMA user_version").fetchone()[0] == 2
-        tables = {
-            row[0]
-            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
-        }
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION == 2
+        assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
     finally:
         conn.close()
-    assert "agent_run_effects" in tables
-    # The runs written before the bump are untouched and still readable.
-    assert reopened.get_run(started.run["run_id"])["current_state"] == "running"
-    assert reopened.list_effects(started.run["run_id"]) == []
+    # Exactly the new objects appeared. Nothing existing was replaced.
+    added = _objects(tmp_path) - objects_before
+    assert objects_before - _objects(tmp_path) == set()
+    assert {name for _, name in added} == {
+        "agent_run_effects",
+        # SQLite's own index for the TEXT PRIMARY KEY.
+        "sqlite_autoindex_agent_run_effects_1",
+        "agent_run_effects_by_run",
+        "agent_run_effects_open",
+        "agent_run_effects_open_as_dispatched",
+        "agent_run_effects_quarantine_is_operator_only",
+        "agent_run_effects_settled_is_final",
+        "agent_run_effects_are_never_deleted",
+    }
+    # Every version 1 row survives byte for byte, including its lease and version.
+    for run_id, run in before.items():
+        assert reopened.get_run(run_id) == run
+        assert reopened.list_checkpoints(run_id) == checkpoints[run_id]
+        assert reopened.list_effects(run_id) == []
+    # The upgraded store works: a fence write lands on a run created before it.
+    live = next(
+        run_id for run_id, run in before.items() if run["current_state"] == "running"
+    )
+    later = NOW + timedelta(seconds=601)
+    lease = reopened.acquire_lease(live, reopened.registry.register(), 600, now=later)
+    assert lease is not None
+    assert reopened.dispatch_effect(
+        lease, tool_name="gmail_send", arguments=SEND_ARGS, now=later
+    ).effect["status"] == EffectStatus.DISPATCHED
+
+
+def test_the_upgrade_is_idempotent_across_reruns_and_a_restart(tmp_path):
+    before, checkpoints = _version_one_store(tmp_path)
+
+    first = AgentRunRepository(tmp_path)
+    settled = _objects(tmp_path)
+    first.close()
+    # Rerun: opening again must change nothing at all.
+    second = AgentRunRepository(tmp_path)
+    second.close()
+    # Post-restart: a third process, no shared connection or in-memory state.
+    third = AgentRunRepository(tmp_path)
+
+    assert _objects(tmp_path) == settled
+    conn = _raw(tmp_path)
+    try:
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 2
+    finally:
+        conn.close()
+    for run_id, run in before.items():
+        assert third.get_run(run_id) == run
+        assert third.list_checkpoints(run_id) == checkpoints[run_id]
+
+
+def test_a_store_from_a_newer_build_fails_closed_without_touching_it(tmp_path):
+    """Unknown future versions refuse to open and modify nothing."""
+    before, checkpoints = _version_one_store(tmp_path)
+    AgentRunRepository(tmp_path).close()
+    conn = _raw(tmp_path)
+    try:
+        conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION + 1}")
+        conn.commit()
+    finally:
+        conn.close()
+    objects_before = _objects(tmp_path)
+
+    with pytest.raises(RuntimeError, match="newer than this build"):
+        AgentRunRepository(tmp_path)
+
+    conn = _raw(tmp_path)
+    try:
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == SCHEMA_VERSION + 1
+    finally:
+        conn.close()
+    assert _objects(tmp_path) == objects_before
+    # Reading it back with a build that does know the version finds it intact.
+    conn = _raw(tmp_path)
+    try:
+        conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+        conn.commit()
+    finally:
+        conn.close()
+    recovered = AgentRunRepository(tmp_path)
+    for run_id, run in before.items():
+        assert recovered.get_run(run_id) == run
+        assert recovered.list_checkpoints(run_id) == checkpoints[run_id]
 
 
 def test_the_record_a_fenced_run_leaves_behind_passes_doctors_history_rules(tmp_path):

--- a/desktop/tests/test_agent_run_restart.py
+++ b/desktop/tests/test_agent_run_restart.py
@@ -1,0 +1,484 @@
+"""Slice 4: restart and resume, cut at five points with a real signal.
+
+Every cut in this file is a real one. A second Python process opens the run
+store, registers an owner and holds its `flock`, drives the run to a named
+point, and reports. The test then sends it SIGKILL. The child runs no cleanup,
+writes no farewell, and cannot: the kernel releases its lock and nothing else.
+That is the only evidence the recovery path is allowed to act on.
+
+The five points are the ones the issue names: mid-model, mid-read-tool,
+mid-approval, mid-write, and after terminal generation but before delivery.
+"""
+
+import json
+import subprocess
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from coworker.agent_run_approval import AgentRunEffectFenced, EffectStatus
+from coworker.agent_run_owner import Liveness, OwnerRegistry
+from coworker.agent_run_repository import AgentRunRepository
+from coworker.agent_run_resume import (
+    ResumeAction,
+    ResumeVerdict,
+    classify_resume,
+    plan_restart,
+    quarantine_unreported_effect,
+    restart,
+)
+
+DESKTOP = str(Path(__file__).resolve().parents[1])
+NOW = datetime(2026, 8, 27, 10, 0, 0, tzinfo=UTC)
+
+# A real second process. It takes a real lease, drives the run to `cut`, says so
+# on stdout, and then blocks forever waiting to be killed.
+CHILD = """
+import json, sys, time
+sys.path.insert(0, sys.argv[1])
+from coworker.agent_run_repository import AgentRunRepository
+
+store, cut = sys.argv[2], sys.argv[3]
+repo = AgentRunRepository(store)
+owner = repo.registry.register()
+started = repo.create_run(
+    session_id="sess-cut", trigger="chat", goal="reach out to Dana",
+    owner=owner, lease_seconds=3600,
+)
+lease = started.lease
+report = {"run_id": started.run["run_id"], "owner_id": owner.owner_id}
+
+if cut == "model":
+    lease = repo.checkpoint(
+        lease, kind="model_pending", payload={"step": 1, "provider": "openai"}
+    ).lease
+elif cut == "read_tool":
+    lease = repo.checkpoint(lease, kind="model_completed", payload={"step": 1}).lease
+    lease = repo.checkpoint(
+        lease,
+        kind="tool_pending",
+        payload={"step": 1, "tool_name": "drive_read", "tool_call_id": "call-r"},
+    ).lease
+elif cut == "approval":
+    lease = repo.checkpoint(lease, kind="model_completed", payload={"step": 1}).lease
+    repo.checkpoint(
+        lease,
+        kind="waiting_approval",
+        state="waiting_approval",
+        payload={"step": 1, "tool_name": "gmail_send", "approval_id": "inbox-7"},
+        approval_ids=["inbox-7"],
+    )
+    lease = None
+elif cut == "approval_resolved":
+    # The other side of the approval boundary: a person said Allow, the run
+    # recorded it, and the process died before dispatching anything.
+    lease = repo.checkpoint(lease, kind="model_completed", payload={"step": 1}).lease
+    parked = repo.checkpoint(
+        lease,
+        kind="waiting_approval",
+        state="waiting_approval",
+        payload={"step": 1, "tool_name": "gmail_send", "approval_id": "inbox-7"},
+        approval_ids=["inbox-7"],
+    )
+    lease = repo.resume_from_approval(
+        started.run["run_id"], owner, approval_id="inbox-7", decision="allow",
+        lease_seconds=3600,
+    ).lease
+elif cut == "write":
+    lease = repo.checkpoint(lease, kind="model_completed", payload={"step": 1}).lease
+    dispatch = repo.dispatch_effect(
+        lease,
+        tool_name="gmail_send",
+        arguments={"to": "dana@ramp.test", "body": "Hello Dana."},
+        tool_call_id="call-w",
+        approval_id="inbox-7",
+        step=1,
+    )
+    lease = dispatch.lease
+    report["effect_id"] = dispatch.effect["effect_id"]
+elif cut == "delivery":
+    lease = repo.checkpoint(
+        lease,
+        kind="model_completed",
+        payload={"step": 2, "text_length": 420},
+        terminal_result={"status": "ok", "message_id": "msg-1", "text_length": 420},
+    ).lease
+elif cut == "unfenced_write":
+    # A caller that skipped the fence: a consequential tool with no effect row.
+    lease = repo.checkpoint(lease, kind="model_completed", payload={"step": 1}).lease
+    lease = repo.checkpoint(
+        lease,
+        kind="tool_pending",
+        payload={"step": 1, "tool_name": "gmail_send", "tool_call_id": "call-u"},
+    ).lease
+elif cut != "idle":
+    raise SystemExit(f"unknown cut {cut}")
+
+print(json.dumps(report))
+sys.stdout.flush()
+while True:
+    time.sleep(3600)
+"""
+
+
+def _cut(tmp_path, cut):
+    """Drive a real process to `cut`, then SIGKILL it mid-flight."""
+    proc = subprocess.Popen(
+        [sys.executable, "-c", CHILD, DESKTOP, str(tmp_path), cut],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    line = proc.stdout.readline()
+    assert line, f"the child never reached the {cut} cut point"
+    report = json.loads(line)
+    proc.kill()
+    assert proc.wait(timeout=30) != 0, "the child must be killed, not exit cleanly"
+    return report
+
+
+def _hold(tmp_path, cut):
+    """Drive a real process to `cut` and leave it alive, holding its lock."""
+    proc = subprocess.Popen(
+        [sys.executable, "-c", CHILD, DESKTOP, str(tmp_path), cut],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    line = proc.stdout.readline()
+    assert line, f"the child never reached the {cut} cut point"
+    return proc, json.loads(line)
+
+
+def _recovering(tmp_path):
+    repo = AgentRunRepository(tmp_path)
+    return repo, repo.registry.register()
+
+
+def _only(outcome, run_id):
+    matching = [item for item in outcome.verdicts if item.run_id == run_id]
+    assert len(matching) == 1, matching
+    return matching[0]
+
+
+# --- cut 1: mid-model ----------------------------------------------------
+
+
+def test_a_cut_mid_model_resumes_the_same_run(tmp_path):
+    report = _cut(tmp_path, "model")
+    repo, owner = _recovering(tmp_path)
+    assert repo.registry.liveness_of(report["owner_id"], repo.registry.host) is (
+        Liveness.DEAD
+    )
+
+    outcome = restart(repo, owner)
+
+    verdict = _only(outcome, report["run_id"])
+    assert verdict.action is ResumeAction.RESUME
+    assert verdict.reason == "model_never_completed"
+    assert verdict.cut_point == "model_pending"
+    assert verdict.step == 1
+    # The identity is the same run, not a new one.
+    run = repo.get_run(report["run_id"])
+    assert run["current_state"] == "interrupted"
+    assert run["lease_owner"] is None
+    assert repo.list_runs(session_id="sess-cut") == [run]
+    assert [item["kind"] for item in repo.list_checkpoints(run["run_id"])] == [
+        "run_started",
+        "model_pending",
+        "process_interrupted",
+    ]
+    # Nothing external was in flight, so there is nothing to quarantine.
+    assert outcome.quarantined == ()
+    assert repo.list_effects(run["run_id"]) == []
+
+
+# --- cut 2: mid-read-tool ------------------------------------------------
+
+
+def test_a_cut_mid_read_tool_resumes_because_the_tool_is_retry_safe(tmp_path):
+    report = _cut(tmp_path, "read_tool")
+    repo, owner = _recovering(tmp_path)
+
+    outcome = restart(repo, owner)
+
+    verdict = _only(outcome, report["run_id"])
+    assert verdict.action is ResumeAction.RESUME
+    assert verdict.reason == "tool_never_completed"
+    assert verdict.tool_name == "drive_read"
+    assert outcome.quarantined == ()
+    assert repo.list_effects(report["run_id"]) == []
+
+
+def test_the_same_cut_on_a_consequential_tool_refuses_to_resume(tmp_path):
+    """Only the retry allowlist made the read-tool case safe. Change the tool."""
+    report = _cut(tmp_path, "unfenced_write")
+    repo, owner = _recovering(tmp_path)
+
+    verdict = _only(restart(repo, owner), report["run_id"])
+
+    assert verdict.action is ResumeAction.REVIEW
+    assert verdict.tool_name == "gmail_send"
+    assert "no effect record" in verdict.reason
+
+
+# --- cut 3: mid-approval -------------------------------------------------
+
+
+def test_a_cut_mid_approval_leaves_the_operator_owning_the_run(tmp_path):
+    report = _cut(tmp_path, "approval")
+    repo, owner = _recovering(tmp_path)
+
+    outcome = restart(repo, owner)
+
+    verdict = _only(outcome, report["run_id"])
+    assert verdict.action is ResumeAction.NOTHING
+    assert verdict.reason == "the run is parked on a person"
+    run = repo.get_run(report["run_id"])
+    # The approval is intact, unowned, and not reclassified by the restart.
+    assert run["current_state"] == "waiting_approval"
+    assert run["lease_owner"] is None
+    assert run["approval_ids"] == ["inbox-7"]
+    assert [item["kind"] for item in repo.list_checkpoints(run["run_id"])] == [
+        "run_started",
+        "model_completed",
+        "waiting_approval",
+    ]
+    # A restart invents no interruption for work that had already parked.
+    assert outcome.quarantined == ()
+
+
+def test_a_cut_after_allow_but_before_dispatch_resumes_because_nothing_left_yet(
+    tmp_path,
+):
+    """The dispatch commits before the call, so no dispatch means no call."""
+    report = _cut(tmp_path, "approval_resolved")
+    repo, owner = _recovering(tmp_path)
+
+    verdict = _only(restart(repo, owner), report["run_id"])
+
+    assert verdict.action is ResumeAction.RESUME
+    assert verdict.reason == "approval_resolved_before_work_resumed"
+    assert verdict.cut_point == "approval_resolved"
+    # Nothing external is on record, which is the fact that makes this safe.
+    assert repo.list_effects(report["run_id"]) == []
+    assert repo.get_run(report["run_id"])["approval_ids"] == ["inbox-7"]
+
+
+# --- cut 4: mid-write, the case with money on the other side -------------
+
+
+def test_a_cut_mid_write_quarantines_the_send_and_never_retries_it(tmp_path):
+    report = _cut(tmp_path, "write")
+    repo, owner = _recovering(tmp_path)
+    run_id, effect_id = report["run_id"], report["effect_id"]
+    # Before recovery the dispatch is on record and no outcome ever was.
+    assert repo.list_effects(run_id)[0]["status"] == EffectStatus.DISPATCHED
+
+    outcome = restart(repo, owner)
+
+    verdict = _only(outcome, run_id)
+    assert verdict.action is ResumeAction.QUARANTINE
+    assert verdict.effect_id == effect_id
+    assert verdict.tool_name == "gmail_send"
+    assert [item["effect_id"] for item in outcome.quarantined] == [effect_id]
+
+    effect = repo.list_effects(run_id)[0]
+    assert effect["status"] == EffectStatus.AMBIGUOUS
+    assert effect["replay_class"] == "consequential"
+    run = repo.get_run(run_id)
+    assert run["current_state"] == "interrupted"
+    assert run["lease_owner"] is None
+    assert "tool_outcome_unknown" in [
+        item["kind"] for item in repo.list_checkpoints(run_id)
+    ]
+
+    # A second restart finds it already quarantined and changes nothing.
+    again = restart(repo, owner)
+    assert _only(again, run_id).action is ResumeAction.REVIEW
+    assert again.quarantined == ()
+    assert repo.list_effects(run_id)[0] == effect
+
+    # And no lease, old or new, can turn the unknown into an outcome.
+    lease = repo.acquire_lease(run_id, owner, 600)
+    assert lease is not None
+    for ok in (True, False):
+        with pytest.raises(AgentRunEffectFenced):
+            repo.record_effect_outcome(lease, effect_id, ok=ok)
+    assert repo.list_effects(run_id)[0]["status"] == EffectStatus.AMBIGUOUS
+
+
+def test_a_quarantined_run_becomes_ordinary_work_again_only_after_a_person(tmp_path):
+    report = _cut(tmp_path, "write")
+    repo, owner = _recovering(tmp_path)
+    run_id, effect_id = report["run_id"], report["effect_id"]
+    restart(repo, owner)
+    assert _only(restart(repo, owner), run_id).action is ResumeAction.REVIEW
+
+    repo.resolve_quarantined_effect(
+        effect_id,
+        decision="resolved_failed",
+        operator="fisher",
+        note="checked the mailbox: nothing went out",
+    )
+
+    verdict = _only(restart(repo, owner), run_id)
+    assert verdict.action is ResumeAction.RESUME
+    assert repo.list_effects(run_id)[0]["resolved_by"] == "fisher"
+
+
+# --- cut 5: after terminal generation, before delivery -------------------
+
+
+def test_a_cut_after_terminal_generation_delivers_instead_of_regenerating(tmp_path):
+    report = _cut(tmp_path, "delivery")
+    repo, owner = _recovering(tmp_path)
+
+    verdict = _only(restart(repo, owner), report["run_id"])
+
+    assert verdict.action is ResumeAction.DELIVER
+    assert verdict.reason == "the final result is on record and its delivery is not"
+    assert verdict.cut_point == "model_completed"
+    run = repo.get_run(report["run_id"])
+    # The answer itself is not here, and must not be: only its shape.
+    assert run["terminal_result"] == {
+        "status": "ok",
+        "message_id": "msg-1",
+        "text_length": 420,
+    }
+    assert run["current_state"] == "interrupted"
+    # DELIVER is distinguishable from RESUME, which is what stops a second
+    # model call from being made and charged for.
+    assert verdict.action is not ResumeAction.RESUME
+
+
+# --- a live owner survives restart ---------------------------------------
+
+
+def test_a_restart_never_touches_a_run_whose_owner_is_still_working_it(tmp_path):
+    proc, report = _hold(tmp_path, "write")
+    run_id = report["run_id"]
+    try:
+        repo, owner = _recovering(tmp_path)
+        assert repo.registry.liveness_of(report["owner_id"], repo.registry.host) is (
+            Liveness.ALIVE
+        )
+
+        outcome = restart(repo, owner)
+
+        verdict = _only(outcome, run_id)
+        assert verdict.action is ResumeAction.NOTHING
+        assert verdict.reason == "another process holds the lease"
+        run = repo.get_run(run_id)
+        assert run["current_state"] == "running"
+        assert run["lease_owner"] == report["owner_id"]
+        # The dispatched send is left exactly as the live owner left it. It is
+        # in flight, not abandoned, and quarantining it would be a lie.
+        assert repo.list_effects(run_id)[0]["status"] == EffectStatus.DISPATCHED
+        assert outcome.quarantined == ()
+        assert repo.acquire_lease(run_id, owner, 600) is None
+    finally:
+        proc.kill()
+        proc.wait(timeout=30)
+
+    # Not vacuous: the same call acts the moment the owner is genuinely gone.
+    outcome = restart(repo, owner)
+    assert _only(outcome, run_id).action is ResumeAction.QUARANTINE
+    assert [item["effect_id"] for item in outcome.quarantined] == [report["effect_id"]]
+
+
+def test_a_restart_leaves_a_run_it_could_not_lease_for_a_later_pass(tmp_path):
+    """Losing the race to quarantine is not a failure; it is someone else's turn."""
+    repo, owner = _recovering(tmp_path)
+    started = repo.create_run(
+        session_id="sess-race",
+        trigger="chat",
+        goal="reach out to Dana",
+        owner=owner,
+        lease_seconds=3600,
+        now=NOW,
+    )
+    dispatch = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments={"to": "d@t.test"}, now=NOW
+    )
+    verdicts = plan_restart(repo, now=NOW)
+    verdict = [item for item in verdicts if item.run_id == started.run["run_id"]]
+    # The live owner still holds it, so the plan says so and stops there.
+    assert verdict[0].action is ResumeAction.NOTHING
+
+    # Force the quarantine attempt anyway: it must decline, not force its way in.
+    forced = quarantine_unreported_effect(
+        repo,
+        OwnerRegistry(tmp_path).register(),
+        ResumeVerdict(
+            run_id=started.run["run_id"],
+            action=ResumeAction.QUARANTINE,
+            reason="forced",
+            effect_id=dispatch.effect["effect_id"],
+        ),
+        now=NOW,
+    )
+    assert forced is None
+    assert repo.list_effects(started.run["run_id"])[0]["status"] == (
+        EffectStatus.DISPATCHED
+    )
+
+
+# --- the classifier on its own -------------------------------------------
+
+
+def test_a_terminal_run_is_never_resumed(tmp_path):
+    repo, owner = _recovering(tmp_path)
+    started = repo.create_run(
+        session_id="sess-done",
+        trigger="chat",
+        goal="done",
+        owner=owner,
+        now=NOW,
+    )
+    repo.checkpoint(
+        started.lease,
+        kind="terminal",
+        state="complete",
+        terminal_result={"status": "ok", "text_length": 12},
+        now=NOW,
+    )
+
+    run = repo.get_run(started.run["run_id"])
+    verdict = classify_resume(run, repo.list_checkpoints(run["run_id"]), [])
+    assert verdict.action is ResumeAction.NOTHING
+    assert verdict.reason == "the run already finished"
+    # A finished run is not even a candidate for the plan.
+    assert [item.run_id for item in plan_restart(repo, now=NOW)] == []
+
+
+def test_quarantine_is_refused_for_a_verdict_that_is_not_one(tmp_path):
+    repo, owner = _recovering(tmp_path)
+    started = repo.create_run(
+        session_id="sess-x", trigger="chat", goal="x", owner=owner, now=NOW
+    )
+    verdict = classify_resume(repo.get_run(started.run["run_id"]), [], [])
+
+    with pytest.raises(ValueError):
+        quarantine_unreported_effect(repo, owner, verdict, now=NOW)
+
+
+def test_an_expired_lease_is_reclaimed_before_anything_is_classified(tmp_path):
+    repo, owner = _recovering(tmp_path)
+    started = repo.create_run(
+        session_id="sess-expiry",
+        trigger="chat",
+        goal="slow work",
+        owner=owner,
+        lease_seconds=60,
+        now=NOW,
+    )
+    repo.checkpoint(started.lease, kind="model_pending", payload={"step": 1}, now=NOW)
+
+    # Still inside the lease: the owner is working, so nothing is picked up.
+    early = plan_restart(repo, now=NOW + timedelta(seconds=30))
+    assert [item.action for item in early] == [ResumeAction.NOTHING]
+
+    late = plan_restart(repo, now=NOW + timedelta(seconds=61))
+    assert [item.action for item in late] == [ResumeAction.RESUME]
+    assert repo.get_run(started.run["run_id"])["current_state"] == "interrupted"

--- a/desktop/tests/test_migrations.py
+++ b/desktop/tests/test_migrations.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from coworker import migrations
+from coworker.agent_run_approval import EFFECT_STATEMENTS
 from coworker.migrations import (
     BackupFailed,
     Migration,
@@ -29,11 +30,28 @@ def _digest(path: Path) -> str:
 
 
 def _tree_digest(root: Path) -> dict[str, str]:
-    return {
-        str(path.relative_to(root)): _digest(path)
-        for path in sorted(root.rglob("*"))
-        if path.is_file()
-    }
+    """Hash the state a store holds, not SQLite's bookkeeping about it.
+
+    A database in WAL mode recreates its `-shm` and `-wal` sidecars whenever it
+    is opened, including read-only: the journal mode lives in the file header,
+    so merely reading one brings them back. Hashing those turns "this changed
+    nothing" into "nobody opened this", which is a different and weaker claim.
+
+    `-shm` is shared memory and never holds committed data, so it is always
+    skipped. A `-wal` is skipped only while it is empty. A write parked in a
+    WAL that has not been checkpointed still shows up, so a change that hid
+    there rather than in the main file is still caught.
+    """
+    digests: dict[str, str] = {}
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        if path.name.endswith("-shm"):
+            continue
+        if path.name.endswith("-wal") and path.stat().st_size == 0:
+            continue
+        digests[str(path.relative_to(root))] = _digest(path)
+    return digests
 
 
 def _user_version(path: Path) -> int:
@@ -87,6 +105,7 @@ def _plan_for(plan, store_id):
 def test_registry_names_every_active_durable_store():
     registered = {spec.store_id for spec in migrations.REGISTRY}
     assert registered == {
+        "agent_runs_db",
         "conversation_db",
         "people_db",
         "drive_ingestion",
@@ -729,3 +748,244 @@ def test_backup_files_keep_owner_only_permissions(tmp_path):
     assert oct((backup.path / "club.db").stat().st_mode & 0o777) == "0o600"
     assert oct((backup.path / "manifest.json").stat().st_mode & 0o777) == "0o600"
     assert oct(os.stat(root / migrations.BACKUPS_DIR_NAME).st_mode & 0o777) == "0o700"
+
+
+# --- the Agent Run store: version 1 to 2, the external-effect fence ------
+
+_EFFECT_OBJECTS = {
+    "agent_run_effects",
+    "agent_run_effects_by_run",
+    "agent_run_effects_open",
+    "agent_run_effects_open_as_dispatched",
+    "agent_run_effects_quarantine_is_operator_only",
+    "agent_run_effects_settled_is_final",
+    "agent_run_effects_are_never_deleted",
+}
+
+
+def _break_agent_run_fence(monkeypatch, apply):
+    """Swap the 1 -> 2 step for one that fails partway through.
+
+    `_break_step` builds a 0 -> 1 step, and the Agent Run store on disk is at
+    version 1, so it needs its own.
+    """
+    original = migrations.spec_for("agent_runs_db")
+    broken = migrations.dataclasses.replace(
+        original,
+        migrations=(
+            Migration(
+                from_version=1,
+                to_version=2,
+                description="deliberately failing fence step",
+                count=lambda _context: 0,
+                apply=apply,
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        migrations,
+        "REGISTRY",
+        tuple(
+            broken if item.store_id == "agent_runs_db" else item
+            for item in migrations.REGISTRY
+        ),
+    )
+
+
+def test_the_agent_run_store_is_registered_with_a_path_from_version_one(tmp_path):
+    root = build_legacy_state(tmp_path / "state")
+
+    plan = migrations.plan_migrations(root)
+    store = _plan_for(plan, "agent_runs_db")
+
+    assert store.status is StoreStatus.PENDING
+    assert store.from_version == 1
+    assert store.to_version == 2
+    assert [(step.from_version, step.to_version) for step in store.steps] == [(1, 2)]
+    assert "external-effect fence" in store.steps[0].description
+
+
+def test_the_agent_run_fence_is_added_without_disturbing_a_single_run(tmp_path):
+    root = build_legacy_state(tmp_path / "state")
+    path = root / "agent_runs.db"
+    before = _dump_database(path)
+    assert before["user_version"] == 1
+    assert len(before["rows"]["agent_runs"]) == 2
+    assert len(before["rows"]["agent_run_checkpoints"]) == 4
+
+    outcome = migrations.apply_migrations(root)
+
+    assert outcome.error is None
+    applied = [item for item in outcome.applied if item.store_id == "agent_runs_db"]
+    assert [(item.from_version, item.to_version) for item in applied] == [(1, 2)]
+    after = _dump_database(path)
+    assert after["integrity"] == ["ok"]
+    assert after["user_version"] == 2
+    # Every run and checkpoint is exactly as it was.
+    assert after["rows"]["agent_runs"] == before["rows"]["agent_runs"]
+    assert (
+        after["rows"]["agent_run_checkpoints"]
+        == before["rows"]["agent_run_checkpoints"]
+    )
+    # Exactly the fence appeared, and nothing that was there was replaced.
+    names_before = {name for _kind, name, _sql in before["schema"]}
+    names_after = {name for _kind, name, _sql in after["schema"]}
+    assert names_after - names_before == _EFFECT_OBJECTS
+    assert names_before - names_after == set()
+
+
+def test_the_agent_run_store_is_backed_up_before_its_fence_is_added(tmp_path):
+    root = build_legacy_state(tmp_path / "state")
+
+    outcome = migrations.apply_migrations(root)
+
+    backup_dir = root / migrations.BACKUPS_DIR_NAME / outcome.backup_id
+    manifest = json.loads((backup_dir / "manifest.json").read_text(encoding="utf-8"))
+    entry = next(
+        item for item in manifest["entries"] if item["store_id"] == "agent_runs_db"
+    )
+    assert entry["content_backed_up"] is True
+    assert entry["store_version"] == 1
+    # The copy is the store as it was: version 1, and no fence in it.
+    copied = _dump_database(backup_dir / "agent_runs.db")
+    assert copied["user_version"] == 1
+    assert {name for _kind, name, _sql in copied["schema"]} & _EFFECT_OBJECTS == set()
+    assert len(copied["rows"]["agent_runs"]) == 2
+
+
+def test_a_failed_fence_step_leaves_the_run_store_at_version_one(tmp_path, monkeypatch):
+    """The rollback has to undo real work, not a no-op."""
+    root = build_legacy_state(tmp_path / "state")
+    path = root / "agent_runs.db"
+    before = _dump_database(path)
+
+    def mutate_then_explode(context):
+        # Land the fence and destroy a run, so an undo is distinguishable.
+        for statement in EFFECT_STATEMENTS:
+            context.connection.execute(statement)
+        context.connection.execute("DELETE FROM agent_runs WHERE run_id = ?",
+                                   ("run-legacy-2",))
+        raise RuntimeError("fence step failed halfway")
+
+    _break_agent_run_fence(monkeypatch, mutate_then_explode)
+
+    outcome = migrations.apply_migrations(root)
+
+    assert outcome.error is not None
+    assert "agent_runs_db" in outcome.rolled_back
+    after = _dump_database(path)
+    assert after["integrity"] == ["ok"]
+    assert after["user_version"] == 1
+    assert after["schema"] == before["schema"]
+    assert after["rows"] == before["rows"]
+    assert {name for _kind, name, _sql in after["schema"]} & _EFFECT_OBJECTS == set()
+
+
+def test_the_fence_step_never_commits_the_transaction_it_runs_inside(tmp_path):
+    """The reason `EFFECT_STATEMENTS` is a tuple and not one script.
+
+    `executescript` issues a COMMIT before it runs. A step that used it would
+    end the transaction `_apply_store` opened, and the rollback above would
+    then have nothing to undo -- silently, with the store left half migrated.
+    """
+    root = build_legacy_state(tmp_path / "state")
+    conn = sqlite3.connect(root / "agent_runs.db")
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        context = migrations.MigrationContext(
+            root=root,
+            spec=migrations.spec_for("agent_runs_db"),
+            path=root / "agent_runs.db",
+            connection=conn,
+        )
+        migrations._add_agent_run_effects(context)
+        assert conn.in_transaction, "the fence step ended its own transaction"
+        conn.rollback()
+        surviving = {
+            str(row[0])
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE name LIKE 'agent_run_effects%'"
+            )
+        }
+    finally:
+        conn.close()
+    assert surviving == set(), "a rolled back fence step left objects behind"
+
+    # Not vacuous: executescript really does end the transaction.
+    other = sqlite3.connect(root / "agent_runs.db")
+    try:
+        other.execute("BEGIN IMMEDIATE")
+        other.executescript("CREATE TABLE probe_that_should_roll_back (x)")
+        assert not other.in_transaction
+        other.rollback()
+        assert other.execute(
+            "SELECT count(*) FROM sqlite_master WHERE name = 'probe_that_should_roll_back'"
+        ).fetchone()[0] == 1, "executescript committed, as documented"
+        other.execute("DROP TABLE probe_that_should_roll_back")
+        other.commit()
+    finally:
+        other.close()
+
+
+def test_rerunning_the_fence_migration_changes_nothing(tmp_path):
+    root = build_legacy_state(tmp_path / "state")
+    migrations.apply_migrations(root)
+    settled = _dump_database(root / "agent_runs.db")
+
+    second = migrations.apply_migrations(root)
+
+    assert second.applied == ()
+    assert _plan_for(migrations.plan_migrations(root), "agent_runs_db").status is (
+        StoreStatus.CURRENT
+    )
+    assert _dump_database(root / "agent_runs.db") == settled
+
+
+def test_the_repository_opens_a_migrated_store_and_uses_its_fence(tmp_path):
+    """The point of the migration: the fence works on a store that predates it."""
+    from coworker.agent_run_approval import EffectStatus
+    from coworker.agent_run_repository import AgentRunRepository
+
+    root = build_legacy_state(tmp_path / "state")
+    migrations.apply_migrations(root)
+
+    repo = AgentRunRepository(root)
+    try:
+        owner = repo.registry.register()
+        started = repo.create_run(
+            session_id="main", trigger="chat", goal="reach out", owner=owner
+        )
+        dispatch = repo.dispatch_effect(
+            started.lease, tool_name="gmail_send", arguments={"to": "d@t.test"}
+        )
+        quarantined = repo.quarantine_effect(
+            dispatch.lease, dispatch.effect["effect_id"], reason="cut"
+        )
+        assert quarantined.effect["status"] == EffectStatus.AMBIGUOUS
+        # The runs that predate the fence are still there and still readable.
+        assert {run["run_id"] for run in repo.list_runs()} >= {
+            "run-legacy-1",
+            "run-legacy-2",
+        }
+    finally:
+        repo.close()
+
+
+def test_starting_the_application_never_upgrades_an_existing_run_store(tmp_path):
+    """Opening a store is not migrating it. Only the registry moves a version."""
+    from coworker.agent_run_repository import AgentRunRepository
+
+    root = build_legacy_state(tmp_path / "state")
+    assert _user_version(root / "agent_runs.db") == 1
+
+    AgentRunRepository(root).close()
+    AgentRunRepository(root).close()
+
+    assert _user_version(root / "agent_runs.db") == 1
+    assert _plan_for(migrations.plan_migrations(root), "agent_runs_db").status is (
+        StoreStatus.PENDING
+    )
+    # And a brand new database is born current, so it needs no migration at all.
+    fresh = tmp_path / "fresh"
+    AgentRunRepository(fresh).close()
+    assert _user_version(fresh / "agent_runs.db") == 2


### PR DESCRIPTION
Slices 3 and 4 of #63. Slices 1 and 2 merged as #105. Slices 5 and 6 remain deferred and are named at the end.

## Domain words

- **Effect** — one external action a run dispatches: a Gmail send, a consequential workspace command.
- **Fence** — the record that says an effect was dispatched, so a crash cannot make it look like it never happened.
- **Quarantine** — the state of an effect that may or may not have reached the world. Not failed. Not succeeded.
- **Cut** — killing a process at a chosen point to test what recovery does.

## Problem

A process can die after dispatching a Gmail send but before recording the outcome. That is not a failure and it is not a success. Retrying it may charge money twice and mail a real person twice. Reporting it failed may cause someone to send again by hand.

## The quarantine state machine

```
                      record_effect_outcome (dispatching owner only)
dispatch_effect  -->  dispatched  ------------------------->  succeeded / failed
 (commits BEFORE          |
  the call)               | quarantine_effect (any owner)
                          v
                      ambiguous  ------------------------->  resolved_succeeded
                                  resolve_quarantined_        resolved_failed
                                  effect (named person)       abandoned
```

The machine outcomes (`succeeded`, `failed`) and the operator outcomes (`resolved_*`, `abandoned`) are **disjoint sets, asserted at import**. A machine observation can never be misread as a human judgement.

Ordering is the whole recovery argument: **dispatch commits before the call, outcome after.** Dead before the dispatch commit means no call was made. Dead after means it may or may not have been.

## Four independent layers stop `ambiguous` becoming a machine outcome

1. **SQL triggers.** Abort an update leaving `ambiguous` for anything but an operator outcome; abort any change to a settled outcome; abort an insert opening anywhere but `dispatched`; abort every delete. `test_raw_sql_cannot_launder_a_quarantined_effect_into_a_success` tries all four routes **including delete-then-reinsert**.
2. **A CHECK constraint.** An operator status cannot exist without a `resolved_by`. An unattributed resolution is not representable.
3. **UPDATE predicates.** `record_effect_outcome` requires `status = 'dispatched' AND dispatched_by = <this lease's owner>`. A second owner did not make the call, so it has nothing to report.
4. **The run state machine.** A quarantined run rests `interrupted`, and that transition already fails validation.

## The five cut points are real

A second Python process opens the store, registers an owner holding a real `flock`, drives the run to the named point, and blocks. The test `SIGKILL`s it and asserts a non-zero exit. The child runs no cleanup and **cannot** — the kernel releases the lock and nothing else does.

| Cut | Verdict | Test |
|---|---|---|
| mid-model | RESUME | `test_a_cut_mid_model_resumes_the_same_run` |
| mid-read-tool | RESUME | `test_a_cut_mid_read_tool_resumes_because_the_tool_is_retry_safe` |
| mid-approval | NOTHING | `test_a_cut_mid_approval_leaves_the_operator_owning_the_run` |
| mid-write | QUARANTINE | `test_a_cut_mid_write_quarantines_the_send_and_never_retries_it` |
| after generation, before delivery | DELIVER | `test_a_cut_after_terminal_generation_delivers_instead_of_regenerating` |

Two more prove the boundaries are the boundaries: the read-tool cut with `gmail_send` substituted returns REVIEW, showing the retry allowlist is what made the first safe; and a cut after allow but before dispatch resumes, because nothing left yet.

## Agreement with `permissions.RETRY_SAFE`, not duplication

`replay_class()` reads `RETRY_SAFE` and calls everything outside it consequential. It keeps no list of its own. `test_replay_class_is_derived_from_permissions_retry_safe` asserts `{n for n in AUTO|ASK if replay_class(n) is SAFE} == set(RETRY_SAFE)`, so adding a tool to one side without the other fails. An unknown tool name is consequential — fail closed.

## A live owner survives restart

`reclaim_dead_owner_leases` (#105) never takes a lease it cannot prove free; `classify_resume` treats any lease still on the row as held. `test_a_restart_never_touches_a_run_whose_owner_is_still_working_it` has a child holding both its `flock` and a dispatched send, alive: restart returns NOTHING and quarantines nothing. Non-vacuous — the same call quarantines the moment the child is killed.

## The versioning gap this closes

`SCHEMA_VERSION` moves 1 → 2. `EFFECT_SCHEMA` was measured, not assumed: seven new objects, **no `ALTER TABLE`**, nothing touching `agent_runs` or `agent_run_checkpoints`. That measurement is now an assertion — `test_the_effect_schema_only_creates_objects_that_did_not_exist` fails the moment someone adds a column to an existing table.

Investigating the bump surfaced the real problem, which was narrower and worse than the bump itself.

**`migrations.py` is the only writer of `PRAGMA user_version` in the codebase — except `agent_run_repository.py`, which stamped its own on every open.** Every other store (club.db, people.db, drive_ingestion, meeting_evidence) creates its tables in its constructor and never touches the version. The store owns its DDL; the registry owns its version. The run store broke that convention, and that is why the bump had no coverage.

It also means registering the store alone would not have been enough. If the repository keeps stamping, the registry's step never fires, Doctor always reports CURRENT, and the backup and rollback machinery never runs on a real upgrade. **That is worse than no registration, because it looks covered.**

So `_initialize_schema` now stamps only a database it creates from nothing. Creating a database at the current version is not a migration; changing an existing one's version is, and only the registry does that.

Across the whole branch, `agent_run_repository.py` has exactly two removed lines:

```
$ git diff 9fdaf19..HEAD -U0 -- desktop/coworker/agent_run_repository.py | grep -E '^-[^-]'
-SCHEMA_VERSION = 1
-            self._conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
```

The second is now guarded by `if fresh:`. This is a non-additive edit to a file otherwise held additive-only, made deliberately and reviewed rather than assumed.

**It also removes the downgrade cliff.** Merging no longer pushes every install to version 2 on next app start. An existing store still gains the fence tables on open — so a store awaiting migration is fenced rather than unprotected — but its recorded version waits for Doctor, which backs up first. A user who rolls back after merely running the app still finds a version their build can open.

### A trap that would have made the rollback fake

`sqlite3.Connection.executescript` issues a COMMIT before it runs. Measured:

```
in_transaction after executescript: False
rows surviving rollback: 1        (1 means the rollback was defeated)
```

A migration step calling `executescript` inside the transaction `_apply_store` opens would end that transaction, and the rollback would then have nothing to undo — silently, leaving the store half migrated. So the migration path uses `EFFECT_STATEMENTS`, a tuple executed one statement at a time. SQLite rolls DDL back like anything else:

```
in_transaction after individual executes: True
objects after rollback: 0
```

`test_the_fence_step_never_commits_the_transaction_it_runs_inside` pins it, and proves it is not vacuous by showing `executescript` really does commit.

### The registration

1. `AGENT_RUNS_DB_VERSION` imported from the repository — same shape as `CONVERSATION_DB_VERSION` and `PEOPLE_DB_VERSION`, so there is one source of truth.
2. A `StoreSpec` for `agent_runs.db` on `SQLITE_USER_VERSION`, carrying #111's `json_columns`.
3. An adoption `Migration` 0 → 1 — counts runs, creates nothing, because the repository already built the tables.
4. `Migration` 1 → 2 running `EFFECT_STATEMENTS`.
5. `doctor.py` drops its private spec for `spec_for("agent_runs_db")` — **which made `doctor.py` smaller**, 14 insertions against 29 deletions. The store joins the `stores` table, the integrity and JSON column checks, and the permission drift check. Duplicate checks in `_check_run_ownership` were removed as redundant.

`agent_run.version_ahead` is kept alongside the generic `store.version_ahead`. They say different things — "the registry will not migrate this" versus "Doctor is not reading the runs, so every check below is absent rather than clean" — and #111's test still passes untouched.

### Backup, failure, rollback, rerun — proven for this store

`build_legacy_state` now builds a real version 1 run store: the v1 DDL in full, two runs, four checkpoints, stamped 1, no effect table. It goes through the suite's existing machinery alongside every other store.

- `test_the_agent_run_fence_is_added_without_disturbing_a_single_run` — every run and checkpoint identical, integrity ok, exactly seven objects added, none removed.
- `test_the_agent_run_store_is_backed_up_before_its_fence_is_added` — manifest entry at version 1, and the copy contains no fence.
- `test_a_failed_fence_step_leaves_the_run_store_at_version_one` — the broken step lands the fence **and deletes a run** before raising, so the rollback has real work to undo.
- `test_starting_the_application_never_upgrades_an_existing_run_store` — two opens leave it at 1 and still PENDING; a new database is born at 2.

### Two test-infrastructure changes, flagged rather than quiet

**`build_current_state` gets an empty run store.** A populated one with a live lease broke 14 of #111's tests by shifting the baseline they measure against. An empty store is realistic for a fresh install and contributes nothing to any ownership finding, so tests that plant a stale owner measure only what they planted.

**`_tree_digest` stops hashing `-shm` and empty `-wal`.** `journal_mode=WAL` lives in the file header, so a **read-only** open recreates the sidecars:

```
after close:        ['agent_runs.db']
after read_version: ['agent_runs.db', 'agent_runs.db-shm', 'agent_runs.db-wal']
```

Hashing them turned "this changed nothing" into "nobody opened this" — a different and weaker claim. `-shm` is shared memory and never holds committed data, so it is always skipped. A `-wal` is skipped only while empty, so a write parked in an uncheckpointed WAL is still caught. This helper backs four fail-closed safety tests, so it was reviewed rather than accepted.

## Doctor still agrees

**No new checkpoint kind and no new run state.** The quarantine reuses `tool_outcome_unknown` → `interrupted` and `waiting_external`, both already in #111's transition table. An unrecognised kind makes #111 withhold a conclusion, which would have been a silent regression in its coverage.

`test_the_record_a_fenced_run_leaves_behind_passes_doctors_history_rules` replays #111's whole walk over a run driven through every new path and asserts `record["unsupported"] == ()`.

`resume_from_approval` grants the lease and unparks in a **single** UPDATE, so a run never rests parked-and-leased — the pair #111 reports as `agent_run.lease_on_unleasable_state`. `test_the_lease_and_the_unparking_commit_together` asserts one version bump and one checkpoint.

## Additive to #105, proven

```
$ git diff 9fdaf19..HEAD -U0 -- desktop/coworker/agent_run_repository.py | grep -E '^-[^-]'
-SCHEMA_VERSION = 1
```

One removed line in the entire file. `checkpoint`, `create_run`, `acquire_lease`, `renew_lease`, `release_lease`, `prune_checkpoints`, `_reconcile`, `_check_fence` are byte-identical. The compare-and-swap path and lease semantics from #105 are untouched.

## Measurements

```
baseline  9fdaf19          : 1238 passed, 3 skipped
after registry work        : 1296 passed, 3 skipped
after rebase onto d2fbc26  : 1338 passed, 3 skipped
tests/test_migrations.py + tests/test_doctor.py : 106 passed
```

Baseline measured by checking out the commit and running it, not by arithmetic. New tests confirmed red first — 18 failing on a missing `dispatch_effect` — before implementation.

Redaction: `test_planted_secrets_never_reach_the_persisted_effect_record` plants a token, an `Authorization` header, a recipient, a subject, and a body across dispatch arguments, a quarantine reason, and an operator note. Non-vacuous — it asserts the row exists with its ids and fingerprint, and that `b"gmail_send"` is really in the on-disk bytes, **before** asserting the five planted strings are absent from db, WAL, and SHM. Both credential shapes assembled at runtime.

## Where slice 5 begins

Nothing here is called by the running application. Every unwired point:

- **turn.py** — nothing calls `dispatch_effect`/`record_effect_outcome` around the real send. The ordering contract is slice 5's to honour.
- **server.py** — no startup `restart()`, no `OwnerRegistry.register()` for the sidecar.
- **store.py / inbox.py** — `resume_from_approval` is not called from the approval path. When the inbox says `interrupted` and the run store says `ambiguous`, the run store is the fence of record; nothing enforces that yet.
- **scheduler.py** — no run identity for scheduled work.
- **run_receipt.py** — `external_effect_evidence` maps to `Evidence.AMBIGUOUS`; no receipt section reads it.
- **UI** — `list_quarantined_effects` is the review queue; nothing renders it.

**A trap for slice 5, documented in `agent-runs.md`:** if a consequential tool is wired without `dispatch_effect`, a crash mid-call parks the run for a human with no effect record to settle. Safe direction, wrong ergonomics.

## Still uncertain

- **A late observation is lost.** If a lease expires, someone quarantines the send, and the original process then wakes knowing it succeeded, `record_effect_outcome` raises. Deliberate — a person may already have acted — and pinned by `test_the_dispatching_owner_waking_up_with_a_result_still_cannot_write_it`. A non-binding "the dispatcher later reported success" note belongs with the review queue in slice 5.
- `external_effect_evidence` has no production caller yet. Eight test-covered lines, kept so the `ambiguous` vocabulary is reused rather than re-coined.
- **The downgrade cliff is narrowed, not gone.** A store the registry has already moved to 2 cannot be opened by a pre-merge build. That is the fail-closed design working; it now requires a deliberate migration rather than an app start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjAD6SVox1gvF4sV3jTnJy
