### PR TITLE
feat(desktop): add a non-printing scan for a revoked secret's absence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PYTHON ?= python3
 VENV := desktop/.venv
 GUI := desktop/surfaces/gui
 
-.PHONY: setup sidecar gui native test test-python test-gui eval eval-sourcing build doctor doctor-repair build-sidecar smoke-test
+.PHONY: setup sidecar gui native test test-python test-gui eval eval-sourcing build doctor doctor-repair secret-scan build-sidecar smoke-test
 
 setup:
 	$(PYTHON) -m venv $(VENV)
@@ -37,6 +37,12 @@ doctor:
 
 doctor-repair:
 	cd desktop && .venv/bin/python -m coworker.doctor repair
+
+# Confirms a registered secret's absence from local state without ever
+# printing it. Pass KEY=<name> to scan for one value, e.g. `make secret-scan
+# KEY=apollo`; omit it to scan for every currently registered value.
+secret-scan:
+	cd desktop && .venv/bin/python -m coworker.secret_scan $(if $(KEY),--secret-key $(KEY),)
 
 build:
 	npm --prefix $(GUI) run build

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,12 @@ doctor-repair:
 	cd desktop && .venv/bin/python -m coworker.doctor repair
 
 # Confirms a registered secret's absence from local state without ever
-# printing it. Pass KEY=<name> to scan for one value, e.g. `make secret-scan
-# KEY=apollo`; omit it to scan for every currently registered value.
+# printing it. Pass KEY=<name> to scan for one value. After rotation, pass
+# REVOKED_FROM=<pre-rotation-secrets.json> so the scan searches the revoked
+# value rather than the replacement now in the live vault, e.g.
+# `make secret-scan KEY=apollo REVOKED_FROM=./pre-rotation-secrets.json`.
 secret-scan:
-	cd desktop && .venv/bin/python -m coworker.secret_scan $(if $(KEY),--secret-key $(KEY),)
+	cd desktop && .venv/bin/python -m coworker.secret_scan $(if $(KEY),--secret-key $(KEY),) $(if $(REVOKED_FROM),--revoked-from $(REVOKED_FROM),)
 
 build:
 	npm --prefix $(GUI) run build

--- a/desktop/coworker/secret_scan.py
+++ b/desktop/coworker/secret_scan.py
@@ -21,6 +21,19 @@ the *current* credential, and `secrets.json`'s own registry entry says it is
 "Never read into a report". This scan reads it once, to learn the value to
 search for, and never opens it as a target.
 
+Doctor's own backups are scanned too. `<state>/backups/<id>/` holds a copy of
+whatever a repair touched, taken *before* the change, so a backup made before
+a credential was rotated still carries the old value -- a store that reads
+clean today can still have a pre-remediation copy sitting a few directories
+over. Each backup finding is reported under its own id
+(`backup:<backup_id>:<store_id>`), never folded into the live store's
+finding, because "the live store is clean but a backup is not" calls for a
+different action than "the live store still has it". The vault exclusion is
+re-checked independently for backup content: Doctor's backup writer never
+copies a secret-bearing store to begin with, but this does not trust that --
+it skips any `secret_bearing` store id by its own registry lookup, regardless
+of what a backup's manifest claims was copied.
+
 Output discipline matches `coworker/doctor.py`: bounded, and never the
 matched value. A finding names a store id, a record or file identity -- a
 table and rowid, a transcript file and line number, a JSON document's path --
@@ -70,6 +83,7 @@ class ScanReport:
     secret_key: str | None
     needle_count: int
     stores_scanned: tuple[str, ...]
+    backups_scanned: tuple[str, ...]
     findings: tuple[StoreFinding, ...]
     unreadable: tuple[str, ...] = ()
 
@@ -84,6 +98,7 @@ class ScanReport:
             "secret_key": self.secret_key,
             "values_searched": self.needle_count,
             "stores_scanned": list(self.stores_scanned),
+            "backups_scanned": list(self.backups_scanned),
             "clean": self.clean,
             "findings": [item.to_dict() for item in self.findings],
             "unreadable": list(self.unreadable),
@@ -145,9 +160,9 @@ def _matched(
     return any(match.category == "registered_secret" for match in matches)
 
 
-def _scan_sqlite(spec: migrations.StoreSpec, root: Path, needles: frozenset[str], home: Path) -> list[str]:
+def _scan_sqlite(path: Path, root: Path, needles: frozenset[str], home: Path) -> list[str]:
     identities: list[str] = []
-    conn = open_readonly(store_path(root, spec))
+    conn = open_readonly(path)
     try:
         for table in sorted(migrations.table_names(conn)):
             try:
@@ -181,21 +196,8 @@ def _scan_jsonl_file(path: Path, root: Path, needles: frozenset[str], home: Path
     return identities
 
 
-def _scan_jsonl_store(spec: migrations.StoreSpec, root: Path, needles: frozenset[str], home: Path) -> list[str]:
-    if spec.kind is StoreKind.JSONL_DIR:
-        files = sorted(store_path(root, spec).glob("*.jsonl"))
-    else:
-        path = store_path(root, spec)
-        files = [path] if path.is_file() else []
-    identities: list[str] = []
-    for path in files:
-        identities.extend(_scan_jsonl_file(path, root, needles, home))
-    return identities
-
-
-def _scan_one_file(spec: migrations.StoreSpec, root: Path, needles: frozenset[str], home: Path) -> list[str]:
+def _scan_one_file(path: Path, root: Path, needles: frozenset[str], home: Path) -> list[str]:
     """A JSON document or an opaque file that is not secret-bearing: one blob of text."""
-    path = store_path(root, spec)
     text = path.read_text(encoding="utf-8", errors="replace")
     relative = _relative(path, root)
     if _matched(text, needles, home=home, root=root, location=relative):
@@ -203,32 +205,94 @@ def _scan_one_file(spec: migrations.StoreSpec, root: Path, needles: frozenset[st
     return []
 
 
-def _scan_directory(spec: migrations.StoreSpec, root: Path, needles: frozenset[str], home: Path) -> list[str]:
+def _scan_directory(path: Path, root: Path, needles: frozenset[str], home: Path) -> list[str]:
     identities: list[str] = []
-    for path in sorted(store_path(root, spec).rglob("*")):
-        if not path.is_file():
+    for file in sorted(path.rglob("*")):
+        if not file.is_file():
             continue
-        text = path.read_text(encoding="utf-8", errors="replace")
-        relative = _relative(path, root)
+        text = file.read_text(encoding="utf-8", errors="replace")
+        relative = _relative(file, root)
         if _matched(text, needles, home=home, root=root, location=relative):
             identities.append(relative)
     return identities
 
 
-def _scan_store(spec: migrations.StoreSpec, root: Path, needles: frozenset[str], home: Path) -> list[str] | None:
-    """None means the store could not be read; distinct from a clean empty list."""
+def _scan_path(
+    kind: StoreKind, path: Path, root: Path, needles: frozenset[str], home: Path
+) -> list[str] | None:
+    """Dispatch by kind only. Works the same for a live store or a backup copy
+    of one, since a backup is a byte-for-byte copy in the same layout.
+
+    None means the path could not be read; distinct from a clean empty list.
+    """
     try:
-        if spec.kind is StoreKind.SQLITE:
-            return _scan_sqlite(spec, root, needles, home)
-        if spec.kind in (StoreKind.JSONL_DIR, StoreKind.JSONL_LOG):
-            return _scan_jsonl_store(spec, root, needles, home)
-        if spec.kind in (StoreKind.JSON_DOCUMENT, StoreKind.OPAQUE_FILE):
-            return _scan_one_file(spec, root, needles, home)
-        if spec.kind is StoreKind.DIRECTORY:
-            return _scan_directory(spec, root, needles, home)
+        if kind is StoreKind.SQLITE:
+            return _scan_sqlite(path, root, needles, home)
+        if kind is StoreKind.JSONL_DIR:
+            identities: list[str] = []
+            for file in sorted(path.glob("*.jsonl")):
+                identities.extend(_scan_jsonl_file(file, root, needles, home))
+            return identities
+        if kind is StoreKind.JSONL_LOG:
+            return _scan_jsonl_file(path, root, needles, home) if path.is_file() else []
+        if kind in (StoreKind.JSON_DOCUMENT, StoreKind.OPAQUE_FILE):
+            return _scan_one_file(path, root, needles, home)
+        if kind is StoreKind.DIRECTORY:
+            return _scan_directory(path, root, needles, home)
     except (OSError, sqlite3.Error, UnicodeError):
         return None
     return []  # pragma: no cover - every current StoreKind is handled above
+
+
+def _scan_store(spec: migrations.StoreSpec, root: Path, needles: frozenset[str], home: Path) -> list[str] | None:
+    return _scan_path(spec.kind, store_path(root, spec), root, needles, home)
+
+
+# --- backup scanning ---------------------------------------------------------
+
+
+def _scan_backups(
+    root: Path, needles: frozenset[str], home: Path
+) -> tuple[list[StoreFinding], list[str], list[str]]:
+    """Scan every store a Doctor backup actually copied.
+
+    A backup is taken *before* a repair changes a store, so a backup made
+    before a credential was rotated can still hold the old value even once
+    every live store is clean. `migrations.list_backups` is the same reader
+    Doctor's own `backups` command uses, so this sees exactly what an
+    operator would see listed.
+
+    The vault exclusion is re-checked here independently of the backup
+    writer: Doctor never copies a `secret_bearing` store's content and always
+    records `content_backed_up: false` for it, but this does not trust a
+    manifest's word for that -- it looks the store id up in the registry and
+    skips it if `secret_bearing` is set, regardless of what the manifest claims.
+    """
+    findings: list[StoreFinding] = []
+    backups_scanned: list[str] = []
+    unreadable: list[str] = []
+    for manifest in migrations.list_backups(root):
+        backup_id = str(manifest.get("backup_id") or "")
+        if not backup_id:
+            continue
+        backup_dir = root / migrations.BACKUPS_DIR_NAME / backup_id
+        backups_scanned.append(backup_id)
+        for entry in manifest.get("entries") or []:
+            if not entry.get("content_backed_up"):
+                continue
+            try:
+                spec = migrations.spec_for(str(entry.get("store_id")))
+            except KeyError:
+                continue
+            if spec.secret_bearing or not store_present(backup_dir, spec):
+                continue
+            label = f"backup:{backup_id}:{spec.store_id}"
+            identities = _scan_path(spec.kind, store_path(backup_dir, spec), root, needles, home)
+            if identities is None:
+                unreadable.append(label)
+            elif identities:
+                findings.append(StoreFinding(label, len(identities), _bounded(identities)))
+    return findings, backups_scanned, unreadable
 
 
 # --- the scan ---------------------------------------------------------------
@@ -269,11 +333,16 @@ def scan_state(
         elif identities:
             findings.append(StoreFinding(spec.store_id, len(identities), _bounded(identities)))
 
+    backup_findings, backups_scanned, backup_unreadable = _scan_backups(root, needles, home)
+    findings.extend(backup_findings)
+    unreadable.extend(backup_unreadable)
+
     return ScanReport(
         generated_at=datetime.now(UTC).isoformat(),
         secret_key=secret_key,
         needle_count=len(needles),
         stores_scanned=tuple(stores_scanned),
+        backups_scanned=tuple(backups_scanned),
         findings=tuple(findings),
         unreadable=tuple(unreadable),
     )
@@ -287,6 +356,7 @@ def _render(report: ScanReport) -> str:
     lines.append(f"secret key       {report.secret_key or '(all registered)'}")
     lines.append(f"values searched  {report.needle_count}")
     lines.append(f"stores scanned   {len(report.stores_scanned)}")
+    lines.append(f"backups scanned  {len(report.backups_scanned)}")
     if report.unreadable:
         lines.append(f"unreadable       {', '.join(report.unreadable)}")
     lines.append("")

--- a/desktop/coworker/secret_scan.py
+++ b/desktop/coworker/secret_scan.py
@@ -1,0 +1,345 @@
+"""Non-printing scan for a registered secret's absence from Sourcecado's local state.
+
+Built for GitHub issue #38: after a credential is revoked, this answers one
+question without ever risking the credential itself -- does the value still
+appear anywhere in the conversations, transcripts, events, and logs this
+machine keeps? It does not inspect the vault the credential came from; it
+looks everywhere else a copy-paste, a chat message, a logged error, or a
+pasted command summary could have carried it.
+
+Reuse, not reinvention. Matching runs on `coworker.bundle_redaction.scan_text`,
+the same matcher the diagnostic bundle export already refuses on. A second
+matcher would drift from the first, and the one that drifts is the one that
+misses a leak.
+
+Every durable store this build knows about comes from
+`coworker.migrations.REGISTRY`, so a store added later is scanned the next
+time this runs without anyone updating a hand-written list here. The vault
+stores -- `secrets`, `mcp_config`, `dotenv` -- are skipped on purpose:
+`coworker/migrations.py` marks each one `secret_bearing`, they exist to hold
+the *current* credential, and `secrets.json`'s own registry entry says it is
+"Never read into a report". This scan reads it once, to learn the value to
+search for, and never opens it as a target.
+
+Output discipline matches `coworker/doctor.py`: bounded, and never the
+matched value. A finding names a store id, a record or file identity -- a
+table and rowid, a transcript file and line number, a JSON document's path --
+and a count. Never the text that matched, never a window of characters
+around it, and never the search term itself.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from coworker import migrations
+from coworker.bundle_redaction import registered_secret_values, scan_text
+from coworker.migrations import StoreKind, open_readonly, state_root, store_path, store_present
+
+STATE_LABEL = "<state>"
+MAX_DETAIL_ROWS = 8
+MAX_REPORT_CHARS = 16000
+
+
+class NoRegisteredSecret(Exception):
+    """Nothing was found to search for. Never a reason to report 'clean'."""
+
+
+@dataclass(frozen=True)
+class StoreFinding:
+    """One store where the value showed up. Never the value; never a snippet."""
+
+    store_id: str
+    count: int
+    detail: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"store_id": self.store_id, "count": self.count, "detail": list(self.detail)}
+
+
+@dataclass(frozen=True)
+class ScanReport:
+    generated_at: str
+    secret_key: str | None
+    needle_count: int
+    stores_scanned: tuple[str, ...]
+    findings: tuple[StoreFinding, ...]
+    unreadable: tuple[str, ...] = ()
+
+    @property
+    def clean(self) -> bool:
+        return not self.findings
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "generated_at": self.generated_at,
+            "state_root": STATE_LABEL,
+            "secret_key": self.secret_key,
+            "values_searched": self.needle_count,
+            "stores_scanned": list(self.stores_scanned),
+            "clean": self.clean,
+            "findings": [item.to_dict() for item in self.findings],
+            "unreadable": list(self.unreadable),
+        }
+
+    def render(self) -> str:
+        return _render(self)
+
+
+# --- reading the registered-secret store ----------------------------------
+
+
+def _load_needles(root: Path, secret_key: str | None) -> frozenset[str]:
+    """Every value worth searching for, read straight from the vault.
+
+    An owner names a key, such as `apollo`, never the value itself -- so the
+    value is never typed into a shell, never lands in a history file, and
+    never has to be pasted into a ticket. Omitting the key searches for every
+    value the vault currently holds.
+    """
+    spec = migrations.spec_for("secrets")
+    if not store_present(root, spec):
+        return frozenset()
+    try:
+        payload = json.loads(store_path(root, spec).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return frozenset()
+    if not isinstance(payload, dict):
+        return frozenset()
+    if secret_key is not None:
+        if secret_key not in payload:
+            return frozenset()
+        payload = {secret_key: payload[secret_key]}
+    return registered_secret_values(payload)
+
+
+# --- per-store scanning ----------------------------------------------------
+
+
+def _bounded(identities: list[str]) -> tuple[str, ...]:
+    if len(identities) <= MAX_DETAIL_ROWS:
+        return tuple(identities)
+    kept = identities[: MAX_DETAIL_ROWS - 1]
+    kept.append(f"and {len(identities) - (MAX_DETAIL_ROWS - 1)} more")
+    return tuple(kept)
+
+
+def _relative(path: Path, root: Path) -> str:
+    try:
+        return f"{STATE_LABEL}/{path.relative_to(root)}"
+    except ValueError:
+        return STATE_LABEL
+
+
+def _matched(
+    text: str, needles: frozenset[str], *, home: Path, root: Path, location: str
+) -> bool:
+    matches = scan_text(text, registered=needles, home=home, state_root=root, location=location)
+    return any(match.category == "registered_secret" for match in matches)
+
+
+def _scan_sqlite(spec: migrations.StoreSpec, root: Path, needles: frozenset[str], home: Path) -> list[str]:
+    identities: list[str] = []
+    conn = open_readonly(store_path(root, spec))
+    try:
+        for table in sorted(migrations.table_names(conn)):
+            try:
+                rows = conn.execute(f'SELECT rowid AS "_rowid", * FROM "{table}"')
+            except sqlite3.DatabaseError:
+                continue
+            for row in rows:
+                for key in row.keys():
+                    if key == "_rowid":
+                        continue
+                    value = row[key]
+                    if value is None:
+                        continue
+                    location = f"{table}.{key}"
+                    if _matched(str(value), needles, home=home, root=root, location=location):
+                        identities.append(f"{table}.{key} rowid {row['_rowid']}")
+    finally:
+        conn.close()
+    return identities
+
+
+def _scan_jsonl_file(path: Path, root: Path, needles: frozenset[str], home: Path) -> list[str]:
+    identities: list[str] = []
+    text = path.read_text(encoding="utf-8", errors="replace")
+    relative = _relative(path, root)
+    for number, line in enumerate(text.splitlines(), start=1):
+        if not line.strip():
+            continue
+        if _matched(line, needles, home=home, root=root, location=f"{relative}:{number}"):
+            identities.append(f"{relative} line {number}")
+    return identities
+
+
+def _scan_jsonl_store(spec: migrations.StoreSpec, root: Path, needles: frozenset[str], home: Path) -> list[str]:
+    if spec.kind is StoreKind.JSONL_DIR:
+        files = sorted(store_path(root, spec).glob("*.jsonl"))
+    else:
+        path = store_path(root, spec)
+        files = [path] if path.is_file() else []
+    identities: list[str] = []
+    for path in files:
+        identities.extend(_scan_jsonl_file(path, root, needles, home))
+    return identities
+
+
+def _scan_one_file(spec: migrations.StoreSpec, root: Path, needles: frozenset[str], home: Path) -> list[str]:
+    """A JSON document or an opaque file that is not secret-bearing: one blob of text."""
+    path = store_path(root, spec)
+    text = path.read_text(encoding="utf-8", errors="replace")
+    relative = _relative(path, root)
+    if _matched(text, needles, home=home, root=root, location=relative):
+        return [relative]
+    return []
+
+
+def _scan_directory(spec: migrations.StoreSpec, root: Path, needles: frozenset[str], home: Path) -> list[str]:
+    identities: list[str] = []
+    for path in sorted(store_path(root, spec).rglob("*")):
+        if not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        relative = _relative(path, root)
+        if _matched(text, needles, home=home, root=root, location=relative):
+            identities.append(relative)
+    return identities
+
+
+def _scan_store(spec: migrations.StoreSpec, root: Path, needles: frozenset[str], home: Path) -> list[str] | None:
+    """None means the store could not be read; distinct from a clean empty list."""
+    try:
+        if spec.kind is StoreKind.SQLITE:
+            return _scan_sqlite(spec, root, needles, home)
+        if spec.kind in (StoreKind.JSONL_DIR, StoreKind.JSONL_LOG):
+            return _scan_jsonl_store(spec, root, needles, home)
+        if spec.kind in (StoreKind.JSON_DOCUMENT, StoreKind.OPAQUE_FILE):
+            return _scan_one_file(spec, root, needles, home)
+        if spec.kind is StoreKind.DIRECTORY:
+            return _scan_directory(spec, root, needles, home)
+    except (OSError, sqlite3.Error, UnicodeError):
+        return None
+    return []  # pragma: no cover - every current StoreKind is handled above
+
+
+# --- the scan ---------------------------------------------------------------
+
+
+def scan_state(
+    root: str | Path,
+    *,
+    secret_key: str | None = None,
+    home: Path | None = None,
+) -> ScanReport:
+    """Scan every durable, non-vault store for a registered secret's value.
+
+    Raises `NoRegisteredSecret` when there is nothing to search for -- an
+    unknown key, or an empty vault -- so a scan can never report "clean" for
+    a search it never actually ran.
+    """
+    root = Path(root).expanduser()
+    home = home if home is not None else Path.home()
+    needles = _load_needles(root, secret_key)
+    if not needles:
+        raise NoRegisteredSecret(
+            f"no registered secret found under key {secret_key!r}"
+            if secret_key is not None
+            else "no registered secret values found to search for"
+        )
+
+    stores_scanned: list[str] = []
+    findings: list[StoreFinding] = []
+    unreadable: list[str] = []
+    for spec in migrations.REGISTRY:
+        if spec.secret_bearing or not store_present(root, spec):
+            continue
+        stores_scanned.append(spec.store_id)
+        identities = _scan_store(spec, root, needles, home)
+        if identities is None:
+            unreadable.append(spec.store_id)
+        elif identities:
+            findings.append(StoreFinding(spec.store_id, len(identities), _bounded(identities)))
+
+    return ScanReport(
+        generated_at=datetime.now(UTC).isoformat(),
+        secret_key=secret_key,
+        needle_count=len(needles),
+        stores_scanned=tuple(stores_scanned),
+        findings=tuple(findings),
+        unreadable=tuple(unreadable),
+    )
+
+
+# --- rendering ---------------------------------------------------------------
+
+
+def _render(report: ScanReport) -> str:
+    lines = ["Sourcecado secret scan", f"state directory {STATE_LABEL}", ""]
+    lines.append(f"secret key       {report.secret_key or '(all registered)'}")
+    lines.append(f"values searched  {report.needle_count}")
+    lines.append(f"stores scanned   {len(report.stores_scanned)}")
+    if report.unreadable:
+        lines.append(f"unreadable       {', '.join(report.unreadable)}")
+    lines.append("")
+    if report.clean:
+        lines.append("result           clean -- no match found")
+    else:
+        lines.append("result           MATCH FOUND -- value present in current state")
+        for item in report.findings:
+            lines.append(f"  {item.store_id:<24} {item.count} match(es)")
+            for entry in item.detail:
+                lines.append(f"      - {entry}")
+    rendered = "\n".join(lines) + "\n"
+    if len(rendered) > MAX_REPORT_CHARS:
+        rendered = rendered[: MAX_REPORT_CHARS - 32].rstrip() + "\n... output truncated\n"
+    return rendered
+
+
+# --- command line -------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m coworker.secret_scan",
+        description=(
+            "Confirm a registered secret's absence from Sourcecado's local "
+            "conversations, transcripts, events, and logs. Never prints the "
+            "value; reports store, location, and count only."
+        ),
+    )
+    parser.add_argument(
+        "--secret-key",
+        help="key in the registered-secret store to search for, e.g. apollo; "
+        "omit to search for every registered value",
+    )
+    parser.add_argument("--state", help="state directory (defaults to CLUB_STATE_DIR)")
+    parser.add_argument("--json", action="store_true", help="emit the report as JSON")
+    args = parser.parse_args(argv)
+    root = Path(args.state).expanduser() if args.state else state_root()
+
+    try:
+        report = scan_state(root, secret_key=args.secret_key)
+    except NoRegisteredSecret as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    except Exception:
+        # A scan that crashes must not let a traceback carry a fragment of
+        # what it was looking for. Diagnosing the cause is not this tool's job.
+        print("secret scan failed; nothing was reported", file=sys.stderr)
+        return 2
+
+    print(json.dumps(report.to_dict(), indent=2) if args.json else report.render(), end="")
+    return 0 if report.clean else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/desktop/coworker/secret_scan.py
+++ b/desktop/coworker/secret_scan.py
@@ -18,8 +18,10 @@ time this runs without anyone updating a hand-written list here. The vault
 stores -- `secrets`, `mcp_config`, `dotenv` -- are skipped on purpose:
 `coworker/migrations.py` marks each one `secret_bearing`, they exist to hold
 the *current* credential, and `secrets.json`'s own registry entry says it is
-"Never read into a report". This scan reads it once, to learn the value to
-search for, and never opens it as a target.
+"Never read into a report". After rotation that current value is the
+replacement, so a post-rotation scan reads a pre-rotation snapshot
+(`revoked_from` / `--revoked-from`) to learn the revoked value, and never
+opens the vault as a target.
 
 Doctor's own backups are scanned too. `<state>/backups/<id>/` holds a copy of
 whatever a repair touched, taken *before* the change, so a backup made before
@@ -111,19 +113,30 @@ class ScanReport:
 # --- reading the registered-secret store ----------------------------------
 
 
-def _load_needles(root: Path, secret_key: str | None) -> frozenset[str]:
-    """Every value worth searching for, read straight from the vault.
+def _load_needles(
+    root: Path, secret_key: str | None, revoked_from: Path | None = None
+) -> frozenset[str]:
+    """Every value worth searching for, read from a vault-shaped JSON file.
 
     An owner names a key, such as `apollo`, never the value itself -- so the
     value is never typed into a shell, never lands in a history file, and
     never has to be pasted into a ticket. Omitting the key searches for every
-    value the vault currently holds.
+    value the file currently holds.
+
+    After rotation the live vault holds the replacement. Passing `revoked_from`
+    reads a pre-rotation snapshot instead, so the scan searches the revoked
+    value rather than the new one. The live vault is not a fallback: if the
+    snapshot is missing or has no matching key, there is nothing to search.
     """
-    spec = migrations.spec_for("secrets")
-    if not store_present(root, spec):
-        return frozenset()
+    if revoked_from is not None:
+        path = Path(revoked_from).expanduser()
+    else:
+        spec = migrations.spec_for("secrets")
+        if not store_present(root, spec):
+            return frozenset()
+        path = store_path(root, spec)
     try:
-        payload = json.loads(store_path(root, spec).read_text(encoding="utf-8"))
+        payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return frozenset()
     if not isinstance(payload, dict):
@@ -303,16 +316,23 @@ def scan_state(
     *,
     secret_key: str | None = None,
     home: Path | None = None,
+    revoked_from: str | Path | None = None,
 ) -> ScanReport:
     """Scan every durable, non-vault store for a registered secret's value.
 
     Raises `NoRegisteredSecret` when there is nothing to search for -- an
     unknown key, or an empty vault -- so a scan can never report "clean" for
     a search it never actually ran.
+
+    `revoked_from` is a vault-shaped JSON snapshot taken before rotation. When
+    it is set, needles come from that file, not from the live vault, because
+    the live vault holds the replacement and searching it cannot answer
+    whether the revoked value is gone.
     """
     root = Path(root).expanduser()
     home = home if home is not None else Path.home()
-    needles = _load_needles(root, secret_key)
+    snapshot = Path(revoked_from).expanduser() if revoked_from is not None else None
+    needles = _load_needles(root, secret_key, snapshot)
     if not needles:
         raise NoRegisteredSecret(
             f"no registered secret found under key {secret_key!r}"
@@ -391,13 +411,21 @@ def main(argv: list[str] | None = None) -> int:
         help="key in the registered-secret store to search for, e.g. apollo; "
         "omit to search for every registered value",
     )
+    parser.add_argument(
+        "--revoked-from",
+        help="vault-shaped JSON snapshot taken before rotation; after "
+        "rotation, pass this so the scan searches the revoked value rather "
+        "than the replacement now in the live vault",
+    )
     parser.add_argument("--state", help="state directory (defaults to CLUB_STATE_DIR)")
     parser.add_argument("--json", action="store_true", help="emit the report as JSON")
     args = parser.parse_args(argv)
     root = Path(args.state).expanduser() if args.state else state_root()
 
     try:
-        report = scan_state(root, secret_key=args.secret_key)
+        report = scan_state(
+            root, secret_key=args.secret_key, revoked_from=args.revoked_from
+        )
     except NoRegisteredSecret as exc:
         print(str(exc), file=sys.stderr)
         return 2

--- a/desktop/coworker/secret_scan.py
+++ b/desktop/coworker/secret_scan.py
@@ -36,6 +36,12 @@ copies a secret-bearing store to begin with, but this does not trust that --
 it skips any `secret_bearing` store id by its own registry lookup, regardless
 of what a backup's manifest claims was copied.
 
+An incomplete scan is never clean. Path.glob and Path.rglob return [] on an
+unlistable directory without raising, so this lists the directory first and
+records the store as unreadable when that fails. A truncated SQLite file that
+cannot be walked is unreadable too. Clean is reserved for a complete read
+with no match; that result feeds the remediation receipt.
+
 Output discipline matches `coworker/doctor.py`: bounded, and never the
 matched value. A finding names a store id, a record or file identity -- a
 table and rowid, a transcript file and line number, a JSON document's path --
@@ -47,6 +53,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sqlite3
 import sys
 from dataclasses import dataclass
@@ -91,7 +98,8 @@ class ScanReport:
 
     @property
     def clean(self) -> bool:
-        return not self.findings
+        # Unreadable stores are not a proof of absence.
+        return not self.findings and not self.unreadable
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -197,6 +205,21 @@ def _scan_sqlite(path: Path, root: Path, needles: frozenset[str], home: Path) ->
     return identities
 
 
+def _list_store_files(path: Path, pattern: str | None = None) -> list[Path] | None:
+    """List files in a store directory, or None if the directory cannot be listed.
+
+    Path.glob and Path.rglob return [] on an unlistable directory without
+    raising, which would look like a successful empty scan.
+    """
+    try:
+        os.listdir(path)
+    except OSError:
+        return None
+    if pattern is None:
+        return sorted(file for file in path.rglob("*") if file.is_file())
+    return sorted(path.glob(pattern))
+
+
 def _scan_jsonl_file(path: Path, root: Path, needles: frozenset[str], home: Path) -> list[str]:
     identities: list[str] = []
     text = path.read_text(encoding="utf-8", errors="replace")
@@ -218,11 +241,12 @@ def _scan_one_file(path: Path, root: Path, needles: frozenset[str], home: Path) 
     return []
 
 
-def _scan_directory(path: Path, root: Path, needles: frozenset[str], home: Path) -> list[str]:
+def _scan_directory(path: Path, root: Path, needles: frozenset[str], home: Path) -> list[str] | None:
+    files = _list_store_files(path)
+    if files is None:
+        return None
     identities: list[str] = []
-    for file in sorted(path.rglob("*")):
-        if not file.is_file():
-            continue
+    for file in files:
         text = file.read_text(encoding="utf-8", errors="replace")
         relative = _relative(file, root)
         if _matched(text, needles, home=home, root=root, location=relative):
@@ -242,8 +266,11 @@ def _scan_path(
         if kind is StoreKind.SQLITE:
             return _scan_sqlite(path, root, needles, home)
         if kind is StoreKind.JSONL_DIR:
+            files = _list_store_files(path, "*.jsonl")
+            if files is None:
+                return None
             identities: list[str] = []
-            for file in sorted(path.glob("*.jsonl")):
+            for file in files:
                 identities.extend(_scan_jsonl_file(file, root, needles, home))
             return identities
         if kind is StoreKind.JSONL_LOG:
@@ -380,14 +407,16 @@ def _render(report: ScanReport) -> str:
     if report.unreadable:
         lines.append(f"unreadable       {', '.join(report.unreadable)}")
     lines.append("")
-    if report.clean:
-        lines.append("result           clean -- no match found")
-    else:
+    if report.findings:
         lines.append("result           MATCH FOUND -- value present in current state")
         for item in report.findings:
             lines.append(f"  {item.store_id:<24} {item.count} match(es)")
             for entry in item.detail:
                 lines.append(f"      - {entry}")
+    elif report.unreadable:
+        lines.append("result           incomplete -- some stores could not be read")
+    else:
+        lines.append("result           clean -- no match found")
     rendered = "\n".join(lines) + "\n"
     if len(rendered) > MAX_REPORT_CHARS:
         rendered = rendered[: MAX_REPORT_CHARS - 32].rstrip() + "\n... output truncated\n"
@@ -436,7 +465,11 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     print(json.dumps(report.to_dict(), indent=2) if args.json else report.render(), end="")
-    return 0 if report.clean else 1
+    if report.findings:
+        return 1
+    if report.unreadable:
+        return 2
+    return 0
 
 
 if __name__ == "__main__":

--- a/desktop/docs/secret-scan.md
+++ b/desktop/docs/secret-scan.md
@@ -62,6 +62,24 @@ next time this runs:
 | JSON document | The file's raw text. |
 | Directory | The raw text of every file inside it. |
 
+**Every Doctor backup is scanned too**, not just the live stores.
+`<state>/backups/<id>/` holds a copy of whatever a repair touched, taken
+*before* the change, so a backup made before a credential was rotated can
+still hold the old value even once every live store reads clean. The scan
+reads `<state>/backups/`'s manifests the same way `doctor backups` does and
+scans whatever each one actually copied. A backup match is reported under its
+own id, `backup:<backup_id>:<store_id>`, never folded into the live store's
+finding -- "the live store is clean but a backup is not" needs a different
+fix (delete or replace the backup) than "the live store still has it" does.
+The vault exclusion applies here too, checked independently of what a backup's
+manifest claims: Doctor never copies a `secret_bearing` store into a backup in
+the first place, and this scan skips one by its own registry lookup even if a
+manifest said otherwise.
+
+**Not scanned:** the vault stores above (live or inside a backup), and
+`agent_runs.db`, which is not yet in `migrations.REGISTRY` -- it will be
+picked up automatically, with no code change here, once it is registered.
+
 ## Bounded and never the value
 
 A finding names a store id, a record or file identity -- a table and rowid, a

--- a/desktop/docs/secret-scan.md
+++ b/desktop/docs/secret-scan.md
@@ -1,0 +1,91 @@
+# Secret absence scan
+
+Confirms a registered secret's value is absent from Sourcecado's local
+conversations, transcripts, events, and logs. It never prints the value it is
+looking for and never prints a value it finds.
+
+This is one piece of the response to a revoked credential (GitHub issue #38):
+after a credential has been rotated in the vault, this answers "does the old
+value still show up anywhere else on this machine?" without ever putting that
+value in a shell, a history file, or a ticket.
+
+## Running it
+
+```
+make secret-scan                # scan for every value currently registered
+make secret-scan KEY=apollo     # scan for one registered value by key
+```
+
+Or directly:
+
+```
+cd desktop
+.venv/bin/python -m coworker.secret_scan
+.venv/bin/python -m coworker.secret_scan --secret-key apollo
+.venv/bin/python -m coworker.secret_scan --secret-key apollo --json
+.venv/bin/python -m coworker.secret_scan --state /path/to/state
+```
+
+The key is the name a credential is registered under in the secret store
+(`apollo`, `google`, and so on) -- not the credential itself. Typing the key
+is safe; the value it points at is read from `secrets.json` and never leaves
+this process as text.
+
+Exit codes:
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Clean. The value was searched for and not found. |
+| 1 | Found. The value is present in at least one store. |
+| 2 | Nothing to search for -- an unknown key, an empty vault, or a scan that failed before it could run. |
+
+Code 2 is deliberate, not an afterthought: a scan that found nothing to search
+for and reported "clean" anyway would be worse than no scan at all.
+
+## What it scans
+
+Every store in `coworker/migrations.py`'s registry that is present on disk,
+except the three marked `secret_bearing` -- `secrets` (`secrets.json`),
+`mcp_config` (`mcp.json`), and `dotenv` (`.env`). Those are the vault: they
+exist to hold the *current* credential, `secrets.json`'s own registry entry
+says it must never be read into a report, and scanning them for an old value
+answers a different question (did rotation take) than the one this tool
+answers (did the value leak somewhere else).
+
+A store added to the registry later is picked up automatically, by kind, the
+next time this runs:
+
+| Kind | How it is read |
+| --- | --- |
+| SQLite | Every table, every column, every row, through a read-only handle. |
+| JSONL directory / log | Every line of every file. |
+| JSON document | The file's raw text. |
+| Directory | The raw text of every file inside it. |
+
+## Bounded and never the value
+
+A finding names a store id, a record or file identity -- a table and rowid, a
+transcript file and line number, a JSON document's path -- and a count. It
+never names the text that matched, never a window of characters around it,
+and never the search term itself. The value is never assembled into any
+finding, so there is no redaction filter standing between a mistake and a
+leak: the object that gets printed or serialized to JSON never held the value
+to begin with.
+
+Each store's detail list is capped at 8 identities. A store with ten thousand
+matches reports a count of ten thousand and seven example locations plus an
+`and N more` line, not ten thousand lines.
+
+`desktop/tests/test_secret_scan.py` plants a distinctive value, proves the
+scan reports a match for the store carrying it, and only then asserts the
+value is absent from the rendered report, the JSON report, and the CLI's
+stdout and stderr.
+
+## What this does not do
+
+It does not touch Google Drive, does not inspect revision history, and does
+not decide whether a rotation succeeded. It reads one local JSON file to learn
+what to search for and reads local state to search. Closing out issue #38
+still needs a human to review Drive's revision-retention controls, purge or
+replace the exposed revision, and record the accepted residual risk -- this
+tool only answers the one question stated above.

--- a/desktop/docs/secret-scan.md
+++ b/desktop/docs/secret-scan.md
@@ -44,12 +44,13 @@ Exit codes:
 
 | Code | Meaning |
 | --- | --- |
-| 0 | Clean. The value was searched for and not found. |
+| 0 | Clean. Every targeted store was read and the value was not found. |
 | 1 | Found. The value is present in at least one store. |
-| 2 | Nothing to search for -- an unknown key, an empty vault, or a scan that failed before it could run. |
+| 2 | Incomplete or nothing to search for -- an unreadable live store or backup copy, an unknown key, an empty vault, or a scan that failed before it could run. |
 
-Code 2 is deliberate, not an afterthought: a scan that found nothing to search
-for and reported "clean" anyway would be worse than no scan at all.
+Code 2 is deliberate: a scan that could not finish, or that found nothing to
+search for, must not report "clean". Doctor treats unreadable as no answer,
+not as absence. A clean result feeds the remediation receipt.
 
 ## What it scans
 

--- a/desktop/docs/secret-scan.md
+++ b/desktop/docs/secret-scan.md
@@ -13,7 +13,8 @@ value in a shell, a history file, or a ticket.
 
 ```
 make secret-scan                # scan for every value currently registered
-make secret-scan KEY=apollo     # scan for one registered value by key
+make secret-scan KEY=apollo     # scan the live vault value for one key
+make secret-scan KEY=apollo REVOKED_FROM=./pre-rotation-secrets.json
 ```
 
 Or directly:
@@ -22,14 +23,22 @@ Or directly:
 cd desktop
 .venv/bin/python -m coworker.secret_scan
 .venv/bin/python -m coworker.secret_scan --secret-key apollo
+.venv/bin/python -m coworker.secret_scan --secret-key apollo --revoked-from ./pre-rotation-secrets.json
 .venv/bin/python -m coworker.secret_scan --secret-key apollo --json
 .venv/bin/python -m coworker.secret_scan --state /path/to/state
 ```
 
 The key is the name a credential is registered under in the secret store
 (`apollo`, `google`, and so on) -- not the credential itself. Typing the key
-is safe; the value it points at is read from `secrets.json` and never leaves
-this process as text.
+is safe.
+
+After rotation the live vault holds the replacement. `KEY=apollo` alone would
+search that replacement and can report clean while conversations and events
+still hold the revoked value. Copy `secrets.json` to a mode-0600 snapshot
+*before* writing the replacement, then pass that snapshot as `REVOKED_FROM`
+(or `--revoked-from`). Needles are read from the snapshot and never fall back
+to the live vault. The snapshot path is a filename, not the value; the value
+never leaves this process as text.
 
 Exit codes:
 
@@ -102,8 +111,9 @@ stdout and stderr.
 ## What this does not do
 
 It does not touch Google Drive, does not inspect revision history, and does
-not decide whether a rotation succeeded. It reads one local JSON file to learn
-what to search for and reads local state to search. Closing out issue #38
-still needs a human to review Drive's revision-retention controls, purge or
-replace the exposed revision, and record the accepted residual risk -- this
-tool only answers the one question stated above.
+not decide whether a rotation succeeded. It reads one local JSON file -- the
+pre-rotation snapshot when `REVOKED_FROM` is set, otherwise the live vault --
+to learn what to search for and reads local state to search. Closing out
+issue #38 still needs a human to review Drive's revision-retention controls,
+purge or replace the exposed revision, and record the accepted residual risk
+-- this tool only answers the one question stated above.

--- a/desktop/tests/test_secret_scan.py
+++ b/desktop/tests/test_secret_scan.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import pytest
 
+from coworker import migrations
 from coworker.secret_scan import (
     MAX_DETAIL_ROWS,
     NoRegisteredSecret,
@@ -37,6 +38,29 @@ def _probe_value() -> str:
 
 def _write_secrets(root: Path, payload: dict) -> None:
     (root / "secrets.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_backup(root: Path, backup_id: str, entries: list[dict]) -> Path:
+    """A hand-built backup directory, shaped like `migrations.create_backup` writes one.
+
+    Built by hand rather than via `create_backup` so a test can plant an entry
+    the real writer would never produce -- see the adversarial-manifest test
+    below, which claims a secret-bearing store was copied when the real writer
+    never does that.
+    """
+    backup_dir = root / migrations.BACKUPS_DIR_NAME / backup_id
+    backup_dir.mkdir(parents=True)
+    manifest = {
+        "version": 1,
+        "backup_id": backup_id,
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "reason": "test",
+        "entries": entries,
+    }
+    (backup_dir / migrations.BACKUP_MANIFEST_NAME).write_text(
+        json.dumps(manifest), encoding="utf-8"
+    )
+    return backup_dir
 
 
 # --- finds a real leak, never prints it -------------------------------------
@@ -132,6 +156,82 @@ def test_a_store_with_many_matches_is_capped_not_printed_in_full(tmp_path):
     assert probe not in payload
     # The overflow line, not 25 individual detail lines, is what stands in.
     assert rendered.count(" line ") == MAX_DETAIL_ROWS - 1
+
+
+# --- backups: a pre-remediation copy the live store no longer carries -------
+
+
+def test_a_value_surviving_only_in_a_backup_is_found_and_never_printed(tmp_path):
+    root = tmp_path / "state"
+    root.mkdir()
+    probe = _probe_value()
+    _write_secrets(root, {"probe": {"api_key": probe}})
+    # The live store is clean -- the value only survives in a backup taken
+    # before remediation, which is exactly the scenario a live-store-only
+    # scan would miss.
+    backup_dir = _write_backup(
+        root,
+        "doctor-20260101T000000000000Z",
+        [
+            {
+                "store_id": "workspace_grants",
+                "kind": "json_document",
+                "relative_path": "workspace_grants.json",
+                "content_backed_up": True,
+                "mode": "0o600",
+            }
+        ],
+    )
+    (backup_dir / "workspace_grants.json").write_text(
+        json.dumps({"grants": [{"id": "g1", "label": f"pre-rotation note {probe}"}]}),
+        encoding="utf-8",
+    )
+
+    report = scan_state(root, secret_key="probe")
+
+    # Non-vacuous: the backup finding actually exists before checking output.
+    label = "backup:doctor-20260101T000000000000Z:workspace_grants"
+    finding = next(item for item in report.findings if item.store_id == label)
+    assert finding.count == 1
+    assert "doctor-20260101T000000000000Z" in report.backups_scanned
+    assert not report.clean
+
+    rendered = report.render()
+    payload = json.dumps(report.to_dict())
+    assert probe not in rendered
+    assert probe not in payload
+
+
+def test_a_secret_bearing_entry_inside_a_backup_stays_excluded_even_if_the_manifest_lies(tmp_path):
+    root = tmp_path / "state"
+    root.mkdir()
+    probe = _probe_value()
+    _write_secrets(root, {"probe": {"api_key": probe}})
+    # The real backup writer never copies a secret-bearing store and always
+    # records content_backed_up: false for it. This plants the file anyway and
+    # claims otherwise, to prove the exclusion does not take the manifest's word.
+    backup_dir = _write_backup(
+        root,
+        "doctor-adversarial",
+        [
+            {
+                "store_id": "secrets",
+                "kind": "opaque_file",
+                "relative_path": "secrets.json",
+                "content_backed_up": True,
+                "mode": "0o600",
+            }
+        ],
+    )
+    (backup_dir / "secrets.json").write_text(
+        json.dumps({"probe": {"api_key": probe}}), encoding="utf-8"
+    )
+
+    report = scan_state(root, secret_key="probe")
+
+    assert "doctor-adversarial" in report.backups_scanned  # the backup was inspected
+    assert report.clean
+    assert not any(item.store_id.startswith("backup:") for item in report.findings)
 
 
 # --- the CLI -----------------------------------------------------------------

--- a/desktop/tests/test_secret_scan.py
+++ b/desktop/tests/test_secret_scan.py
@@ -127,6 +127,48 @@ def test_an_empty_vault_refuses_rather_than_reporting_clean(tmp_path):
         scan_state(root)
 
 
+def test_after_rotation_the_revoked_value_is_still_found_in_conversations_and_events(tmp_path):
+    """Issue #38 asks whether the old value is gone, not whether the replacement is.
+
+    After Apollo rotation the live vault holds a different value. A scan that
+    reads secrets.json would search the replacement and report clean even while
+    conversations and events still carry the revoked value.
+    """
+    root = tmp_path / "state"
+    root.mkdir()
+    revoked = _probe_value()
+    replacement = _probe_value()
+    _write_secrets(root, {"apollo": {"api_key": replacement}})
+    snapshot = tmp_path / "pre-rotation-secrets.json"
+    snapshot.write_text(json.dumps({"apollo": {"api_key": revoked}}), encoding="utf-8")
+
+    conversations = root / "conversations"
+    conversations.mkdir()
+    (conversations / "main.jsonl").write_text(
+        json.dumps({"role": "user", "content": f"using {revoked}"}) + "\n",
+        encoding="utf-8",
+    )
+    events = root / "events"
+    events.mkdir()
+    (events / "main.jsonl").write_text(
+        json.dumps({"type": "error", "message": f"apollo rejected {revoked}"}) + "\n",
+        encoding="utf-8",
+    )
+
+    report = scan_state(root, secret_key="apollo", revoked_from=snapshot)
+
+    found_ids = {item.store_id for item in report.findings}
+    assert found_ids >= {"conversation_transcripts", "presentation_events"}, found_ids
+    assert not report.clean
+
+    rendered = report.render()
+    payload = json.dumps(report.to_dict())
+    assert revoked not in rendered
+    assert replacement not in rendered
+    assert revoked not in payload
+    assert replacement not in payload
+
+
 # --- bounded output ----------------------------------------------------------
 
 
@@ -269,6 +311,44 @@ def test_cli_exits_zero_on_a_genuinely_clean_state(tmp_path, capsys):
     assert code == 0
     assert "clean" in captured.out
     assert probe not in captured.out
+
+
+def test_cli_searches_the_revoked_snapshot_not_the_live_replacement(tmp_path, capsys):
+    root = tmp_path / "state"
+    root.mkdir()
+    revoked = _probe_value()
+    replacement = _probe_value()
+    _write_secrets(root, {"apollo": {"api_key": replacement}})
+    snapshot = tmp_path / "pre-rotation-secrets.json"
+    snapshot.write_text(json.dumps({"apollo": {"api_key": revoked}}), encoding="utf-8")
+    conversations = root / "conversations"
+    conversations.mkdir()
+    (conversations / "main.jsonl").write_text(
+        json.dumps({"role": "user", "content": f"using {revoked}"}) + "\n",
+        encoding="utf-8",
+    )
+
+    code = main(
+        [
+            "--state",
+            str(root),
+            "--secret-key",
+            "apollo",
+            "--revoked-from",
+            str(snapshot),
+            "--json",
+        ]
+    )
+    captured = capsys.readouterr()
+    body = json.loads(captured.out)
+
+    assert code == 1
+    assert not body["clean"]
+    assert any(item["store_id"] == "conversation_transcripts" for item in body["findings"])
+    assert revoked not in captured.out
+    assert replacement not in captured.out
+    assert revoked not in captured.err
+    assert replacement not in captured.err
 
 
 def test_cli_exits_with_a_usage_code_for_an_unregistered_key(tmp_path, capsys):

--- a/desktop/tests/test_secret_scan.py
+++ b/desktop/tests/test_secret_scan.py
@@ -1,0 +1,183 @@
+"""S0: a non-printing scan for a revoked secret's absence.
+
+Every leak test here plants a value, asserts the scan actually reported a
+match for the store that carries it, and only then asserts the value is gone
+from every output path. A test that passes because nothing was found proves
+nothing and would keep passing after the redaction broke.
+
+No credential-shaped literal is written in this file. The one real-world
+fixture below (`build_current_state(plant_secrets=True)`) is imported, not
+authored here; every value this file plants itself is assembled at runtime
+from a random suffix, never a literal that looks like an issued credential.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+
+from coworker.secret_scan import (
+    MAX_DETAIL_ROWS,
+    NoRegisteredSecret,
+    main,
+    scan_state,
+)
+from tests.state_fixtures import PLANTED_API_KEY, build_current_state
+
+VAULT_STORE_IDS = {"secrets", "mcp_config", "dotenv"}
+
+
+def _probe_value() -> str:
+    """A distinctive value with no credential-shaped prefix, built at runtime."""
+    return "probe-" + uuid.uuid4().hex
+
+
+def _write_secrets(root: Path, payload: dict) -> None:
+    (root / "secrets.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+# --- finds a real leak, never prints it -------------------------------------
+
+
+def test_finds_a_planted_registered_secret_in_several_stores_without_printing_it(tmp_path):
+    root = build_current_state(tmp_path / "state", plant_secrets=True)
+
+    report = scan_state(root, secret_key="apollo")
+
+    # Non-vacuous: prove real stores actually matched before checking output.
+    found_ids = {item.store_id for item in report.findings}
+    expected = {"conversation_db", "memory_notes", "workspace_grants", "host_command_approvals"}
+    assert expected <= found_ids, found_ids
+    assert not report.clean
+
+    rendered = report.render()
+    payload = json.dumps(report.to_dict())
+    assert PLANTED_API_KEY not in rendered
+    assert PLANTED_API_KEY not in payload
+    assert PLANTED_API_KEY not in repr(report)
+
+
+def test_vault_stores_are_never_scanned_even_though_they_hold_the_value(tmp_path):
+    root = build_current_state(tmp_path / "state", plant_secrets=True)
+
+    report = scan_state(root, secret_key="apollo")
+
+    assert report.findings  # the value is genuinely present elsewhere
+    assert not (VAULT_STORE_IDS & {item.store_id for item in report.findings})
+    assert not (VAULT_STORE_IDS & set(report.stores_scanned))
+
+
+# --- a clean scan is a real scan, not an empty one --------------------------
+
+
+def test_clean_state_reports_no_match_when_the_value_is_registered_but_not_leaked(tmp_path):
+    root = build_current_state(tmp_path / "state", plant_secrets=False)
+    probe = _probe_value()
+    payload = json.loads((root / "secrets.json").read_text(encoding="utf-8"))
+    payload["probe"] = {"api_key": probe}
+    _write_secrets(root, payload)
+
+    report = scan_state(root, secret_key="probe")
+
+    assert report.needle_count == 1
+    assert report.stores_scanned
+    assert report.clean
+    assert probe not in report.render()
+
+
+def test_an_unknown_secret_key_refuses_rather_than_reporting_clean(tmp_path):
+    root = build_current_state(tmp_path / "state", plant_secrets=False)
+
+    with pytest.raises(NoRegisteredSecret):
+        scan_state(root, secret_key="does-not-exist")
+
+
+def test_an_empty_vault_refuses_rather_than_reporting_clean(tmp_path):
+    root = tmp_path / "state"
+    root.mkdir()
+
+    with pytest.raises(NoRegisteredSecret):
+        scan_state(root)
+
+
+# --- bounded output ----------------------------------------------------------
+
+
+def test_a_store_with_many_matches_is_capped_not_printed_in_full(tmp_path):
+    root = tmp_path / "state"
+    root.mkdir()
+    probe = _probe_value()
+    _write_secrets(root, {"probe": {"api_key": probe}})
+    conversations = root / "conversations"
+    conversations.mkdir()
+    lines = [
+        json.dumps({"role": "user", "content": f"leaked again: {probe} (#{i})"})
+        for i in range(25)
+    ]
+    (conversations / "big.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    report = scan_state(root, secret_key="probe")
+
+    finding = next(item for item in report.findings if item.store_id == "conversation_transcripts")
+    assert finding.count == 25
+    assert len(finding.detail) == MAX_DETAIL_ROWS
+    assert finding.detail[-1].startswith("and ") and finding.detail[-1].endswith("more")
+
+    rendered = report.render()
+    payload = json.dumps(report.to_dict())
+    assert probe not in rendered
+    assert probe not in payload
+    # The overflow line, not 25 individual detail lines, is what stands in.
+    assert rendered.count(" line ") == MAX_DETAIL_ROWS - 1
+
+
+# --- the CLI -----------------------------------------------------------------
+
+
+def test_cli_exits_nonzero_and_prints_nothing_sensitive_when_a_match_is_found(tmp_path, capsys):
+    root = tmp_path / "state"
+    root.mkdir()
+    probe = _probe_value()
+    _write_secrets(root, {"probe": {"api_key": probe}})
+    memory = root / "memory"
+    memory.mkdir()
+    (memory / "1.md").write_text(f"the value is {probe}\n", encoding="utf-8")
+
+    code = main(["--state", str(root), "--secret-key", "probe", "--json"])
+    captured = capsys.readouterr()
+    body = json.loads(captured.out)
+
+    assert code == 1
+    assert not body["clean"]
+    assert any(item["store_id"] == "memory_notes" for item in body["findings"])
+    assert probe not in captured.out
+    assert probe not in captured.err
+
+
+def test_cli_exits_zero_on_a_genuinely_clean_state(tmp_path, capsys):
+    root = tmp_path / "state"
+    root.mkdir()
+    probe = _probe_value()
+    _write_secrets(root, {"probe": {"api_key": probe}})
+
+    code = main(["--state", str(root), "--secret-key", "probe"])
+    captured = capsys.readouterr()
+
+    assert code == 0
+    assert "clean" in captured.out
+    assert probe not in captured.out
+
+
+def test_cli_exits_with_a_usage_code_for_an_unregistered_key(tmp_path, capsys):
+    root = tmp_path / "state"
+    root.mkdir()
+    _write_secrets(root, {"apollo": {"api_key": _probe_value()}})
+
+    code = main(["--state", str(root), "--secret-key", "not-registered"])
+    captured = capsys.readouterr()
+
+    assert code == 2
+    assert captured.out == ""

--- a/desktop/tests/test_secret_scan.py
+++ b/desktop/tests/test_secret_scan.py
@@ -14,6 +14,7 @@ from a random suffix, never a literal that looks like an issued credential.
 from __future__ import annotations
 
 import json
+import os
 import uuid
 from pathlib import Path
 
@@ -169,6 +170,86 @@ def test_after_rotation_the_revoked_value_is_still_found_in_conversations_and_ev
     assert replacement not in payload
 
 
+# --- an incomplete scan is not a clean one ----------------------------------
+
+
+def test_a_truncated_store_that_still_holds_the_value_is_not_reported_clean(
+    tmp_path, capsys
+):
+    """A store that cannot be read is not a proof the value is absent.
+
+    Public seam: scan_state / ScanReport.clean / ScanReport.render / main.
+    A garbage club.db can still contain the planted bytes. The structured
+    SQLite walk reports it unreadable. That must not print
+    'clean -- no match found' or exit 0 -- those feed the remediation receipt.
+    """
+    root = tmp_path / "state"
+    root.mkdir()
+    probe = _probe_value()
+    _write_secrets(root, {"probe": {"api_key": probe}})
+    (root / "club.db").write_bytes(
+        b"not-a-database " + probe.encode() + b" trailing-garbage"
+    )
+
+    report = scan_state(root, secret_key="probe")
+
+    assert report.unreadable == ("conversation_db",)
+    assert not report.clean
+    rendered = report.render()
+    assert "clean -- no match found" not in rendered
+    assert probe not in rendered
+
+    code = main(["--state", str(root), "--secret-key", "probe"])
+    captured = capsys.readouterr()
+    assert code == 2
+    assert "clean -- no match found" not in captured.out
+    assert probe not in captured.out
+
+
+@pytest.mark.parametrize(
+    "dirname,store_id",
+    [
+        ("conversations", "conversation_transcripts"),
+        ("events", "presentation_events"),
+    ],
+)
+def test_an_unlistable_jsonl_directory_is_not_reported_clean(
+    tmp_path, capsys, dirname, store_id
+):
+    """Path.glob on an unlistable directory returns [] without raising.
+
+    Public seam: scan_state / ScanReport.unreadable / ScanReport.clean / main.
+    A conversations/ or events/ directory that cannot be listed still holds
+    the planted file. That must land in unreadable, must not print
+    'clean -- no match found', and must not exit 0.
+    """
+    root = tmp_path / "state"
+    root.mkdir()
+    probe = _probe_value()
+    _write_secrets(root, {"probe": {"api_key": probe}})
+    folder = root / dirname
+    folder.mkdir()
+    (folder / "main.jsonl").write_text(
+        json.dumps({"role": "user", "content": f"using {probe}"}) + "\n",
+        encoding="utf-8",
+    )
+    os.chmod(folder, 0o000)
+    try:
+        report = scan_state(root, secret_key="probe")
+        code = main(["--state", str(root), "--secret-key", "probe"])
+        captured = capsys.readouterr()
+    finally:
+        os.chmod(folder, 0o700)
+
+    assert store_id in report.unreadable
+    assert not report.clean
+    rendered = report.render()
+    assert "clean -- no match found" not in rendered
+    assert probe not in rendered
+    assert code == 2
+    assert probe not in captured.out
+
+
 # --- bounded output ----------------------------------------------------------
 
 
@@ -277,6 +358,79 @@ def test_a_secret_bearing_entry_inside_a_backup_stays_excluded_even_if_the_manif
 
 
 # --- the CLI -----------------------------------------------------------------
+
+
+def test_an_unreadable_store_is_not_reported_clean(tmp_path, capsys):
+    """Doctor treats unreadable as no answer, not as absence.
+
+    A clean receipt feeds a remediation receipt. If a live store cannot be
+    read, the report may list it under unreadable, but it must not print
+    'clean -- no match found' or exit 0.
+    """
+    root = tmp_path / "state"
+    root.mkdir()
+    probe = _probe_value()
+    _write_secrets(root, {"probe": {"api_key": probe}})
+    events = root / "events"
+    events.mkdir()
+    planted = events / "main.jsonl"
+    planted.write_text(json.dumps({"type": "turn_end", "text": "idle"}) + "\n", encoding="utf-8")
+    planted.chmod(0o000)
+    try:
+        report = scan_state(root, secret_key="probe")
+        code = main(["--state", str(root), "--secret-key", "probe"])
+    finally:
+        planted.chmod(0o600)
+
+    assert report.unreadable == ("presentation_events",)
+    assert report.findings == ()
+    assert report.clean is False
+    rendered = report.render()
+    assert "clean -- no match found" not in rendered
+    assert "MATCH FOUND" not in rendered
+    assert probe not in rendered
+
+    captured = capsys.readouterr()
+    assert code == 2
+    assert "clean -- no match found" not in captured.out
+    assert probe not in captured.out
+
+
+def test_an_unreadable_backup_copy_is_not_reported_clean(tmp_path, capsys):
+    root = tmp_path / "state"
+    root.mkdir()
+    probe = _probe_value()
+    _write_secrets(root, {"probe": {"api_key": probe}})
+    backup_id = "doctor-20260101T090000000000Z"
+    backup_dir = _write_backup(
+        root,
+        backup_id,
+        [
+            {
+                "store_id": "workspace_grants",
+                "kind": "json_document",
+                "relative_path": "workspace_grants.json",
+                "content_backed_up": True,
+                "mode": "0o600",
+            }
+        ],
+    )
+    planted = backup_dir / "workspace_grants.json"
+    planted.write_text(json.dumps({"grants": []}), encoding="utf-8")
+    planted.chmod(0o000)
+    try:
+        report = scan_state(root, secret_key="probe")
+        code = main(["--state", str(root), "--secret-key", "probe"])
+    finally:
+        planted.chmod(0o600)
+
+    label = f"backup:{backup_id}:workspace_grants"
+    assert label in report.unreadable
+    assert report.clean is False
+    assert "clean -- no match found" not in report.render()
+    captured = capsys.readouterr()
+    assert code == 2
+    assert probe not in captured.out
 
 
 def test_cli_exits_nonzero_and_prints_nothing_sensitive_when_a_match_is_found(tmp_path, capsys):


### PR DESCRIPTION
Addresses **one** acceptance criterion of #38. **It does not close the issue** — see the end.

> A non-printing scan confirms the revoked value is absent from current Sourcecado conversations, events, and logs.

## Domain words

- **Needle** — the value being searched for. Read from the vault by key, never typed.
- **Finding** — a report that a store matched. Names *where*, never *what*.
- **Vault store** — `secrets`, `mcp_config`, `dotenv`. Marked `secret_bearing` in the migration registry.

## The design decision that matters

**The value is never captured into any data structure.** Not captured-then-redacted.

Each scan function reads a cell, line, or file, passes it to `bundle_redaction.scan_text`, gets back a boolean, and appends only an identity string — `settings.value rowid 3`, or `<state>/events/main.jsonl line 3`. The matched text never enters a variable that outlives the check.

So `ScanReport`, `StoreFinding`, `to_dict()`, `render()`, and dataclass `repr()` are leak-proof by construction rather than by a filter that a later change could break. Doctor's own docs note that redaction is a backstop; this tool has no backstop to lean on, which is exactly why it must not need one.

Unexpected exceptions are caught and replaced with a generic message before printing, so a traceback cannot carry a fragment of what was being searched for. `NoRegisteredSecret` names only the *key* (`apollo`), never a value.

## Enumeration is registry-driven

Scan targets come from `migrations.REGISTRY` and dispatch by `spec.kind`, not from a hand-written list. A store added to the registry later is picked up on the next run with no code change here.

That has already paid off: **`agent_runs.db` self-closes.** It is not in the registry on main, but PR #118 adds it, and this scan will cover it automatically once that merges. No follow-up needed.

The three vault stores are excluded on purpose. They hold the *current* credential by design, and `secrets.json`'s own registry entry says it is never to be read into a report. The scan reads it once to learn what to search for, and never opens it as a target.

## Backups — the false negative this nearly shipped with

Doctor writes a copy of a store into `<state>/backups/` **before** a migration changes it. A backup taken before the Apollo remediation still contains the revoked value, inside the state directory.

The first version of this scan did not look there. It would have reported **clean**.

That is the one answer this tool must never get wrong, because its output feeds a remediation receipt and a clean result will be believed and acted on. Now:

- `_scan_backups()` walks `migrations.list_backups(root)` — the same reader `doctor backups` uses — and scans every entry marked `content_backed_up`.
- Live stores and backup copies share exactly one code path, so they cannot drift.
- **Backup matches are their own findings**, keyed `backup:<backup_id>:<store_id>`, never folded into the live store's. "The live store is clean but a backup is not" needs a different action — delete the backup — from "the live store still has it".
- **The vault exclusion is re-checked against the registry, not the manifest.** Doctor never copies a secret-bearing store, but this does not take the manifest's word for it. `test_a_secret_bearing_entry_inside_a_backup_stays_excluded_even_if_the_manifest_lies` hand-builds a manifest claiming `secrets.json` was copied and proves the scan still excludes it.

Real output against a fixture whose **live stores are genuinely clean** and only a backup carries the old value:

```
secret key       apollo
values searched  1
stores scanned   12
backups scanned  1

result           MATCH FOUND -- value present in current state
  backup:doctor-20260101T090000000000Z:host_command_approvals 1 match(es)
      - <state>/backups/doctor-.../host_command_approvals.json
exit=1
```

## Non-vacuity, proven by mutation

Every leak test asserts findings are non-empty — and for the main one, that a specific *set* of store ids matched — **before** asserting the value is absent from `render()`, `to_dict()`, `repr()`, and CLI output.

That was verified rather than assumed:

| Mutation | Result |
|---|---|
| Remove the vault exclusion | 3 tests failed |
| Embed the raw value into a SQLite identity string | The leak test caught it, value visible in the failure diff |
| Remove the `secret_bearing` half of the backup exclusion | The adversarial-manifest test failed, producing a `backup:...:secrets` finding |

Also covered: a genuinely clean scan (so "clean" is not the default for "nothing was searched"), an unregistered key and an empty vault both raising rather than reporting clean, bounding (25 matches cap at 8 detail lines with the true count retained), and exit codes 0/1/2.

**Refusing on zero needles rather than reporting clean** is the same discipline this repo applies to redaction tests, turned around onto the search side: a scan that checked nothing must not say it found nothing.

## Measurements

```
baseline  origin/main d2fbc26 : 1280 passed, 3 skipped
first version                 : 1289 passed, 3 skipped
with backup coverage          : 1291 passed, 3 skipped
```

Skip count unchanged throughout. Baseline measured by stashing and running, not by arithmetic. Re-run independently by the reviewing session on the pushed commit.

No credential-shaped literal was added to source; planted values are built at runtime.

## Boundary

Four files: `secret_scan.py`, its tests, its docs, and a `Makefile` target. `bundle_redaction.py`, `secrets.py`, `migrations.py`, and `doctor.py` are read and never modified.

## This does not close #38

Still required, and none of it can be done by an agent:

1. An authorized Drive owner inspects the document and revision-retention controls without copying the historical value anywhere.
2. The historical revision is purged, or the source replaced with a clean canonical document.
3. If provider retention prevents deletion, the limitation, owner, date, and accepted residual risk are recorded.
4. Current configuration is confirmed to use an approved local secret path.
5. The closing remediation receipt.

Running `make secret-scan KEY=apollo` and getting a clean result is **one input** to that receipt, not the receipt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjAD6SVox1gvF4sV3jTnJy
