### PR TITLE
feat(desktop): replace the eight-step ceiling with explicit run budgets

### DIFF
--- a/desktop/coworker/run_budget.py
+++ b/desktop/coworker/run_budget.py
@@ -1,0 +1,412 @@
+"""What one Sourcecado run may spend before it stops and asks.
+
+The fixed eight-step ceiling this replaces had two problems. It cut ordinary
+sourcing work short, because a real run reads a board, checks several sources,
+and drafts, which is more than eight steps. And it bounded the wrong thing: a
+run that repeats one tool forever and a run that reads a hundred large pages
+both cost the director something, but only the second is expensive and only
+the first is stuck.
+
+So there are two mechanisms here, in a deliberate order.
+
+The loop detector fires first. It watches for tool calls that produce nothing
+new and stops the run while the absolute budgets still have room, so the
+operator is told the run is stuck rather than that it was expensive. Those are
+different diagnoses and they lead to different actions.
+
+The absolute budgets are the backstop: model turns, tool calls, elapsed time,
+input tokens, output tokens, and estimated cost. Exhausting one stops the run
+with the work it has actually completed, never with a claim that it finished.
+
+Nothing in this module decides what a run is allowed to do. Permission lives
+in `permissions.decide`, is asked per tool call, and is unaffected by how much
+budget is left or by whether the director chose to continue.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from coworker.telemetry import CostEstimate, UsageEvent
+
+# Defaults. See `desktop/docs/run-budgets.md` for how each was chosen.
+#
+# A model turn is one pass of the agent loop: one model request plus the tool
+# calls it asked for. Provider retries and failovers are not model turns; they
+# repeat a request the loop already counted and are bounded by RetryPolicy.
+DEFAULT_MODEL_TURNS = 40
+# A model turn may request several tools at once, so this is not a multiple of
+# the turn budget by accident: roughly three calls per turn.
+DEFAULT_TOOL_CALLS = 120
+# Fifteen minutes. Long enough for forty turns of connector work, short enough
+# that an unattended run cannot quietly spend an afternoon.
+DEFAULT_ELAPSED_SECONDS = 900.0
+# The token ceilings exist for models with no entry in the pricing table,
+# where the cost meter reads zero and cannot bind. On a priced model the cost
+# ceiling is reached first.
+DEFAULT_INPUT_TOKENS = 2_000_000
+DEFAULT_OUTPUT_TOKENS = 200_000
+DEFAULT_ESTIMATED_COST_USD = 2.00
+# Warn once a budget passes this fraction, so the director sees it coming.
+DEFAULT_WARN_AT = 0.8
+# Consecutive tool calls that repeat a (call, result) pair already seen in
+# this run. Three is enough to distinguish a cycle from a coincidence.
+DEFAULT_LOOP_REPEAT_LIMIT = 3
+
+_FINGERPRINT_CHARS = 16
+
+
+class BudgetName(StrEnum):
+    MODEL_TURNS = "model_turns"
+    TOOL_CALLS = "tool_calls"
+    ELAPSED = "elapsed_seconds"
+    INPUT_TOKENS = "input_tokens"
+    OUTPUT_TOKENS = "output_tokens"
+    COST = "estimated_cost_usd"
+
+
+#: How each number reaching a budget was obtained. Two of the six are provider
+#: estimates rather than measurements, and the operator is told which.
+MEASUREMENT_SOURCES: dict[str, str] = {
+    BudgetName.MODEL_TURNS.value: "counted",
+    BudgetName.TOOL_CALLS.value: "counted",
+    BudgetName.ELAPSED.value: "monotonic_clock",
+    BudgetName.INPUT_TOKENS.value: "provider_usage",
+    BudgetName.OUTPUT_TOKENS.value: "provider_usage",
+    BudgetName.COST.value: "provider_cost_estimate",
+}
+
+_LABELS: dict[str, str] = {
+    BudgetName.MODEL_TURNS.value: "model turns",
+    BudgetName.TOOL_CALLS.value: "tool calls",
+    BudgetName.ELAPSED.value: "elapsed time",
+    BudgetName.INPUT_TOKENS.value: "input tokens",
+    BudgetName.OUTPUT_TOKENS.value: "output tokens",
+    BudgetName.COST.value: "estimated cost",
+}
+
+
+class StopKind(StrEnum):
+    #: A no-progress tool pattern, caught before any absolute budget.
+    LOOP = "loop"
+    #: An absolute budget ran out.
+    BUDGET = "budget"
+
+
+@dataclass(frozen=True)
+class RunBudgetPolicy:
+    model_turns: int = DEFAULT_MODEL_TURNS
+    tool_calls: int = DEFAULT_TOOL_CALLS
+    elapsed_seconds: float = DEFAULT_ELAPSED_SECONDS
+    input_tokens: int = DEFAULT_INPUT_TOKENS
+    output_tokens: int = DEFAULT_OUTPUT_TOKENS
+    estimated_cost_usd: float = DEFAULT_ESTIMATED_COST_USD
+    warn_at: float = DEFAULT_WARN_AT
+    loop_repeat_limit: int = DEFAULT_LOOP_REPEAT_LIMIT
+
+    def __post_init__(self) -> None:
+        for name in (
+            "model_turns",
+            "tool_calls",
+            "input_tokens",
+            "output_tokens",
+            "loop_repeat_limit",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+                raise ValueError(f"{name} must be a positive integer")
+        for name in ("elapsed_seconds", "estimated_cost_usd"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ValueError(f"{name} must be a positive number")
+            if value <= 0:
+                raise ValueError(f"{name} must be a positive number")
+        if not 0 < self.warn_at < 1:
+            raise ValueError("warn_at must be a fraction between 0 and 1")
+        # Criterion 7's ordering, enforced in the type rather than left to the
+        # numbers happening to line up: a stuck run must be able to reach the
+        # loop detector before it can exhaust the tool-call budget.
+        if self.loop_repeat_limit >= self.tool_calls:
+            raise ValueError(
+                "loop_repeat_limit must be below tool_calls so the loop "
+                "detector can fire before the absolute budget"
+            )
+
+    def limits(self) -> dict[str, float | int]:
+        return {
+            BudgetName.MODEL_TURNS.value: self.model_turns,
+            BudgetName.TOOL_CALLS.value: self.tool_calls,
+            BudgetName.ELAPSED.value: self.elapsed_seconds,
+            BudgetName.INPUT_TOKENS.value: self.input_tokens,
+            BudgetName.OUTPUT_TOKENS.value: self.output_tokens,
+            BudgetName.COST.value: self.estimated_cost_usd,
+        }
+
+
+@dataclass(frozen=True)
+class BudgetWarning:
+    budget: str
+    used: float
+    limit: float
+
+    @property
+    def used_ratio(self) -> float:
+        return self.used / self.limit if self.limit else 0.0
+
+    def message(self) -> str:
+        return (
+            f"This run has used {round(self.used_ratio * 100)}% of its "
+            f"{_LABELS[self.budget]} budget. It will stop and ask before "
+            "going further."
+        )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "budget": self.budget,
+            "used": self.used,
+            "limit": self.limit,
+            "used_ratio": self.used_ratio,
+            "message": self.message(),
+        }
+
+
+@dataclass(frozen=True)
+class BudgetStop:
+    kind: StopKind
+    #: For a budget stop, every budget that is out, first-reached first. For a
+    #: loop stop, empty: no budget ran out.
+    exhausted: tuple[str, ...]
+    #: For a loop stop, how many consecutive no-progress calls tripped it.
+    repeats: int = 0
+
+    def message(self) -> str:
+        if self.kind is StopKind.LOOP:
+            return (
+                f"Stopped after {self.repeats} tool calls in a row that "
+                "returned nothing new. The run was repeating itself, not "
+                "making progress."
+            )
+        names = " and ".join(_LABELS[name] for name in self.exhausted)
+        return f"Stopped after this run reached its {names} budget."
+
+
+@dataclass
+class _ToolRecord:
+    call_id: str
+    name: str
+    ok: bool
+
+
+def _fingerprint(value: Any) -> str:
+    """A stable, content-free handle for a tool result.
+
+    The digest never leaves this module: it decides whether a call produced
+    something new, and only the count of repeats is ever reported.
+    """
+    try:
+        rendered = json.dumps(value, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        rendered = repr(value)
+    return hashlib.sha256(rendered.encode("utf-8", "replace")).hexdigest()[
+        :_FINGERPRINT_CHARS
+    ]
+
+
+class RunBudgetMeter:
+    """Measures one run against one policy.
+
+    Every input is a typed runtime telemetry value or an exact count taken at
+    the point the loop does the work: `UsageEvent` for tokens, `CostEstimate`
+    for spend, the monotonic clock for elapsed time. Nothing here re-derives a
+    measurement from text.
+    """
+
+    def __init__(
+        self,
+        policy: RunBudgetPolicy | None = None,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.policy = policy or RunBudgetPolicy()
+        self._clock = clock
+        self._started_at = clock()
+        self._model_turns = 0
+        self._tool_calls = 0
+        self._input_tokens = 0
+        self._output_tokens = 0
+        self._cost_usd = 0.0
+        self._unpriced_requests = 0
+        self._unmeasured_requests = 0
+        self._completed: list[_ToolRecord] = []
+        self._seen_outcomes: set[tuple[str, str]] = set()
+        self._stale_streak = 0
+        self._warned: set[str] = set()
+
+    # --- measurement intake ------------------------------------------------
+
+    def start_model_turn(self) -> None:
+        """One pass of the agent loop. Retries inside it are not turns."""
+        self._model_turns += 1
+
+    def record_request(
+        self,
+        usage: UsageEvent | None,
+        cost: CostEstimate | None,
+    ) -> None:
+        """Take one model request's telemetry as the provider reported it."""
+        if usage is None:
+            self._unmeasured_requests += 1
+        else:
+            self._input_tokens += usage.input_tokens or 0
+            self._output_tokens += usage.output_tokens or 0
+        if cost is None:
+            self._unpriced_requests += 1
+        else:
+            self._cost_usd += cost.estimated_cost_usd
+
+    def charge_tool_call(self) -> None:
+        self._tool_calls += 1
+
+    def record_tool_outcome(
+        self,
+        *,
+        call_id: str,
+        name: str,
+        arguments: Any,
+        result: Any,
+        ok: bool,
+    ) -> None:
+        """A completed call: a receipt, and one reading for the loop detector.
+
+        Progress means this exact call has not already produced this exact
+        result in this run. A refusal counts: a model that asks for a denied
+        tool over and over is looping just as much as one that re-reads the
+        same page.
+        """
+        self._completed.append(_ToolRecord(call_id=call_id, name=name, ok=ok))
+        outcome = (f"{name}:{_fingerprint(arguments)}", _fingerprint(result))
+        if outcome in self._seen_outcomes:
+            self._stale_streak += 1
+        else:
+            self._seen_outcomes.add(outcome)
+            self._stale_streak = 0
+
+    # --- readings ----------------------------------------------------------
+
+    @property
+    def elapsed_seconds(self) -> float:
+        return max(0.0, self._clock() - self._started_at)
+
+    def consumed(self) -> dict[str, float | int]:
+        return {
+            BudgetName.MODEL_TURNS.value: self._model_turns,
+            BudgetName.TOOL_CALLS.value: self._tool_calls,
+            BudgetName.ELAPSED.value: self.elapsed_seconds,
+            BudgetName.INPUT_TOKENS.value: self._input_tokens,
+            BudgetName.OUTPUT_TOKENS.value: self._output_tokens,
+            BudgetName.COST.value: self._cost_usd,
+        }
+
+    def exhausted(self) -> tuple[str, ...]:
+        limits = self.policy.limits()
+        consumed = self.consumed()
+        return tuple(
+            name for name in limits if consumed[name] >= limits[name]
+        )
+
+    def looping(self) -> bool:
+        return self._stale_streak >= self.policy.loop_repeat_limit
+
+    def check(self) -> BudgetStop | None:
+        """The stop decision, loop detector first.
+
+        Order is the point. A run that is stuck must be reported as stuck even
+        if it also happens to be out of budget on the same call.
+        """
+        if self.looping():
+            return BudgetStop(
+                kind=StopKind.LOOP,
+                exhausted=(),
+                repeats=self._stale_streak,
+            )
+        out = self.exhausted()
+        if out:
+            return BudgetStop(kind=StopKind.BUDGET, exhausted=out)
+        return None
+
+    def warning(self) -> BudgetWarning | None:
+        """The first budget past the warning threshold, reported once."""
+        limits = self.policy.limits()
+        consumed = self.consumed()
+        for name, limit in limits.items():
+            used = consumed[name]
+            if used >= limit or used < limit * self.policy.warn_at:
+                continue
+            if name in self._warned:
+                continue
+            self._warned.add(name)
+            return BudgetWarning(budget=name, used=used, limit=limit)
+        return None
+
+    # --- projections -------------------------------------------------------
+
+    def live_payload(self) -> dict[str, Any]:
+        """What the thread shows while the run is working."""
+        warning = self.warning()
+        return {
+            "state": "warning" if warning is not None else "running",
+            "consumed": self.consumed(),
+            "limits": self.policy.limits(),
+            "warning": warning.as_dict() if warning is not None else None,
+        }
+
+    def terminal_payload(
+        self,
+        *,
+        stop: BudgetStop | None,
+        pending_calls: tuple[tuple[str, str], ...] = (),
+        final_answer: bool,
+    ) -> dict[str, Any]:
+        """The record of what this run actually did.
+
+        `final_answer` is the whole difference between a result and a stopping
+        point. It is false whenever the run ended without the model closing
+        it, and the operator surfaces that as unfinished work rather than as
+        an answer.
+        """
+        return {
+            "state": "exhausted" if stop is not None else "finished",
+            "stopped_by": (
+                None
+                if stop is None
+                else (
+                    StopKind.LOOP.value
+                    if stop.kind is StopKind.LOOP
+                    else stop.exhausted[0]
+                )
+            ),
+            "exhausted": list(stop.exhausted) if stop is not None else [],
+            "repeats": stop.repeats if stop is not None else 0,
+            "consumed": self.consumed(),
+            "limits": self.policy.limits(),
+            "measurement": dict(MEASUREMENT_SOURCES),
+            "unpriced_requests": self._unpriced_requests,
+            "unmeasured_requests": self._unmeasured_requests,
+            "completed": [
+                {"id": record.call_id, "name": record.name, "ok": record.ok}
+                for record in self._completed
+            ],
+            "remaining": {
+                "requested_tools": [
+                    {"id": call_id, "name": name} for call_id, name in pending_calls
+                ],
+                "final_answer": final_answer,
+            },
+            "continue_available": stop is not None,
+        }

--- a/desktop/coworker/turn.py
+++ b/desktop/coworker/turn.py
@@ -44,6 +44,7 @@ from coworker.provider_retry import (
     compatible_failover_chain,
     safe_provider_failure_message,
 )
+from coworker.run_budget import BudgetStop, RunBudgetMeter, RunBudgetPolicy
 from coworker.store import ConversationStore
 from coworker.telemetry import (
     AgentTurnSpan,
@@ -60,7 +61,6 @@ from coworker.telemetry import (
 )
 from coworker.tools import evidence_for, execute
 
-MAX_STEPS = 8
 INTERRUPTED_TOOL = '{"error": "tool call interrupted"}'
 
 
@@ -669,6 +669,7 @@ async def run_turn(
     retry_sleep: Callable[[float], Awaitable[None]] | None = None,
     retry_random: Callable[[], float] = random.random,
     compactor: SessionCompactor | None = None,
+    run_budget_policy: RunBudgetPolicy | None = None,
     context_projection: Any = None,
     projection_identity: Any = None,
 ) -> dict[str, Any]:
@@ -684,6 +685,9 @@ async def run_turn(
     if control is not None:
         await control.attach(events)
     recorder = telemetry or TelemetryRecorder()
+    # One meter per run. Nothing carries over from a previous run, and
+    # nothing it measures reaches a permission decision.
+    budget = RunBudgetMeter(run_budget_policy)
     trace_context = TraceContext(
         session_id=events.identity.session_id,
         run_id=events.identity.run_id,
@@ -740,6 +744,25 @@ async def run_turn(
         _persist_message(
             _stamp(_evidence_message(call, evidence_for(call.name, redacted, ok=ok)))
         )
+
+    def _record_call_outcome(
+        call: ToolCall, ok: bool, result: dict[str, Any]
+    ) -> None:
+        """One place every finished call is written down.
+
+        The person file gets the record it always got; the meter gets the
+        reading the loop detector needs. A call that returns what an earlier
+        identical call already returned is not progress, and a refusal counts
+        the same as a result: asking for a denied tool ten times is a loop.
+        """
+        budget.record_tool_outcome(
+            call_id=call.id,
+            name=call.name,
+            arguments=call.arguments,
+            result=result,
+            ok=ok,
+        )
+        _record_person_file(sid, call, ok, result, execute_kwargs)
 
     async def _terminal(event: dict[str, Any]) -> None:
         if control is None:
@@ -903,7 +926,16 @@ async def run_turn(
                 for message in history
             ]
         )
-        for _ in range(MAX_STEPS):
+        budget_stop: BudgetStop | None = None
+        pending_calls: tuple[tuple[str, str], ...] = ()
+        while True:
+            # The stop decision, before any spend. `check` puts the loop
+            # detector ahead of the absolute budgets on purpose: a run that
+            # is repeating itself is reported as stuck, not as expensive.
+            budget_stop = budget.check()
+            if budget_stop is not None:
+                break
+            budget.start_model_turn()
             _persist_closed(store, sid, history, workspace_runtime)
             # The canonical view. Compaction reads it and never writes it; the
             # transcript on disk stays the record of what actually happened.
@@ -1124,6 +1156,9 @@ async def run_turn(
                     usage=provider_usage,
                     cost=provider_cost,
                 )
+                # The same typed values the provider span just recorded, so
+                # the budget is measured from telemetry rather than re-derived.
+                budget.record_request(provider_usage, provider_cost)
                 if provider_usage is not None:
                     # The provider's own count of the prompt it just read.
                     # Preferred over the estimate when sizing the next step.
@@ -1142,7 +1177,15 @@ async def run_turn(
             tool_msg = _stamp(_assistant_tool_message(last_text, calls))
             history.append(tool_msg)
             _persist_message(tool_msg)
-            for call in calls:
+            for index, call in enumerate(calls):
+                if index:
+                    budget_stop = budget.check()
+                    if budget_stop is not None:
+                        pending_calls = tuple(
+                            (pending.id, pending.name) for pending in calls[index:]
+                        )
+                        break
+                budget.charge_tool_call()
                 approval_claimant: str | None = None
                 approval_scope = "once"
                 approval_fingerprint: str | None = None
@@ -1162,7 +1205,7 @@ async def run_turn(
                     unavailable = _stamp(_tool_result_message(call, result))
                     history.append(unavailable)
                     _persist_message(unavailable)
-                    _record_person_file(sid, call, False, result, execute_kwargs)
+                    _record_call_outcome(call, False, result)
                     continue
                 workspace_runtime = execute_kwargs.get("workspace_runtime")
                 if workspace_runtime is not None and workspace_runtime.owns_tool(
@@ -1193,7 +1236,7 @@ async def run_turn(
                     denied = _stamp(_tool_result_message(call, result))
                     history.append(denied)
                     _persist_message(denied)
-                    _record_person_file(sid, call, False, result, execute_kwargs)
+                    _record_call_outcome(call, False, result)
                     continue
                 if gate.needs_user:
                     resource = approval_resource(
@@ -1286,7 +1329,7 @@ async def run_turn(
                         failed = _stamp(_tool_result_message(call, result))
                         history.append(failed)
                         _persist_message(failed)
-                        _record_person_file(sid, call, False, result, execute_kwargs)
+                        _record_call_outcome(call, False, result)
                         continue
                     approval_scope = authority.clamp_scope(
                         str(claim.item.get("scope") or "once"), call.arguments
@@ -1311,7 +1354,7 @@ async def run_turn(
                         denied = _stamp(_tool_result_message(call, result))
                         history.append(denied)
                         _persist_message(denied)
-                        _record_person_file(sid, call, False, result, execute_kwargs)
+                        _record_call_outcome(call, False, result)
                         if receipt is not None:
                             await _approval_receipt(receipt, resolution="denied")
                         continue
@@ -1340,7 +1383,7 @@ async def run_turn(
                         tool_result = _stamp(_evidence_message(call, parts))
                         history.append(tool_result)
                         _persist_tool_result(call, result, ok, tool_result)
-                        _record_person_file(sid, call, ok, result, execute_kwargs)
+                        _record_call_outcome(call, ok, result)
                         if receipt is not None and receipt.get(
                             "execution_status"
                         ) not in ("executing", "pending"):
@@ -1355,6 +1398,9 @@ async def run_turn(
                         "name": call.name,
                         "arguments": call.arguments,
                         "started_at": _now_iso(),
+                        # Counts only, and the one warning per budget that
+                        # says the run is approaching a stop.
+                        "run_budget": budget.live_payload(),
                     }
                 )
                 tool_span = turn_span.child(_telemetry_tool_span(call.name))
@@ -1409,7 +1455,7 @@ async def run_turn(
                 tool_result = _stamp(_evidence_message(call, parts))
                 history.append(tool_result)
                 _persist_tool_result(call, result, ok, tool_result)
-                _record_person_file(sid, call, ok, result, execute_kwargs)
+                _record_call_outcome(call, ok, result)
                 if approval_claimant is not None:
                     receipt = inbox.complete_execution(
                         call.id,
@@ -1424,14 +1470,25 @@ async def run_turn(
                     if control.cancel_requested.is_set():
                         return await _stopped(history, last_text)
                     control.current_action = None
-        else:
-            turn_span.cancel()
+        if budget_stop is not None:
+            # A run that ran out of budget did not finish. It says so, lists
+            # what it actually completed, names what it had queued and did
+            # not run, and leaves continuing to the director.
+            _persist_closed(store, sid, history, workspace_runtime)
+            turn_span.partial(ErrorKind.POLICY)
+            stop_notice = active_compactor.notice()
             await _terminal(
                 {
                     "type": "turn_end",
                     "state": "stopped",
                     "text": last_text,
-                    "message": f"Stopped after {MAX_STEPS} tool steps.",
+                    "message": budget_stop.message(),
+                    "run_budget": budget.terminal_payload(
+                        stop=budget_stop,
+                        pending_calls=pending_calls,
+                        final_answer=False,
+                    ),
+                    **({"compaction": stop_notice} if stop_notice else {}),
                 }
             )
             return {"status": "stopped", "text": last_text}
@@ -1459,6 +1516,7 @@ async def run_turn(
             "type": "turn_end",
             "text": last_text,
             "state": final_state,
+            "run_budget": budget.terminal_payload(stop=None, final_answer=True),
             **({"compaction": compaction_notice} if compaction_notice else {}),
         }
     )

--- a/desktop/docs/run-budgets.md
+++ b/desktop/docs/run-budgets.md
@@ -1,0 +1,186 @@
+# Run budgets
+
+Issue #83. What one Sourcecado run may spend before it stops, how each number
+is measured, and what a stopped run is allowed to claim about itself.
+
+This replaces the fixed eight-step loop ceiling in `turn.py`.
+
+## Words used here
+
+- **Run** — one call to `run_turn`. One director message, the model turns it
+  takes, and the tool calls those turns make.
+- **Model turn** — one pass of the agent loop: one model request plus the tool
+  calls it asked for. A provider retry or failover is not a model turn; it
+  repeats a request the loop already counted.
+- **Budget** — an absolute ceiling on one measurement for one run.
+- **Loop detector** — the check that stops a run for repeating itself, before
+  any budget runs out.
+- **No progress** — a tool call whose exact arguments have already produced
+  this exact result in this run.
+- **Continuation** — a new run on the same conversation, started by the
+  director. Not a resumption: a new run, with a new budget and the same gates.
+
+## Where the code is
+
+| File | What it does |
+| --- | --- |
+| `coworker/run_budget.py` | All of the policy. `RunBudgetPolicy`, `RunBudgetMeter`, the loop detector, the payload projections. |
+| `coworker/turn.py` | Creates one meter per run, feeds it, and stops on its decision. |
+| `coworker/telemetry/` | The typed values the meter reads: `UsageEvent`, `CostEstimate`. |
+| `surfaces/gui/src/chat/protocol.ts` | Parses the operator payload. Drops anything not on the allowlist. |
+| `surfaces/gui/src/chat/RunBudget.tsx` | The live strip, the warning, the stop card, the Continue action. |
+
+## The defaults
+
+| Budget | Default | How it is measured | Why this number |
+| --- | --- | --- | --- |
+| `model_turns` | 40 | counted in the loop | Five times the ceiling it replaces. A real sourcing run reads the board, checks several sources, enriches, and drafts. Eight was below ordinary work; forty is above it. |
+| `tool_calls` | 120 | counted in the loop | A model turn may request several tools at once. Roughly three per turn. |
+| `elapsed_seconds` | 900 | `time.monotonic` | Fifteen minutes. Long enough for forty turns of connector work, short enough that an unattended run cannot spend an afternoon. |
+| `input_tokens` | 2,000,000 | provider-reported usage | About 50,000 tokens of prompt per turn across the turn budget, which is what a compacted sourcing conversation actually costs. |
+| `output_tokens` | 200,000 | provider-reported usage | Ten percent of the input allowance. A run that writes more than this is not drafting outreach. |
+| `estimated_cost_usd` | 2.00 | provider-reported cost estimate | The spend ceiling for one unattended run. |
+
+Two of the six are not measurements and the payload says so.
+`MEASUREMENT_SOURCES` names the origin of each number, and the operator
+surface repeats it.
+
+- **Cost is an estimate.** It comes from the provider stream's
+  `estimated_cost_usd`, which `provider.py` derives from the Sourcecado-owned
+  pricing table. A model with no entry in that table reports no cost at all,
+  contributes nothing to the meter, and is counted in `unpriced_requests`. A
+  run showing `$0.02` with four unpriced requests is not a run that cost two
+  cents, and the stop card says that in words.
+- **Elapsed time is wall clock.** It includes time spent waiting for a
+  director to answer an approval.
+
+Tokens and cost bind at different places on purpose. On `deepseek-v4-pro` the
+token ceilings are worth about $1.04, so the two land close together. On a
+model priced like `kimi-k3` the $2.00 ceiling is reached long before the token
+ceilings. The token ceilings exist for the case the cost ceiling cannot cover:
+a model with no price, where the cost meter reads zero forever.
+
+Every default is a field on `RunBudgetPolicy`. `run_turn` takes
+`run_budget_policy` and falls back to the defaults, so nothing outside this
+module has to know the numbers.
+
+## The order: loop detector first
+
+`RunBudgetMeter.check` asks two questions and the order is the point.
+
+1. Is the run repeating itself?
+2. Has any budget run out?
+
+A run stuck on one tool and a run that read a hundred large pages both stop.
+They are different problems and they lead to different operator actions, so
+they must not produce the same message. Checking the loop detector first means
+a stuck run is reported as stuck even when it has also exhausted a budget.
+
+`RunBudgetPolicy.__post_init__` rejects any policy where
+`loop_repeat_limit >= tool_calls`. Without that, a policy could be configured
+where the tool-call ceiling is reached before the detector can fire, and the
+ordering would hold only by luck.
+
+### What counts as no progress
+
+Every completed call contributes one pair: a fingerprint of `(tool name,
+arguments)` and a fingerprint of the result. A pair already seen in this run is
+a stale call. `loop_repeat_limit` consecutive stale calls, three by default,
+trip the detector. Anything new resets the streak to zero.
+
+A refusal is an outcome. A model that asks for a denied tool ten times is
+looping exactly as much as one re-reading the same page, so gate refusals and
+tool failures feed the detector alongside successes.
+
+The fingerprints never leave `run_budget.py`. Only the count of repeats is
+reported.
+
+## What a stopped run says
+
+`turn_end` carries `state: "stopped"` and a `run_budget` payload. The store
+maps that state to a `partial` run status, the same as the ceiling it replaces,
+so nothing downstream reads a budget stop as a success.
+
+The payload's job is to make a stopping point impossible to read as a
+conclusion:
+
+- `state: "exhausted"` and `stopped_by`, a budget name or `"loop"`.
+- `completed`, a receipt for every tool call that actually ran, with its
+  outcome. Failed calls are receipts too.
+- `remaining.requested_tools`, the calls the model asked for in the final batch
+  that were never run.
+- `remaining.final_answer: false`, whenever the run ended without the model
+  closing it.
+- `consumed`, `limits`, `measurement`, `unpriced_requests`,
+  `unmeasured_requests`.
+- `continue_available: true`.
+
+The UI writes its own sentences from those numbers. `runBudgetStatus` in
+`protocol.ts` rebuilds the payload field by field, so a sidecar that starts
+sending prose cannot get it rendered as Sourcecado's account of the run. The
+stop card leads with "This run did not finish."
+
+## The warning
+
+`tool_started` carries a smaller `run_budget` payload with the run's current
+spend. Once a budget passes `warn_at`, 80 percent by default, the next of
+those events carries a warning naming that budget. Each budget warns once.
+
+The thread renders it as one quiet line under the activity list, not a banner.
+A director who is watching sees the run approaching a stop; a director who is
+away sees it in the transcript afterwards.
+
+## Continuation
+
+Continue is not a resumption. It is an ordinary new turn on the same
+conversation, sent by the director from the stop card, and everything follows
+from that.
+
+**What it preserves,** because a new turn on the same session already has it:
+
+- the bound person file, which is bound to the session;
+- the conversation, which is the target;
+- every completed tool result, which is in the transcript on disk;
+- the compaction state, which `SessionCompactor.restore` reads back from the
+  store.
+
+**What it does not do:** re-run anything. The completed results reach the model
+as transcript, not as fresh calls.
+
+**What it never becomes: permission.** Nothing in `run_budget.py` touches a
+permission decision. The gate is `permissions.decide`, asked per tool call
+inside the loop, and it reads the tool name and its arguments — never how much
+budget is left, never whether this run is a continuation. A `gmail_send` that
+needed an exact approval before the stop needs the same exact approval after
+Continue. The meter is constructed fresh in `run_turn`, the approval claim is
+scoped to one run id, and a parked approval's scope is `once`.
+
+The one thing that does span runs is a workspace shell grant the director
+issued deliberately, through the workspace grant system. That grant applied
+before the stop and applies after it, unchanged. Continuation neither creates
+it nor widens it.
+
+Declining costs nothing. The director who does not click Continue keeps every
+completed result, every receipt, and the partial text, because all of it was
+persisted as it happened.
+
+## Tests
+
+| File | What it covers |
+| --- | --- |
+| `tests/test_run_budget.py` | Ordinary work past eight steps; each of the six budgets; two at once; loop detection; the warning; the partial result; continuation, no replay, restart, compaction, the bound person; cancellation; retry; the meter on its own. Criterion 8 is parametrized over the real `ASK` set. |
+| `tests/test_run_budget_mutations.py` | Each guard broken on purpose: a budget that never trips, a loop detector that never fires, budgets checked before the loop detector, a detector that ignores refusals, a continuation that grants authority, a partial result that claims completion, receipts that omit failed calls. |
+| `surfaces/gui/tests/runBudget.test.tsx` | The allowlist projection, the live strip and warning, the stop card and its receipts, Continue sending the director's message, and the same after a restore. |
+
+## Known gaps
+
+- The warning rides on `tool_started`. A run whose every tool is
+  approval-gated emits `permission_required` instead and gets no live warning
+  before its stop, though the terminal payload still carries the full record.
+  Adding a new event type would need `events.py`, which is outside this
+  change.
+- Budgets are per run. Continuing four times spends four budgets. There is no
+  per-day or per-session ceiling.
+- `estimated_cost_usd` cannot bind on a model with no pricing entry. The token
+  ceilings are the backstop, and `unpriced_requests` is how the operator finds
+  out.

--- a/desktop/surfaces/gui/src/chat/AssistantMessage.tsx
+++ b/desktop/surfaces/gui/src/chat/AssistantMessage.tsx
@@ -9,10 +9,12 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { ActivityGroup } from "./ActivityGroup";
 import { ApprovalCard } from "./ApprovalCard";
+import { RunBudgetView } from "./RunBudget";
 import { useLastApprovalDelivery } from "./approvalDelivery";
 import { SourceCitation } from "./SourceCitation";
 import { useInspector } from "./Inspector";
 import { resolveInbox } from "../api";
+import type { RunBudgetStatus } from "./protocol";
 
 function AssistantText({ text }: TextMessagePartProps) {
   return (
@@ -70,6 +72,9 @@ function SafeToolFallback(part: ToolCallMessagePartProps) {
 export function AssistantMessage() {
   const message = useAuiState((state) => state.message);
   const sourcecadoState = message.metadata.custom?.sourcecadoState;
+  const runBudget = message.metadata.custom?.sourcecadoRunBudget as
+    | RunBudgetStatus
+    | undefined;
   const notice = message.metadata.custom?.sourcecadoNotice === true;
   const noticeCode = message.metadata.custom?.sourcecadoNoticeCode;
   const transportNotice = noticeCode === "transport";
@@ -113,6 +118,7 @@ export function AssistantMessage() {
         }}
       />
       <ActivityGroup tools={tools} messageState={sourcecadoState} />
+      <RunBudgetView status={runBudget} messageState={sourcecadoState} />
       {artifacts.length > 0 ? <ArtifactControls artifacts={artifacts} /> : null}
       {sourcecadoState === "cancelled" ? (
         <p className="sourcecado-terminal-receipt">Run cancelled.</p>

--- a/desktop/surfaces/gui/src/chat/ComposerDraftContext.tsx
+++ b/desktop/surfaces/gui/src/chat/ComposerDraftContext.tsx
@@ -2,22 +2,42 @@ import { createContext, useContext, type ReactNode } from "react";
 
 type PopulateComposer = (draft: string) => void;
 
-const ComposerDraftContext = createContext<PopulateComposer | null>(null);
+type ComposerActions = {
+  /** Put text in the composer and leave sending to the director. */
+  readonly populate: PopulateComposer;
+  /** Send text as the director's own message on this thread. */
+  readonly send: (text: string) => void;
+};
+
+const ComposerDraftContext = createContext<ComposerActions | null>(null);
 
 export function ComposerDraftProvider({
   populate,
+  send,
   children,
 }: {
   readonly populate: PopulateComposer;
+  readonly send: (text: string) => void;
   readonly children: ReactNode;
 }) {
   return (
-    <ComposerDraftContext.Provider value={populate}>
+    <ComposerDraftContext.Provider value={{ populate, send }}>
       {children}
     </ComposerDraftContext.Provider>
   );
 }
 
 export function usePopulateComposer(): PopulateComposer | null {
-  return useContext(ComposerDraftContext);
+  return useContext(ComposerDraftContext)?.populate ?? null;
+}
+
+/**
+ * The thread composer's send, reachable from inside a message.
+ *
+ * A component rendered under a message has its own edit composer in scope, so
+ * it cannot start a new turn on its own. This hands it the thread's composer,
+ * which is the only way an in-message action can send the director's message.
+ */
+export function useSendComposer(): ((text: string) => void) | null {
+  return useContext(ComposerDraftContext)?.send ?? null;
 }

--- a/desktop/surfaces/gui/src/chat/RunBudget.tsx
+++ b/desktop/surfaces/gui/src/chat/RunBudget.tsx
@@ -1,0 +1,123 @@
+import { useSendComposer } from "./ComposerDraftContext";
+import {
+  CONTINUE_RUN_PROMPT,
+  runBudgetStopText,
+  runBudgetWarningText,
+  type RunBudgetStatus,
+} from "./protocol";
+
+const RECEIPT_LIMIT = 12;
+
+function duration(seconds: number): string {
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}m ${String(Math.round(seconds % 60)).padStart(2, "0")}s`;
+}
+
+function money(value: number): string {
+  const digits = value === 0 ? 2 : value < 0.01 ? 4 : 2;
+  return `$${value.toFixed(digits)}`;
+}
+
+/**
+ * What the run is spending, in the same dense strip the header metrics use.
+ * Deliberately quiet: it sits under the activity list and reads as a status
+ * line, not as an alarm.
+ */
+function RunBudgetStrip({ status }: { readonly status: RunBudgetStatus }) {
+  const { consumed, limits } = status;
+  return (
+    <section
+      className="sourcecado-run-metrics sourcecado-run-metrics-running"
+      aria-label="Run budget"
+    >
+      <span>{`Step ${consumed.model_turns} of ${limits.model_turns}`}</span>
+      <span>{`${consumed.tool_calls} of ${limits.tool_calls} tool calls`}</span>
+      <span>
+        {`${duration(consumed.elapsed_seconds)} of ${duration(limits.elapsed_seconds)}`}
+      </span>
+      <span>
+        {`${money(consumed.estimated_cost_usd)} of ${money(limits.estimated_cost_usd)} est.`}
+      </span>
+    </section>
+  );
+}
+
+/**
+ * The stop. A run that ran out of budget did not finish, so this says so
+ * first, then lists what it actually completed, what it had queued, and
+ * offers to go on.
+ *
+ * Continue puts the director's own message in the composer and sends it. It
+ * starts an ordinary turn on the same conversation, which is why nothing here
+ * carries permission forward: every approval gate is asked again by the run
+ * itself.
+ */
+function RunBudgetStop({ status }: { readonly status: RunBudgetStatus }) {
+  const send = useSendComposer();
+  const receipts = status.completed.slice(0, RECEIPT_LIMIT);
+  const hidden = status.completed.length - receipts.length;
+  return (
+    <section
+      className="sourcecado-notice"
+      role="note"
+      aria-label="Run stopped before finishing"
+    >
+      <p className="sourcecado-notice-title">This run did not finish.</p>
+      <p className="sourcecado-notice-detail">{runBudgetStopText(status)}</p>
+      {receipts.length > 0 ? (
+        <ul aria-label="Completed tool steps">
+          {receipts.map((receipt) => (
+            <li key={receipt.id}>
+              {receipt.name}
+              {receipt.ok ? "" : " — failed"}
+            </li>
+          ))}
+          {hidden > 0 ? <li>{`and ${hidden} more`}</li> : null}
+        </ul>
+      ) : null}
+      {status.continue_available && send ? (
+        <div className="sourcecado-recovery-actions">
+          <button type="button" onClick={() => send(CONTINUE_RUN_PROMPT)}>
+            Continue this run
+          </button>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+/** The warning that arrives before a budget runs out. One sentence, no badge. */
+function RunBudgetWarning({
+  status,
+}: {
+  readonly status: RunBudgetStatus;
+}) {
+  if (!status.warning) return null;
+  return (
+    <p className="sourcecado-terminal-receipt" role="status">
+      {runBudgetWarningText(status.warning)}
+    </p>
+  );
+}
+
+/** Picks the one view that fits the run's current state. */
+export function RunBudgetView({
+  status,
+  messageState,
+}: {
+  readonly status: RunBudgetStatus | undefined;
+  readonly messageState: unknown;
+}) {
+  if (!status) return null;
+  if (status.state === "exhausted") return <RunBudgetStop status={status} />;
+  if (status.state === "finished") return null;
+  const live = messageState === "running" || messageState === "waiting-approval";
+  if (!live) return null;
+  return (
+    <>
+      <RunBudgetStrip status={status} />
+      <RunBudgetWarning status={status} />
+    </>
+  );
+}

--- a/desktop/surfaces/gui/src/chat/ThreadView.tsx
+++ b/desktop/surfaces/gui/src/chat/ThreadView.tsx
@@ -76,8 +76,16 @@ export function ThreadView({
     aui.composer.setText(draft);
     onDraftChange(draft);
   };
+  // Built here on purpose: this is the thread's composer. A component
+  // rendered under a message sees the edit composer instead, so it cannot
+  // start a turn without this.
+  const sendMessage = (text: string) => {
+    aui.composer.setText(text);
+    void aui.composer.send();
+    onDraftChange("");
+  };
   return (
-    <ComposerDraftProvider populate={populateComposer}>
+    <ComposerDraftProvider populate={populateComposer} send={sendMessage}>
     <div className="sourcecado-chat-workspace">
     <ThreadPrimitive.Root className="sourcecado-thread">
       <ThreadHeader

--- a/desktop/surfaces/gui/src/chat/messageAdapter.ts
+++ b/desktop/surfaces/gui/src/chat/messageAdapter.ts
@@ -1,5 +1,5 @@
 import type { ThreadMessageLike } from "@assistant-ui/react";
-import type { ApprovalResource, ToolFailure } from "./protocol";
+import type { ApprovalResource, RunBudgetStatus, ToolFailure } from "./protocol";
 import type { ProvenanceArtifact, ProvenanceSource } from "./protocol";
 
 export type LegacyStoredMessage = {
@@ -96,6 +96,8 @@ export type SourcecadoPart =
 export type SourcecadoStructuredMessage = {
   readonly id: string;
   readonly role: "assistant" | "user" | "system";
+  /** The run's spend against its budget, as of the last event for it. */
+  readonly runBudget?: RunBudgetStatus;
   readonly state:
     | "running"
     | "stopping"
@@ -342,6 +344,7 @@ export function convertStructuredMessage(
     metadata: {
       custom: {
         sourcecadoState: message.state,
+        ...(message.runBudget ? { sourcecadoRunBudget: message.runBudget } : {}),
         sourcecadoPartIds: message.parts.map((part) => part.id),
         ...(() => {
           const notice = message.parts.find(

--- a/desktop/surfaces/gui/src/chat/protocol.ts
+++ b/desktop/surfaces/gui/src/chat/protocol.ts
@@ -117,6 +117,7 @@ export type ProtocolChatEvent = ChatEventEnvelope &
         readonly name: string;
         readonly arguments: Readonly<Record<string, unknown>>;
         readonly started_at?: string;
+        readonly run_budget?: RunBudgetStatus;
       }
     | {
         readonly type: "tool_finished";
@@ -157,6 +158,7 @@ export type ProtocolChatEvent = ChatEventEnvelope &
         readonly state: "complete" | "partial" | "stopped" | "interrupted";
         readonly message?: string;
         readonly compaction?: CompactionNotice;
+        readonly run_budget?: RunBudgetStatus;
       }
     | {
         readonly type: "error";
@@ -228,6 +230,222 @@ export function compactionNoticeText(value: unknown): string {
     );
   }
   parts.push("The full conversation is still saved on this machine.");
+  return parts.join(" ");
+}
+
+/**
+ * What the operator is told about a run's budget: counts and outcomes, never
+ * prose from the sidecar.
+ *
+ * Same discipline as `CompactionNotice`. Fields are copied one at a time and
+ * every sentence below is written here, so a sidecar that starts sending a
+ * reassuring message cannot get it rendered as Sourcecado's own account of
+ * what happened.
+ */
+export type RunBudgetName =
+  | "model_turns"
+  | "tool_calls"
+  | "elapsed_seconds"
+  | "input_tokens"
+  | "output_tokens"
+  | "estimated_cost_usd";
+
+export type RunBudgetMeasurements = Readonly<Record<RunBudgetName, number>>;
+
+export type RunBudgetWarning = {
+  readonly budget: RunBudgetName;
+  readonly used: number;
+  readonly limit: number;
+  readonly used_ratio: number;
+};
+
+export type RunBudgetReceipt = {
+  readonly id: string;
+  readonly name: string;
+  readonly ok: boolean;
+};
+
+export type RunBudgetStatus = {
+  readonly state: "running" | "warning" | "exhausted" | "finished";
+  /** A budget name, or "loop" when the run was stopped for repeating itself. */
+  readonly stopped_by: RunBudgetName | "loop" | null;
+  readonly exhausted: readonly RunBudgetName[];
+  readonly repeats: number;
+  readonly consumed: RunBudgetMeasurements;
+  readonly limits: RunBudgetMeasurements;
+  readonly warning: RunBudgetWarning | null;
+  readonly completed: readonly RunBudgetReceipt[];
+  readonly remaining: {
+    readonly requested_tools: readonly { readonly id: string; readonly name: string }[];
+    /** False whenever the run ended without the model closing it. */
+    readonly final_answer: boolean;
+  };
+  readonly unpriced_requests: number;
+  readonly unmeasured_requests: number;
+  readonly continue_available: boolean;
+};
+
+const RUN_BUDGET_NAMES: readonly RunBudgetName[] = [
+  "model_turns",
+  "tool_calls",
+  "elapsed_seconds",
+  "input_tokens",
+  "output_tokens",
+  "estimated_cost_usd",
+];
+
+const RUN_BUDGET_LABELS: Readonly<Record<RunBudgetName, string>> = {
+  model_turns: "model turns",
+  tool_calls: "tool calls",
+  elapsed_seconds: "time",
+  input_tokens: "input tokens",
+  output_tokens: "output tokens",
+  estimated_cost_usd: "estimated cost",
+};
+
+/** The text Sourcecado shows the operator when the composer offers to go on. */
+export const CONTINUE_RUN_PROMPT = "Continue this run from where it stopped.";
+
+function budgetName(value: unknown): RunBudgetName | null {
+  return RUN_BUDGET_NAMES.includes(value as RunBudgetName)
+    ? (value as RunBudgetName)
+    : null;
+}
+
+function measurements(value: unknown): RunBudgetMeasurements {
+  const source = isRecord(value) ? value : {};
+  const out = {} as Record<RunBudgetName, number>;
+  for (const name of RUN_BUDGET_NAMES) out[name] = countOf(source[name]);
+  return out;
+}
+
+function budgetWarning(value: unknown): RunBudgetWarning | null {
+  if (!isRecord(value)) return null;
+  const budget = budgetName(value.budget);
+  if (!budget) return null;
+  return {
+    budget,
+    used: countOf(value.used),
+    limit: countOf(value.limit),
+    used_ratio: countOf(value.used_ratio),
+  };
+}
+
+function budgetReceipts(value: unknown): RunBudgetReceipt[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) =>
+    isRecord(entry) &&
+    typeof entry.id === "string" &&
+    typeof entry.name === "string"
+      ? [{ id: entry.id, name: entry.name, ok: entry.ok === true }]
+      : [],
+  );
+}
+
+export function runBudgetStatus(value: unknown): RunBudgetStatus | undefined {
+  if (!isRecord(value)) return undefined;
+  const state = ["running", "warning", "exhausted", "finished"].includes(
+    String(value.state),
+  )
+    ? (value.state as RunBudgetStatus["state"])
+    : "running";
+  const remaining = isRecord(value.remaining) ? value.remaining : {};
+  const requested = Array.isArray(remaining.requested_tools)
+    ? remaining.requested_tools
+    : [];
+  return {
+    state,
+    stopped_by:
+      value.stopped_by === "loop" ? "loop" : budgetName(value.stopped_by),
+    exhausted: Array.isArray(value.exhausted)
+      ? value.exhausted.flatMap((entry) => {
+          const name = budgetName(entry);
+          return name ? [name] : [];
+        })
+      : [],
+    repeats: countOf(value.repeats),
+    consumed: measurements(value.consumed),
+    limits: measurements(value.limits),
+    warning: budgetWarning(value.warning),
+    completed: budgetReceipts(value.completed),
+    remaining: {
+      requested_tools: requested.flatMap((entry: unknown) =>
+        isRecord(entry) &&
+        typeof entry.id === "string" &&
+        typeof entry.name === "string"
+          ? [{ id: entry.id, name: entry.name }]
+          : [],
+      ),
+      // Absent means "we were not told the run closed", which is the safe
+      // reading: unfinished until the sidecar says otherwise.
+      final_answer: remaining.final_answer === true,
+    },
+    unpriced_requests: countOf(value.unpriced_requests),
+    unmeasured_requests: countOf(value.unmeasured_requests),
+    continue_available: value.continue_available === true,
+  };
+}
+
+function runBudgetLabel(name: RunBudgetName): string {
+  return RUN_BUDGET_LABELS[name];
+}
+
+/** One plain sentence, before the stop, naming the budget that is running out. */
+export function runBudgetWarningText(warning: RunBudgetWarning): string {
+  const percent = Math.min(100, Math.round(warning.used_ratio * 100));
+  return (
+    `This run has used ${percent}% of its ${runBudgetLabel(warning.budget)} ` +
+    "budget. It will stop and ask before going further."
+  );
+}
+
+/**
+ * What a stopped run says about itself. It never reads as a conclusion: the
+ * first sentence says the run did not finish, and the rest is what it did.
+ */
+export function runBudgetStopText(status: RunBudgetStatus): string {
+  const parts: string[] = [];
+  if (status.stopped_by === "loop") {
+    parts.push(
+      `Sourcecado stopped this run after ${status.repeats} tool calls in a ` +
+        "row that returned nothing new. It was repeating itself, not making " +
+        "progress, so it did not finish.",
+    );
+  } else {
+    const names = status.exhausted.length
+      ? status.exhausted.map(runBudgetLabel).join(" and ")
+      : "run";
+    parts.push(
+      `Sourcecado stopped this run at its ${names} budget. It did not finish.`,
+    );
+  }
+  const ran = status.completed.length;
+  const failed = status.completed.filter((receipt) => !receipt.ok).length;
+  parts.push(
+    ran === 1
+      ? "1 tool step completed."
+      : `${ran} tool steps completed.`,
+  );
+  if (failed > 0) {
+    parts.push(`${failed} of them failed.`);
+  }
+  const queued = status.remaining.requested_tools.length;
+  if (queued > 0) {
+    parts.push(
+      queued === 1
+        ? "1 more was queued and never ran."
+        : `${queued} more were queued and never ran.`,
+    );
+  }
+  if (!status.remaining.final_answer) {
+    parts.push("No final answer was written, so anything above is partial.");
+  }
+  if (status.unpriced_requests > 0) {
+    parts.push(
+      `The cost figure does not cover ${status.unpriced_requests} of this ` +
+        "run's model requests, because the provider reported no price for them.",
+    );
+  }
   return parts.join(" ");
 }
 
@@ -528,6 +746,21 @@ export function parseChatEvent(value: unknown): ChatEvent {
           delay_ms: value.delay_ms as number,
           message: value.message as string,
         };
+      }
+      if (
+        (value.type === "turn_end" || value.type === "tool_started") &&
+        "run_budget" in value
+      ) {
+        const budget = runBudgetStatus(value.run_budget);
+        const sanitized: Record<string, unknown> = { ...value };
+        delete sanitized.run_budget;
+        if (budget) sanitized.run_budget = budget;
+        if (value.type === "turn_end" && "compaction" in sanitized) {
+          const notice = compactionNotice(sanitized.compaction);
+          delete sanitized.compaction;
+          if (notice) sanitized.compaction = notice;
+        }
+        return sanitized as ProtocolChatEvent;
       }
       if (value.type === "turn_end" && "compaction" in value) {
         const notice = compactionNotice(value.compaction);

--- a/desktop/surfaces/gui/src/chat/store.ts
+++ b/desktop/surfaces/gui/src/chat/store.ts
@@ -12,6 +12,7 @@ import type {
   ApprovalResource,
   ProvenanceArtifact,
   ProvenanceSource,
+  RunBudgetStatus,
   ToolFailure,
 } from "./protocol";
 
@@ -164,6 +165,12 @@ export type SourcecadoEvent =
         | "failed"
         | "stopped"
         | "interrupted";
+    }
+  | {
+      readonly type: "run_budget_changed";
+      readonly threadId: string;
+      readonly messageId: string;
+      readonly status: RunBudgetStatus;
     }
   | {
       readonly type: "message_finished";
@@ -421,6 +428,14 @@ export class SourcecadoChatStore {
       const startedAt = event.started_at
         ? Date.parse(event.started_at)
         : undefined;
+      if (event.run_budget) {
+        this.apply({
+          type: "run_budget_changed",
+          threadId: event.session_id,
+          messageId: event.message_id,
+          status: event.run_budget,
+        });
+      }
       this.apply({
         type: "tool_started",
         threadId: event.session_id,
@@ -468,6 +483,14 @@ export class SourcecadoChatStore {
       return;
     }
     if (event.type === "turn_end") {
+      if (event.run_budget) {
+        this.apply({
+          type: "run_budget_changed",
+          threadId: event.session_id,
+          messageId: event.message_id,
+          status: event.run_budget,
+        });
+      }
       if (event.compaction) {
         this.addNotice(
           event.session_id,
@@ -514,6 +537,18 @@ export class SourcecadoChatStore {
           parts: [],
         },
       ]);
+      return;
+    }
+
+    if (event.type === "run_budget_changed") {
+      this.threads.set(
+        event.threadId,
+        messages.map((message) =>
+          message.id === event.messageId
+            ? { ...message, runBudget: event.status }
+            : message,
+        ),
+      );
       return;
     }
 

--- a/desktop/surfaces/gui/tests/runBudget.test.tsx
+++ b/desktop/surfaces/gui/tests/runBudget.test.tsx
@@ -1,0 +1,378 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ChatPage } from "../src/routes/ChatPage";
+import {
+  parseChatEvent,
+  runBudgetStatus,
+  runBudgetStopText,
+  type RunBudgetStatus,
+} from "../src/chat/protocol";
+
+const api = vi.hoisted(() => ({
+  getHealth: vi.fn(),
+  getSessions: vi.fn(),
+  getPersona: vi.fn(),
+  getSchedule: vi.fn(),
+  getGmail: vi.fn(),
+  getConnectors: vi.fn(),
+  getSettings: vi.fn(),
+  getInbox: vi.fn(),
+  getSession: vi.fn(),
+  getCurrentRunTelemetry: vi.fn(),
+  openChat: vi.fn(),
+}));
+const chatSend = vi.fn();
+let onChatEvent: ((event: Record<string, unknown>) => void) | undefined;
+
+vi.mock("../src/api", () => ({
+  connectCalendar: vi.fn(),
+  connectDrive: vi.fn(),
+  connectGmail: vi.fn(),
+  connectGranola: vi.fn(),
+  disconnectGmail: vi.fn(),
+  getHealth: api.getHealth,
+  getSessions: api.getSessions,
+  getPersona: api.getPersona,
+  getSchedule: api.getSchedule,
+  getGmail: api.getGmail,
+  getConnectors: api.getConnectors,
+  getSettings: api.getSettings,
+  getInbox: api.getInbox,
+  getSession: api.getSession,
+  getCurrentRunTelemetry: api.getCurrentRunTelemetry,
+  hasToken: () => true,
+  openChat: api.openChat,
+  resolveInbox: vi.fn(),
+  runScheduleJob: vi.fn(),
+  setPersona: vi.fn(),
+}));
+
+const LIMITS = {
+  model_turns: 40,
+  tool_calls: 120,
+  elapsed_seconds: 900,
+  input_tokens: 2000000,
+  output_tokens: 200000,
+  estimated_cost_usd: 2,
+};
+
+function envelope(type: string, extra: Record<string, unknown>) {
+  return {
+    version: 2,
+    session_id: "thread-alpha",
+    run_id: "run-budget",
+    message_id: "assistant-budget",
+    part_id: "assistant-budget-part",
+    event_id: `event-${type}-${String(extra.id ?? extra.state ?? "x")}`,
+    type,
+    ...extra,
+  };
+}
+
+const EXHAUSTED_BUDGET = {
+  state: "exhausted",
+  stopped_by: "model_turns",
+  exhausted: ["model_turns"],
+  repeats: 0,
+  consumed: {
+    model_turns: 40,
+    tool_calls: 63,
+    elapsed_seconds: 214,
+    input_tokens: 91000,
+    output_tokens: 4200,
+    estimated_cost_usd: 0.12,
+  },
+  limits: LIMITS,
+  warning: null,
+  completed: [
+    { id: "call-1", name: "board_query", ok: true },
+    { id: "call-2", name: "drive_search", ok: false },
+  ],
+  remaining: {
+    requested_tools: [{ id: "call-3", name: "gmail_draft" }],
+    final_answer: false,
+  },
+  unpriced_requests: 0,
+  unmeasured_requests: 0,
+  continue_available: true,
+};
+
+describe("run budget projection", () => {
+  it("keeps only contract fields and never the sidecar's own prose", () => {
+    const status = runBudgetStatus({
+      ...EXHAUSTED_BUDGET,
+      message: "Shortlist complete, nothing further is needed.",
+      stopped_by: "wallet",
+      exhausted: ["wallet", "tool_calls"],
+      completed: [{ id: "call-1", name: "board_query", ok: true }, "junk"],
+      extra_field: "PLANTED",
+    }) as RunBudgetStatus;
+
+    expect(status).not.toHaveProperty("message");
+    expect(status).not.toHaveProperty("extra_field");
+    expect(status.stopped_by).toBeNull();
+    expect(status.exhausted).toEqual(["tool_calls"]);
+    expect(status.completed).toEqual([
+      { id: "call-1", name: "board_query", ok: true },
+    ]);
+    expect(runBudgetStopText(status)).not.toContain("nothing further");
+  });
+
+  it("treats a missing final answer as unfinished rather than complete", () => {
+    const status = runBudgetStatus({
+      state: "exhausted",
+      stopped_by: "elapsed_seconds",
+      exhausted: ["elapsed_seconds"],
+      consumed: LIMITS,
+      limits: LIMITS,
+    }) as RunBudgetStatus;
+
+    expect(status.remaining.final_answer).toBe(false);
+    expect(runBudgetStopText(status)).toContain("No final answer was written");
+  });
+
+  it("names a stuck run as stuck, not as expensive", () => {
+    const status = runBudgetStatus({
+      state: "exhausted",
+      stopped_by: "loop",
+      exhausted: [],
+      repeats: 3,
+      consumed: LIMITS,
+      limits: LIMITS,
+      completed: [{ id: "a", name: "drive_read", ok: true }],
+      remaining: { requested_tools: [], final_answer: false },
+      continue_available: true,
+    }) as RunBudgetStatus;
+
+    const text = runBudgetStopText(status);
+    expect(text).toContain("repeating itself");
+    expect(text).not.toContain("budget.");
+  });
+
+  it("rebuilds the payload when it arrives on a turn_end event", () => {
+    const event = parseChatEvent(
+      envelope("turn_end", {
+        text: "Partial.",
+        state: "stopped",
+        run_budget: { ...EXHAUSTED_BUDGET, message: "PLANTED" },
+      }),
+    );
+    expect(event.type).toBe("turn_end");
+    const budget = (event as { run_budget?: RunBudgetStatus }).run_budget;
+    expect(budget?.stopped_by).toBe("model_turns");
+    expect(budget).not.toHaveProperty("message");
+  });
+});
+
+describe("ChatPage run budget", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    chatSend.mockReset();
+    onChatEvent = undefined;
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: vi.fn(),
+    });
+    api.getHealth.mockResolvedValue({
+      status: "ok",
+      piece: "desktop",
+      slice: 1,
+      model: "operator-model",
+    });
+    api.getSessions.mockResolvedValue({ sessions: [], open_id: "thread-alpha" });
+    api.getPersona.mockResolvedValue({
+      id: "sourcing",
+      name: "Sourcing Operator",
+      tools: [],
+    });
+    api.getSchedule.mockResolvedValue({ jobs: [], runs: [] });
+    api.getGmail.mockResolvedValue({ connected: false, email: null });
+    api.getConnectors.mockResolvedValue({ connectors: [] });
+    api.getSettings.mockResolvedValue({
+      persona: { id: "sourcing", name: "Sourcing Operator" },
+      model: "operator-model",
+      gmail: { connected: false, email: null },
+      apollo: { configured: false },
+    });
+    api.getInbox.mockResolvedValue({ items: [] });
+    api.getCurrentRunTelemetry.mockResolvedValue({
+      version: 1,
+      session_id: "thread-alpha",
+      current_run: null,
+    });
+    api.openChat.mockImplementation((callback: typeof onChatEvent) => {
+      onChatEvent = callback;
+      return {
+        send: chatSend,
+        approve: vi.fn(),
+        cancel: vi.fn(),
+        queue: vi.fn(),
+        recover: vi.fn(),
+        close: vi.fn(),
+      };
+    });
+    api.getSession.mockResolvedValue({
+      id: "thread-alpha",
+      title: "Budgeted run",
+      messages: [],
+      events: [],
+    });
+  });
+
+  it("shows what the run is doing and warns before a budget is exhausted", async () => {
+    render(<ChatPage sessionId="thread-alpha" />);
+    await waitFor(() => expect(onChatEvent).toBeDefined());
+
+    act(() => {
+      onChatEvent?.(envelope("turn_start", { state: "running" }));
+      onChatEvent?.(
+        envelope("tool_started", {
+          id: "call-1",
+          name: "drive_search",
+          arguments: {},
+          run_budget: {
+            state: "warning",
+            stopped_by: null,
+            exhausted: [],
+            consumed: {
+              model_turns: 33,
+              tool_calls: 61,
+              elapsed_seconds: 214,
+              input_tokens: 91000,
+              output_tokens: 4200,
+              estimated_cost_usd: 0.12,
+            },
+            limits: LIMITS,
+            warning: {
+              budget: "model_turns",
+              used: 33,
+              limit: 40,
+              used_ratio: 0.825,
+            },
+          },
+        }),
+      );
+    });
+
+    // Current activity is named, and the run's spend sits beside it.
+    const strip = await screen.findByRole("region", { name: "Run budget" });
+    const activity = document.querySelector(".sourcecado-activity");
+    expect(activity).toHaveTextContent("Searched Drive");
+    expect(activity).toHaveTextContent("Running");
+    expect(strip).toHaveTextContent("Step 33 of 40");
+    expect(strip).toHaveTextContent("61 of 120 tool calls");
+    expect(strip).toHaveTextContent("3m 34s of 15m 00s");
+    expect(strip).toHaveTextContent("$0.12 of $2.00 est.");
+    expect(
+      screen.getByText(/used 83% of its model turns budget/i),
+    ).toBeInTheDocument();
+    // The warning arrives before the stop, not with it.
+    expect(screen.queryByRole("note")).not.toBeInTheDocument();
+  });
+
+  it("marks an exhausted run unfinished, shows receipts, and offers Continue", async () => {
+    render(<ChatPage sessionId="thread-alpha" />);
+    await waitFor(() => expect(onChatEvent).toBeDefined());
+
+    act(() => {
+      onChatEvent?.(envelope("turn_start", { state: "running" }));
+      onChatEvent?.(
+        envelope("assistant_delta", { delta: "Three names so far." }),
+      );
+      onChatEvent?.(
+        envelope("turn_end", {
+          text: "Three names so far.",
+          state: "stopped",
+          run_budget: EXHAUSTED_BUDGET,
+        }),
+      );
+    });
+
+    const note = await screen.findByRole("note", {
+      name: "Run stopped before finishing",
+    });
+    expect(note).toHaveTextContent("This run did not finish.");
+    expect(note).toHaveTextContent("stopped this run at its model turns budget");
+    expect(note).toHaveTextContent("2 tool steps completed.");
+    expect(note).toHaveTextContent("1 of them failed.");
+    expect(note).toHaveTextContent("1 more was queued and never ran.");
+    expect(note).toHaveTextContent("No final answer was written");
+    const receipts = screen.getByRole("list", { name: "Completed tool steps" });
+    expect(receipts).toHaveTextContent("board_query");
+    expect(receipts).toHaveTextContent("drive_search — failed");
+
+    fireEvent.click(screen.getByRole("button", { name: "Continue this run" }));
+
+    await waitFor(() =>
+      expect(chatSend).toHaveBeenCalledWith(
+        "Continue this run from where it stopped.",
+        "thread-alpha",
+      ),
+    );
+  });
+
+  it("shows no stop card when the run actually finished", async () => {
+    render(<ChatPage sessionId="thread-alpha" />);
+    await waitFor(() => expect(onChatEvent).toBeDefined());
+
+    act(() => {
+      onChatEvent?.(envelope("turn_start", { state: "running" }));
+      onChatEvent?.(envelope("assistant_delta", { delta: "Here is the shortlist." }));
+      onChatEvent?.(
+        envelope("turn_end", {
+          text: "Here is the shortlist.",
+          state: "complete",
+          run_budget: {
+            ...EXHAUSTED_BUDGET,
+            state: "finished",
+            stopped_by: null,
+            exhausted: [],
+            remaining: { requested_tools: [], final_answer: true },
+            continue_available: false,
+          },
+        }),
+      );
+    });
+
+    expect(await screen.findByText("Here is the shortlist.")).toBeInTheDocument();
+    expect(screen.queryByRole("note")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Continue this run" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("still offers Continue after the UI is restarted and the run is restored", async () => {
+    api.getSession.mockResolvedValue({
+      id: "thread-alpha",
+      title: "Budgeted run",
+      messages: [
+        { role: "user", content: "Build the shortlist." },
+        { role: "assistant", content: "Three names so far." },
+      ],
+      events: [
+        envelope("turn_start", { state: "running" }),
+        envelope("assistant_delta", { delta: "Three names so far." }),
+        envelope("turn_end", {
+          text: "Three names so far.",
+          state: "stopped",
+          run_budget: EXHAUSTED_BUDGET,
+        }),
+      ],
+    });
+
+    render(<ChatPage sessionId="thread-alpha" />);
+
+    const note = await screen.findByRole("note", {
+      name: "Run stopped before finishing",
+    });
+    expect(note).toHaveTextContent("This run did not finish.");
+    fireEvent.click(screen.getByRole("button", { name: "Continue this run" }));
+    await waitFor(() =>
+      expect(chatSend).toHaveBeenCalledWith(
+        "Continue this run from where it stopped.",
+        "thread-alpha",
+      ),
+    );
+  });
+});

--- a/desktop/tests/test_chat.py
+++ b/desktop/tests/test_chat.py
@@ -558,7 +558,10 @@ def test_ws_persists_a_failed_terminal_event_with_the_turn_identity(tmp_path):
     assert built.state.store.load_events(sid) == events
 
 
-def test_ws_persists_a_stopped_terminal_event_at_the_step_limit(tmp_path):
+def test_ws_persists_a_stopped_terminal_event_when_a_run_repeats_itself(tmp_path):
+    """These eight identical calls used to hit the fixed step ceiling. They now
+    trip the loop detector, which reports the run as stuck rather than as
+    having reached an arbitrary limit."""
     fake = FakeProvider(
         steps=[
             {
@@ -580,7 +583,9 @@ def test_ws_persists_a_stopped_terminal_event_at_the_step_limit(tmp_path):
     stopped = events[-1]
     assert stopped["type"] == "turn_end"
     assert stopped["state"] == "stopped"
-    assert "8 tool steps" in stopped["message"]
+    assert "returned nothing new" in stopped["message"]
+    assert stopped["run_budget"]["stopped_by"] == "loop"
+    assert stopped["run_budget"]["continue_available"] is True
     assert stopped["run_id"] == events[0]["run_id"]
     assert built.state.store.load_events(sid) == events
 

--- a/desktop/tests/test_run_budget.py
+++ b/desktop/tests/test_run_budget.py
@@ -1,0 +1,956 @@
+"""Run budgets in the real turn loop.
+
+Every test here first proves the run actually got far enough to produce the
+state under test, and only then asserts the property. A budget test that
+passed because the run never started would keep passing after the budget it
+covers was deleted, which is the failure mode these are written against.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from coworker import turn as turn_module
+from coworker.automation.scheduler import RECEIPT_STATUSES
+from coworker.compaction import (
+    OPEN_TAG,
+    CompactionPolicy,
+    SessionCompactor,
+    state_key,
+    transcript_defects,
+)
+from coworker.inbox import Inbox
+from coworker.people import PersonStore
+from coworker.permissions import ASK, AUTO, RETRY_SAFE, decide
+from coworker.provider import (
+    FakeProvider,
+    ModelUsage,
+    ProviderErrorKind,
+    ProviderStreamError,
+    ProviderTerminal,
+    StreamChunk,
+    ToolCall,
+)
+from coworker.provider_retry import RetryPolicy
+from coworker.run_budget import (
+    DEFAULT_ELAPSED_SECONDS,
+    DEFAULT_ESTIMATED_COST_USD,
+    DEFAULT_INPUT_TOKENS,
+    DEFAULT_LOOP_REPEAT_LIMIT,
+    DEFAULT_MODEL_TURNS,
+    DEFAULT_OUTPUT_TOKENS,
+    DEFAULT_TOOL_CALLS,
+    MEASUREMENT_SOURCES,
+    BudgetName,
+    RunBudgetMeter,
+    RunBudgetPolicy,
+)
+from coworker.store import ConversationStore
+from coworker.tools import OPENAI_TOOLS
+from coworker.turn import RunControl, new_turn_identity, run_turn
+
+SID = "sess-budget"
+
+
+def _usage(input_tokens: int, output_tokens: int) -> ModelUsage:
+    return ModelUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=input_tokens + output_tokens,
+        cached_input_tokens=0,
+        uncached_input_tokens=input_tokens,
+        reasoning_tokens=0,
+    )
+
+
+class SourcingProvider:
+    """A model that keeps asking distinct Board questions and never stops.
+
+    Distinct on purpose: this is the shape of ordinary sourcing work, so a run
+    driven by it can only be stopped by an absolute budget, never by the loop
+    detector. Tests that want the loop detector use `RepeatingProvider`.
+    """
+
+    provider_id = "fake"
+    model_id = "fake"
+
+    def __init__(
+        self,
+        *,
+        usage: ModelUsage | None = None,
+        cost_usd: float | None = None,
+        calls_per_turn: int = 1,
+        tool_name: str = "board_query",
+        arguments: Any = None,
+        sleep_seconds: float = 0.0,
+    ) -> None:
+        self.usage = usage
+        self.cost_usd = cost_usd
+        self.calls_per_turn = calls_per_turn
+        self.tool_name = tool_name
+        self.arguments = arguments
+        self.sleep_seconds = sleep_seconds
+        self.calls: list[list[dict[str, Any]]] = []
+        self.requests = 0
+
+    def _call(self, turn_index: int, slot: int) -> ToolCall:
+        arguments = (
+            dict(self.arguments)
+            if self.arguments is not None
+            else {"company": f"Company {turn_index}-{slot}"}
+        )
+        return ToolCall(
+            id=f"call_{turn_index}_{slot}",
+            name=self.tool_name,
+            arguments=arguments,
+        )
+
+    async def astream(self, *, messages, tools=None, context_id=None):
+        self.calls.append(list(messages))
+        turn_index = self.requests
+        self.requests += 1
+        if self.sleep_seconds:
+            await asyncio.sleep(self.sleep_seconds)
+        yield StreamChunk.started(provider=self.provider_id, model=self.model_id)
+        yield StreamChunk(text_delta=f"Working step {turn_index}. ")
+        if self.usage is not None:
+            yield StreamChunk(usage=self.usage)
+        yield StreamChunk(
+            finish_reason="tool_calls",
+            terminal=ProviderTerminal(
+                stop_reason="tool_calls",
+                usage=self.usage,
+                latency_ms=1.0,
+                estimated_cost_usd=self.cost_usd,
+            ),
+        )
+        yield StreamChunk(
+            tool_calls=[
+                self._call(turn_index, slot) for slot in range(self.calls_per_turn)
+            ]
+        )
+
+
+class RepeatingProvider(SourcingProvider):
+    """A model stuck asking the same question with the same answer."""
+
+    def _call(self, turn_index: int, slot: int) -> ToolCall:
+        return ToolCall(
+            id=f"call_{turn_index}_{slot}",
+            name=self.tool_name,
+            arguments={"company": "Nimbus"},
+        )
+
+
+class ScriptedProvider(SourcingProvider):
+    """Distinct tool steps for a while, then a closing answer."""
+
+    def __init__(self, *, tool_turns: int, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.tool_turns = tool_turns
+
+    async def astream(self, *, messages, tools=None, context_id=None):
+        self.calls.append(list(messages))
+        turn_index = self.requests
+        self.requests += 1
+        yield StreamChunk.started(provider=self.provider_id, model=self.model_id)
+        if turn_index >= self.tool_turns:
+            yield StreamChunk(text_delta="Here is the shortlist.")
+            yield StreamChunk(finish_reason="stop")
+            return
+        yield StreamChunk(text_delta=f"Checking source {turn_index}. ")
+        if self.usage is not None:
+            yield StreamChunk(usage=self.usage)
+        yield StreamChunk(finish_reason="tool_calls")
+        yield StreamChunk(tool_calls=[self._call(turn_index, 0)])
+
+
+def _events(store: ConversationStore, sid: str = SID) -> list[dict]:
+    return list(store.load_events(sid))
+
+
+def _terminal(store: ConversationStore, sid: str = SID) -> dict:
+    ends = [
+        event
+        for event in _events(store, sid)
+        if event["type"] in {"turn_end", "turn_stopped"}
+    ]
+    assert ends, "the run produced no terminal event"
+    return ends[-1]
+
+
+def _tool_started(store: ConversationStore, sid: str = SID) -> list[dict]:
+    return [event for event in _events(store, sid) if event["type"] == "tool_started"]
+
+
+def _turn(
+    tmp_path,
+    *,
+    provider,
+    text="Build the shortlist.",
+    sid=SID,
+    store=None,
+    people=None,
+    inbox=None,
+    wait=None,
+    gmail=None,
+    **kwargs,
+):
+    conv = store if store is not None else ConversationStore(tmp_path)
+    person_store = people if people is not None else PersonStore(tmp_path)
+
+    async def _wait(_call_id: str) -> str:
+        return wait or "allow"
+
+    result = asyncio.run(
+        run_turn(
+            text=text,
+            sid=sid,
+            store=conv,
+            provider=provider,
+            persona=None,
+            skills=None,
+            inbox=inbox if inbox is not None else Inbox(conv),
+            openai_tools=OPENAI_TOOLS,
+            execute_kwargs={"people": person_store, "gmail": gmail},
+            wait_permission=_wait if wait is not None else None,
+            **kwargs,
+        )
+    )
+    return result, conv
+
+
+# --- criterion 9, first case: ordinary work is not cut short ---------------
+
+
+def test_ordinary_sourcing_work_past_eight_steps_simply_finishes(tmp_path):
+    """The point of the whole issue. Twelve honest steps, no interruption."""
+    provider = ScriptedProvider(tool_turns=12, usage=_usage(900, 60))
+    result, conv = _turn(tmp_path, provider=provider)
+
+    assert len(_tool_started(conv)) == 12, "the run did not take twelve tool steps"
+    assert result["status"] == "ok"
+    assert result["text"] == "Here is the shortlist."
+    terminal = _terminal(conv)
+    assert terminal["state"] == "complete"
+    assert terminal["run_budget"]["state"] == "finished"
+    assert terminal["run_budget"]["stopped_by"] is None
+    assert terminal["run_budget"]["remaining"]["final_answer"] is True
+    assert terminal["run_budget"]["continue_available"] is False
+
+
+# --- criterion 1: documented defaults --------------------------------------
+
+
+def test_documented_defaults_cover_every_budget_and_name_their_measurement():
+    limits = RunBudgetPolicy().limits()
+
+    assert limits == {
+        "model_turns": DEFAULT_MODEL_TURNS,
+        "tool_calls": DEFAULT_TOOL_CALLS,
+        "elapsed_seconds": DEFAULT_ELAPSED_SECONDS,
+        "input_tokens": DEFAULT_INPUT_TOKENS,
+        "output_tokens": DEFAULT_OUTPUT_TOKENS,
+        "estimated_cost_usd": DEFAULT_ESTIMATED_COST_USD,
+    }
+    assert set(MEASUREMENT_SOURCES) == set(limits)
+    assert set(limits) == {name.value for name in BudgetName}
+    # The two the operator must not read as measurements.
+    assert MEASUREMENT_SOURCES["estimated_cost_usd"] == "provider_cost_estimate"
+    assert MEASUREMENT_SOURCES["elapsed_seconds"] == "monotonic_clock"
+
+
+def test_a_policy_that_cannot_detect_a_loop_before_its_ceiling_is_rejected():
+    """Criterion 7's ordering, held in the type rather than left to luck."""
+    with pytest.raises(ValueError, match="before the absolute budget"):
+        RunBudgetPolicy(tool_calls=DEFAULT_LOOP_REPEAT_LIMIT)
+
+
+# --- criterion 2 and 9: each individual budget ------------------------------
+
+
+def test_the_model_turn_budget_stops_a_run_that_will_not_end(tmp_path):
+    provider = SourcingProvider()
+    result, conv = _turn(
+        tmp_path,
+        provider=provider,
+        run_budget_policy=RunBudgetPolicy(model_turns=5),
+    )
+
+    assert provider.requests == 5, "the run did not reach the model-turn budget"
+    assert len(_tool_started(conv)) == 5
+    terminal = _terminal(conv)
+    assert result["status"] == "stopped"
+    assert terminal["state"] == "stopped"
+    assert terminal["run_budget"]["stopped_by"] == "model_turns"
+    assert terminal["run_budget"]["consumed"]["model_turns"] == 5
+
+
+def test_the_tool_call_budget_stops_a_run_mid_batch_and_names_what_was_queued(
+    tmp_path,
+):
+    provider = SourcingProvider(calls_per_turn=3)
+    result, conv = _turn(
+        tmp_path,
+        provider=provider,
+        run_budget_policy=RunBudgetPolicy(model_turns=40, tool_calls=7),
+    )
+
+    started = _tool_started(conv)
+    assert len(started) == 7, "the run did not reach the tool-call budget"
+    terminal = _terminal(conv)
+    assert result["status"] == "stopped"
+    assert terminal["run_budget"]["stopped_by"] == "tool_calls"
+    assert terminal["run_budget"]["consumed"]["tool_calls"] == 7
+    # The two calls in the batch that were requested and never run.
+    remaining = terminal["run_budget"]["remaining"]["requested_tools"]
+    assert [item["name"] for item in remaining] == ["board_query", "board_query"]
+    assert {item["id"] for item in remaining}.isdisjoint(
+        {event["id"] for event in started}
+    )
+    # Stopping inside a batch leaves tool calls with no results. They are
+    # closed on the way out, so the continuation reads a well-formed
+    # transcript instead of an orphaned call.
+    assert transcript_defects(conv.load(SID)) == []
+
+
+def test_the_elapsed_time_budget_stops_a_slow_run(tmp_path):
+    provider = SourcingProvider(sleep_seconds=0.05)
+    result, conv = _turn(
+        tmp_path,
+        provider=provider,
+        run_budget_policy=RunBudgetPolicy(elapsed_seconds=0.01),
+    )
+
+    assert provider.requests >= 1, "the run never issued a model request"
+    terminal = _terminal(conv)
+    assert result["status"] == "stopped"
+    assert terminal["run_budget"]["stopped_by"] == "elapsed_seconds"
+    assert terminal["run_budget"]["consumed"]["elapsed_seconds"] >= 0.01
+
+
+def test_the_input_token_budget_counts_only_what_the_provider_reported(tmp_path):
+    provider = SourcingProvider(usage=_usage(1_000, 10))
+    result, conv = _turn(
+        tmp_path,
+        provider=provider,
+        run_budget_policy=RunBudgetPolicy(input_tokens=2_500),
+    )
+
+    assert provider.requests == 3, "the run did not reach the input-token budget"
+    terminal = _terminal(conv)
+    assert result["status"] == "stopped"
+    assert terminal["run_budget"]["stopped_by"] == "input_tokens"
+    assert terminal["run_budget"]["consumed"]["input_tokens"] == 3_000
+    assert terminal["run_budget"]["unmeasured_requests"] == 0
+
+
+def test_the_output_token_budget_stops_a_verbose_run(tmp_path):
+    provider = SourcingProvider(usage=_usage(10, 1_000))
+    result, conv = _turn(
+        tmp_path,
+        provider=provider,
+        run_budget_policy=RunBudgetPolicy(output_tokens=2_500),
+    )
+
+    assert provider.requests == 3, "the run did not reach the output-token budget"
+    terminal = _terminal(conv)
+    assert result["status"] == "stopped"
+    assert terminal["run_budget"]["stopped_by"] == "output_tokens"
+    assert terminal["run_budget"]["consumed"]["output_tokens"] == 3_000
+
+
+def test_the_cost_budget_stops_a_run_and_says_the_figure_is_an_estimate(tmp_path):
+    provider = SourcingProvider(usage=_usage(100, 10), cost_usd=0.05)
+    result, conv = _turn(
+        tmp_path,
+        provider=provider,
+        run_budget_policy=RunBudgetPolicy(estimated_cost_usd=0.12),
+    )
+
+    assert provider.requests == 3, "the run did not reach the cost budget"
+    terminal = _terminal(conv)
+    assert result["status"] == "stopped"
+    assert terminal["run_budget"]["stopped_by"] == "estimated_cost_usd"
+    assert terminal["run_budget"]["consumed"]["estimated_cost_usd"] == pytest.approx(
+        0.15
+    )
+    assert terminal["run_budget"]["unpriced_requests"] == 0
+    assert (
+        terminal["run_budget"]["measurement"]["estimated_cost_usd"]
+        == "provider_cost_estimate"
+    )
+
+
+def test_a_run_on_an_unpriced_model_says_the_cost_meter_did_not_cover_it(tmp_path):
+    """The honest failure mode: no pricing means the cost budget cannot bind,
+    and the operator has to be told rather than shown a reassuring $0.00."""
+    provider = SourcingProvider(usage=_usage(1_000, 10), cost_usd=None)
+    _result, conv = _turn(
+        tmp_path,
+        provider=provider,
+        run_budget_policy=RunBudgetPolicy(input_tokens=2_500),
+    )
+
+    terminal = _terminal(conv)
+    assert terminal["run_budget"]["stopped_by"] == "input_tokens"
+    assert terminal["run_budget"]["consumed"]["estimated_cost_usd"] == 0.0
+    assert terminal["run_budget"]["unpriced_requests"] == 3
+
+
+def test_two_budgets_reached_together_are_both_reported(tmp_path):
+    provider = SourcingProvider()
+    _result, conv = _turn(
+        tmp_path,
+        provider=provider,
+        run_budget_policy=RunBudgetPolicy(model_turns=4, tool_calls=4),
+    )
+
+    assert provider.requests == 4, "the run did not reach either budget"
+    terminal = _terminal(conv)
+    assert terminal["run_budget"]["exhausted"] == ["model_turns", "tool_calls"]
+    assert terminal["run_budget"]["stopped_by"] == "model_turns"
+    assert "model turns and tool calls" in terminal["message"]
+
+
+# --- criterion 7: the loop detector fires first -----------------------------
+
+
+def test_a_repeating_run_is_reported_as_stuck_before_any_budget_runs_out(tmp_path):
+    provider = RepeatingProvider()
+    result, conv = _turn(tmp_path, provider=provider)
+
+    started = _tool_started(conv)
+    assert len(started) > DEFAULT_LOOP_REPEAT_LIMIT - 1, "no repeats ever happened"
+    terminal = _terminal(conv)
+    assert result["status"] == "stopped"
+    assert terminal["run_budget"]["stopped_by"] == "loop"
+    assert terminal["run_budget"]["exhausted"] == []
+    assert terminal["run_budget"]["repeats"] == DEFAULT_LOOP_REPEAT_LIMIT
+    assert "returned nothing new" in terminal["message"]
+    # The ordering claim, checked rather than assumed: every absolute budget
+    # still had room when the run stopped.
+    consumed = terminal["run_budget"]["consumed"]
+    limits = terminal["run_budget"]["limits"]
+    for name, limit in limits.items():
+        assert consumed[name] < limit, f"{name} was already exhausted"
+
+
+def test_a_run_that_keeps_asking_for_a_refused_tool_is_a_loop(tmp_path):
+    """A refusal is an outcome. Asking for the same denied tool forever is not
+    progress, so it has to reach the detector the same way a stale read does."""
+    provider = RepeatingProvider(tool_name="board_get", arguments={})
+    _result, conv = _turn(tmp_path, provider=provider)
+
+    terminal = _terminal(conv)
+    assert terminal["run_budget"]["stopped_by"] == "loop"
+    assert all(record["ok"] is False for record in terminal["run_budget"]["completed"])
+
+
+def test_distinct_work_never_trips_the_loop_detector(tmp_path):
+    """The false positive that would replace one bad ceiling with another."""
+    provider = ScriptedProvider(tool_turns=30)
+    result, conv = _turn(tmp_path, provider=provider)
+
+    assert len(_tool_started(conv)) == 30
+    assert result["status"] == "ok"
+    assert _terminal(conv)["run_budget"]["stopped_by"] is None
+
+
+# --- criterion 3: the warning arrives before the stop -----------------------
+
+
+def test_the_thread_is_warned_before_a_budget_is_exhausted(tmp_path):
+    provider = SourcingProvider()
+    _result, conv = _turn(
+        tmp_path,
+        provider=provider,
+        run_budget_policy=RunBudgetPolicy(model_turns=5, warn_at=0.6),
+    )
+
+    events = _events(conv)
+    started = [event for event in events if event["type"] == "tool_started"]
+    assert len(started) == 5, "the run did not reach the budget"
+    states = [event["run_budget"]["state"] for event in started]
+    assert states == ["running", "running", "warning", "running", "running"]
+    warning = started[2]["run_budget"]["warning"]
+    assert warning["budget"] == "model_turns"
+    assert "will stop and ask" in warning["message"]
+    # Before, not with, the stop.
+    assert events.index(started[2]) < events.index(_terminal(conv))
+
+
+def test_every_activity_beat_carries_the_run_s_current_spend(tmp_path):
+    provider = SourcingProvider(usage=_usage(100, 10))
+    _result, conv = _turn(
+        tmp_path,
+        provider=provider,
+        run_budget_policy=RunBudgetPolicy(model_turns=3),
+    )
+
+    started = _tool_started(conv)
+    assert len(started) == 3
+    turns = [event["run_budget"]["consumed"]["model_turns"] for event in started]
+    assert turns == [1, 2, 3]
+    assert started[0]["run_budget"]["limits"]["model_turns"] == 3
+    assert started[0]["name"] == "board_query"
+
+
+# --- criterion 4: a partial result is not a conclusion ----------------------
+
+
+def test_an_exhausted_run_reports_receipts_and_unfinished_work_not_completion(
+    tmp_path,
+):
+    provider = SourcingProvider()
+    result, conv = _turn(
+        tmp_path,
+        provider=provider,
+        run_budget_policy=RunBudgetPolicy(model_turns=3),
+    )
+
+    events = _events(conv)
+    finished = [event for event in events if event["type"] == "tool_finished"]
+    assert len(finished) == 3, "the run did not complete three tool calls"
+
+    terminal = _terminal(conv)
+    budget = terminal["run_budget"]
+    assert result["status"] == "stopped"
+    assert terminal["state"] == "stopped"
+    assert budget["state"] == "exhausted"
+    assert budget["remaining"]["final_answer"] is False
+    assert budget["continue_available"] is True
+    # The receipts are the calls that actually ran, in order, with outcomes.
+    assert budget["completed"] == [
+        {"id": event["id"], "name": event["name"], "ok": event["ok"]}
+        for event in finished
+    ]
+    # And the run status the rest of Sourcecado derives from this is partial,
+    # never success.
+    assert RECEIPT_STATUSES[result["status"]] == "partial"
+
+
+def test_a_stopped_run_never_claims_a_final_answer(tmp_path):
+    provider = SourcingProvider()
+    _result, conv = _turn(
+        tmp_path,
+        provider=provider,
+        run_budget_policy=RunBudgetPolicy(model_turns=2),
+    )
+
+    terminal = _terminal(conv)
+    assert terminal["state"] != "complete"
+    assert terminal["run_budget"]["remaining"]["final_answer"] is False
+    assert terminal["text"], "the partial text was thrown away"
+
+
+# --- criterion 6: declining continuation loses nothing ----------------------
+
+
+def test_declining_to_continue_leaves_every_completed_result_in_place(tmp_path):
+    provider = SourcingProvider()
+    _result, conv = _turn(
+        tmp_path,
+        provider=provider,
+        run_budget_policy=RunBudgetPolicy(model_turns=3),
+    )
+
+    terminal = _terminal(conv)
+    assert terminal["run_budget"]["stopped_by"] == "model_turns"
+
+    # The director does nothing. The transcript still holds the work.
+    transcript = conv.load(SID)
+    tool_results = [message for message in transcript if message["role"] == "tool"]
+    assert len(tool_results) == 3
+    assert all(
+        json.loads(message["content"]) for message in tool_results
+    ), "a completed result was emptied"
+    receipts = terminal["run_budget"]["completed"]
+    assert {record["id"] for record in receipts} == {
+        message["tool_call_id"] for message in tool_results
+    }
+
+
+# --- criterion 5: continuation preserves, and never replays -----------------
+
+
+def test_continuing_reuses_completed_results_instead_of_running_them_again(
+    tmp_path, monkeypatch
+):
+    executed: list[tuple[str, dict]] = []
+    real_execute = turn_module.execute
+
+    def _counting_execute(name, arguments=None, **kwargs):
+        executed.append((name, dict(arguments or {})))
+        return real_execute(name, arguments, **kwargs)
+
+    monkeypatch.setattr(turn_module, "execute", _counting_execute)
+
+    conv = ConversationStore(tmp_path)
+    people = PersonStore(tmp_path)
+    first = SourcingProvider()
+    _result, _conv = _turn(
+        tmp_path,
+        provider=first,
+        store=conv,
+        people=people,
+        run_budget_policy=RunBudgetPolicy(model_turns=2),
+    )
+    assert _terminal(conv)["run_budget"]["stopped_by"] == "model_turns"
+    assert len(executed) == 2, "the first run did not complete two tool calls"
+    first_calls = list(executed)
+
+    # The director clicks Continue: an ordinary new turn on the same session.
+    second = ScriptedProvider(tool_turns=0)
+    result, _conv = _turn(
+        tmp_path,
+        provider=second,
+        store=conv,
+        people=people,
+        text="Continue this run from where it stopped.",
+    )
+
+    assert result["status"] == "ok"
+    assert executed == first_calls, "a completed tool result was replayed"
+    view = second.calls[-1]
+    carried = [
+        message for message in view if message.get("role") == "tool"
+    ]
+    assert {message["tool_call_id"] for message in carried} == {
+        f"call_{index}_0" for index in range(2)
+    }
+
+
+def test_continuing_after_a_ui_restart_still_carries_the_completed_work(tmp_path):
+    """A restart means a fresh store handle and a fresh inbox over the same
+    state directory. The continuation has to survive that, because that is
+    what a director who reopens the app actually does."""
+    conv = ConversationStore(tmp_path)
+    people = PersonStore(tmp_path)
+    first = SourcingProvider()
+    _turn(
+        tmp_path,
+        provider=first,
+        store=conv,
+        people=people,
+        run_budget_policy=RunBudgetPolicy(model_turns=2),
+    )
+    stop = _terminal(conv)
+    assert stop["run_budget"]["continue_available"] is True
+
+    restarted = ConversationStore(tmp_path)
+    # What a reopened UI restores from still offers the Continue action.
+    restored = [
+        event for event in restarted.load_events(SID) if event["type"] == "turn_end"
+    ][-1]
+    assert restored["run_budget"]["continue_available"] is True
+    assert len(restored["run_budget"]["completed"]) == 2
+
+    second = ScriptedProvider(tool_turns=0)
+    result, _conv = _turn(
+        tmp_path,
+        provider=second,
+        store=restarted,
+        people=PersonStore(tmp_path),
+        inbox=Inbox(restarted),
+        text="Continue this run from where it stopped.",
+    )
+    assert result["status"] == "ok"
+    carried = [
+        message for message in second.calls[-1] if message.get("role") == "tool"
+    ]
+    assert len(carried) == 2
+
+
+def test_continuing_preserves_the_bound_person_and_the_compaction_state(tmp_path):
+    conv = ConversationStore(tmp_path)
+    people = PersonStore(tmp_path)
+    person = people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Nimbus Robotics",
+        target="Nimbus",
+    )
+    people.bind_session(SID, person["person_id"])
+
+    async def _summary(_request):
+        return "Earlier: the director asked about Nimbus and three names came back."
+
+    compactor = SessionCompactor(
+        store=conv,
+        session_id=SID,
+        policy=CompactionPolicy(threshold_pct=0.0001, keep_fraction=0.02),
+        summarize=_summary,
+    )
+    first = SourcingProvider(usage=_usage(900, 20))
+    _turn(
+        tmp_path,
+        provider=first,
+        store=conv,
+        people=people,
+        compactor=compactor,
+        run_budget_policy=RunBudgetPolicy(model_turns=4),
+    )
+    stop = _terminal(conv)
+    assert stop["run_budget"]["stopped_by"] == "model_turns"
+    assert stop.get("compaction"), "the run never compacted, so nothing was preserved"
+    generation = stop["compaction"]["generation"]
+    assert generation >= 1
+
+    saved = json.loads(conv.get_setting(state_key(SID)))
+    assert saved["generation"] == generation
+
+    second = ScriptedProvider(tool_turns=0)
+    result, _conv = _turn(
+        tmp_path,
+        provider=second,
+        store=conv,
+        people=people,
+        text="Continue this run from where it stopped.",
+    )
+    assert result["status"] == "ok"
+    assert people.person_for_session(SID) == person["person_id"]
+    assert json.loads(conv.get_setting(state_key(SID)))["generation"] >= generation
+    view = "".join(
+        str(message.get("content") or "") for message in second.calls[-1]
+    )
+    assert OPEN_TAG in view, "the continuation lost the compacted context"
+
+
+# --- criterion 8: continuation is not standing permission -------------------
+
+
+class ApprovalProvider(SourcingProvider):
+    """Asks for one approval-gated tool, once."""
+
+    def __init__(self, *, tool_name: str) -> None:
+        super().__init__(tool_name=tool_name, arguments={})
+
+    async def astream(self, *, messages, tools=None, context_id=None):
+        self.calls.append(list(messages))
+        index = self.requests
+        self.requests += 1
+        yield StreamChunk.started(provider=self.provider_id, model=self.model_id)
+        if index > 0:
+            yield StreamChunk(text_delta="Stopping there.")
+            yield StreamChunk(finish_reason="stop")
+            return
+        yield StreamChunk(text_delta="Sending it now. ")
+        yield StreamChunk(finish_reason="tool_calls")
+        yield StreamChunk(
+            tool_calls=[
+                ToolCall(id="call_gated", name=self.tool_name, arguments={})
+            ]
+        )
+
+
+@pytest.mark.parametrize("gated", sorted(ASK))
+def test_continuation_never_becomes_standing_permission(tmp_path, gated):
+    """Every gate that applied before a budget stop applies after Continue.
+
+    Driven against the real ASK set, not a stand-in, so a tool moving between
+    the sets cannot quietly slip past this.
+    """
+    assert decide(gated).needs_user is True
+    assert gated not in AUTO and gated not in RETRY_SAFE
+
+    conv = ConversationStore(tmp_path)
+    people = PersonStore(tmp_path)
+
+    # Run one reaches the budget with real work behind it.
+    first = SourcingProvider()
+    _turn(
+        tmp_path,
+        provider=first,
+        store=conv,
+        people=people,
+        run_budget_policy=RunBudgetPolicy(model_turns=2),
+    )
+    stop = _terminal(conv)
+    assert stop["run_budget"]["stopped_by"] == "model_turns"
+    assert len(stop["run_budget"]["completed"]) == 2
+
+    # The director continues. The gated tool still has to be approved, and a
+    # denial still stops it.
+    second = ApprovalProvider(tool_name=gated)
+    result, _conv = _turn(
+        tmp_path,
+        provider=second,
+        store=conv,
+        people=people,
+        text="Continue this run from where it stopped.",
+        wait="deny",
+    )
+
+    events = _events(conv)
+    asked = [
+        event
+        for event in events
+        if event["type"] == "permission_required" and event["name"] == gated
+    ]
+    assert len(asked) == 1, f"{gated} ran without asking after continuation"
+    assert not [
+        event
+        for event in events
+        if event["type"] == "tool_started" and event["name"] == gated
+    ], f"{gated} executed despite the denial"
+    resolved = [
+        event
+        for event in events
+        if event["type"] == "approval_resolved" and event["name"] == gated
+    ]
+    assert resolved and resolved[-1]["resolution"] == "denied"
+    assert result["status"] in {"partial", "ok"}
+
+
+def test_a_continuation_run_asks_again_for_a_tool_approved_in_the_run_before(
+    tmp_path,
+):
+    """An approval granted before the budget stop does not carry forward."""
+    conv = ConversationStore(tmp_path)
+    people = PersonStore(tmp_path)
+
+    granted = ApprovalProvider(tool_name="calendar_create")
+    _turn(tmp_path, provider=granted, store=conv, people=people, wait="allow")
+    first_asks = [
+        event
+        for event in _events(conv)
+        if event["type"] == "permission_required"
+        and event["name"] == "calendar_create"
+    ]
+    assert len(first_asks) == 1, "the first run never asked"
+
+    again = ApprovalProvider(tool_name="calendar_create")
+    _turn(
+        tmp_path,
+        provider=again,
+        store=conv,
+        people=people,
+        text="Continue this run from where it stopped.",
+        wait="deny",
+    )
+    asks = [
+        event
+        for event in _events(conv)
+        if event["type"] == "permission_required"
+        and event["name"] == "calendar_create"
+    ]
+    assert len(asks) == 2, "the continuation reused the earlier approval"
+
+
+# --- criterion 9: cancellation, retry -------------------------------------
+
+
+def test_cancelling_a_budgeted_run_still_reports_a_cancellation(tmp_path):
+    """A budget must not take credit for a stop the director asked for."""
+    conv = ConversationStore(tmp_path)
+    identity = new_turn_identity(SID)
+    control = RunControl(identity)
+    provider = SourcingProvider()
+
+    async def _drive():
+        async def _emit(event):
+            if event.get("type") == "tool_finished":
+                await control.request_cancel()
+
+        return await run_turn(
+            text="Build the shortlist.",
+            sid=SID,
+            store=conv,
+            provider=provider,
+            persona=None,
+            skills=None,
+            inbox=Inbox(conv),
+            openai_tools=OPENAI_TOOLS,
+            execute_kwargs={"people": PersonStore(tmp_path)},
+            emit=_emit,
+            identity=identity,
+            control=control,
+            run_budget_policy=RunBudgetPolicy(model_turns=40),
+        )
+
+    result = asyncio.run(_drive())
+
+    assert result["status"] == "stopped"
+    assert provider.requests == 1, "the run never got going"
+    terminal = _terminal(conv)
+    assert terminal["type"] == "turn_stopped"
+    assert terminal["message"] == "Run cancelled."
+    assert "run_budget" not in terminal
+
+
+def test_a_provider_retry_costs_tokens_but_not_a_model_turn(tmp_path):
+    """Retries repeat a request the loop already counted. Charging them to the
+    turn budget would let a flaky provider eat a run's allowance."""
+    rate_limited = ProviderStreamError(
+        provider="fake",
+        model="fake",
+        kind=ProviderErrorKind.RATE_LIMIT,
+        message="rate limited",
+        retryable=True,
+    )
+    provider = FakeProvider(
+        steps=[
+            {"error": rate_limited},
+            {
+                "tool_calls": [
+                    ToolCall(id="call_1", name="board_query", arguments={"company": "Nimbus"})
+                ],
+                "finish_reason": "tool_calls",
+                "usage": _usage(500, 20),
+            },
+            {"deltas": ("Done.",), "finish_reason": "stop", "usage": _usage(600, 30)},
+        ]
+    )
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    result, conv = _turn(
+        tmp_path,
+        provider=provider,
+        retry_policy=RetryPolicy(),
+        retry_sleep=_no_sleep,
+        retry_random=lambda: 0.0,
+    )
+
+    assert provider.i == 3, "the retry never happened"
+    assert result["status"] == "ok"
+    budget = _terminal(conv)["run_budget"]
+    assert budget["consumed"]["model_turns"] == 2
+    assert budget["consumed"]["input_tokens"] == 1_100
+
+
+# --- the meter on its own --------------------------------------------------
+
+
+def test_the_elapsed_budget_reads_a_monotonic_clock(tmp_path):
+    ticks = iter([0.0, 5.0, 11.0])
+    readings = [0.0]
+
+    def _clock() -> float:
+        try:
+            readings[0] = next(ticks)
+        except StopIteration:
+            pass
+        return readings[0]
+
+    meter = RunBudgetMeter(RunBudgetPolicy(elapsed_seconds=10.0), clock=_clock)
+    assert meter.check() is None
+    stop = meter.check()
+    assert stop is not None and stop.exhausted == ("elapsed_seconds",)
+
+
+def test_the_meter_reports_requests_the_provider_did_not_measure():
+    meter = RunBudgetMeter()
+    meter.record_request(None, None)
+    payload = meter.terminal_payload(stop=None, final_answer=True)
+    assert payload["unmeasured_requests"] == 1
+    assert payload["unpriced_requests"] == 1
+    assert payload["consumed"]["input_tokens"] == 0

--- a/desktop/tests/test_run_budget_mutations.py
+++ b/desktop/tests/test_run_budget_mutations.py
@@ -1,0 +1,355 @@
+"""Each guard is broken on purpose, and the property it protects must fail.
+
+A passing budget test proves nothing if it would also pass with the budget
+deleted. Every test here removes one guard and asserts the corresponding
+property collapses. If one of these starts failing, the guard it names has
+stopped doing work and the test that covers it has gone vacuous.
+
+The four failure modes this issue is most exposed to, one test each: a budget
+that never trips, a loop detector that never fires, a continuation that grants
+authority, and a partial result that claims completion.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+from coworker import run_budget as run_budget_module
+from coworker import turn as turn_module
+from coworker.permissions import ASK, Decision
+from coworker.run_budget import RunBudgetMeter, RunBudgetPolicy
+from coworker.store import ConversationStore
+from coworker.people import PersonStore
+
+from tests.test_run_budget import (
+    SID,
+    ApprovalProvider,
+    RepeatingProvider,
+    ScriptedProvider,
+    SourcingProvider,
+    _events,
+    _terminal,
+    _tool_started,
+    _turn,
+)
+
+GATED = "gmail_send"
+
+
+# --- mutation: a budget that never trips -----------------------------------
+
+
+def test_a_budget_that_never_trips_lets_a_run_past_its_ceiling(tmp_path, monkeypatch):
+    honest_provider = ScriptedProvider(tool_turns=12)
+    honest_store = ConversationStore(tmp_path / "honest")
+    result, _conv = _turn(
+        tmp_path,
+        provider=honest_provider,
+        store=honest_store,
+        run_budget_policy=RunBudgetPolicy(model_turns=5),
+    )
+    assert result["status"] == "stopped"
+    assert _terminal(honest_store)["run_budget"]["stopped_by"] == "model_turns"
+    assert len(_tool_started(honest_store)) == 5
+
+    monkeypatch.setattr(RunBudgetMeter, "exhausted", lambda self: ())
+
+    broken_provider = ScriptedProvider(tool_turns=12)
+    broken_store = ConversationStore(tmp_path / "broken")
+    broken, _conv = _turn(
+        tmp_path,
+        provider=broken_provider,
+        store=broken_store,
+        run_budget_policy=RunBudgetPolicy(model_turns=5),
+    )
+
+    assert broken["status"] == "ok"
+    assert len(_tool_started(broken_store)) == 12
+    assert _terminal(broken_store)["run_budget"]["stopped_by"] is None
+
+
+# --- mutation: a loop detector that never fires ----------------------------
+
+
+def test_a_loop_detector_that_never_fires_reports_a_stuck_run_as_expensive(
+    tmp_path, monkeypatch
+):
+    """The diagnosis, not just the stop, is what the detector buys."""
+    policy = RunBudgetPolicy(tool_calls=8, loop_repeat_limit=3)
+
+    honest_store = ConversationStore(tmp_path / "honest")
+    _result, _conv = _turn(
+        tmp_path,
+        provider=RepeatingProvider(),
+        store=honest_store,
+        run_budget_policy=policy,
+    )
+    honest = _terminal(honest_store)["run_budget"]
+    assert honest["stopped_by"] == "loop"
+    assert honest["consumed"]["tool_calls"] < policy.tool_calls
+
+    # Every call now looks new, which is what a detector keyed on the wrong
+    # thing would see.
+    counter = itertools.count()
+    monkeypatch.setattr(
+        run_budget_module,
+        "_fingerprint",
+        lambda value: f"unique-{next(counter)}",
+    )
+
+    broken_store = ConversationStore(tmp_path / "broken")
+    _broken, _conv = _turn(
+        tmp_path,
+        provider=RepeatingProvider(),
+        store=broken_store,
+        run_budget_policy=policy,
+    )
+    broken = _terminal(broken_store)["run_budget"]
+
+    assert broken["stopped_by"] == "tool_calls"
+    assert broken["consumed"]["tool_calls"] == policy.tool_calls
+
+
+def test_checking_budgets_before_the_loop_detector_misnames_a_stuck_run(
+    tmp_path, monkeypatch
+):
+    """Both conditions are true on the same call. Order decides the diagnosis."""
+    policy = RunBudgetPolicy(tool_calls=4, loop_repeat_limit=3)
+
+    honest_store = ConversationStore(tmp_path / "honest")
+    _turn(
+        tmp_path,
+        provider=RepeatingProvider(),
+        store=honest_store,
+        run_budget_policy=policy,
+    )
+    honest = _terminal(honest_store)["run_budget"]
+    assert honest["stopped_by"] == "loop"
+    assert honest["consumed"]["tool_calls"] == policy.tool_calls, (
+        "the absolute budget was not also exhausted, so order proved nothing"
+    )
+
+    def _budget_first(self):
+        out = self.exhausted()
+        if out:
+            return run_budget_module.BudgetStop(
+                kind=run_budget_module.StopKind.BUDGET, exhausted=out
+            )
+        if self.looping():
+            return run_budget_module.BudgetStop(
+                kind=run_budget_module.StopKind.LOOP,
+                exhausted=(),
+                repeats=self._stale_streak,
+            )
+        return None
+
+    monkeypatch.setattr(RunBudgetMeter, "check", _budget_first)
+
+    broken_store = ConversationStore(tmp_path / "broken")
+    _turn(
+        tmp_path,
+        provider=RepeatingProvider(),
+        store=broken_store,
+        run_budget_policy=policy,
+    )
+    assert _terminal(broken_store)["run_budget"]["stopped_by"] == "tool_calls"
+
+
+def test_a_detector_that_ignores_refusals_misses_a_run_stuck_on_a_denied_tool(
+    tmp_path, monkeypatch
+):
+    honest_store = ConversationStore(tmp_path / "honest")
+    _turn(
+        tmp_path,
+        provider=RepeatingProvider(tool_name="board_get", arguments={}),
+        store=honest_store,
+        run_budget_policy=RunBudgetPolicy(tool_calls=8, loop_repeat_limit=3),
+    )
+    assert _terminal(honest_store)["run_budget"]["stopped_by"] == "loop"
+
+    real = RunBudgetMeter.record_tool_outcome
+
+    def _successes_only(self, *, call_id, name, arguments, result, ok):
+        if not ok:
+            return None
+        return real(
+            self,
+            call_id=call_id,
+            name=name,
+            arguments=arguments,
+            result=result,
+            ok=ok,
+        )
+
+    monkeypatch.setattr(RunBudgetMeter, "record_tool_outcome", _successes_only)
+
+    broken_store = ConversationStore(tmp_path / "broken")
+    _turn(
+        tmp_path,
+        provider=RepeatingProvider(tool_name="board_get", arguments={}),
+        store=broken_store,
+        run_budget_policy=RunBudgetPolicy(tool_calls=8, loop_repeat_limit=3),
+    )
+    assert _terminal(broken_store)["run_budget"]["stopped_by"] == "tool_calls"
+
+
+# --- mutation: a continuation that grants authority ------------------------
+
+
+def test_a_continuation_that_grants_authority_skips_the_approval_entirely(
+    tmp_path, monkeypatch
+):
+    """The mutation criterion 8 exists to forbid: the second run treats the
+    director's Continue as permission to act."""
+    assert GATED in ASK
+
+    def _run(store, people, *, gated_provider):
+        _turn(
+            tmp_path,
+            provider=SourcingProvider(),
+            store=store,
+            people=people,
+            run_budget_policy=RunBudgetPolicy(model_turns=2),
+        )
+        stop = _terminal(store)["run_budget"]
+        assert stop["stopped_by"] == "model_turns"
+        _turn(
+            tmp_path,
+            provider=gated_provider,
+            store=store,
+            people=people,
+            text="Continue this run from where it stopped.",
+            wait="deny",
+        )
+        events = _events(store)
+        return (
+            [
+                event
+                for event in events
+                if event["type"] == "permission_required"
+                and event["name"] == GATED
+            ],
+            [
+                event
+                for event in events
+                if event["type"] == "tool_started" and event["name"] == GATED
+            ],
+        )
+
+    honest_store = ConversationStore(tmp_path / "honest")
+    asked, executed = _run(
+        honest_store,
+        PersonStore(tmp_path / "honest-people"),
+        gated_provider=ApprovalProvider(tool_name=GATED),
+    )
+    assert len(asked) == 1
+    assert executed == []
+
+    monkeypatch.setattr(
+        turn_module,
+        "decide",
+        lambda name, arguments=None, **kwargs: Decision(True, False, "continued"),
+    )
+
+    broken_store = ConversationStore(tmp_path / "broken")
+    asked, executed = _run(
+        broken_store,
+        PersonStore(tmp_path / "broken-people"),
+        gated_provider=ApprovalProvider(tool_name=GATED),
+    )
+    assert asked == []
+    assert len(executed) == 1
+
+
+# --- mutation: a partial result that claims completion ---------------------
+
+
+def test_a_partial_result_that_claims_completion_hides_the_stop(
+    tmp_path, monkeypatch
+):
+    honest_store = ConversationStore(tmp_path / "honest")
+    result, _conv = _turn(
+        tmp_path,
+        provider=SourcingProvider(),
+        store=honest_store,
+        run_budget_policy=RunBudgetPolicy(model_turns=3),
+    )
+    honest = _terminal(honest_store)["run_budget"]
+    assert result["status"] == "stopped"
+    assert honest["state"] == "exhausted"
+    assert honest["remaining"]["final_answer"] is False
+
+    real = RunBudgetMeter.terminal_payload
+
+    def _always_finished(self, *, stop, pending_calls=(), final_answer):
+        payload = real(
+            self, stop=stop, pending_calls=pending_calls, final_answer=final_answer
+        )
+        payload["state"] = "finished"
+        payload["stopped_by"] = None
+        payload["remaining"] = {"requested_tools": [], "final_answer": True}
+        return payload
+
+    monkeypatch.setattr(RunBudgetMeter, "terminal_payload", _always_finished)
+
+    broken_store = ConversationStore(tmp_path / "broken")
+    _turn(
+        tmp_path,
+        provider=SourcingProvider(),
+        store=broken_store,
+        run_budget_policy=RunBudgetPolicy(model_turns=3),
+    )
+    broken = _terminal(broken_store)["run_budget"]
+    assert broken["state"] == "finished"
+    assert broken["remaining"]["final_answer"] is True
+
+
+def test_receipts_that_omit_failed_calls_understate_what_the_run_did(
+    tmp_path, monkeypatch
+):
+    """The defect the receipt check itself could miss: a completed call that
+    failed is still work the run did, and a receipt list that drops it reads
+    as a cleaner run than actually happened."""
+    honest_store = ConversationStore(tmp_path / "honest")
+    _turn(
+        tmp_path,
+        provider=SourcingProvider(tool_name="board_get", arguments={}),
+        store=honest_store,
+        run_budget_policy=RunBudgetPolicy(model_turns=3),
+    )
+    honest = _terminal(honest_store)["run_budget"]
+    finished = [
+        event for event in _events(honest_store) if event["type"] == "tool_finished"
+    ]
+    assert len(finished) == 3
+    assert all(event["ok"] is False for event in finished)
+    assert len(honest["completed"]) == 3
+
+    real = RunBudgetMeter.record_tool_outcome
+
+    def _successes_only(self, *, call_id, name, arguments, result, ok):
+        if not ok:
+            return None
+        return real(
+            self,
+            call_id=call_id,
+            name=name,
+            arguments=arguments,
+            result=result,
+            ok=ok,
+        )
+
+    monkeypatch.setattr(RunBudgetMeter, "record_tool_outcome", _successes_only)
+
+    broken_store = ConversationStore(tmp_path / "broken")
+    _turn(
+        tmp_path,
+        provider=SourcingProvider(tool_name="board_get", arguments={}),
+        store=broken_store,
+        run_budget_policy=RunBudgetPolicy(model_turns=3),
+    )
+    broken = _terminal(broken_store)["run_budget"]
+    assert [
+        event for event in _events(broken_store) if event["type"] == "tool_finished"
+    ]
+    assert broken["completed"] == []

--- a/desktop/tests/test_telemetry_live.py
+++ b/desktop/tests/test_telemetry_live.py
@@ -632,7 +632,7 @@ def test_task_cancellation_settles_the_active_tool_and_agent_spans(
     assert terminals[starts[AgentTurnSpan]] is SpanStatus.CANCELLED
 
 
-def test_step_limit_settles_the_agent_span_instead_of_leaving_it_running(tmp_path):
+def test_a_budget_stop_settles_the_agent_span_instead_of_leaving_it_running(tmp_path):
     provider = StepProvider(
         [
             [
@@ -662,4 +662,7 @@ def test_step_limit_settles_the_agent_span_instead_of_leaving_it_running(tmp_pat
         if isinstance(record, SpanSettledRecord)
         and record.span_id == agent_start.span_id
     )
-    assert agent_terminal.status is SpanStatus.CANCELLED
+    # A run policy stopped it. That is real but unfinished work, not a
+    # cancellation the director asked for.
+    assert agent_terminal.status is SpanStatus.PARTIAL
+    assert agent_terminal.error_kind is ErrorKind.POLICY


### PR DESCRIPTION
Closes #83.

## Domain words

- **Budget** — a bound on one dimension of a run: model turns, tool calls, elapsed time, tokens, or estimated cost.
- **Loop detector** — the check that notices a run repeating itself with no progress.
- **Continuation** — the director's explicit choice to let a stopped run keep working.

## Problem

The agent loop stopped after eight steps, regardless of whether it was making progress or burning money. Ordinary sourcing work that needed nine steps was cut off; a run stuck repeating one tool looked the same as one doing useful work.

## The point of the issue, tested first

`test_ordinary_sourcing_work_past_eight_steps_simply_finishes`

If budgets make normal work stop early, one bad ceiling has been replaced with another. That test is the check on everything else here.

## Criterion 7: the ordering is a policy invariant, not just a behaviour

A stuck run and an expensive run need different operator responses — "it is looping" versus "it is costing too much" — so the loop detector must fire **before** the absolute budget.

That is enforced at the policy level rather than only observed in a test: `test_a_policy_that_cannot_detect_a_loop_before_its_ceiling_is_rejected` refuses a configuration where the detector could never fire first. A future budget change cannot silently invert the ordering.

Behaviourally: `test_a_repeating_run_is_reported_as_stuck_before_any_budget_runs_out`, `test_a_run_that_keeps_asking_for_a_refused_tool_is_a_loop`, and `test_distinct_work_never_trips_the_loop_detector` — the last being the one that stops the detector becoming a nuisance.

## Criterion 8: continuation is not standing permission

This is an authority boundary, and the natural implementation quietly widens it.

`test_continuation_never_becomes_standing_permission` and `test_a_continuation_run_asks_again_for_a_tool_approved_in_the_run_before`. The second is the sharp one: a tool approved *before* the budget ran out must be approved **again** after Continue. A Continue click is permission to keep working, never permission to act.

## Criterion 4: a partial result cannot read as a conclusion

A run that stopped on budget did not finish. It says so, lists what it completed with receipts, and names what remains — because a director acting on "here is your shortlist" when the truth is "I stopped a third of the way through" is the failure this criterion exists to prevent.

`test_declining_to_continue_leaves_every_completed_result_in_place` covers criterion 6: declining loses nothing. `test_continuing_reuses_completed_results_instead_of_running_them_again` covers criterion 5: no replay. `test_continuing_after_a_ui_restart_still_carries_the_completed_work` covers the restart case.

## Every guarantee broken on purpose

`test_run_budget_mutations.py`:

| Mutation | Would have caused |
|---|---|
| `test_a_budget_that_never_trips_lets_a_run_past_its_ceiling` | Budgets that do not bound |
| `test_a_loop_detector_that_never_fires_reports_a_stuck_run_as_expensive` | The wrong diagnosis |
| `test_checking_budgets_before_the_loop_detector_misnames_a_stuck_run` | The ordering inverted |
| `test_a_detector_that_ignores_refusals_misses_a_run_stuck_on_a_denied_tool` | A run looping on a refusal |
| `test_a_continuation_that_grants_authority_skips_the_approval_entirely` | Criterion 8 broken |
| `test_a_partial_result_that_claims_completion_hides_the_stop` | Criterion 4 broken |
| `test_receipts_that_omit_failed_calls_understate_what_the_run_did` | A truthful-looking but incomplete receipt |

The last is the subtle one — receipts that quietly omit failed calls would understate what a run actually did, without ever looking wrong.

## Measurements

```
1664 passed, 3 skipped, 1 warning in 75.77s
 Test Files  52 passed (52)
      Tests  469 passed (469)
tsc --noEmit && vite build   clean
```

Skip count held at 3 throughout — the three pre-existing environmental skips (live Apollo, live provider smoke, Docker sandbox). Re-run independently by the reviewing session on the pushed commit.

## Rebase note

This branch was originally stacked on #119 (#72, compaction). #119 was squash-merged, so rebasing tried to replay commits main already had under different SHAs, producing add/add conflicts on files that were not in dispute. Rebuilt instead by resetting to `origin/main` and cherry-picking the single run-budget commit — the branch now contains exactly this issue's work, and the suite went from 1558 (on the stacked base) to 1664 (on main) with no conflicts.

## Boundary

`store.py`, `scheduler.py`, `permissions.py`, `people.py`, `migrations.py`, `doctor.py`, `run_ledger*`, the `agent_run_*` modules, `context_projection.py`, `brief.py`, `evidence_envelope.py`, and every connector module are untouched. `permissions.py` in particular is read-only, so criterion 8 is tested against the real approval sets rather than a mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjAD6SVox1gvF4sV3jTnJy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added run budgets for model turns, tool calls, elapsed time, tokens, and estimated cost.
  * Detects repeated tool activity and stops stuck runs with a clear explanation.
  * Displays live usage, warnings, completed tool results, and budget status in chat.
  * Provides a **Continue** option for unfinished runs while preserving completed work.

* **Bug Fixes**
  * Stopped runs are now reported as partial rather than complete or cancelled.
  * Improved handling and reporting of failed, pending, unmeasured, and unpriced activity.

* **Documentation**
  * Added guidance on budget limits, warnings, continuation, and partial-run behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->