### PR TITLE
feat(desktop): gate the macOS preview update channel on a signed manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,24 @@ jobs:
         working-directory: desktop/surfaces/gui
         run: npm test
 
+      - name: Stamp the preview channel into the build
+        run: |
+          set -euo pipefail
+          BASE="$(node -p "require('./desktop/surfaces/gui/package.json').version")"
+          # Preview builds carry a fourth component so consecutive builds are
+          # always an upgrade of each other without anyone hand-bumping a
+          # version. `minimum_upgradable_version` stays at the package version.
+          PREVIEW="${BASE}.${{ github.run_number }}"
+          {
+            echo "VITE_SOURCECADO_CHANNEL=preview"
+            echo "VITE_SOURCECADO_VERSION=${PREVIEW}"
+            echo "VITE_SOURCECADO_COMMIT=${{ github.sha }}"
+            echo "SOURCECADO_PREVIEW_VERSION=${PREVIEW}"
+            echo "SOURCECADO_MINIMUM_FROM=${BASE}"
+            echo "SOURCECADO_ARCH=$(uname -m | sed 's/^arm64$/aarch64/')"
+          } >> "$GITHUB_ENV"
+          echo "preview channel stamp: ${PREVIEW}"
+
       - name: GUI typecheck and build
         working-directory: desktop/surfaces/gui
         run: npm run build
@@ -124,6 +142,96 @@ jobs:
           python3 desktop/packaging/smoke_test.py \
             "desktop/surfaces/gui/src-tauri/target/release/bundle/macos/Sourcecado.app/Contents/Resources/resources/sourcecado-sidecar/sourcecado-sidecar"
 
+      # --- preview channel: signing, notarization, and the update manifest ---
+      #
+      # Everything from here to the end of the job is AUTHORED AND UNRUN. It is
+      # guarded on the signing credentials being present, and a run without them
+      # emits a warning and produces an unsigned build, so a skipped signing pass
+      # can never be mistaken for a successful one.
+      #
+      # desktop/docs/update-channel.md lists every secret and variable that has
+      # to be supplied, and how to generate the update signing key offline.
+
+      - name: Check for signing credentials
+        id: signing
+        env:
+          CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+          UPDATE_KEY: ${{ secrets.SOURCECADO_UPDATE_SIGNING_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -n "$CERTIFICATE" ] && [ -n "$UPDATE_KEY" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No Apple signing identity or update signing key is configured. This build is UNSIGNED and UNNOTARIZED and has no update manifest. See desktop/docs/update-channel.md."
+          fi
+
+      - name: Import the Developer ID certificate
+        if: steps.signing.outputs.available == 'true'
+        env:
+          CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN="$RUNNER_TEMP/sourcecado-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(python3 -c 'import secrets; print(secrets.token_hex(24))')"
+          printf '%s' "$CERTIFICATE" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 900 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$RUNNER_TEMP/certificate.p12" -k "$KEYCHAIN" \
+            -P "$CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" > /dev/null
+          security list-keychain -d user -s "$KEYCHAIN" login.keychain-db
+          rm -f "$RUNNER_TEMP/certificate.p12"
+
+      - name: Sign the application
+        if: steps.signing.outputs.available == 'true'
+        env:
+          IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY }}
+        working-directory: desktop/surfaces/gui/src-tauri/target/release/bundle/macos
+        run: |
+          set -euo pipefail
+          # Inner code first, then the bundle. `codesign --deep` is unsupported
+          # for distribution and mis-signs nested code quietly, and the frozen
+          # sidecar is exactly the nested code that would be mis-signed.
+          find Sourcecado.app/Contents -type f \
+            \( -perm -u+x -o -name '*.dylib' -o -name '*.so' \) -print0 \
+            | xargs -0 -n 1 codesign --force --options runtime --timestamp \
+                --sign "$IDENTITY"
+          codesign --force --options runtime --timestamp --sign "$IDENTITY" Sourcecado.app
+          codesign --verify --strict --verbose=2 Sourcecado.app
+
+      - name: Notarize and staple
+        if: steps.signing.outputs.available == 'true'
+        env:
+          NOTARY_ISSUER: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+          NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          NOTARY_PRIVATE_KEY: ${{ secrets.APPLE_NOTARY_PRIVATE_KEY }}
+        working-directory: desktop/surfaces/gui/src-tauri/target/release/bundle/macos
+        run: |
+          set -euo pipefail
+          printf '%s' "$NOTARY_PRIVATE_KEY" > "$RUNNER_TEMP/notary.p8"
+          ditto -c -k --keepParent Sourcecado.app "$RUNNER_TEMP/notarize.zip"
+          xcrun notarytool submit "$RUNNER_TEMP/notarize.zip" \
+            --issuer "$NOTARY_ISSUER" --key-id "$NOTARY_KEY_ID" \
+            --key "$RUNNER_TEMP/notary.p8" --wait --timeout 30m
+          rm -f "$RUNNER_TEMP/notary.p8" "$RUNNER_TEMP/notarize.zip"
+          xcrun stapler staple Sourcecado.app
+
+      - name: Verify the signed build independently
+        if: steps.signing.outputs.available == 'true'
+        working-directory: desktop/surfaces/gui/src-tauri/target/release/bundle/macos
+        run: |
+          set -euo pipefail
+          # Independent of the signing step: this reads only what is on disk.
+          codesign --verify --strict --deep --verbose=2 Sourcecado.app
+          codesign --display --verbose=4 Sourcecado.app 2>&1 \
+            | grep -F "Authority=Developer ID Application"
+          xcrun stapler validate Sourcecado.app
+          spctl --assess --type execute --verbose=4 Sourcecado.app
+
       - name: Audit locked Python dependencies
         run: |
           python -m pip install --quiet pip-audit
@@ -143,6 +251,61 @@ jobs:
           } > provenance.txt
           find Sourcecado.app -type f -exec shasum -a 256 {} \; > checksums.txt
           cat provenance.txt
+
+      - name: Package the artifact and generate the signed update manifest
+        if: steps.signing.outputs.available == 'true'
+        env:
+          SOURCECADO_UPDATE_SIGNING_KEY: ${{ secrets.SOURCECADO_UPDATE_SIGNING_KEY }}
+        working-directory: desktop/surfaces/gui/src-tauri/target/release/bundle/macos
+        run: |
+          set -euo pipefail
+          ARTIFACT="Sourcecado-${SOURCECADO_PREVIEW_VERSION}-macos-${SOURCECADO_ARCH}.zip"
+          # `ditto` keeps the signature and the staple; `zip` does not.
+          ditto -c -k --keepParent Sourcecado.app "$ARTIFACT"
+          shasum -a 256 "$ARTIFACT" >> checksums.txt
+          # Generation refuses if the manifest or either attestation file matches
+          # the credential scan, and writes nothing when it does.
+          python3 "$GITHUB_WORKSPACE/desktop/packaging/update_manifest.py" generate \
+            --artifact "$ARTIFACT" \
+            --output update-preview.json \
+            --channel preview \
+            --version "$SOURCECADO_PREVIEW_VERSION" \
+            --minimum-from "$SOURCECADO_MINIMUM_FROM" \
+            --arch "$SOURCECADO_ARCH" \
+            --released-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --commit "${{ github.sha }}" \
+            --key-id "${{ vars.SOURCECADO_UPDATE_KEY_ID }}" \
+            --attest provenance.txt \
+            --attest checksums.txt \
+            --state-root "$RUNNER_TEMP/absent-state" \
+            --home "$HOME"
+
+      - name: Verify the update manifest independently
+        if: steps.signing.outputs.available == 'true'
+        working-directory: desktop/surfaces/gui/src-tauri/target/release/bundle/macos
+        run: |
+          set -euo pipefail
+          # No signing key here on purpose: verification needs only the public
+          # key, which is what every installation will have.
+          python3 "$GITHUB_WORKSPACE/desktop/packaging/update_manifest.py" verify \
+            --manifest update-preview.json \
+            --artifact "Sourcecado-${SOURCECADO_PREVIEW_VERSION}-macos-${SOURCECADO_ARCH}.zip" \
+            --channel preview \
+            --arch "$SOURCECADO_ARCH" \
+            --installed-version "$SOURCECADO_MINIMUM_FROM" \
+            --trust "${{ vars.SOURCECADO_UPDATE_KEY_ID }}=${{ vars.SOURCECADO_UPDATE_PUBLIC_KEY }}"
+
+      - name: Upload the signed preview artifact and its manifest
+        if: steps.signing.outputs.available == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: sourcecado-macos-preview-signed
+          path: |
+            desktop/surfaces/gui/src-tauri/target/release/bundle/macos/Sourcecado-*.zip
+            desktop/surfaces/gui/src-tauri/target/release/bundle/macos/update-preview.json
+            desktop/surfaces/gui/src-tauri/target/release/bundle/macos/checksums.txt
+            desktop/surfaces/gui/src-tauri/target/release/bundle/macos/provenance.txt
+          retention-days: 14
 
       - uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PYTHON ?= python3
 VENV := desktop/.venv
 GUI := desktop/surfaces/gui
 
-.PHONY: setup sidecar gui native test test-python test-gui eval eval-sourcing build doctor doctor-repair build-sidecar smoke-test
+.PHONY: setup sidecar gui native test test-python test-gui eval eval-sourcing build doctor doctor-repair build-sidecar smoke-test test-update update-status update-rollback update-manifest update-verify
 
 setup:
 	$(PYTHON) -m venv $(VENV)
@@ -46,3 +46,38 @@ build-sidecar:
 
 smoke-test:
 	$(PYTHON) desktop/packaging/smoke_test.py desktop/surfaces/gui/src-tauri/resources/sourcecado-sidecar/sourcecado-sidecar
+
+# --- preview update channel -------------------------------------------------
+# desktop/docs/update-channel.md explains every target below.
+
+test-update:
+	cd desktop && .venv/bin/pytest -q tests/test_update_manifest.py tests/test_update_drain.py \
+		tests/test_update_apply.py tests/test_update_exercises.py \
+		tests/test_update_secrets.py tests/test_update_health.py \
+		tests/test_update_channel_mutations.py
+
+# Is anything in flight that an update would interrupt? Reads only.
+update-status:
+	cd desktop && .venv/bin/python -m coworker.update_channel status
+
+# BUNDLE is the installed app. BACKUP is optional: omit it when the failed
+# update never reached the migration step. Quit Sourcecado first.
+update-rollback:
+	cd desktop && .venv/bin/python -m coworker.update_channel rollback \
+		--bundle "$(BUNDLE)" $(if $(BACKUP),--backup "$(BACKUP)",) $(if $(LIST),--list-backups,)
+
+# Needs SOURCECADO_UPDATE_SIGNING_KEY in the environment. Refuses to write a
+# manifest whose build metadata matches the credential scan.
+update-manifest:
+	cd desktop && .venv/bin/python packaging/update_manifest.py generate \
+		--artifact "$(ARTIFACT)" --output "$(MANIFEST)" --version "$(VERSION)" \
+		--minimum-from "$(MINIMUM_FROM)" --key-id "$(KEY_ID)" \
+		--commit "$$(git rev-parse HEAD)" \
+		--released-at "$$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# Needs only the public key, the same one every installation would hold.
+update-verify:
+	cd desktop && .venv/bin/python packaging/update_manifest.py verify \
+		--manifest "$(MANIFEST)" --artifact "$(ARTIFACT)" \
+		--installed-version "$(INSTALLED_VERSION)" \
+		--trust "$(KEY_ID)=$(PUBLIC_KEY)"

--- a/desktop/coworker/update_channel/__init__.py
+++ b/desktop/coworker/update_channel/__init__.py
@@ -1,0 +1,85 @@
+"""The Sourcecado macOS preview channel: how a new build replaces a running one.
+
+Three modules, in the order an update passes through them.
+
+- `manifest` authenticates. Nothing installs without a signature over a closed
+  field set that binds the exact version, channel, platform, architecture, and
+  artifact digest.
+- `drain` decides whether now is a safe moment. It is the module that exists
+  because the obvious updater -- stop, swap, start -- is wrong here. A run that
+  has dispatched a Gmail send and does not yet know the outcome must not be
+  killed, because killing it turns a knowable outcome into a permanently
+  ambiguous one, and a restart that "resumes" it could send a second real email
+  to a real person. See `coworker/agent_run_approval.py` for the fence that
+  holds an ambiguous effect, and note that this module never writes to it: an
+  update neither creates a quarantine nor settles one.
+- `apply` sequences the rest: state compatibility through the migration
+  registry, the backup that registry requires, the bundle swap, the health
+  check, and the rollback that puts the last usable version back.
+
+State compatibility is not re-implemented here. `coworker/migrations.py` is the
+one registry of store versions, backups, and rollback, and this package calls
+it. A second compatibility check would be a second opinion, and the one that
+drifts is the one that is wrong.
+"""
+
+from coworker.update_channel.apply import (
+    Installation,
+    UpdateOutcome,
+    UpdateStage,
+    UpdateStatus,
+    apply_update,
+    rollback,
+)
+from coworker.update_channel.drain import (
+    DrainAssessment,
+    DrainBlocker,
+    DrainStatus,
+    assess_drain,
+    wait_for_drain,
+)
+from coworker.update_channel.manifest import (
+    MANIFEST_VERSION,
+    SIGNED_FIELDS,
+    TRUSTED_KEYS,
+    BoundManifest,
+    BuildIdentity,
+    Channel,
+    Refusal,
+    Verification,
+    build_manifest,
+    registry_state_versions,
+    sha256_file,
+    sign_manifest,
+    verify_manifest,
+)
+from coworker.update_channel.redaction import registered_secrets, safe_text
+
+__all__ = [
+    "MANIFEST_VERSION",
+    "SIGNED_FIELDS",
+    "TRUSTED_KEYS",
+    "BoundManifest",
+    "BuildIdentity",
+    "Channel",
+    "DrainAssessment",
+    "DrainBlocker",
+    "DrainStatus",
+    "Installation",
+    "Refusal",
+    "UpdateOutcome",
+    "UpdateStage",
+    "UpdateStatus",
+    "Verification",
+    "apply_update",
+    "assess_drain",
+    "build_manifest",
+    "registered_secrets",
+    "registry_state_versions",
+    "rollback",
+    "safe_text",
+    "sha256_file",
+    "sign_manifest",
+    "verify_manifest",
+    "wait_for_drain",
+]

--- a/desktop/coworker/update_channel/__main__.py
+++ b/desktop/coworker/update_channel/__main__.py
@@ -1,0 +1,114 @@
+"""Operator commands for the preview channel: is it safe to update, and go back.
+
+Two subcommands, both read-only about the run store.
+
+`status` answers the question an operator actually has before quitting the app:
+is anything in flight that an update would interrupt? It reports the same
+assessment the updater's own gate uses, and it writes nothing -- in particular
+it never quarantines or settles an external effect.
+
+`rollback` is the manual half of criterion 4. A failed update rolls itself back;
+this is for the update that installed cleanly and turned out to be wrong.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from coworker import migrations
+from coworker.update_channel.apply import (
+    Installation,
+    UpdateStatus,
+    rollback,
+    running_identity,
+)
+from coworker.update_channel.drain import DrainStatus, assess_drain
+
+RUN_STORE_NAME = "agent_runs.db"
+
+
+def _installation(args: argparse.Namespace) -> Installation:
+    return Installation(
+        identity=running_identity(channel=args.channel, version=args.version),
+        bundle_path=Path(args.bundle).expanduser(),
+        state_root=Path(args.state_root).expanduser(),
+    )
+
+
+def status(args: argparse.Namespace) -> int:
+    root = Path(args.state_root).expanduser()
+    print(f"channel   {args.channel}")
+    print(f"version   {args.version}")
+    if not (root / RUN_STORE_NAME).exists():
+        print("runs      no run store on this machine")
+        print("update    safe to update")
+        return 0
+
+    from coworker.agent_run_repository import AgentRunRepository
+
+    repo = AgentRunRepository(root)
+    try:
+        assessment = assess_drain(repo)
+    finally:
+        repo.close()
+
+    print(f"drain     {assessment.status}")
+    for blocker in assessment.blockers:
+        detail = f" ({blocker.tool_name})" if blocker.tool_name else ""
+        print(f"  {blocker.run_id}{detail}: {blocker.reason}")
+    if assessment.continuable:
+        print(f"continue  {len(assessment.continuable)} run(s) resume after a restart")
+    if assessment.status is DrainStatus.READY:
+        print("update    safe to update")
+        return 0
+    if assessment.status is DrainStatus.QUARANTINED_EFFECT:
+        print(
+            "update    settle the quarantined effect in review first. "
+            "Sourcecado will not decide it for you."
+        )
+        return 1
+    print("update    wait for the work above to finish, then try again")
+    return 1
+
+
+def undo(args: argparse.Namespace) -> int:
+    installation = _installation(args)
+    if args.list_backups:
+        for entry in migrations.list_backups(installation.state_root):
+            print(f"{entry['backup_id']}  {entry['created_at']}  {entry['reason']}")
+        return 0
+    outcome = rollback(installation, backup_id=args.backup)
+    print(f"{outcome.status}: {outcome.guidance}")
+    if outcome.restored:
+        print(f"restored  {', '.join(outcome.restored)}")
+    return 0 if outcome.status is UpdateStatus.ROLLED_BACK else 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m coworker.update_channel")
+    parser.add_argument("--state-root", default=str(migrations.state_root()))
+    parser.add_argument("--channel", default="preview")
+    parser.add_argument("--version", default="0.0.0")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    check = sub.add_parser("status", help="is it safe to update right now")
+    check.set_defaults(handler=status)
+
+    back = sub.add_parser("rollback", help="go back to the previous version")
+    back.add_argument("--bundle", default="/Applications/Sourcecado.app")
+    back.add_argument("--backup", default=None, help="state backup id to restore")
+    back.add_argument(
+        "--list-backups", action="store_true", help="list backups and exit"
+    )
+    back.set_defaults(handler=undo)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return int(args.handler(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/desktop/coworker/update_channel/apply.py
+++ b/desktop/coworker/update_channel/apply.py
@@ -1,0 +1,804 @@
+"""Applying one update, and putting the last usable version back when it fails.
+
+The order of the stages is the design. Everything that can fail without
+consequence happens before anything is touched:
+
+    verify -> drain -> compatibility -> stage -> backup -> migrate -> activate
+    -> health
+
+Verification, the drain gate, the compatibility read, and unpacking the archive
+all change nothing, so a failure in any of them leaves the running installation
+exactly as it was. Only after all four pass does the update take a backup and
+begin to move.
+
+Migrating before activating is deliberate. The migration registry that runs is
+this build's, so the state it produces is state this build already understands:
+a crash between the migration and the bundle swap leaves a consistent system,
+and a failure at the migration step leaves the old bundle untouched with only
+the state to restore. The reverse order would open a window where a new bundle
+sits over state it has not migrated yet.
+
+State compatibility and backup are `coworker/migrations.py`'s job, and this
+module calls it rather than repeating it. What this module adds is the one
+thing that registry cannot know about: whether an update is safe to start at
+all. That is `drain`, and it is the reason this file does not contain the
+obvious "stop, swap, start" sequence.
+
+One gap in the registry is compensated for here rather than worked around.
+`migrations.restore_backup` restores store contents but not `state_versions.json`,
+which is where JSONL logs, opaque files, and config documents record their
+version. Rolling back without it would leave those stores' recorded versions
+ahead of their restored contents, so the updater snapshots that file into the
+backup directory before it migrates and puts it back when it rolls back. The
+registry itself should do this; see `docs/update-channel.md`.
+"""
+
+from __future__ import annotations
+
+import http.client
+import json
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass, replace
+from datetime import datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Callable
+
+from coworker import migrations
+from coworker.update_channel import drain as drain_module
+from coworker.update_channel.drain import DEFAULT_POLL, DEFAULT_TIMEOUT, DrainBlocker
+from coworker.update_channel.manifest import (
+    BoundManifest,
+    BuildIdentity,
+    Refusal,
+    verify_manifest,
+)
+from coworker.update_channel.redaction import registered_secrets, safe_text
+
+STAGING_DIR_NAME = ".sourcecado-update"
+PREVIOUS_SUFFIX = ".previous"
+RUN_STORE_NAME = "agent_runs.db"
+VERSIONS_SNAPSHOT = "pre-update-state-versions.json"
+SIDECAR_RELATIVE = Path(
+    "Contents/Resources/resources/sourcecado-sidecar/sourcecado-sidecar"
+)
+HEALTH_TIMEOUT = 40.0
+
+
+class UpdateStage(StrEnum):
+    """How far the update got. A refusal names the gate that stopped it."""
+
+    VERIFY = "verify"
+    DRAIN = "drain"
+    COMPATIBILITY = "compatibility"
+    STAGE = "stage"
+    BACKUP = "backup"
+    MIGRATE = "migrate"
+    ACTIVATE = "activate"
+    HEALTH = "health"
+    DONE = "done"
+
+
+class UpdateStatus(StrEnum):
+    APPLIED = "applied"
+    # Stopped before anything was touched.
+    REFUSED = "refused"
+    # Stopped by active work. Try again when it drains.
+    BLOCKED = "blocked"
+    # Something changed and was put back.
+    ROLLED_BACK = "rolled_back"
+    # Something changed and could not be put back. Loud on purpose.
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class Installation:
+    """Where this Sourcecado lives and what it is."""
+
+    identity: BuildIdentity
+    bundle_path: Path
+    state_root: Path
+
+    @property
+    def previous_path(self) -> Path:
+        return self.bundle_path.with_name(self.bundle_path.name + PREVIOUS_SUFFIX)
+
+    @property
+    def staging_root(self) -> Path:
+        return self.bundle_path.parent / STAGING_DIR_NAME
+
+    def at_version(self, version: str) -> "Installation":
+        return replace(self, identity=replace(self.identity, version=str(version)))
+
+
+@dataclass(frozen=True)
+class UpdateOutcome:
+    status: UpdateStatus
+    stage: UpdateStage
+    reason: str
+    guidance: str
+    from_version: str
+    to_version: str | None = None
+    backup_id: str | None = None
+    blockers: tuple[DrainBlocker, ...] = ()
+    # Runs that were open when the update ran and are safe to pick up after it:
+    # they live in the run store and `agent_run_resume.restart()` classifies them
+    # on the next launch. Recorded so the decision is auditable afterwards.
+    continuable: tuple[str, ...] = ()
+    migrated: tuple[str, ...] = ()
+    restored: tuple[str, ...] = ()
+
+    @property
+    def ok(self) -> bool:
+        return self.status is UpdateStatus.APPLIED
+
+    def to_dict(self) -> dict[str, Any]:
+        """The whole outcome as plain data. Nothing here carries a credential."""
+        return {
+            "status": str(self.status),
+            "stage": str(self.stage),
+            "reason": self.reason,
+            "guidance": self.guidance,
+            "from_version": self.from_version,
+            "to_version": self.to_version,
+            "backup_id": self.backup_id,
+            "continuable": list(self.continuable),
+            "blockers": [
+                {
+                    "run_id": blocker.run_id,
+                    "status": str(blocker.status),
+                    "reason": blocker.reason,
+                    "effect_id": blocker.effect_id,
+                    "tool_name": blocker.tool_name,
+                }
+                for blocker in self.blockers
+            ],
+            "migrated": list(self.migrated),
+            "restored": list(self.restored),
+        }
+
+
+_GUIDANCE: dict[str, str] = {
+    str(Refusal.UNTRUSTED_KEY): (
+        "This build does not trust the key that signed that update. Download the "
+        "preview build again from the Sourcecado release page."
+    ),
+    str(Refusal.BAD_SIGNATURE): (
+        "The download does not match what was signed. Delete it and download it "
+        "again. Nothing on this Mac was changed."
+    ),
+    str(Refusal.ARTIFACT_DIGEST_MISMATCH): (
+        "The download is not the file the manifest describes. Delete it and "
+        "download it again."
+    ),
+    str(Refusal.CHANNEL_MISMATCH): (
+        "That update is for a different release channel. A preview build only "
+        "installs preview updates."
+    ),
+    "run_store_not_inspected": (
+        "Sourcecado could not read its own run store, so it cannot tell whether "
+        "work is in flight. Run Sourcecado Doctor and try again."
+    ),
+    "state_incompatible": (
+        "Your local data is not in a state this update can move. Run Sourcecado "
+        "Doctor and follow what it reports. Nothing was changed."
+    ),
+    "artifact_shape": (
+        "The download did not contain a single application. Delete it and "
+        "download it again."
+    ),
+    "backup_failed": (
+        "Sourcecado could not write the backup it takes before changing your "
+        "data, so it stopped. Free up disk space and try again."
+    ),
+}
+
+_DRAIN_GUIDANCE = {
+    drain_module.DrainStatus.ACTIVE_WORK: (
+        "Sourcecado is still working. The update did not start. Let the current "
+        "run finish and try again."
+    ),
+    drain_module.DrainStatus.UNSETTLED_EFFECT: (
+        "A send has gone out and has not reported back yet, so nobody knows if "
+        "it arrived. Sourcecado will not restart while that is true, because a "
+        "restart could send it twice. Wait for the run to finish, then update."
+    ),
+    drain_module.DrainStatus.QUARANTINED_EFFECT: (
+        "An external action is waiting for you to say what happened to it. "
+        "Settle it in review, then update. Sourcecado will not decide it for you."
+    ),
+}
+
+
+def _outcome(
+    status: UpdateStatus,
+    stage: UpdateStage,
+    reason: str,
+    installation: Installation,
+    *,
+    guidance: str = "",
+    **extra: Any,
+) -> UpdateOutcome:
+    """Assemble the outcome, and scan the operator-facing sentence one last time.
+
+    Call sites wrap the variable half of a message -- an exception string, a
+    registry error -- in `safe_text` themselves, so a credential in there is
+    withheld in place and the fixed sentence survives. This second pass exists
+    for the call site that forgets: it withholds the whole sentence rather than
+    letting it through, which is the direction this has to fail in.
+    """
+    text = guidance or _GUIDANCE.get(reason, "")
+    return UpdateOutcome(
+        status=status,
+        stage=stage,
+        reason=reason,
+        guidance=safe_text(
+            text,
+            state_root=installation.state_root,
+            registered=registered_secrets(installation.state_root),
+        ),
+        from_version=installation.identity.version,
+        **extra,
+    )
+
+
+def _detail(text: Any, installation: Installation) -> str:
+    """The variable half of a message, withheld on its own if it matches."""
+    return safe_text(
+        text,
+        state_root=installation.state_root,
+        registered=registered_secrets(installation.state_root),
+    )
+
+
+# --- the bundle on disk --------------------------------------------------
+
+
+def _clear(path: Path) -> None:
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path, ignore_errors=True)
+    elif path.exists() or path.is_symlink():
+        path.unlink(missing_ok=True)
+
+
+def stage_artifact(installation: Installation, artifact_path: Path) -> Path:
+    """Unpack the archive and return the single application it contains.
+
+    Raises `ValueError` when the archive holds anything other than exactly one
+    top-level directory. Content authenticity is already settled by the
+    manifest's digest; this only refuses a shape the installer cannot place.
+    """
+    staging = installation.staging_root
+    _clear(staging)
+    staging.mkdir(parents=True, exist_ok=True)
+    os.chmod(staging, migrations.DIR_MODE)
+    shutil.unpack_archive(str(artifact_path), str(staging))
+    entries = [item for item in staging.iterdir() if not item.name.startswith(".")]
+    directories = [item for item in entries if item.is_dir()]
+    if len(entries) != 1 or len(directories) != 1:
+        raise ValueError(
+            f"the archive holds {len(entries)} top-level entries; an update holds one"
+        )
+    return directories[0]
+
+
+def activate(installation: Installation, staged: Path) -> None:
+    """Put the new application where the old one is, keeping the old one aside.
+
+    Two renames on one filesystem. Between them the application is briefly
+    absent, which is the smallest window this can be reduced to without a
+    filesystem that can swap two directories in one call.
+    """
+    _clear(installation.previous_path)
+    if installation.bundle_path.exists():
+        os.replace(installation.bundle_path, installation.previous_path)
+    os.replace(staged, installation.bundle_path)
+
+
+def restore_bundle(installation: Installation) -> bool:
+    """Put the previous application back. False when there is nothing to put back."""
+    if not installation.previous_path.exists():
+        return False
+    _clear(installation.bundle_path)
+    os.replace(installation.previous_path, installation.bundle_path)
+    return True
+
+
+# --- the version manifest the registry does not back up ------------------
+
+
+def _snapshot_versions(state_root: Path, backup: migrations.Backup) -> None:
+    """Record `state_versions.json` as it stands, including not existing yet.
+
+    Absence is as much a fact as a version number. A state directory that has
+    never been migrated has no version manifest at all, and a rollback that
+    left the migration's new one behind would report versions for stores whose
+    contents had just been restored to an earlier shape.
+    """
+    live = state_root / migrations.MANIFEST_NAME
+    payload: dict[str, Any] = {"present": live.is_file(), "document": None}
+    if payload["present"]:
+        try:
+            payload["document"] = json.loads(live.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            payload["present"] = False
+    target = backup.path / VERSIONS_SNAPSHOT
+    target.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    os.chmod(target, migrations.FILE_MODE)
+
+
+def _restore_versions(state_root: Path, backup_id: str) -> None:
+    source = state_root / migrations.BACKUPS_DIR_NAME / backup_id / VERSIONS_SNAPSHOT
+    if not source.is_file():
+        return
+    try:
+        payload = json.loads(source.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return
+    live = state_root / migrations.MANIFEST_NAME
+    if not payload.get("present"):
+        live.unlink(missing_ok=True)
+        return
+    live.write_text(
+        json.dumps(payload.get("document") or {}, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    os.chmod(live, migrations.FILE_MODE)
+
+
+def _restore_state(state_root: Path, backup_id: str | None) -> tuple[str, ...]:
+    if backup_id is None:
+        return ()
+    restored = migrations.restore_backup(state_root, backup_id)
+    _restore_versions(state_root, backup_id)
+    return tuple(restored.get("restored") or ())
+
+
+# --- health --------------------------------------------------------------
+
+
+def _free_port() -> int:
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+
+
+def sidecar_health_check(
+    installation: Installation, *, timeout: float = HEALTH_TIMEOUT
+) -> bool:
+    """Launch the installed sidecar against throwaway state and ask if it is well.
+
+    The state directory is a temporary one, never the operator's. A health check
+    that wrote to real state would be a change the rollback could not undo.
+    """
+    import secrets as secrets_module
+
+    binary = installation.bundle_path / SIDECAR_RELATIVE
+    if not binary.is_file() or not os.access(binary, os.X_OK):
+        return False
+    token = secrets_module.token_hex(16)
+    port = _free_port()
+    scratch = tempfile.mkdtemp(prefix="sourcecado-update-health-")
+    environment = dict(os.environ)
+    environment["CLUB_STATE_DIR"] = scratch
+    environment["CLUB_API_TOKEN"] = token
+    environment.pop("CLUB_EXIT_WITH_PARENT", None)
+    process = subprocess.Popen(
+        [str(binary), "--host", "127.0.0.1", "--port", str(port)],
+        cwd=tempfile.gettempdir(),
+        env=environment,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if process.poll() is not None:
+                return False
+            try:
+                connection = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+                connection.request("GET", "/v1/health", headers={"X-Club-Token": token})
+                response = connection.getresponse()
+                if response.status != 200:
+                    return False
+                return json.loads(response.read()).get("status") == "ok"
+            except (OSError, ValueError):
+                time.sleep(0.25)
+        return False
+    finally:
+        process.kill()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
+        shutil.rmtree(scratch, ignore_errors=True)
+
+
+# --- the update ----------------------------------------------------------
+
+
+def apply_update(
+    document: Any,
+    *,
+    installation: Installation,
+    artifact_path: str | Path,
+    trust: Any = None,
+    runs: Any = None,
+    health_check: Callable[[Installation], bool] = sidecar_health_check,
+    drain_timeout: float = DEFAULT_TIMEOUT,
+    drain_poll: float = DEFAULT_POLL,
+    sleep: Callable[[float], None] = time.sleep,
+    clock: Callable[[], float] = time.monotonic,
+    now: datetime | None = None,
+) -> UpdateOutcome:
+    """Install a verified update, or explain why this Mac is staying where it is."""
+    artifact = Path(artifact_path)
+    state_root = Path(installation.state_root)
+
+    # 1. Authenticate. Nothing has been touched and nothing will be if this fails.
+    verification = verify_manifest(
+        document,
+        installed=installation.identity,
+        artifact_path=artifact,
+        trust=trust,
+    )
+    if not verification.ok or verification.manifest is None:
+        return _outcome(
+            UpdateStatus.REFUSED,
+            UpdateStage.VERIFY,
+            str(verification.refusal),
+            installation,
+            guidance=_GUIDANCE.get(
+                str(verification.refusal),
+                "Sourcecado refused that update: "
+                f"{_detail(verification.detail, installation)}. Nothing on this "
+                "Mac was changed.",
+            ),
+        )
+    bound: BoundManifest = verification.manifest
+
+    # 2. Is now a safe moment? This is the gate that makes an updater safe on a
+    #    machine that sends real mail. It reads; it never writes.
+    blocked, continuable = _drain_gate(
+        installation,
+        bound,
+        runs,
+        state_root,
+        drain_timeout=drain_timeout,
+        drain_poll=drain_poll,
+        sleep=sleep,
+        clock=clock,
+        now=now,
+    )
+    if blocked is not None:
+        return blocked
+
+    # The gate has passed, so the updater now owns the state directory. Closing
+    # the run store here is not tidiness: migrating or restoring a SQLite file
+    # underneath an open connection can corrupt it, and every step below this
+    # line does one or the other. The application is not running at this point;
+    # `docs/update-channel.md` records that precondition.
+    _close_quietly(runs)
+
+    # 3. Can this build's migration registry move the state? Its answer, not ours.
+    plan = migrations.plan_migrations(state_root)
+    if plan.blocked:
+        detail = ", ".join(
+            f"{item.store_id}: {item.status}" for item in plan.blockers
+        )
+        return _outcome(
+            UpdateStatus.REFUSED,
+            UpdateStage.COMPATIBILITY,
+            "state_incompatible",
+            installation,
+            guidance=(
+                f"{_GUIDANCE['state_incompatible']} Doctor will report: "
+                f"{_detail(detail, installation)}."
+            ),
+            to_version=bound.version,
+        )
+
+    # 4. Unpack. Still nothing touched.
+    try:
+        staged = stage_artifact(installation, artifact)
+    except (OSError, ValueError, shutil.ReadError) as exc:
+        _clear(installation.staging_root)
+        return _outcome(
+            UpdateStatus.REFUSED,
+            UpdateStage.STAGE,
+            "artifact_shape",
+            installation,
+            guidance=f"{_GUIDANCE['artifact_shape']} ({_detail(exc, installation)})",
+            to_version=bound.version,
+        )
+
+    # 5. Back up before the first change, when there is a change to make.
+    backup: migrations.Backup | None = None
+    if plan.pending:
+        try:
+            backup = migrations.create_backup(
+                state_root,
+                [spec.store_id for spec in migrations.REGISTRY],
+                reason=f"update {installation.identity.version} to {bound.version}",
+            )
+            _snapshot_versions(state_root, backup)
+        except (migrations.BackupFailed, OSError) as exc:
+            _clear(installation.staging_root)
+            return _outcome(
+                UpdateStatus.REFUSED,
+                UpdateStage.BACKUP,
+                "backup_failed",
+                installation,
+                guidance=(
+                    f"{_GUIDANCE['backup_failed']} ({_detail(exc, installation)})"
+                ),
+                to_version=bound.version,
+            )
+
+    return _install(
+        installation,
+        bound,
+        plan=plan,
+        backup=backup,
+        staged=staged,
+        health_check=health_check,
+        state_root=state_root,
+        continuable=continuable,
+    )
+
+
+def _close_quietly(runs: Any) -> None:
+    if runs is None:
+        return
+    try:
+        runs.close()
+    except Exception:  # already closed, or never ours to close
+        pass
+
+
+def _drain_gate(
+    installation: Installation,
+    bound: BoundManifest,
+    runs: Any,
+    state_root: Path,
+    *,
+    drain_timeout: float,
+    drain_poll: float,
+    sleep: Callable[[float], None],
+    clock: Callable[[], float],
+    now: datetime | None,
+) -> tuple[UpdateOutcome | None, tuple[str, ...]]:
+    """Criterion 3, in one place.
+
+    Returns the outcome that stops the update, or None plus the runs that are
+    safe to pick up after it. An installation with no run store has nothing in
+    flight. An installation with a run store the caller did not open is not the
+    same thing, and it refuses rather than assuming.
+    """
+    if runs is None:
+        if (state_root / RUN_STORE_NAME).exists():
+            return (
+                _outcome(
+                    UpdateStatus.REFUSED,
+                    UpdateStage.DRAIN,
+                    "run_store_not_inspected",
+                    installation,
+                    to_version=bound.version,
+                ),
+                (),
+            )
+        return None, ()
+    assessment = drain_module.wait_for_drain(
+        runs,
+        timeout=drain_timeout,
+        poll=drain_poll,
+        sleep=sleep,
+        clock=clock,
+        now=now,
+    )
+    if assessment.ready:
+        return None, assessment.continuable
+    return (
+        _outcome(
+            UpdateStatus.BLOCKED,
+            UpdateStage.DRAIN,
+            str(assessment.status),
+            installation,
+            guidance=_DRAIN_GUIDANCE[assessment.status],
+            to_version=bound.version,
+            blockers=assessment.blockers,
+            continuable=assessment.continuable,
+        ),
+        assessment.continuable,
+    )
+
+
+def _install(
+    installation: Installation,
+    bound: BoundManifest,
+    *,
+    plan: migrations.MigrationPlan,
+    backup: migrations.Backup | None,
+    staged: Path,
+    health_check: Callable[[Installation], bool],
+    state_root: Path,
+    continuable: tuple[str, ...] = (),
+) -> UpdateOutcome:
+    backup_id = backup.backup_id if backup is not None else None
+    migrated: tuple[str, ...] = ()
+
+    if plan.pending:
+        outcome = migrations.apply_migrations(state_root, plan=plan, backup=backup)
+        if outcome.blocked or outcome.error:
+            restored = _restore_state(state_root, backup_id)
+            _clear(installation.staging_root)
+            return _outcome(
+                UpdateStatus.ROLLED_BACK,
+                UpdateStage.MIGRATE,
+                "migration_failed",
+                installation,
+                guidance=(
+                    "The update could not move your data, so Sourcecado put it "
+                    f"back and stayed on {installation.identity.version}. "
+                    f"({_detail(outcome.error, installation)})"
+                ),
+                to_version=bound.version,
+                backup_id=backup_id,
+                restored=restored,
+            )
+        migrated = tuple(step.store_id for step in outcome.applied)
+
+    try:
+        activate(installation, staged)
+    except OSError as exc:
+        restore_bundle(installation)
+        restored = _restore_state(state_root, backup_id)
+        _clear(installation.staging_root)
+        return _outcome(
+            UpdateStatus.ROLLED_BACK,
+            UpdateStage.ACTIVATE,
+            "activation_failed",
+            installation,
+            guidance=(
+                "The new version could not be put in place, so Sourcecado "
+                f"stayed on {installation.identity.version}. "
+                f"({_detail(exc, installation)})"
+            ),
+            to_version=bound.version,
+            backup_id=backup_id,
+            restored=restored,
+        )
+
+    try:
+        healthy = bool(health_check(installation.at_version(bound.version)))
+        failure = ""
+    except Exception as exc:  # a health check that raises is a health check that failed
+        healthy = False
+        failure = f" ({exc})"
+    if not healthy:
+        restore_bundle(installation)
+        restored = _restore_state(state_root, backup_id)
+        _clear(installation.staging_root)
+        return _outcome(
+            UpdateStatus.ROLLED_BACK,
+            UpdateStage.HEALTH,
+            "health_check_failed",
+            installation,
+            guidance=(
+                f"Version {bound.version} did not start correctly, so Sourcecado "
+                f"put version {installation.identity.version} back and restored "
+                f"your data.{_detail(failure, installation) if failure else ''}"
+            ),
+            to_version=bound.version,
+            backup_id=backup_id,
+            restored=restored,
+        )
+
+    _clear(installation.staging_root)
+    return _outcome(
+        UpdateStatus.APPLIED,
+        UpdateStage.DONE,
+        "applied",
+        installation,
+        guidance=(
+            f"Sourcecado is now on version {bound.version}. The previous version "
+            "is kept until the next update, so you can roll back."
+        ),
+        to_version=bound.version,
+        backup_id=backup_id,
+        migrated=migrated,
+        continuable=continuable,
+    )
+
+
+def rollback(
+    installation: Installation, *, backup_id: str | None = None
+) -> UpdateOutcome:
+    """Deliberately go back to the version this Mac was on before the last update."""
+    state_root = Path(installation.state_root)
+    if not installation.previous_path.exists():
+        return _outcome(
+            UpdateStatus.REFUSED,
+            UpdateStage.ACTIVATE,
+            "no_previous_version",
+            installation,
+            guidance=(
+                "There is no previous version kept on this Mac, so there is "
+                "nothing to roll back to. Download the version you want and "
+                "install it."
+            ),
+        )
+    restore_bundle(installation)
+    restored: tuple[str, ...] = ()
+    if backup_id is not None:
+        try:
+            restored = _restore_state(state_root, backup_id)
+        except (migrations.BackupFailed, OSError, ValueError) as exc:
+            return _outcome(
+                UpdateStatus.FAILED,
+                UpdateStage.MIGRATE,
+                "state_not_restored",
+                installation,
+                guidance=(
+                    "The previous version is back, but your data could not be "
+                    f"restored from backup {backup_id}. Run Sourcecado Doctor "
+                    f"before using it. ({_detail(exc, installation)})"
+                ),
+                backup_id=backup_id,
+            )
+    return _outcome(
+        UpdateStatus.ROLLED_BACK,
+        UpdateStage.DONE,
+        "rolled_back",
+        installation,
+        guidance=(
+            "Sourcecado is back on the version it was running before the last "
+            "update, and your data was restored with it."
+        ),
+        backup_id=backup_id,
+        restored=restored,
+    )
+
+
+def running_identity(*, channel: str, version: str) -> BuildIdentity:
+    """Describe this build for verification: what it is, and what state it reaches."""
+    import platform
+
+    from coworker.update_channel.manifest import PRODUCT, registry_state_versions
+
+    system = {"Darwin": "macos", "Linux": "linux", "Windows": "windows"}.get(
+        platform.system(), platform.system().lower()
+    )
+    machine = {"arm64": "aarch64", "AMD64": "x86_64"}.get(
+        platform.machine(), platform.machine()
+    )
+    return BuildIdentity(
+        product=PRODUCT,
+        channel=str(channel),
+        version=str(version),
+        platform=system,
+        arch=machine,
+        state_versions=registry_state_versions(),
+    )
+
+
+__all__ = [
+    "Installation",
+    "UpdateOutcome",
+    "UpdateStage",
+    "UpdateStatus",
+    "activate",
+    "apply_update",
+    "restore_bundle",
+    "rollback",
+    "running_identity",
+    "sidecar_health_check",
+    "stage_artifact",
+]

--- a/desktop/coworker/update_channel/apply.py
+++ b/desktop/coworker/update_channel/apply.py
@@ -683,9 +683,27 @@ def _install(
         healthy = False
         failure = f" ({exc})"
     if not healthy:
-        restore_bundle(installation)
+        previous_restored = restore_bundle(installation)
+        if not previous_restored:
+            _clear(installation.bundle_path)
         restored = _restore_state(state_root, backup_id)
         _clear(installation.staging_root)
+        if not previous_restored:
+            return _outcome(
+                UpdateStatus.FAILED,
+                UpdateStage.HEALTH,
+                "health_check_failed",
+                installation,
+                guidance=(
+                    f"Version {bound.version} did not start correctly, and there "
+                    "was no previous version to put back. Sourcecado is not "
+                    "installed. Download it again and try a different build."
+                    f"{_detail(failure, installation) if failure else ''}"
+                ),
+                to_version=bound.version,
+                backup_id=backup_id,
+                restored=restored,
+            )
         return _outcome(
             UpdateStatus.ROLLED_BACK,
             UpdateStage.HEALTH,

--- a/desktop/coworker/update_channel/drain.py
+++ b/desktop/coworker/update_channel/drain.py
@@ -1,0 +1,213 @@
+"""Whether an update may proceed right now. Reads only; decides nothing else.
+
+The natural updater stops the app, swaps the bundle, and starts it again. On a
+machine that sends real mail to real people, that sequence is the bug. An
+external effect that has been dispatched and has not reported back is a window
+where nobody knows whether the send happened. Killing the process closes that
+window on "unknown" forever, and a restart that resumes the run can put a
+second copy of the same message in a real inbox.
+
+So this module answers one question -- may an update proceed -- with three
+answers, and "proceed anyway" is not among them:
+
+- `READY`: every run is finished, parked on a person, or free of any external
+  effect that has not reported. Whatever is left is restart-safe: it lives in
+  the run store, and `agent_run_resume.restart()` picks it up after the new
+  build launches.
+- `ACTIVE_WORK` or `UNSETTLED_EFFECT`: wait. Both resolve on their own when the
+  process that owns the work finishes. If the wait runs out, the update refuses;
+  it never forces.
+- `QUARANTINED_EFFECT`: refuse now, and do not wait. An ambiguous effect is
+  settled by a person and by nothing else, so waiting cannot help.
+
+The second half of the contract is what this module does *not* do. It performs
+no writes at all. It does not quarantine an unreported effect -- that is
+`agent_run_resume.restart()`'s decision after a crash has actually happened --
+and it does not resolve a quarantine, which is a person's decision and carries
+their name. An updater that "tidies up" the run store on the way past is how a
+machine ends up recording an outcome nobody observed.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any, Callable
+
+from coworker.agent_run_approval import unreported
+from coworker.agent_run_resume import OPEN_AGENT_RUN_STATES
+from coworker.agent_run_state import is_waiting
+
+DEFAULT_TIMEOUT = 120.0
+DEFAULT_POLL = 1.0
+DEFAULT_LIMIT = 500
+
+
+class DrainStatus(StrEnum):
+    READY = "ready"
+    ACTIVE_WORK = "active_work"
+    UNSETTLED_EFFECT = "unsettled_effect"
+    QUARANTINED_EFFECT = "quarantined_effect"
+
+
+# Worst last. The reported status is the worst blocker found.
+_SEVERITY: dict[DrainStatus, int] = {
+    DrainStatus.READY: 0,
+    DrainStatus.ACTIVE_WORK: 1,
+    DrainStatus.UNSETTLED_EFFECT: 2,
+    DrainStatus.QUARANTINED_EFFECT: 3,
+}
+
+# The two states that clear on their own when the owning process finishes.
+# A quarantine is not among them: only a person moves it.
+WAITABLE = frozenset({DrainStatus.ACTIVE_WORK, DrainStatus.UNSETTLED_EFFECT})
+
+
+@dataclass(frozen=True)
+class DrainBlocker:
+    run_id: str
+    status: DrainStatus
+    reason: str
+    effect_id: str | None = None
+    tool_name: str | None = None
+
+
+@dataclass(frozen=True)
+class DrainAssessment:
+    status: DrainStatus
+    blockers: tuple[DrainBlocker, ...] = ()
+    continuable: tuple[str, ...] = ()
+
+    @property
+    def ready(self) -> bool:
+        return self.status is DrainStatus.READY
+
+    @property
+    def may_wait(self) -> bool:
+        """Whether waiting could change this answer. A quarantine never does."""
+        return self.status in WAITABLE
+
+
+def _lease_is_live(run: dict[str, Any], now: datetime) -> bool:
+    """A lease that has not expired belongs to a process that may still be working.
+
+    An expired lease is the run store's own definition of reclaimable, and the
+    run behind it is durable, so it is restart-safe rather than active. Proving
+    an owner dead is `reclaim_dead_owner_leases`' job and it writes; this module
+    does not, so it uses the expiry the store already records.
+    """
+    if run.get("lease_owner") is None:
+        return False
+    expires = run.get("lease_expires_at")
+    if not expires:
+        return False
+    try:
+        return datetime.fromisoformat(str(expires)) > now
+    except ValueError:
+        # An unreadable expiry is not proof the lease is free.
+        return True
+
+
+def assess_drain(
+    repo: Any, *, now: datetime | None = None, limit: int = DEFAULT_LIMIT
+) -> DrainAssessment:
+    """Report what would stop an update, without touching anything.
+
+    Quarantined effects are swept across every run, not just open ones: an
+    effect record outlives the run it belongs to, and a run can reach `partial`
+    with a person still owing a decision on what left the machine.
+    """
+    moment = now or datetime.now(UTC)
+    blockers: list[DrainBlocker] = []
+    continuable: list[str] = []
+
+    held: dict[str, DrainBlocker] = {}
+    for effect in repo.list_quarantined_effects(limit=limit):
+        run_id = str(effect["run_id"])
+        held.setdefault(
+            run_id,
+            DrainBlocker(
+                run_id=run_id,
+                status=DrainStatus.QUARANTINED_EFFECT,
+                reason=(
+                    "an external effect is quarantined and only a person can "
+                    "settle it"
+                ),
+                effect_id=str(effect["effect_id"]),
+                tool_name=str(effect["tool_name"]),
+            ),
+        )
+    blockers.extend(held.values())
+
+    for run in repo.list_runs(states=sorted(OPEN_AGENT_RUN_STATES), limit=limit):
+        run_id = str(run["run_id"])
+        if run_id in held:
+            continue
+        open_effects = unreported(repo.list_effects(run_id))
+        if open_effects:
+            effect = open_effects[0]
+            blockers.append(
+                DrainBlocker(
+                    run_id=run_id,
+                    status=DrainStatus.UNSETTLED_EFFECT,
+                    reason=(
+                        "an external effect was dispatched and has not reported "
+                        "back, so whether it happened is not yet known"
+                    ),
+                    effect_id=str(effect["effect_id"]),
+                    tool_name=str(effect["tool_name"]),
+                )
+            )
+            continue
+        if is_waiting(str(run["current_state"])):
+            continuable.append(run_id)
+            continue
+        if _lease_is_live(run, moment):
+            blockers.append(
+                DrainBlocker(
+                    run_id=run_id,
+                    status=DrainStatus.ACTIVE_WORK,
+                    reason="a process is working this run",
+                )
+            )
+            continue
+        continuable.append(run_id)
+
+    if not blockers:
+        return DrainAssessment(
+            status=DrainStatus.READY, continuable=tuple(continuable)
+        )
+    ordered = tuple(sorted(blockers, key=lambda item: -_SEVERITY[item.status]))
+    return DrainAssessment(
+        status=ordered[0].status,
+        blockers=ordered,
+        continuable=tuple(continuable),
+    )
+
+
+def wait_for_drain(
+    repo: Any,
+    *,
+    timeout: float = DEFAULT_TIMEOUT,
+    poll: float = DEFAULT_POLL,
+    sleep: Callable[[float], None] = time.sleep,
+    clock: Callable[[], float] = time.monotonic,
+    now: datetime | None = None,
+    limit: int = DEFAULT_LIMIT,
+) -> DrainAssessment:
+    """Poll until the work drains, the deadline passes, or waiting is pointless.
+
+    Returns the last assessment either way. The caller refuses on anything that
+    is not `READY`; there is no argument this function can be given that makes
+    it force an update through.
+    """
+    deadline = clock() + max(0.0, float(timeout))
+    while True:
+        assessment = assess_drain(repo, now=now, limit=limit)
+        if assessment.ready or not assessment.may_wait:
+            return assessment
+        if clock() >= deadline:
+            return assessment
+        sleep(max(0.0, float(poll)))

--- a/desktop/coworker/update_channel/manifest.py
+++ b/desktop/coworker/update_channel/manifest.py
@@ -1,0 +1,459 @@
+"""The authenticated update manifest: what a build must prove before it installs.
+
+An update is the one moment Sourcecado takes a directory it did not build and
+puts it where the application lives. Everything that makes that safe is in this
+file, and it is all one idea: nothing is trusted because of where it came from.
+
+The manifest binds the artifact to a signature over a closed field set. Exact
+version, channel, platform, architecture, size, and SHA-256 digest are all
+inside the signed bytes, so an artifact that differs from the one the publisher
+signed -- in content, in target, or in identity -- cannot be described by a
+manifest that verifies.
+
+Three properties are load-bearing:
+
+- **The field set is closed.** A key this build does not know refuses the
+  manifest rather than being ignored. A field that is ignored is a field an
+  attacker gets for free the day a future build starts reading it.
+- **The signature is checked over canonical bytes with a domain prefix**, so a
+  signature made for anything else in Sourcecado cannot be replayed here.
+- **Trust is scoped by channel.** A key authorized for `stable` cannot sign a
+  `preview` manifest and the reverse. That is what makes the preview channel
+  opt-in rather than a toggle: a stable installation has no key that can
+  authenticate a preview manifest, so it cannot drift onto the channel by
+  accident, and a preview installation cannot be handed a stable artifact.
+
+Verification returns a `Verification`, never an exception, so the refusal
+reason can be shown to an operator and logged. Every path that cannot reach a
+positive answer refuses; there is no default-allow branch.
+
+`TRUSTED_KEYS` is empty. Sourcecado has no update signing key yet, so in a real
+installation every manifest is refused. That is the correct behaviour until an
+authorized identity exists, and `docs/update-channel.md` records what must be
+supplied to change it.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any, Mapping
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+MANIFEST_VERSION = 1
+SIGNATURE_ALGORITHM = "ed25519"
+# Domain separation. A signature over these bytes cannot be a signature over
+# anything else Sourcecado ever signs, and the reverse.
+SIGNING_CONTEXT = b"sourcecado.update-manifest.v1"
+
+# The closed field set. Adding a field here is a manifest version bump.
+SIGNED_FIELDS: tuple[str, ...] = (
+    "manifest_version",
+    "product",
+    "channel",
+    "version",
+    "platform",
+    "arch",
+    "artifact_name",
+    "artifact_size",
+    "artifact_sha256",
+    "minimum_upgradable_version",
+    "state_versions",
+    "released_at",
+    "commit",
+)
+
+_TEXT_FIELDS = frozenset(
+    {
+        "product",
+        "channel",
+        "version",
+        "platform",
+        "arch",
+        "artifact_name",
+        "artifact_sha256",
+        "minimum_upgradable_version",
+        "released_at",
+        "commit",
+    }
+)
+_INT_FIELDS = frozenset({"manifest_version", "artifact_size"})
+
+PRODUCT = "sourcecado"
+
+# Channel -> key id -> base64 Ed25519 public key.
+#
+# Empty on purpose. No authorized signing identity has been issued, so no
+# manifest can verify. `tests/test_update_manifest.py` holds a tripwire that
+# goes red the day a key is added, so adding one cannot happen quietly.
+TRUSTED_KEYS: dict[str, dict[str, str]] = {}
+
+
+class Channel(StrEnum):
+    STABLE = "stable"
+    PREVIEW = "preview"
+
+
+class Refusal(StrEnum):
+    """Why a manifest was refused. One reason per way of being wrong."""
+
+    MALFORMED = "malformed"
+    MISSING_FIELD = "missing_field"
+    UNKNOWN_FIELD = "unknown_field"
+    UNSUPPORTED_MANIFEST_VERSION = "unsupported_manifest_version"
+    UNKNOWN_ALGORITHM = "unknown_algorithm"
+    UNTRUSTED_KEY = "untrusted_key"
+    BAD_SIGNATURE = "bad_signature"
+    PRODUCT_MISMATCH = "product_mismatch"
+    CHANNEL_MISMATCH = "channel_mismatch"
+    PLATFORM_MISMATCH = "platform_mismatch"
+    ARCH_MISMATCH = "arch_mismatch"
+    ARTIFACT_MISSING = "artifact_missing"
+    ARTIFACT_SIZE_MISMATCH = "artifact_size_mismatch"
+    ARTIFACT_DIGEST_MISMATCH = "artifact_digest_mismatch"
+    NOT_AN_UPGRADE = "not_an_upgrade"
+    UNSUPPORTED_UPGRADE_PATH = "unsupported_upgrade_path"
+    UNKNOWN_STORE = "unknown_store"
+    STATE_DOWNGRADE = "state_downgrade"
+    STATE_AHEAD_OF_MIGRATOR = "state_ahead_of_migrator"
+
+
+@dataclass(frozen=True)
+class BuildIdentity:
+    """What the running installation is, and what state versions it can reach.
+
+    `state_versions` is this build's migration registry, not what is on disk.
+    It answers "which schema can this build produce", which is the question a
+    manifest's own `state_versions` has to agree with before anything installs.
+    """
+
+    product: str
+    channel: str
+    version: str
+    platform: str
+    arch: str
+    state_versions: Mapping[str, int]
+
+
+@dataclass(frozen=True)
+class BoundManifest:
+    """A manifest that verified, reduced to what the caller acts on."""
+
+    key_id: str
+    product: str
+    channel: str
+    version: str
+    platform: str
+    arch: str
+    artifact_name: str
+    artifact_size: int
+    artifact_sha256: str
+    state_versions: Mapping[str, int]
+    released_at: str
+    commit: str
+
+
+@dataclass(frozen=True)
+class Verification:
+    ok: bool
+    refusal: Refusal | None = None
+    detail: str = ""
+    manifest: BoundManifest | None = None
+
+
+def sha256_file(path: str | Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def registry_state_versions() -> dict[str, int]:
+    """The version of every registered store this build knows how to produce.
+
+    Imported here rather than at module scope so the packaging scripts can use
+    the manifest format without pulling in the whole sidecar.
+    """
+    from coworker import migrations
+
+    return {spec.store_id: spec.current_version for spec in migrations.REGISTRY}
+
+
+def canonical_bytes(signed: Mapping[str, Any]) -> bytes:
+    """Exactly what gets signed. Key order in the document is not part of it."""
+    body = json.dumps(
+        dict(signed),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    )
+    return SIGNING_CONTEXT + b"\n" + body.encode("utf-8")
+
+
+def build_manifest(**fields: Any) -> dict[str, Any]:
+    """Assemble the signed half, refusing any field the format does not carry."""
+    fields.setdefault("manifest_version", MANIFEST_VERSION)
+    unknown = sorted(set(fields) - set(SIGNED_FIELDS))
+    if unknown:
+        raise ValueError(f"unknown manifest field(s): {', '.join(unknown)}")
+    missing = sorted(set(SIGNED_FIELDS) - set(fields))
+    if missing:
+        raise ValueError(f"missing manifest field(s): {', '.join(missing)}")
+    return {name: fields[name] for name in SIGNED_FIELDS}
+
+
+def sign_manifest(
+    signed: Mapping[str, Any], *, seed: bytes, key_id: str
+) -> dict[str, Any]:
+    """Sign the canonical bytes with a raw Ed25519 seed."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    private = Ed25519PrivateKey.from_private_bytes(bytes(seed))
+    signature = private.sign(canonical_bytes(signed))
+    return {
+        "signed": dict(signed),
+        "signature": {
+            "algorithm": SIGNATURE_ALGORITHM,
+            "key_id": str(key_id),
+            "value": base64.b64encode(signature).decode("ascii"),
+        },
+    }
+
+
+def parse_version(text: Any) -> tuple[int, ...] | None:
+    """A dotted numeric version, or None. None always refuses; it never passes."""
+    parts = str(text).split(".")
+    if not parts or len(parts) > 4:
+        return None
+    try:
+        numbers = tuple(int(part) for part in parts)
+    except ValueError:
+        return None
+    if any(number < 0 for number in numbers):
+        return None
+    return numbers
+
+
+def _refuse(refusal: Refusal, detail: str) -> Verification:
+    return Verification(ok=False, refusal=refusal, detail=detail)
+
+
+def _shape(document: Any) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    if not isinstance(document, dict):
+        return None
+    signed = document.get("signed")
+    signature = document.get("signature")
+    if not isinstance(signed, dict) or not isinstance(signature, dict):
+        return None
+    return signed, signature
+
+
+def _field_types(signed: Mapping[str, Any]) -> str | None:
+    for name in _TEXT_FIELDS:
+        if not isinstance(signed.get(name), str):
+            return f"{name} must be a string"
+    for name in _INT_FIELDS:
+        value = signed.get(name)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            return f"{name} must be a non-negative integer"
+    versions = signed.get("state_versions")
+    if not isinstance(versions, dict):
+        return "state_versions must be an object"
+    for store, version in versions.items():
+        if not isinstance(store, str):
+            return "state_versions keys must be strings"
+        if not isinstance(version, int) or isinstance(version, bool) or version < 0:
+            return f"state_versions.{store} must be a non-negative integer"
+    return None
+
+
+def _state_refusal(
+    declared: Mapping[str, int], known: Mapping[str, int]
+) -> Verification | None:
+    """Compare what the artifact expects against what this build can produce.
+
+    Three ways to disagree, and all three refuse. A store this build has never
+    heard of cannot be reasoned about at all. A version above what this build's
+    registry reaches is a migration this process cannot perform, so installing
+    the artifact would strand the state below the binary. A version below is a
+    downgrade, which would strand the state above it.
+    """
+    for store, version in sorted(declared.items()):
+        if store not in known:
+            return _refuse(
+                Refusal.UNKNOWN_STORE,
+                f"the artifact names a store this build does not have: {store}",
+            )
+        current = int(known[store])
+        if version > current:
+            return _refuse(
+                Refusal.STATE_AHEAD_OF_MIGRATOR,
+                f"{store} would need version {version}; this build reaches {current}",
+            )
+        if version < current:
+            return _refuse(
+                Refusal.STATE_DOWNGRADE,
+                f"{store} is at version {current}; the artifact expects {version}",
+            )
+    return None
+
+
+def verify_manifest(
+    document: Any,
+    *,
+    installed: BuildIdentity,
+    artifact_path: str | Path,
+    trust: Mapping[str, Mapping[str, str]] | None = None,
+) -> Verification:
+    """Decide whether this artifact may be installed over this installation.
+
+    Every branch either refuses or falls through to the next check. There is no
+    path that returns `ok` without having reached the end.
+    """
+    keys = TRUSTED_KEYS if trust is None else trust
+
+    shape = _shape(document)
+    if shape is None:
+        return _refuse(Refusal.MALFORMED, "a manifest is a signed document")
+    signed, signature = shape
+
+    missing = sorted(set(SIGNED_FIELDS) - set(signed))
+    if missing:
+        return _refuse(Refusal.MISSING_FIELD, f"missing: {', '.join(missing)}")
+    unknown = sorted(set(signed) - set(SIGNED_FIELDS))
+    if unknown:
+        return _refuse(Refusal.UNKNOWN_FIELD, f"unknown: {', '.join(unknown)}")
+    type_error = _field_types(signed)
+    if type_error is not None:
+        return _refuse(Refusal.MALFORMED, type_error)
+
+    if int(signed["manifest_version"]) != MANIFEST_VERSION:
+        return _refuse(
+            Refusal.UNSUPPORTED_MANIFEST_VERSION,
+            f"manifest version {signed['manifest_version']}; this build reads "
+            f"{MANIFEST_VERSION}",
+        )
+
+    if str(signature.get("algorithm")) != SIGNATURE_ALGORITHM:
+        return _refuse(
+            Refusal.UNKNOWN_ALGORITHM,
+            f"signature algorithm {signature.get('algorithm')!r} is not accepted",
+        )
+
+    # The channel selects which keys govern the document, so it is settled
+    # before any key is looked up. A preview installation never consults a
+    # stable key, and a stable installation never consults a preview key.
+    channel = str(signed["channel"])
+    if channel != str(installed.channel):
+        return _refuse(
+            Refusal.CHANNEL_MISMATCH,
+            f"this installation is on {installed.channel}; the artifact is {channel}",
+        )
+
+    key_id = str(signature.get("key_id") or "")
+    public_b64 = dict(keys.get(channel, {})).get(key_id)
+    if not public_b64:
+        return _refuse(
+            Refusal.UNTRUSTED_KEY,
+            f"no key {key_id!r} is trusted for the {channel} channel",
+        )
+
+    try:
+        public = Ed25519PublicKey.from_public_bytes(
+            base64.b64decode(str(public_b64), validate=True)
+        )
+        raw = base64.b64decode(str(signature.get("value") or ""), validate=True)
+    except (binascii.Error, ValueError) as exc:
+        return _refuse(Refusal.MALFORMED, f"signature could not be read: {exc}")
+    try:
+        public.verify(raw, canonical_bytes(signed))
+    except InvalidSignature:
+        return _refuse(
+            Refusal.BAD_SIGNATURE, "the signature does not cover this manifest"
+        )
+
+    # Authentic. Now: is it for this installation, and is it this artifact?
+    if str(signed["product"]) != str(installed.product):
+        return _refuse(
+            Refusal.PRODUCT_MISMATCH, f"the artifact is {signed['product']!r}"
+        )
+    if str(signed["platform"]) != str(installed.platform):
+        return _refuse(
+            Refusal.PLATFORM_MISMATCH,
+            f"the artifact is for {signed['platform']}; this is {installed.platform}",
+        )
+    if str(signed["arch"]) != str(installed.arch):
+        return _refuse(
+            Refusal.ARCH_MISMATCH,
+            f"the artifact is for {signed['arch']}; this is {installed.arch}",
+        )
+
+    offered = parse_version(signed["version"])
+    running = parse_version(installed.version)
+    floor = parse_version(signed["minimum_upgradable_version"])
+    if offered is None or running is None or floor is None:
+        return _refuse(Refusal.MALFORMED, "a version must be dotted numbers")
+    if offered <= running:
+        return _refuse(
+            Refusal.NOT_AN_UPGRADE,
+            f"version {signed['version']} is not newer than {installed.version}",
+        )
+    if running < floor:
+        return _refuse(
+            Refusal.UNSUPPORTED_UPGRADE_PATH,
+            f"{signed['version']} upgrades from {signed['minimum_upgradable_version']} "
+            f"or later; this is {installed.version}",
+        )
+
+    state_refusal = _state_refusal(
+        dict(signed["state_versions"]), dict(installed.state_versions)
+    )
+    if state_refusal is not None:
+        return state_refusal
+
+    path = Path(artifact_path)
+    # One signed file, not a directory. A tree has no single digest to bind.
+    if not path.is_file():
+        return _refuse(Refusal.ARTIFACT_MISSING, f"no artifact file at {path.name}")
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        return _refuse(Refusal.ARTIFACT_MISSING, f"artifact unreadable: {exc.strerror}")
+    if size != int(signed["artifact_size"]):
+        return _refuse(
+            Refusal.ARTIFACT_SIZE_MISMATCH,
+            f"the artifact is {size} bytes; the manifest says "
+            f"{signed['artifact_size']}",
+        )
+    if sha256_file(path) != str(signed["artifact_sha256"]):
+        return _refuse(
+            Refusal.ARTIFACT_DIGEST_MISMATCH,
+            "the artifact does not hash to what the manifest signed",
+        )
+
+    return Verification(
+        ok=True,
+        manifest=BoundManifest(
+            key_id=key_id,
+            product=str(signed["product"]),
+            channel=channel,
+            version=str(signed["version"]),
+            platform=str(signed["platform"]),
+            arch=str(signed["arch"]),
+            artifact_name=str(signed["artifact_name"]),
+            artifact_size=int(signed["artifact_size"]),
+            artifact_sha256=str(signed["artifact_sha256"]),
+            state_versions=dict(signed["state_versions"]),
+            released_at=str(signed["released_at"]),
+            commit=str(signed["commit"]),
+        ),
+    )

--- a/desktop/coworker/update_channel/redaction.py
+++ b/desktop/coworker/update_channel/redaction.py
@@ -1,0 +1,104 @@
+"""One scanner, used everywhere the update channel produces text.
+
+`coworker/bundle_redaction.py` already owns the pattern vocabulary that decides
+whether a string carries a credential or a home path. This module does not add
+patterns; it only gathers the values to scan against and applies the same
+matcher to the update channel's four output surfaces: the manifest, the update
+log lines, the packaged artifact's sidecar files, and anything a diagnostic
+bundle could later pick up.
+
+A second matcher would drift, and the one that drifts is the one that misses.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from coworker.bundle_redaction import (
+    ScanMatch,
+    registered_secret_values,
+    relativize,
+    scan,
+    scan_text,
+)
+
+__all__ = [
+    "ScanMatch",
+    "registered_secrets",
+    "refusal_summary",
+    "safe_text",
+    "scan",
+    "scan_text",
+]
+
+_CREDENTIAL_WORDS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL", "PASSPHRASE")
+_MIN_ENV_LENGTH = 16
+
+
+def registered_secrets(
+    state_root: str | Path | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> frozenset[str]:
+    """Every credential this machine holds, so the scan can refuse on any one.
+
+    These values are used for matching only. They are never rendered, never
+    logged, and never placed in a refusal. The environment is included because
+    a build runs with signing and connector credentials in it, and the manifest
+    is generated from build metadata.
+    """
+    values: set[str] = set()
+    if state_root is not None:
+        path = Path(state_root) / "secrets.json"
+        if path.is_file():
+            try:
+                values |= registered_secret_values(
+                    json.loads(path.read_text(encoding="utf-8"))
+                )
+            except (OSError, ValueError):
+                pass
+    for name, value in dict(os.environ if environ is None else environ).items():
+        if not any(word in name.upper() for word in _CREDENTIAL_WORDS):
+            continue
+        if len(value) < _MIN_ENV_LENGTH or value.startswith("/") or "://" in value:
+            continue
+        values.add(value)
+    return frozenset(values)
+
+
+def refusal_summary(matches: Iterable[ScanMatch]) -> str:
+    """Name the categories and where they were found. Never the value."""
+    found = sorted({f"{match.category} at {match.location}" for match in matches})
+    return ", ".join(found)
+
+
+def safe_text(
+    value: Any,
+    *,
+    state_root: str | Path,
+    home: str | Path | None = None,
+    registered: Iterable[str] = (),
+) -> str:
+    """Operator-facing text with paths anchored, and withheld if it still matches.
+
+    Redaction is not enough on its own. A path can be rewritten; a credential
+    cannot be partially rewritten without leaving the part that identifies it.
+    So a string that still matches after `relativize` is replaced whole, and the
+    replacement names only the category.
+    """
+    root = Path(state_root)
+    dwelling = Path(home) if home is not None else Path.home()
+    text = relativize(value, home=dwelling, state_root=root)
+    matches = scan_text(
+        text,
+        registered=registered,
+        home=dwelling,
+        state_root=root,
+        location="update",
+    )
+    if matches:
+        categories = sorted({match.category for match in matches})
+        return f"[withheld: {', '.join(categories)}]"
+    return text

--- a/desktop/docs/packaging.md
+++ b/desktop/docs/packaging.md
@@ -36,6 +36,13 @@ The smoke test launches the sidecar exactly as the shell does (loopback only, is
 
 ## Known gaps
 
-- No code signing or notarization. Gatekeeper requires right-click → Open on first launch. Not required for this preview-build slice (issue #76, criterion 9).
+- No code signing or notarization has run. The CI steps for signing, notarization, stapling, and independent verification are written in the `macos-preview` job and guarded on the signing credentials being present, so a run without them warns and produces an unsigned build. Until an authorized Apple identity is supplied, Gatekeeper still requires right-click → Open on first launch. See [the preview channel notes](update-channel.md) for exactly what has to be supplied.
 - `bundle.targets` is `["app"]` only. DMG creation depends on Finder AppleScript automation that is not reliable in non-interactive sessions (see ADR 0003) and is not required by any acceptance criterion.
 - Verified on `aarch64-apple-darwin` only.
+
+## Updating an installed preview build
+
+The artifact this page builds is what an update manifest describes. How that
+manifest is signed and verified, when an update is allowed to interrupt a
+running Sourcecado, and how to roll one back are in
+[update-channel.md](update-channel.md).

--- a/desktop/docs/update-channel.md
+++ b/desktop/docs/update-channel.md
@@ -219,7 +219,8 @@ in plain words.
 | Backup cannot be written | `refused`. Nothing touched. |
 | Migration fails | `rolled_back`. State restored from the backup, old bundle never moved. |
 | Bundle cannot be swapped | `rolled_back`. Both restored. |
-| New version does not start | `rolled_back`. Both restored. |
+| New version does not start, previous version exists | `rolled_back`. Both restored. |
+| New version does not start, nothing was installed | `failed`. Failed bundle removed. There is no previous version to put back. |
 
 The launch check runs the sidecar inside the newly installed application on
 loopback with its own token and a **throwaway** state directory, and waits for

--- a/desktop/docs/update-channel.md
+++ b/desktop/docs/update-channel.md
@@ -1,0 +1,351 @@
+# The macOS preview channel
+
+How a new Sourcecado build replaces a running one without losing local state and
+without restarting an external action that may already have happened.
+
+## Words used here
+
+- **Channel** — `stable` or `preview`. A property of the build you installed, not
+  a setting inside it.
+- **Manifest** — a small signed JSON document that describes one artifact.
+- **Artifact** — the zipped `Sourcecado.app` a manifest describes.
+- **Store** — one durable local file or database, as declared in
+  `coworker/migrations.py`.
+- **External effect** — a tool call that reaches the outside world. `gmail_send`
+  is the one this design exists for.
+- **Unsettled effect** — an external effect that was dispatched and has not
+  reported an outcome. Nobody knows whether it happened.
+- **Quarantined effect** — an unsettled effect that a restart has moved into
+  review. Only a person settles it.
+
+## How opting in works
+
+You join the preview channel by installing a preview build. There is no toggle.
+
+That is enforced, not just a convention. The manifest binds the channel, and the
+client trusts a different signing key per channel
+(`coworker/update_channel/manifest.py`, `TRUSTED_KEYS`). A stable installation
+holds no key that can authenticate a preview manifest, so it refuses one with
+`channel_mismatch` before it looks at anything else. The reverse holds too.
+
+A preview build says so permanently. `PreviewChannelBadge` renders a fixed badge
+in the top-right corner on every screen, and Settings carries a **Release
+channel** section naming the version, the build, what is different, and what to
+do when an update goes wrong. A stable build renders neither.
+
+## The manifest
+
+One JSON document, two halves. `signed` carries the facts; `signature` carries an
+Ed25519 signature over the canonical bytes of `signed`.
+
+```json
+{
+  "signed": {
+    "manifest_version": 1,
+    "product": "sourcecado",
+    "channel": "preview",
+    "version": "0.0.1.123",
+    "platform": "macos",
+    "arch": "aarch64",
+    "artifact_name": "Sourcecado-0.0.1.123-macos-aarch64.zip",
+    "artifact_size": 234995,
+    "artifact_sha256": "988e24b7…",
+    "minimum_upgradable_version": "0.0.1",
+    "state_versions": { "people_db": 1, "conversation_db": 1, "…": 0 },
+    "released_at": "2026-08-28T05:56:38Z",
+    "commit": "fcb6e64aca18c836fa807ee0a009ccd2c9ca3c8a"
+  },
+  "signature": {
+    "algorithm": "ed25519",
+    "key_id": "sourcecado-preview-2026",
+    "value": "BuIALj18…"
+  }
+}
+```
+
+What it binds, and why each one is in the signed bytes:
+
+| Field | Binds |
+| --- | --- |
+| `version` | The exact version. An older or equal version is refused, so an update cannot walk backwards. |
+| `channel` | Which key set governs the document, and which installations may accept it. |
+| `platform`, `arch` | The machine. An `x86_64` artifact cannot install on `aarch64`. |
+| `artifact_sha256`, `artifact_size` | The exact bytes. A different file cannot be described by a manifest that verifies. |
+| `minimum_upgradable_version` | The oldest version this artifact can upgrade from. |
+| `state_versions` | What store versions the artifact expects, checked against what this build can produce. |
+| `manifest_version` | The format. A future format is refused, not partially read. |
+| `product`, `artifact_name`, `released_at`, `commit` | Identity and provenance. |
+
+### Verification fails closed
+
+`verify_manifest` returns a `Verification`, never an exception, and every branch
+either refuses or falls through to the next check. There is no default-allow
+path. The checks run in this order, and the first failure wins:
+
+1. Document shape.
+2. **Closed field set.** A field this build does not know refuses the manifest.
+   An ignored field is a field an attacker gets for free the day a future build
+   starts reading it.
+3. Field types.
+4. `manifest_version`.
+5. Signature algorithm.
+6. Channel, which selects the key set.
+7. Key id present in that channel's trust store.
+8. Signature over the canonical bytes, with the domain prefix
+   `sourcecado.update-manifest.v1`.
+9. Product, platform, architecture.
+10. Version is newer, and the upgrade path is supported.
+11. `state_versions` against this build's migration registry.
+12. Artifact exists, is the signed size, and hashes to the signed digest.
+
+`TRUSTED_KEYS` is empty in this build. Sourcecado has no update signing identity
+yet, so every real manifest is refused with `untrusted_key`. That is the correct
+behaviour until an identity exists.
+`tests/test_update_manifest.py::test_no_signing_key_is_shipped_yet_so_nothing_verifies_in_production`
+goes red the day a key is added, so adding one cannot happen quietly.
+
+## The rule that shapes everything: draining
+
+The obvious updater stops the app, swaps the bundle, and starts it again. On a
+machine that sends real mail to real people, that sequence is the bug.
+
+If a run has dispatched a Gmail send and has not yet learned the outcome, killing
+the process closes that window on "unknown" forever. Worse, a restart that
+"resumes" the run could put a second copy of the same message in a real person's
+inbox. `coworker/agent_run_approval.py` exists to hold that state as `ambiguous`
+until a person settles it.
+
+So `coworker/update_channel/drain.py` gates every update, and it has three
+answers. Proceeding regardless is not one of them.
+
+| State | What the update does |
+| --- | --- |
+| Nothing running, or every run is finished, parked on a person, or free of open effects | Proceed. Whatever is left is restart-safe: it lives in the run store and `agent_run_resume.restart()` picks it up after the new build launches. |
+| A process holds a live lease on a run | **Wait.** It clears on its own. If the wait runs out, refuse. |
+| An effect is dispatched and has not reported back | **Wait.** The dispatching process may still report. If the wait runs out, refuse. |
+| An effect is quarantined | **Refuse now.** Waiting cannot settle it; only a person can. |
+
+The second half of the contract is what the gate does *not* do. **It performs no
+writes at all.** It does not quarantine an unreported effect — that is
+`agent_run_resume.restart()`'s decision after a crash actually happened — and it
+does not resolve a quarantine, which is a person's decision and carries their
+name. An updater that tidies the run store on the way past is exactly how a
+machine records an outcome nobody observed.
+
+The criterion has two halves: wait for active work to drain, **or** record
+restart-safe continuation. The second half is `UpdateOutcome.continuable`, which
+lists the runs that were open when the update ran and are safe to pick up after
+it — parked on a person, or free of any open external effect. The record is
+declarative: the work itself is already durable in the run store, and
+`agent_run_resume.restart()` classifies it on the next launch. The update does
+not resume anything itself.
+(`tests/test_update_apply.py::test_an_update_records_the_work_that_will_continue_after_the_restart`)
+
+`tests/test_update_apply.py::test_an_update_requested_during_an_unsettled_send_does_not_proceed`
+is the test that proves the refusing half. It asserts the update reached the drain stage first
+(so the assertion is not passing because nothing started), then asserts the
+bundle is untouched, the effect row is byte-identical, no checkpoint was
+appended, and the quarantine queue is still empty.
+
+## State compatibility and the backup
+
+Neither is re-implemented here. `coworker/migrations.py` is the one registry of
+store versions, backups, and rollback, and the updater calls it:
+
+- `plan_migrations` decides compatibility. A store at an unknown future version,
+  an unreadable store, or a store with no registered path forward blocks the
+  whole update — the registry's own fail-closed rule, not a second opinion about
+  it.
+- `create_backup` takes the backup, covering every registered store, before the
+  first change. Only taken when the plan has pending work, because an update with
+  no migration changes no state and has nothing to restore.
+- `apply_migrations` applies it, with the same backup handed in so a single
+  update does not write the same files twice.
+- `restore_backup` puts it back.
+
+### The stage order, and why
+
+```
+verify → drain → compatibility → stage → backup → migrate → activate → health
+```
+
+Everything that can fail without consequence runs first. Verification, the drain
+gate, the compatibility read, and unpacking the archive all change nothing, so a
+failure in any of them leaves the installation exactly as it was.
+
+Migrating before activating is deliberate. The registry that runs is *this*
+build's, so the state it produces is state this build already understands: a
+crash between the migration and the bundle swap leaves a consistent system, and a
+failure at the migration step leaves the old bundle untouched with only the state
+to restore. The reverse order opens a window where a new bundle sits over state
+it has not migrated.
+
+That order has a consequence worth stating plainly: **a release that raises a
+store version cannot be installed by this path.** The updater running is the old
+build, and it can only reach the versions its own registry knows. The manifest's
+`state_versions` is what enforces it — an artifact declaring a version this build
+cannot produce is refused with `state_ahead_of_migrator` rather than installed
+over state it would strand. In practice that means the migration ships in the
+release *before* the one that needs it. The alternative, handing the migration to
+the new build's first launch, needs a launch-time migration hook in `server.py`
+and is not in this change.
+
+### A gap in the registry, compensated for here
+
+`migrations.restore_backup` restores store contents but not `state_versions.json`,
+which is where JSONL logs, opaque files, and config documents record their
+version. Measured on this branch: after backup, migrate, and restore of a legacy
+state directory, five stores read back at version 1 with version 0 contents.
+
+Today that is harmless, because those stores' `0 → 1` steps only record a version
+and change no content. It will not stay harmless. The updater therefore snapshots
+`state_versions.json` into the backup directory before it migrates and restores it
+on rollback, including restoring the fact that the file did not exist yet.
+`tests/test_update_channel_mutations.py::test_mutant_a_rollback_that_forgets_the_version_manifest_is_caught`
+holds that in place. **The registry itself should do this**; the fix belongs in
+`coworker/migrations.py` and was outside this change's write boundary.
+
+## When an update fails
+
+Every failure keeps or restores the last usable version, and says what happened
+in plain words.
+
+| Failure | Result |
+| --- | --- |
+| Manifest does not verify | `refused`. Nothing touched. |
+| Work still in flight | `blocked`. Nothing touched, nothing recorded. |
+| Local state is incompatible | `refused`. Nothing touched. Doctor's exact reason is quoted. |
+| Archive is corrupt or the wrong shape | `refused`. Nothing touched, no backup written. |
+| Backup cannot be written | `refused`. Nothing touched. |
+| Migration fails | `rolled_back`. State restored from the backup, old bundle never moved. |
+| Bundle cannot be swapped | `rolled_back`. Both restored. |
+| New version does not start | `rolled_back`. Both restored. |
+
+The launch check runs the sidecar inside the newly installed application on
+loopback with its own token and a **throwaway** state directory, and waits for
+`/v1/health`. A launch check that opened the operator's real state would be a
+change the rollback could not undo.
+
+### Rolling back by hand
+
+The previous version stays on disk as `Sourcecado.app.previous` beside the
+current one, and the backup taken before the update stays under
+`<state>/backups/<backup_id>/`.
+
+```sh
+# Quit Sourcecado first. Rolling back while it is running is the one thing
+# that can lose work.
+make update-rollback BUNDLE=/Applications/Sourcecado.app BACKUP=<backup_id>
+```
+
+`make update-rollback` without `BACKUP` restores only the application, which is
+correct when the failed update never reached the migration step. Sourcecado
+Doctor lists the backups: `make doctor`.
+
+## The five exercises
+
+`tests/test_update_exercises.py` runs them. The names below are the test names,
+so the prose and the code cannot drift.
+
+| Exercise | Test | What it proves |
+| --- | --- | --- |
+| Clean install | `test_exercise_clean_install` | No previous application and no previous state. Installs, takes no backup, migrates nothing. |
+| Upgrade from the prior preview | `test_exercise_upgrade_from_the_prior_preview` | State written by the previous build's schema comes forward. Backup taken, `people_db` migrated, nothing pending afterwards, previous bundle kept. |
+| Failed update | `test_exercise_failed_update_restores_the_last_usable_version` | The launch check fails. Bundle back at the old version, staging cleared, every store version back where it started, and Doctor does not disagree. |
+| Rollback | `test_exercise_rollback_after_a_successful_update` | A clean update is deliberately reversed. Bundle and every store restored. |
+| Preserved person file | `test_exercise_the_person_file_reads_back_through_its_own_store` and `test_exercise_the_person_file_survives_a_failed_update_and_a_rollback` | The person file opens through `PersonStore` after the upgrade, with name, company, email, sequence state, and timeline intact — and survives a failed update and a rollback unchanged. |
+
+The person-file exercise is the one a user would notice. A failed update is
+visible; a lost person file is not.
+
+## Credentials, and the four surfaces they could leak through
+
+`coworker/bundle_redaction.py` is the only matcher used. A second matcher drifts,
+and the one that drifts is the one that misses. `tests/test_update_secrets.py`
+plants a credential on each surface and proves it did not arrive.
+
+| Surface | Guard |
+| --- | --- |
+| **Manifest** | `packaging/update_manifest.py generate` scans the assembled manifest and refuses to write on a match. This is the new surface and the most likely to leak, because it is built from build metadata. The refusal names the category and location, never the value. |
+| **Artifact** | Files shipped beside the artifact (`provenance.txt`, `checksums.txt`) are passed with `--attest` and scanned by the same pass. A match stops the build with no manifest written. |
+| **Logs** | Operator-facing text is built as a fixed sentence plus a variable half. The variable half — an exception string, a registry error — goes through `safe_text` on its own, so a credential there is withheld in place and the sentence survives. `_outcome` scans the composed sentence again, and withholds all of it if a call site forgot. |
+| **Diagnostic bundles** | `UpdateOutcome.to_dict()` is asserted clean under `bundle_redaction.scan` with planted canaries, which is the same check the bundle fails closed on. |
+
+The signing key is read from an environment variable, never written to the
+manifest, and never repeated in an error. The registered scan reads the build's
+own environment, so pasting the signing key into a commit message is caught as
+`registered_secret`.
+
+## Signing and notarization: what is authored and what is unrun
+
+The CI steps are written in `.github/workflows/ci.yml` in the `macos-preview`
+job. **None of them have run.** They are guarded on the signing secret being
+present and are skipped with an explicit notice when it is not, so a run without
+credentials cannot be mistaken for a signed one.
+
+To turn them on, supply these as protected repository secrets and variables:
+
+| Name | Kind | What it is |
+| --- | --- | --- |
+| `MACOS_CERTIFICATE_P12` | secret | Base64 of the Developer ID Application `.p12`. |
+| `MACOS_CERTIFICATE_PASSWORD` | secret | Password for that `.p12`. |
+| `MACOS_SIGNING_IDENTITY` | secret | e.g. `Developer ID Application: NAME (TEAMID)`. |
+| `APPLE_NOTARY_ISSUER_ID` | secret | App Store Connect API issuer id. |
+| `APPLE_NOTARY_KEY_ID` | secret | App Store Connect API key id. |
+| `APPLE_NOTARY_PRIVATE_KEY` | secret | The `.p8` contents. |
+| `SOURCECADO_UPDATE_SIGNING_KEY` | secret | Base64 of a 32-byte Ed25519 seed. Generate it offline, never in CI. |
+| `SOURCECADO_UPDATE_KEY_ID` | variable | The key id written into every manifest. |
+| `SOURCECADO_UPDATE_PUBLIC_KEY` | variable | Base64 of the matching public key, used by the in-CI verification step. |
+
+Then add the public key to `TRUSTED_KEYS` in
+`coworker/update_channel/manifest.py` under the `preview` channel and update the
+tripwire test. Until that happens, no manifest verifies on any machine.
+
+Generate the update signing key offline:
+
+```sh
+python3 -c "
+import base64
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+k = Ed25519PrivateKey.generate()
+seed = k.private_bytes(serialization.Encoding.Raw, serialization.PrivateFormat.Raw, serialization.NoEncryption())
+pub = k.public_key().public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
+print('secret SOURCECADO_UPDATE_SIGNING_KEY =', base64.b64encode(seed).decode())
+print('variable SOURCECADO_UPDATE_PUBLIC_KEY =', base64.b64encode(pub).decode())
+"
+```
+
+## Preview version numbers
+
+The preview channel stamps `<package.json version>.<CI run number>`, for example
+`0.0.1.123`. Four dotted components parse, and the run number rises on every
+build, so consecutive preview builds are always an upgrade of each other without
+anyone hand-bumping a version. `minimum_upgradable_version` stays at the
+package.json version.
+
+## Local commands
+
+```sh
+make test-update              # the whole update channel suite, exercises and mutations
+make update-manifest ARTIFACT=… VERSION=… KEY_ID=…    # needs SOURCECADO_UPDATE_SIGNING_KEY
+make update-verify ARTIFACT=… MANIFEST=… PUBLIC_KEY=…
+make update-rollback BUNDLE=… [BACKUP=…]
+```
+
+## Known gaps
+
+- **Nothing is signed or notarized yet.** The steps are written and unrun. See
+  the table above.
+- **No download client.** `apply_update` takes an artifact that is already on
+  disk. Fetching it, and where the manifest is published, are not in this change.
+- **No in-app update trigger.** The GUI shows the channel and the rollback path;
+  it does not start an update. Wiring one needs an endpoint in `server.py`, which
+  was outside this change's write boundary.
+- **A release that raises a store version cannot be installed by this path.** See
+  the stage-order section.
+- **`migrations.restore_backup` does not restore `state_versions.json`.**
+  Compensated for here; the fix belongs in the registry.
+- **Verified on `aarch64-apple-darwin` only**, and the manifest generation and
+  verification runs recorded on this branch used a stand-in artifact, because no
+  Tauri release build exists in this worktree.

--- a/desktop/packaging/update_manifest.py
+++ b/desktop/packaging/update_manifest.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Generate and verify the signed update manifest for a preview artifact.
+
+Two subcommands, and they are deliberately separable. `generate` runs where the
+signing key is, which is inside a protected CI job. `verify` runs anywhere, needs
+no key, and is what an operator or a release reviewer uses to check that the
+manifest on the release page really describes the file they downloaded.
+
+Generation refuses rather than redacts. The manifest is assembled from build
+metadata -- a commit, a file name, a timestamp, whatever the workflow passes --
+and build metadata is exactly the kind of text that carries a runner path, an
+environment variable, or a token someone pasted into a commit message. So the
+assembled manifest and every attestation file named on the command line are
+scanned with `coworker/bundle_redaction.py`, the same matcher the diagnostic
+bundle fails closed on, and a match stops the build with nothing written.
+
+The signing key is read from an environment variable and never appears in the
+manifest, in the output, or in an error message.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from coworker.update_channel import manifest as m  # noqa: E402
+from coworker.update_channel.redaction import (  # noqa: E402
+    refusal_summary,
+    registered_secrets,
+    scan,
+    scan_text,
+)
+
+EXIT_OK = 0
+EXIT_REFUSED = 1
+EXIT_LEAK = 2
+
+
+def _scan_everything(
+    signed: dict, attestations: list[Path], *, state_root: Path, home: Path
+) -> tuple:
+    """Scan the manifest and the files that ship beside it. Report every match."""
+    registered = registered_secrets(environ=os.environ)
+    matches = list(
+        scan(
+            signed,
+            registered=registered,
+            home=home,
+            state_root=state_root,
+            location="manifest",
+        )
+    )
+    for path in attestations:
+        if not path.is_file():
+            continue
+        matches.extend(
+            scan_text(
+                path.read_text(encoding="utf-8", errors="replace"),
+                registered=registered,
+                home=home,
+                state_root=state_root,
+                location=f"artifact:{path.name}",
+            )
+        )
+    return tuple(matches)
+
+
+def generate(args: argparse.Namespace) -> int:
+    artifact = Path(args.artifact)
+    if not artifact.is_file():
+        print(f"error: no artifact at {artifact.name}", file=sys.stderr)
+        return EXIT_REFUSED
+
+    signed = m.build_manifest(
+        product=args.product,
+        channel=args.channel,
+        version=args.version,
+        platform=args.platform,
+        arch=args.arch,
+        artifact_name=args.artifact_name or artifact.name,
+        artifact_size=artifact.stat().st_size,
+        artifact_sha256=m.sha256_file(artifact),
+        minimum_upgradable_version=args.minimum_from,
+        state_versions=m.registry_state_versions(),
+        released_at=args.released_at,
+        commit=args.commit,
+    )
+
+    matches = _scan_everything(
+        signed,
+        [Path(item) for item in args.attest],
+        state_root=Path(args.state_root),
+        home=Path(args.home),
+    )
+    if matches:
+        # The categories and locations, never the values. Nothing is written.
+        print(
+            "error: refusing to write a manifest that matched the credential "
+            f"scan: {refusal_summary(matches)}",
+            file=sys.stderr,
+        )
+        return EXIT_LEAK
+
+    raw = os.environ.get(args.key_env, "")
+    if not raw:
+        print(f"error: {args.key_env} is not set", file=sys.stderr)
+        return EXIT_REFUSED
+    try:
+        seed = base64.b64decode(raw, validate=True)
+    except (binascii.Error, ValueError):
+        print(f"error: {args.key_env} is not base64", file=sys.stderr)
+        return EXIT_REFUSED
+    if len(seed) != 32:
+        print(
+            f"error: {args.key_env} is not a 32-byte Ed25519 seed", file=sys.stderr
+        )
+        return EXIT_REFUSED
+
+    document = m.sign_manifest(signed, seed=seed, key_id=args.key_id)
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(document, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(f"wrote {output.name} for {args.product} {args.version} ({args.channel})")
+    print(f"  artifact  {signed['artifact_name']}")
+    print(f"  sha256    {signed['artifact_sha256']}")
+    print(f"  key id    {args.key_id}")
+    return EXIT_OK
+
+
+def verify(args: argparse.Namespace) -> int:
+    try:
+        document = json.loads(Path(args.manifest).read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        print(f"REFUSED malformed: {exc}", file=sys.stderr)
+        return EXIT_REFUSED
+
+    trust: dict[str, dict[str, str]] = {}
+    for entry in args.trust:
+        key_id, _, public = entry.partition("=")
+        if not key_id or not public:
+            print(f"error: --trust wants KEY_ID=BASE64, got {entry!r}", file=sys.stderr)
+            return EXIT_REFUSED
+        trust.setdefault(args.channel, {})[key_id] = public
+
+    installed = m.BuildIdentity(
+        product=args.product,
+        channel=args.channel,
+        version=args.installed_version,
+        platform=args.platform,
+        arch=args.arch,
+        state_versions=m.registry_state_versions(),
+    )
+    outcome = m.verify_manifest(
+        document,
+        installed=installed,
+        artifact_path=Path(args.artifact),
+        trust=trust or None,
+    )
+    if not outcome.ok or outcome.manifest is None:
+        print(f"REFUSED {outcome.refusal}: {outcome.detail}", file=sys.stderr)
+        return EXIT_REFUSED
+    bound = outcome.manifest
+    print(
+        f"OK   {bound.product} {bound.version} ({bound.channel}) for "
+        f"{bound.platform}/{bound.arch}"
+    )
+    print(f"OK   artifact {bound.artifact_name} matches sha256 {bound.artifact_sha256}")
+    print(f"OK   signed by {bound.key_id}")
+    return EXIT_OK
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    make = sub.add_parser("generate", help="sign a manifest for a built artifact")
+    make.add_argument("--artifact", required=True)
+    make.add_argument("--artifact-name", default="")
+    make.add_argument("--output", required=True)
+    make.add_argument("--channel", default=str(m.Channel.PREVIEW))
+    make.add_argument("--product", default=m.PRODUCT)
+    make.add_argument("--version", required=True)
+    make.add_argument("--platform", default="macos")
+    make.add_argument("--arch", default="aarch64")
+    make.add_argument("--minimum-from", required=True)
+    make.add_argument("--released-at", required=True)
+    make.add_argument("--commit", required=True)
+    make.add_argument(
+        "--attest",
+        action="append",
+        default=[],
+        help="a text file shipped beside the artifact, scanned before signing",
+    )
+    make.add_argument("--key-env", default="SOURCECADO_UPDATE_SIGNING_KEY")
+    make.add_argument("--key-id", required=True)
+    make.add_argument("--state-root", default=str(Path.home() / ".sourcecado"))
+    make.add_argument("--home", default=str(Path.home()))
+    make.set_defaults(handler=generate)
+
+    check = sub.add_parser("verify", help="check a manifest against an artifact")
+    check.add_argument("--manifest", required=True)
+    check.add_argument("--artifact", required=True)
+    check.add_argument("--channel", default=str(m.Channel.PREVIEW))
+    check.add_argument("--product", default=m.PRODUCT)
+    check.add_argument("--installed-version", default="0.0.0")
+    check.add_argument("--platform", default="macos")
+    check.add_argument("--arch", default="aarch64")
+    check.add_argument(
+        "--trust",
+        action="append",
+        default=[],
+        help="KEY_ID=BASE64_PUBLIC_KEY, repeatable",
+    )
+    check.set_defaults(handler=verify)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return int(args.handler(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/desktop/surfaces/gui/src/app/AppShell.tsx
+++ b/desktop/surfaces/gui/src/app/AppShell.tsx
@@ -16,6 +16,7 @@ import { ConnectionsPage } from "../routes/ConnectionsPage";
 import { ScheduledPage } from "../routes/ScheduledPage";
 import { SettingsPage } from "../routes/SettingsPage";
 import { SkillsPage } from "../routes/SkillsPage";
+import { PreviewChannelBadge } from "../routes/UpdateChannel";
 import { UnavailableThreadPage } from "../routes/UnavailableThreadPage";
 import { WelcomePage } from "../routes/WelcomePage";
 import { CommandSearch } from "./CommandSearch";
@@ -258,6 +259,7 @@ export function AppShell() {
   }
   return (
     <div className="app-shell">
+      <PreviewChannelBadge />
       <button
         ref={railTriggerRef}
         type="button"

--- a/desktop/surfaces/gui/src/routes/SettingsPage.tsx
+++ b/desktop/surfaces/gui/src/routes/SettingsPage.tsx
@@ -10,6 +10,7 @@ import {
   type WorkspaceDiagnostics,
 } from "../api";
 import { DiagnosticBundle } from "./DiagnosticBundle";
+import { ReleaseChannelSettings } from "./UpdateChannel";
 import { WorkspaceSettings } from "./WorkspaceSettings";
 
 type SettingsState =
@@ -281,6 +282,8 @@ export function SettingsPage() {
               )
             }
           />
+
+          <ReleaseChannelSettings />
 
           <DiagnosticBundle />
         </div>

--- a/desktop/surfaces/gui/src/routes/UpdateChannel.tsx
+++ b/desktop/surfaces/gui/src/routes/UpdateChannel.tsx
@@ -1,0 +1,87 @@
+import { currentChannel, isPreview, type ChannelDescriptor } from "../updateChannel";
+
+/**
+ * The release channel, shown two ways.
+ *
+ * `PreviewChannelBadge` is persistent chrome that only a preview build renders,
+ * so an operator can never be unsure which build is in front of them.
+ * `ReleaseChannelSettings` is the full explanation, including what to do when an
+ * update goes wrong.
+ *
+ * Neither one can change the channel, because nothing in Sourcecado can. See
+ * `src/updateChannel.ts` for why that is the design rather than a missing feature.
+ */
+
+export function PreviewChannelBadge({
+  descriptor = currentChannel(),
+}: {
+  descriptor?: ChannelDescriptor;
+}) {
+  if (!isPreview(descriptor)) return null;
+  return (
+    <div className="preview-channel-badge" role="status" aria-label="Release channel">
+      <span className="preview-channel-dot" aria-hidden="true" />
+      <strong>Preview build</strong>
+      <code>{descriptor.version}</code>
+    </div>
+  );
+}
+
+export function ReleaseChannelSettings({
+  descriptor = currentChannel(),
+}: {
+  descriptor?: ChannelDescriptor;
+}) {
+  const preview = isPreview(descriptor);
+  return (
+    <section className="settings-section" aria-labelledby="release-channel-heading">
+      <h2 id="release-channel-heading">Release channel</h2>
+      <p className="settings-status">
+        <span className={`channel-pill channel-pill-${descriptor.channel}`}>
+          {descriptor.label}
+        </span>
+        <span>{descriptor.summary}</span>
+      </p>
+
+      <dl className="settings-facts">
+        <div>
+          <dt>Version</dt>
+          <dd>
+            <code>{descriptor.version}</code>
+          </dd>
+        </div>
+        <div>
+          <dt>Build</dt>
+          <dd>
+            <code>{descriptor.commit}</code>
+          </dd>
+        </div>
+      </dl>
+
+      <h3>{preview ? "What is different on this channel" : "About the preview channel"}</h3>
+      <ul className="channel-differences" aria-label="Channel behaviour">
+        {descriptor.differences.map((line) => (
+          <li key={line}>{line}</li>
+        ))}
+      </ul>
+
+      {preview && (
+        <div className="channel-rollback">
+          <strong>If an update goes wrong</strong>
+          <p>
+            Sourcecado keeps the version you were on beside the new one, as
+            <code> Sourcecado.app.previous</code>, and keeps a backup of your local
+            data taken just before the update. A failed update puts both back on
+            its own and tells you it did.
+          </p>
+          <p>
+            To go back after an update that installed cleanly, quit Sourcecado
+            first, then follow the rollback steps in the preview channel notes.
+            Rolling back while Sourcecado is running is the one thing that can
+            lose work.
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/desktop/surfaces/gui/src/styles/route.css
+++ b/desktop/surfaces/gui/src/styles/route.css
@@ -1602,3 +1602,57 @@
   margin: 6px 0 0;
   padding-left: 18px;
 }
+
+/* Release channel. The preview pill is the one place the warm warning tint is
+   used outside an actual warning: a preview build is a "know what you are
+   running" state, not an error, and DESIGN.md reserves the error family for
+   things that went wrong. */
+.channel-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 10px;
+  border-radius: 9999px;
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.channel-pill-preview {
+  background: var(--warn-bg);
+  color: var(--warn);
+}
+
+.channel-pill-stable {
+  background: var(--accent-tint);
+  color: var(--accent-deep);
+}
+
+.channel-differences {
+  margin: 8px 0 0;
+  padding-left: 18px;
+}
+
+.channel-differences li {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.channel-rollback {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 16px 0 0;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--raised);
+}
+
+.channel-rollback p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}

--- a/desktop/surfaces/gui/src/styles/shell.css
+++ b/desktop/surfaces/gui/src/styles/shell.css
@@ -500,3 +500,38 @@ h1 {
     animation: none;
   }
 }
+
+/* Preview builds say so, permanently, in a corner nothing else uses. Fixed
+   rather than in the flex row so it cannot shift the shell layout, and below
+   the alert layer so a real problem still wins. */
+.preview-channel-badge {
+  position: fixed;
+  z-index: 55;
+  top: 12px;
+  right: 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  border-radius: 9999px;
+  background: var(--warn-bg);
+  color: var(--warn);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.preview-channel-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 9999px;
+  background: var(--pit);
+}
+
+.preview-channel-badge code {
+  color: inherit;
+  font-size: 11px;
+  letter-spacing: 0;
+  text-transform: none;
+}

--- a/desktop/surfaces/gui/src/updateChannel.ts
+++ b/desktop/surfaces/gui/src/updateChannel.ts
@@ -1,0 +1,83 @@
+/**
+ * Which release channel this build is on, and what that changes for the operator.
+ *
+ * The channel is a property of the build, not a setting. You join the preview
+ * channel by installing a preview build, and there is no control anywhere in
+ * Sourcecado that switches you onto it. That is the whole opt-in design: the
+ * sidecar trusts a different signing key per channel, so a stable installation
+ * cannot authenticate a preview update even if it is handed one. A toggle would
+ * be one mis-click away from putting an operator on a channel they did not
+ * choose; an install is not.
+ *
+ * An unknown or missing channel reads as stable. A build that cannot say what
+ * it is gets the more conservative of the two answers.
+ */
+
+export type ReleaseChannel = "stable" | "preview";
+
+export type ChannelDescriptor = {
+  channel: ReleaseChannel;
+  label: string;
+  version: string;
+  commit: string;
+  summary: string;
+  differences: string[];
+};
+
+const UNKNOWN_VERSION = "unknown";
+
+const PREVIEW_DIFFERENCES = [
+  "Updates are installed by hand. Sourcecado never updates itself in the background.",
+  "Sourcecado backs up your local data before an update changes it, and puts the backup back if the update fails.",
+  "An update waits for work that is still running. If a send has gone out and has not reported back yet, the update stops instead of restarting Sourcecado.",
+  "Preview builds are signed for the preview channel only. A stable update cannot be installed over this build.",
+];
+
+const STABLE_DIFFERENCES = [
+  "This build installs stable updates only. It cannot verify a preview update, so it will refuse one.",
+  "To join the preview channel, download a preview build from the release page and install it yourself.",
+  "Sourcecado never changes your channel on its own.",
+];
+
+export function readChannel(raw: unknown): ReleaseChannel {
+  return raw === "preview" ? "preview" : "stable";
+}
+
+function text(raw: unknown, fallback: string): string {
+  const value = typeof raw === "string" ? raw.trim() : "";
+  return value || fallback;
+}
+
+/** Build the descriptor from raw build-time values. Pure, so it is testable. */
+export function describeChannel(
+  rawChannel: unknown,
+  rawVersion: unknown,
+  rawCommit: unknown,
+): ChannelDescriptor {
+  const channel = readChannel(rawChannel);
+  const preview = channel === "preview";
+  return {
+    channel,
+    label: preview ? "Preview build" : "Stable",
+    version: text(rawVersion, UNKNOWN_VERSION),
+    commit: text(rawCommit, UNKNOWN_VERSION).slice(0, 12),
+    summary: preview
+      ? "This is a preview build of Sourcecado. It gets changes before the stable release does."
+      : "This is a stable build of Sourcecado.",
+    differences: preview ? PREVIEW_DIFFERENCES : STABLE_DIFFERENCES,
+  };
+}
+
+/** The channel this bundle was built for. Stamped at build time, not read at runtime. */
+export function currentChannel(): ChannelDescriptor {
+  const env = import.meta.env ?? {};
+  return describeChannel(
+    env.VITE_SOURCECADO_CHANNEL,
+    env.VITE_SOURCECADO_VERSION,
+    env.VITE_SOURCECADO_COMMIT,
+  );
+}
+
+export function isPreview(descriptor: ChannelDescriptor): boolean {
+  return descriptor.channel === "preview";
+}

--- a/desktop/surfaces/gui/src/vite-env.d.ts
+++ b/desktop/surfaces/gui/src/vite-env.d.ts
@@ -6,3 +6,13 @@ interface Window {
   __CLUB_HTTP__?: string;
   __CLUB_API_TOKEN__?: string;
 }
+
+/**
+ * Stamped into the bundle at build time by the packaging workflow. Absent in a
+ * developer build, which `describeChannel` reads as the stable channel.
+ */
+interface ImportMetaEnv {
+  readonly VITE_SOURCECADO_CHANNEL?: string;
+  readonly VITE_SOURCECADO_VERSION?: string;
+  readonly VITE_SOURCECADO_COMMIT?: string;
+}

--- a/desktop/surfaces/gui/tests/updateChannel.test.tsx
+++ b/desktop/surfaces/gui/tests/updateChannel.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  PreviewChannelBadge,
+  ReleaseChannelSettings,
+} from "../src/routes/UpdateChannel";
+import { currentChannel, describeChannel, readChannel } from "../src/updateChannel";
+
+const PREVIEW = describeChannel("preview", "0.0.2", "a1b2c3d4e5f60718293a");
+const STABLE = describeChannel("stable", "0.0.1", "0f0e0d0c0b0a09080706");
+
+describe("release channel identity", () => {
+  it("reads a preview build as preview", () => {
+    expect(readChannel("preview")).toBe("preview");
+    expect(PREVIEW.label).toBe("Preview build");
+  });
+
+  it("reads anything it does not recognise as stable", () => {
+    // A build that cannot say what it is gets the conservative answer, because
+    // the stable channel refuses preview updates and the reverse would not.
+    expect(readChannel(undefined)).toBe("stable");
+    expect(readChannel("")).toBe("stable");
+    expect(readChannel("PREVIEW")).toBe("stable");
+    expect(readChannel("nightly")).toBe("stable");
+    expect(readChannel(null)).toBe("stable");
+  });
+
+  it("defaults a developer build with no build stamp to stable", () => {
+    expect(currentChannel().channel).toBe("stable");
+  });
+
+  it("reads the stamp the packaging workflow writes into the bundle", () => {
+    // The one seam between the build and the UI. If the workflow renames a
+    // variable, this is what notices.
+    vi.stubEnv("VITE_SOURCECADO_CHANNEL", "preview");
+    vi.stubEnv("VITE_SOURCECADO_VERSION", "0.0.1.123");
+    vi.stubEnv("VITE_SOURCECADO_COMMIT", "fcb6e64aca18c836fa807ee0a009ccd2c9ca3c8a");
+    const stamped = currentChannel();
+    expect(stamped.channel).toBe("preview");
+    expect(stamped.version).toBe("0.0.1.123");
+    expect(stamped.commit).toBe("fcb6e64aca18");
+  });
+
+  it("shortens the commit and falls back when the build did not stamp one", () => {
+    expect(PREVIEW.commit).toBe("a1b2c3d4e5f6");
+    expect(describeChannel("preview", "", "").version).toBe("unknown");
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("preview badge", () => {
+  it("marks a preview build permanently", () => {
+    render(<PreviewChannelBadge descriptor={PREVIEW} />);
+    const badge = screen.getByRole("status", { name: "Release channel" });
+    expect(badge).toHaveTextContent("Preview build");
+    expect(badge).toHaveTextContent("0.0.2");
+  });
+
+  it("renders nothing at all on a stable build", () => {
+    const { container } = render(<PreviewChannelBadge descriptor={STABLE} />);
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText(/preview/i)).toBeNull();
+  });
+});
+
+describe("release channel settings", () => {
+  it("names the channel, the version, and what is different about it", () => {
+    render(<ReleaseChannelSettings descriptor={PREVIEW} />);
+    expect(screen.getByRole("heading", { name: "Release channel" })).toBeVisible();
+    expect(screen.getByText("Preview build")).toBeVisible();
+    expect(screen.getByText("0.0.2")).toBeVisible();
+    const behaviour = screen.getByRole("list", { name: "Channel behaviour" });
+    expect(behaviour).toHaveTextContent("never updates itself in the background");
+    expect(behaviour).toHaveTextContent("backs up your local data");
+    expect(behaviour).toHaveTextContent("has not reported back");
+  });
+
+  it("tells a preview operator how to get back to a working version", () => {
+    render(<ReleaseChannelSettings descriptor={PREVIEW} />);
+    expect(screen.getByText("If an update goes wrong")).toBeVisible();
+    expect(screen.getByText(/Sourcecado\.app\.previous/)).toBeVisible();
+    expect(screen.getByText(/quit Sourcecado/i)).toBeVisible();
+  });
+
+  it("offers a stable operator no control that would switch the channel", () => {
+    render(<ReleaseChannelSettings descriptor={STABLE} />);
+    expect(screen.getByText("Stable")).toBeVisible();
+    expect(screen.queryAllByRole("button")).toEqual([]);
+    expect(screen.queryAllByRole("checkbox")).toEqual([]);
+    expect(screen.queryAllByRole("switch")).toEqual([]);
+    const behaviour = screen.getByRole("list", { name: "Channel behaviour" });
+    expect(behaviour).toHaveTextContent("install it yourself");
+    expect(behaviour).toHaveTextContent("never changes your channel on its own");
+  });
+
+  it("does not show the rollback panel on a stable build", () => {
+    render(<ReleaseChannelSettings descriptor={STABLE} />);
+    expect(screen.queryByText("If an update goes wrong")).toBeNull();
+  });
+});

--- a/desktop/surfaces/gui/tests/updateChannelStyles.test.ts
+++ b/desktop/surfaces/gui/tests/updateChannelStyles.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { styles } from "./cssBundle";
+
+describe("release channel styles", () => {
+  it("marks a preview build with the warm warning tint, never a saturated dot", () => {
+    expect(styles).toMatch(
+      /\.channel-pill-preview\s*\{[^}]*background:\s*var\(--warn-bg\);[^}]*color:\s*var\(--warn\);/,
+    );
+    expect(styles).toMatch(
+      /\.channel-pill-stable\s*\{[^}]*background:\s*var\(--accent-tint\);[^}]*color:\s*var\(--accent-deep\);/,
+    );
+  });
+
+  it("keeps the preview badge out of the shell layout and under the alert layer", () => {
+    expect(styles).toMatch(/\.preview-channel-badge\s*\{[^}]*position:\s*fixed;/);
+    expect(styles).toMatch(/\.preview-channel-badge\s*\{[^}]*z-index:\s*55;/);
+  });
+
+  it("uses design tokens rather than literal colours", () => {
+    const blocks =
+      styles.match(/\.(channel-pill[\w-]*|channel-rollback|preview-channel[\w-]*)[^{]*\{[^}]*\}/g) ||
+      [];
+    expect(blocks.length).toBeGreaterThan(4);
+    for (const block of blocks) {
+      expect(block).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+    }
+  });
+
+  it("uses the friendly-precise radius band", () => {
+    expect(styles).toMatch(/\.channel-rollback\s*\{[^}]*border-radius:\s*8px;/);
+    expect(styles).toMatch(/\.channel-pill\s*\{[^}]*border-radius:\s*9999px;/);
+  });
+});

--- a/desktop/tests/test_update_apply.py
+++ b/desktop/tests/test_update_apply.py
@@ -356,6 +356,41 @@ def test_a_failed_health_check_restores_the_previous_bundle(tmp_path):
     assert "0.0.1" in outcome.guidance
 
 
+def test_a_failed_health_check_on_a_clean_install_does_not_claim_a_rollback(
+    tmp_path,
+):
+    """Last usable version on a machine with no app is nothing installed.
+
+    Issue #77 criterion 6: a failed launch keeps or restores that last usable
+    version and says so. There is no previous bundle to put back, so the
+    outcome is FAILED rather than a rollback that did not happen.
+    """
+    seed, public = fx.keypair()
+    artifact = fx.artifact(tmp_path, version="0.0.2")
+    install = fx.installation(tmp_path, version="0.0.0")
+    assert not install.bundle_path.exists()
+
+    outcome = _apply(
+        fx.document(artifact, seed, minimum_upgradable_version="0.0.0"),
+        install,
+        artifact,
+        public,
+        health_check=_unhealthy,
+    )
+
+    assert outcome.stage is UpdateStage.HEALTH
+    assert outcome.status is UpdateStatus.FAILED
+    assert fx.bundle_version(install.bundle_path) is None
+    assert not install.bundle_path.exists()
+    assert not install.previous_path.exists()
+    assert "0.0.2" in outcome.guidance
+    assert "0.0.0" not in outcome.guidance
+    assert "put version" not in outcome.guidance
+    reverted = rollback(install)
+    assert reverted.status is UpdateStatus.REFUSED
+    assert reverted.reason == "no_previous_version"
+
+
 def test_a_health_check_that_raises_is_a_failed_health_check(tmp_path):
     seed, public, artifact, install = _prepare(tmp_path)
 

--- a/desktop/tests/test_update_apply.py
+++ b/desktop/tests/test_update_apply.py
@@ -1,0 +1,523 @@
+"""The update state machine: what it refuses, what it changes, and what it puts back.
+
+Two properties carry most of the weight.
+
+Criterion 2 -- state compatibility and the required backup -- is not decided
+here. `coworker/migrations.py` is the one registry of store versions, backups,
+and rollback, and these tests assert that the updater *calls* it rather than
+forming a second opinion.
+
+Criterion 4 -- a failure keeps or restores the last usable version -- is tested
+by breaking each stage in turn and reading the bundle and the state back
+afterwards. The negative tests assert the update reached the stage that stopped
+it before they assert it stopped, because a test that passes because nothing
+started is not a test.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import update_fixtures as fx  # noqa: E402
+from coworker import migrations  # noqa: E402
+from coworker.agent_run_repository import AgentRunRepository  # noqa: E402
+from coworker.update_channel import (  # noqa: E402
+    UpdateStage,
+    UpdateStatus,
+    apply_update,
+    drain,
+    manifest as m,
+    rollback,
+)
+from state_fixtures import build_legacy_state  # noqa: E402
+
+NOW = datetime(2026, 8, 27, 10, 0, 0, tzinfo=UTC)
+SEND_ARGS = {"to": "dana@ramp.test", "subject": "Intro", "body": "Hello Dana."}
+
+
+def _healthy(_installation) -> bool:
+    return True
+
+
+def _unhealthy(_installation) -> bool:
+    return False
+
+
+def _apply(document, install, artifact, public, **kwargs):
+    kwargs.setdefault("health_check", _healthy)
+    kwargs.setdefault("trust", fx.trust(public))
+    kwargs.setdefault("drain_timeout", 0.0)
+    kwargs.setdefault("sleep", lambda _: None)
+    # An installation with existing state has a run store, and a real caller
+    # opens it. Only a test that is about the missing-store refusal passes None.
+    opened = None
+    if "runs" not in kwargs and (install.state_root / "agent_runs.db").exists():
+        opened = AgentRunRepository(install.state_root)
+        kwargs["runs"] = opened
+    try:
+        return apply_update(
+            document, installation=install, artifact_path=artifact, **kwargs
+        )
+    finally:
+        # apply_update closes the run store once the drain gate passes; closing
+        # a second time is harmless and covers the paths that stop before it.
+        if opened is not None:
+            try:
+                opened.close()
+            except Exception:
+                pass
+
+
+def _prepare(tmp_path, *, installed_version="0.0.1", state=None):
+    seed, public = fx.keypair()
+    artifact = fx.artifact(tmp_path, version="0.0.2")
+    install = fx.installation(tmp_path, version=installed_version)
+    if state is not None:
+        state(install.state_root)
+    fx.app_tree(install.bundle_path.parent, version=installed_version)
+    return seed, public, artifact, install
+
+
+def _runs(install):
+    """The run store an installation with existing state already has."""
+    return AgentRunRepository(install.state_root)
+
+
+# --- the update actually works -------------------------------------------
+
+
+def test_a_verified_update_installs_the_new_bundle(tmp_path):
+    seed, public, artifact, install = _prepare(tmp_path)
+    assert fx.bundle_version(install.bundle_path) == "0.0.1"
+
+    outcome = _apply(fx.document(artifact, seed), install, artifact, public)
+
+    assert outcome.status is UpdateStatus.APPLIED, outcome.reason
+    assert outcome.stage is UpdateStage.DONE
+    assert outcome.to_version == "0.0.2"
+    assert fx.bundle_version(install.bundle_path) == "0.0.2"
+
+
+def test_a_clean_install_needs_no_previous_version_and_takes_no_backup(tmp_path):
+    seed, public = fx.keypair()
+    artifact = fx.artifact(tmp_path, version="0.0.2")
+    install = fx.installation(tmp_path, version="0.0.0")
+    assert not install.bundle_path.exists()
+
+    outcome = _apply(
+        fx.document(artifact, seed, minimum_upgradable_version="0.0.0"),
+        install,
+        artifact,
+        public,
+    )
+
+    assert outcome.status is UpdateStatus.APPLIED, outcome.reason
+    assert fx.bundle_version(install.bundle_path) == "0.0.2"
+    assert outcome.backup_id is None
+    assert outcome.migrated == ()
+
+
+# --- criterion 3: the drain gate -----------------------------------------
+
+
+def test_an_update_requested_during_an_unsettled_send_does_not_proceed(tmp_path):
+    seed, public, artifact, install = _prepare(tmp_path)
+    install.state_root.mkdir(parents=True, exist_ok=True)
+    repo = AgentRunRepository(install.state_root)
+    owner = repo.registry.register()
+    started = repo.create_run(
+        session_id="sess-1",
+        trigger="chat",
+        goal="reach out to Dana",
+        owner=owner,
+        lease_seconds=600,
+        now=NOW,
+    )
+    commit = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+    before = repo.list_effects(started.run["run_id"])
+    before_checkpoints = len(repo.list_checkpoints(started.run["run_id"]))
+
+    outcome = _apply(
+        fx.document(artifact, seed), install, artifact, public, runs=repo, now=NOW
+    )
+
+    # It started: verification passed and the gate is what stopped it.
+    assert outcome.stage is UpdateStage.DRAIN
+    assert outcome.status is UpdateStatus.BLOCKED
+    assert outcome.blockers[0].status is drain.DrainStatus.UNSETTLED_EFFECT
+    assert outcome.blockers[0].effect_id == commit.effect["effect_id"]
+    assert outcome.blockers[0].tool_name == "gmail_send"
+
+    # It did not kill anything: the running bundle is untouched.
+    assert fx.bundle_version(install.bundle_path) == "0.0.1"
+    assert not install.previous_path.exists()
+
+    # It did not mark the effect anything. Not succeeded, not failed, not
+    # quarantined, not abandoned. The row is exactly as the dispatcher left it.
+    assert repo.list_effects(started.run["run_id"]) == before
+    assert len(repo.list_checkpoints(started.run["run_id"])) == before_checkpoints
+    assert repo.list_quarantined_effects() == []
+    assert outcome.backup_id is None
+    repo.close()
+
+
+def test_an_update_never_settles_a_quarantined_effect_to_get_past_it(tmp_path):
+    seed, public, artifact, install = _prepare(tmp_path)
+    install.state_root.mkdir(parents=True, exist_ok=True)
+    repo = AgentRunRepository(install.state_root)
+    owner = repo.registry.register()
+    started = repo.create_run(
+        session_id="sess-1",
+        trigger="chat",
+        goal="reach out to Dana",
+        owner=owner,
+        lease_seconds=600,
+        now=NOW,
+    )
+    commit = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+    repo.quarantine_effect(
+        commit.lease, commit.effect["effect_id"], reason="owner died", now=NOW
+    )
+    before = repo.list_effects(started.run["run_id"])
+
+    outcome = _apply(
+        fx.document(artifact, seed), install, artifact, public, runs=repo, now=NOW
+    )
+
+    assert outcome.stage is UpdateStage.DRAIN
+    assert outcome.status is UpdateStatus.BLOCKED
+    assert outcome.blockers[0].status is drain.DrainStatus.QUARANTINED_EFFECT
+    assert repo.list_effects(started.run["run_id"]) == before
+    assert repo.list_quarantined_effects()[0]["resolved_by"] is None
+    assert fx.bundle_version(install.bundle_path) == "0.0.1"
+    repo.close()
+
+
+def test_an_update_with_a_run_store_it_was_not_given_refuses(tmp_path):
+    """Fail closed. An uninspected run store is not an empty one."""
+    seed, public, artifact, install = _prepare(tmp_path)
+    install.state_root.mkdir(parents=True, exist_ok=True)
+    AgentRunRepository(install.state_root).close()
+
+    outcome = _apply(fx.document(artifact, seed), install, artifact, public, runs=None)
+
+    assert outcome.stage is UpdateStage.DRAIN
+    assert outcome.status is UpdateStatus.REFUSED
+    assert outcome.reason == "run_store_not_inspected"
+    assert fx.bundle_version(install.bundle_path) == "0.0.1"
+
+
+def test_an_update_records_the_work_that_will_continue_after_the_restart(tmp_path):
+    """The other half of criterion 3: drain, *or* record restart-safe continuation."""
+    seed, public, artifact, install = _prepare(tmp_path)
+    install.state_root.mkdir(parents=True, exist_ok=True)
+    repo = AgentRunRepository(install.state_root)
+    owner = repo.registry.register()
+    started = repo.create_run(
+        session_id="sess-1",
+        trigger="chat",
+        goal="reach out to Dana",
+        owner=owner,
+        lease_seconds=600,
+        now=NOW,
+    )
+    # Parked on a person: durable in the run store, so a restart picks it up.
+    repo.checkpoint(
+        started.lease,
+        kind="waiting_approval",
+        state="waiting_approval",
+        payload={"approval_id": "appr-1"},
+        now=NOW,
+    )
+
+    outcome = _apply(
+        fx.document(artifact, seed), install, artifact, public, runs=repo, now=NOW
+    )
+
+    assert outcome.status is UpdateStatus.APPLIED, outcome.reason
+    assert outcome.continuable == (started.run["run_id"],)
+    assert outcome.to_dict()["continuable"] == [started.run["run_id"]]
+    # The run itself is untouched: continuation is recorded, not performed.
+    reopened = AgentRunRepository(install.state_root)
+    try:
+        run = reopened.get_run(started.run["run_id"])
+        assert run["current_state"] == "waiting_approval"
+        assert reopened.list_effects(started.run["run_id"]) == []
+    finally:
+        reopened.close()
+
+
+def test_an_installation_with_no_run_store_at_all_proceeds(tmp_path):
+    seed, public, artifact, install = _prepare(tmp_path)
+    outcome = _apply(fx.document(artifact, seed), install, artifact, public, runs=None)
+    assert outcome.status is UpdateStatus.APPLIED, outcome.reason
+
+
+# --- criterion 2: compatibility and backup, delegated --------------------
+
+
+def test_a_pending_migration_is_backed_up_and_applied_by_the_registry(tmp_path):
+    seed, public, artifact, install = _prepare(tmp_path, state=build_legacy_state)
+    pending_before = {
+        item.store_id for item in migrations.plan_migrations(install.state_root).pending
+    }
+    assert "people_db" in pending_before
+
+    outcome = _apply(fx.document(artifact, seed), install, artifact, public)
+
+    assert outcome.status is UpdateStatus.APPLIED, outcome.reason
+    assert outcome.backup_id is not None
+    assert pending_before <= set(outcome.migrated)
+    assert migrations.plan_migrations(install.state_root).pending == ()
+    # The backup the registry wrote is on disk and describes itself.
+    backups = migrations.list_backups(install.state_root)
+    assert any(item["backup_id"] == outcome.backup_id for item in backups)
+
+
+def test_the_backup_is_created_before_anything_changes(tmp_path):
+    seed, public, artifact, install = _prepare(tmp_path, state=build_legacy_state)
+    order: list[str] = []
+    real_backup = migrations.create_backup
+    real_apply = migrations.apply_migrations
+
+    def watched_backup(*args, **kwargs):
+        order.append("backup")
+        return real_backup(*args, **kwargs)
+
+    def watched_apply(*args, **kwargs):
+        order.append("migrate")
+        return real_apply(*args, **kwargs)
+
+    migrations.create_backup = watched_backup
+    migrations.apply_migrations = watched_apply
+    try:
+        outcome = _apply(
+            fx.document(artifact, seed),
+            install,
+            artifact,
+            public,
+            health_check=lambda _i: (order.append("health"), True)[1],
+        )
+    finally:
+        migrations.create_backup = real_backup
+        migrations.apply_migrations = real_apply
+
+    assert outcome.status is UpdateStatus.APPLIED, outcome.reason
+    assert order[0] == "backup"
+    assert order.index("backup") < order.index("migrate") < order.index("health")
+
+
+def test_a_store_from_a_future_version_refuses_the_whole_update(tmp_path):
+    """The registry's own fail-closed rule, not a second opinion about it."""
+    seed, public, artifact, install = _prepare(tmp_path, state=build_legacy_state)
+    conn = sqlite3.connect(install.state_root / "people.db")
+    conn.execute("PRAGMA user_version = 99")
+    conn.commit()
+    conn.close()
+    assert migrations.plan_migrations(install.state_root).blocked
+
+    outcome = _apply(fx.document(artifact, seed), install, artifact, public)
+
+    assert outcome.stage is UpdateStage.COMPATIBILITY
+    assert outcome.status is UpdateStatus.REFUSED
+    assert "people_db" in outcome.reason or "people_db" in outcome.guidance
+    assert fx.bundle_version(install.bundle_path) == "0.0.1"
+
+
+# --- criterion 4: keep or restore the last usable version ----------------
+
+
+def test_a_failed_health_check_restores_the_previous_bundle(tmp_path):
+    seed, public, artifact, install = _prepare(tmp_path)
+
+    outcome = _apply(
+        fx.document(artifact, seed),
+        install,
+        artifact,
+        public,
+        health_check=_unhealthy,
+    )
+
+    assert outcome.stage is UpdateStage.HEALTH
+    assert outcome.status is UpdateStatus.ROLLED_BACK
+    assert fx.bundle_version(install.bundle_path) == "0.0.1"
+    assert not install.previous_path.exists()
+    assert "0.0.1" in outcome.guidance
+
+
+def test_a_health_check_that_raises_is_a_failed_health_check(tmp_path):
+    seed, public, artifact, install = _prepare(tmp_path)
+
+    def explode(_installation):
+        raise RuntimeError("the sidecar never opened its port")
+
+    outcome = _apply(
+        fx.document(artifact, seed), install, artifact, public, health_check=explode
+    )
+
+    assert outcome.status is UpdateStatus.ROLLED_BACK
+    assert fx.bundle_version(install.bundle_path) == "0.0.1"
+
+
+def test_a_failed_health_check_restores_the_state_it_migrated(tmp_path):
+    seed, public, artifact, install = _prepare(tmp_path, state=build_legacy_state)
+    before = _people_rows(install.state_root)
+    versions_before = _versions(install.state_root)
+
+    outcome = _apply(
+        fx.document(artifact, seed),
+        install,
+        artifact,
+        public,
+        health_check=_unhealthy,
+    )
+
+    assert outcome.status is UpdateStatus.ROLLED_BACK
+    assert outcome.backup_id is not None
+    assert _versions(install.state_root) == versions_before
+    assert _people_rows(install.state_root) == before
+    assert fx.bundle_version(install.bundle_path) == "0.0.1"
+
+
+def test_a_failed_migration_rolls_the_state_back_and_leaves_the_bundle_alone(
+    tmp_path, monkeypatch
+):
+    seed, public, artifact, install = _prepare(tmp_path, state=build_legacy_state)
+    versions_before = _versions(install.state_root)
+    people_before = _people_rows(install.state_root)
+
+    def broken(root, *, plan=None, backup=None):
+        return migrations.MigrationOutcome(
+            backup_id=backup.backup_id if backup else None,
+            error="people_db: the step raised",
+        )
+
+    monkeypatch.setattr(migrations, "apply_migrations", broken)
+    outcome = _apply(fx.document(artifact, seed), install, artifact, public)
+
+    assert outcome.stage is UpdateStage.MIGRATE
+    assert outcome.status is UpdateStatus.ROLLED_BACK
+    assert _versions(install.state_root) == versions_before
+    assert _people_rows(install.state_root) == people_before
+    assert fx.bundle_version(install.bundle_path) == "0.0.1"
+
+
+def test_a_corrupt_artifact_is_refused_before_anything_is_touched(tmp_path):
+    seed, public, artifact, install = _prepare(tmp_path, state=build_legacy_state)
+    document = fx.document(artifact, seed)
+    artifact.write_bytes(b"not a zip")
+    document["signed"]["artifact_size"] = artifact.stat().st_size
+    document["signed"]["artifact_sha256"] = m.sha256_file(artifact)
+    document = m.sign_manifest(document["signed"], seed=seed, key_id=fx.KEY_ID)
+
+    outcome = _apply(document, install, artifact, public)
+
+    assert outcome.stage is UpdateStage.STAGE
+    assert outcome.status is UpdateStatus.REFUSED
+    assert migrations.list_backups(install.state_root) == []
+    assert fx.bundle_version(install.bundle_path) == "0.0.1"
+
+
+def test_an_unverified_manifest_never_reaches_the_run_store(tmp_path):
+    seed, _public, artifact, install = _prepare(tmp_path)
+    _, other_public = fx.keypair()
+
+    outcome = _apply(fx.document(artifact, seed), install, artifact, other_public)
+
+    assert outcome.stage is UpdateStage.VERIFY
+    assert outcome.status is UpdateStatus.REFUSED
+    assert outcome.reason == str(m.Refusal.BAD_SIGNATURE)
+    assert fx.bundle_version(install.bundle_path) == "0.0.1"
+
+
+def test_a_backup_that_cannot_be_written_stops_the_update(tmp_path, monkeypatch):
+    seed, public, artifact, install = _prepare(tmp_path, state=build_legacy_state)
+
+    def refuse(*args, **kwargs):
+        raise migrations.BackupFailed("the disk is full")
+
+    monkeypatch.setattr(migrations, "create_backup", refuse)
+    outcome = _apply(fx.document(artifact, seed), install, artifact, public)
+
+    assert outcome.stage is UpdateStage.BACKUP
+    assert outcome.status is UpdateStatus.REFUSED
+    assert fx.bundle_version(install.bundle_path) == "0.0.1"
+    assert migrations.plan_migrations(install.state_root).pending != ()
+
+
+# --- explicit rollback ---------------------------------------------------
+
+
+def test_rollback_puts_the_previous_bundle_and_state_back(tmp_path):
+    seed, public, artifact, install = _prepare(tmp_path, state=build_legacy_state)
+    people_before = _people_rows(install.state_root)
+    versions_before = _versions(install.state_root)
+
+    applied = _apply(fx.document(artifact, seed), install, artifact, public)
+    assert applied.status is UpdateStatus.APPLIED, applied.reason
+    assert fx.bundle_version(install.bundle_path) == "0.0.2"
+    assert _versions(install.state_root) != versions_before
+
+    reverted = rollback(install, backup_id=applied.backup_id)
+
+    assert reverted.status is UpdateStatus.ROLLED_BACK, reverted.reason
+    assert fx.bundle_version(install.bundle_path) == "0.0.1"
+    assert _versions(install.state_root) == versions_before
+    assert _people_rows(install.state_root) == people_before
+
+
+def test_rollback_with_nothing_to_roll_back_to_says_so(tmp_path):
+    install = fx.installation(tmp_path)
+    fx.app_tree(install.bundle_path.parent, version="0.0.1")
+    outcome = rollback(install)
+    assert outcome.status is UpdateStatus.REFUSED
+    assert outcome.reason == "no_previous_version"
+    assert fx.bundle_version(install.bundle_path) == "0.0.1"
+
+
+# --- helpers -------------------------------------------------------------
+
+
+def _versions(root: Path) -> dict[str, int | None]:
+    return {
+        spec.store_id: migrations.read_version(root, spec)
+        for spec in migrations.REGISTRY
+        if migrations.store_present(root, spec)
+    }
+
+
+def _people_rows(root: Path) -> list[tuple]:
+    """The person file as content, over the columns the old schema had."""
+    path = root / "people.db"
+    if not path.is_file():
+        return []
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute("SELECT * FROM people ORDER BY person_id").fetchall()
+        columns = (
+            "person_id",
+            "apollo_id",
+            "first_name",
+            "last_name",
+            "title",
+            "company",
+            "email",
+            "linkedin_url",
+            "sequence_state",
+            "target",
+        )
+        return [tuple(row[name] for name in columns) for row in rows]
+    finally:
+        conn.close()

--- a/desktop/tests/test_update_channel_mutations.py
+++ b/desktop/tests/test_update_channel_mutations.py
@@ -1,0 +1,135 @@
+"""Break one guard at a time and require the test that owns it to go red.
+
+A test suite can be green because the code is right or because the assertions
+never look. This file tells those apart. Each case disables exactly one guard in
+the update channel and then runs the test that is supposed to catch it, in the
+normal way, and requires it to fail.
+
+Every case is paired with a control that runs the same owning test with nothing
+mutated. A mutation that "passes" because the owning test was already failing
+would prove nothing, and the control is what rules that out.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import test_update_apply as apply_tests  # noqa: E402
+import test_update_exercises as exercise_tests  # noqa: E402
+import test_update_manifest as manifest_tests  # noqa: E402
+from coworker import migrations  # noqa: E402
+from coworker.update_channel import apply as apply_module  # noqa: E402
+from coworker.update_channel import drain as drain_module  # noqa: E402
+from coworker.update_channel import manifest as manifest_module  # noqa: E402
+
+DIGEST_CASE = (
+    "artifact_sha256",
+    "f" * 64,
+    manifest_module.Refusal.ARTIFACT_DIGEST_MISMATCH,
+)
+
+
+# --- guard 1: the manifest must not verify a digest that does not match ---
+
+
+def test_control_the_digest_guard_holds(tmp_path):
+    manifest_tests.test_changing_one_bound_field_refuses_with_its_own_reason(
+        tmp_path, *DIGEST_CASE
+    )
+
+
+def test_mutant_a_manifest_that_verifies_a_wrong_digest_is_caught(
+    tmp_path, monkeypatch
+):
+    """Defeat the digest comparison: hash every artifact to whatever was claimed."""
+    monkeypatch.setattr(manifest_module, "sha256_file", lambda path: "f" * 64)
+    with pytest.raises(AssertionError):
+        manifest_tests.test_changing_one_bound_field_refuses_with_its_own_reason(
+            tmp_path, *DIGEST_CASE
+        )
+
+
+# --- guard 2: an update must not proceed during an unsettled effect ------
+
+
+def test_control_the_drain_gate_holds(tmp_path):
+    apply_tests.test_an_update_requested_during_an_unsettled_send_does_not_proceed(
+        tmp_path
+    )
+
+
+def test_mutant_an_update_that_proceeds_during_an_unsettled_effect_is_caught(
+    tmp_path, monkeypatch
+):
+    """Defeat the gate entirely: report every installation ready to be replaced."""
+    monkeypatch.setattr(
+        drain_module,
+        "assess_drain",
+        lambda repo, **kwargs: drain_module.DrainAssessment(
+            status=drain_module.DrainStatus.READY
+        ),
+    )
+    with pytest.raises(AssertionError):
+        apply_tests.test_an_update_requested_during_an_unsettled_send_does_not_proceed(
+            tmp_path
+        )
+
+
+def test_mutant_a_gate_that_only_misreads_the_effect_is_still_caught(
+    tmp_path, monkeypatch
+):
+    """A subtler break: the gate still stops, but stops for the wrong reason."""
+    monkeypatch.setattr(drain_module, "unreported", lambda effects: [])
+    with pytest.raises(AssertionError):
+        apply_tests.test_an_update_requested_during_an_unsettled_send_does_not_proceed(
+            tmp_path
+        )
+
+
+# --- guard 3: a rollback must actually restore ---------------------------
+
+
+def test_control_the_rollback_guard_holds(tmp_path):
+    exercise_tests.test_exercise_failed_update_restores_the_last_usable_version(
+        tmp_path
+    )
+
+
+def test_mutant_a_rollback_that_leaves_the_new_bundle_in_place_is_caught(
+    tmp_path, monkeypatch
+):
+    """Defeat the bundle half: claim the previous version was put back."""
+    monkeypatch.setattr(apply_module, "restore_bundle", lambda installation: True)
+    with pytest.raises(AssertionError):
+        exercise_tests.test_exercise_failed_update_restores_the_last_usable_version(
+            tmp_path
+        )
+
+
+def test_mutant_a_rollback_that_leaves_the_state_migrated_is_caught(
+    tmp_path, monkeypatch
+):
+    """Defeat the state half: claim the backup was restored and restore nothing."""
+    monkeypatch.setattr(
+        migrations, "restore_backup", lambda root, backup_id: {"restored": []}
+    )
+    with pytest.raises(AssertionError):
+        exercise_tests.test_exercise_failed_update_restores_the_last_usable_version(
+            tmp_path
+        )
+
+
+def test_mutant_a_rollback_that_forgets_the_version_manifest_is_caught(
+    tmp_path, monkeypatch
+):
+    """The one the migration registry itself gets wrong; see docs/update-channel.md."""
+    monkeypatch.setattr(apply_module, "_restore_versions", lambda root, backup_id: None)
+    with pytest.raises(AssertionError):
+        exercise_tests.test_exercise_failed_update_restores_the_last_usable_version(
+            tmp_path
+        )

--- a/desktop/tests/test_update_cli.py
+++ b/desktop/tests/test_update_cli.py
@@ -1,0 +1,151 @@
+"""The two commands an operator runs by hand, and what they refuse to do.
+
+`status` is the question before quitting the app: is anything in flight? It has
+to answer honestly and it has to answer without writing, because the state it is
+reporting on is the state a careless read-and-fix would destroy.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import update_fixtures as fx  # noqa: E402
+from coworker.agent_run_repository import AgentRunRepository  # noqa: E402
+from coworker.update_channel import __main__ as cli  # noqa: E402
+from state_fixtures import build_legacy_state  # noqa: E402
+
+NOW = datetime(2026, 8, 27, 10, 0, 0, tzinfo=UTC)
+SEND_ARGS = {"to": "dana@ramp.test", "subject": "Intro", "body": "Hello Dana."}
+
+
+def _dispatched_send(root: Path):
+    root.mkdir(parents=True, exist_ok=True)
+    repo = AgentRunRepository(root)
+    owner = repo.registry.register()
+    started = repo.create_run(
+        session_id="sess-1",
+        trigger="chat",
+        goal="reach out to Dana",
+        owner=owner,
+        lease_seconds=600,
+        now=NOW,
+    )
+    commit = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+    return repo, commit
+
+
+def test_status_says_it_is_safe_when_nothing_is_running(tmp_path, capsys):
+    code = cli.main(["--state-root", str(tmp_path / "state"), "status"])
+    assert code == 0
+    assert "safe to update" in capsys.readouterr().out
+
+
+def test_status_reports_an_unsettled_send_and_refuses(tmp_path, capsys):
+    root = tmp_path / "state"
+    repo, commit = _dispatched_send(root)
+    before = repo.list_effects(commit.effect["run_id"])
+    repo.close()
+
+    code = cli.main(["--state-root", str(root), "status"])
+
+    assert code == 1
+    output = capsys.readouterr().out
+    assert "gmail_send" in output
+    assert "wait for the work above to finish" in output
+    # Reporting must not have changed the thing being reported on.
+    repo = AgentRunRepository(root)
+    try:
+        assert repo.list_effects(commit.effect["run_id"]) == before
+        assert repo.list_quarantined_effects() == []
+    finally:
+        repo.close()
+
+
+def test_status_sends_a_quarantine_to_a_person_and_never_settles_it(tmp_path, capsys):
+    root = tmp_path / "state"
+    repo, commit = _dispatched_send(root)
+    repo.quarantine_effect(
+        commit.lease, commit.effect["effect_id"], reason="owner died", now=NOW
+    )
+    repo.close()
+
+    code = cli.main(["--state-root", str(root), "status"])
+
+    assert code == 1
+    assert "settle the quarantined effect" in capsys.readouterr().out
+    repo = AgentRunRepository(root)
+    try:
+        assert repo.list_quarantined_effects()[0]["resolved_by"] is None
+    finally:
+        repo.close()
+
+
+def test_rollback_lists_the_backups_it_could_restore(tmp_path, capsys):
+    from coworker import migrations
+
+    root = tmp_path / "state"
+    build_legacy_state(root)
+    backup = migrations.create_backup(
+        root, [spec.store_id for spec in migrations.REGISTRY], reason="update 1 to 2"
+    )
+
+    code = cli.main(
+        [
+            "--state-root",
+            str(root),
+            "rollback",
+            "--bundle",
+            str(tmp_path / "Sourcecado.app"),
+            "--list-backups",
+        ]
+    )
+    assert code == 0
+    assert backup.backup_id in capsys.readouterr().out
+
+
+def test_rollback_restores_the_previous_application(tmp_path, capsys):
+    install = fx.installation(tmp_path, version="0.0.2")
+    fx.app_tree(install.bundle_path.parent, version="0.0.2")
+    previous = fx.app_tree(tmp_path / "old", version="0.0.1")
+    previous.rename(install.previous_path)
+
+    code = cli.main(
+        [
+            "--state-root",
+            str(install.state_root),
+            "rollback",
+            "--bundle",
+            str(install.bundle_path),
+        ]
+    )
+
+    assert code == 0
+    assert "rolled_back" in capsys.readouterr().out
+    assert fx.bundle_version(install.bundle_path) == "0.0.1"
+
+
+def test_rollback_with_nothing_kept_refuses_rather_than_removing_anything(
+    tmp_path, capsys
+):
+    install = fx.installation(tmp_path, version="0.0.2")
+    fx.app_tree(install.bundle_path.parent, version="0.0.2")
+
+    code = cli.main(
+        [
+            "--state-root",
+            str(install.state_root),
+            "rollback",
+            "--bundle",
+            str(install.bundle_path),
+        ]
+    )
+
+    assert code == 1
+    assert "nothing to roll back to" in capsys.readouterr().out
+    assert fx.bundle_version(install.bundle_path) == "0.0.2"

--- a/desktop/tests/test_update_drain.py
+++ b/desktop/tests/test_update_drain.py
@@ -1,0 +1,304 @@
+"""Criterion 3: when an update may proceed, and what it must never do to get there.
+
+The obvious updater stops the app, swaps the bundle, and starts it again. That
+is the wrong shape here. If a run has dispatched a Gmail send and does not yet
+know the outcome, killing the process turns a knowable outcome into a
+permanently ambiguous one; a restart that "resumes" it can put a second real
+email in front of a real person.
+
+So the drain gate has exactly two safe answers -- wait, or refuse -- and one
+forbidden one: proceed. It also has a second obligation that is easy to miss.
+It must not *record* anything. Quarantining an unreported effect is
+`agent_run_resume.restart()`'s decision after a crash, not an updater's, and
+resolving a quarantine is a person's. Every assertion about writes below exists
+because a helpful updater is how "we do not know" quietly becomes "it worked".
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from coworker.agent_run_approval import EffectStatus
+from coworker.agent_run_repository import AgentRunRepository
+from coworker.update_channel import drain
+
+NOW = datetime(2026, 8, 27, 10, 0, 0, tzinfo=UTC)
+SEND_ARGS = {"to": "dana@ramp.test", "subject": "Intro", "body": "Hello Dana."}
+
+
+def _repo(tmp_path):
+    repo = AgentRunRepository(tmp_path)
+    return repo, repo.registry.register()
+
+
+def _run(repo, owner, *, session_id="sess-1", now=NOW):
+    return repo.create_run(
+        session_id=session_id,
+        trigger="chat",
+        goal="reach out to Dana",
+        owner=owner,
+        lease_seconds=600,
+        now=now,
+    )
+
+
+def _snapshot(repo, run_id) -> tuple:
+    """Everything an update must leave exactly as it found it."""
+    return (
+        repo.get_run(run_id),
+        repo.list_effects(run_id),
+        len(repo.list_checkpoints(run_id)),
+    )
+
+
+# --- nothing to drain ----------------------------------------------------
+
+
+def test_an_idle_installation_is_ready(tmp_path):
+    repo, _ = _repo(tmp_path)
+    assessment = drain.assess_drain(repo)
+    assert assessment.status is drain.DrainStatus.READY
+    assert assessment.ready
+    assert assessment.blockers == ()
+
+
+def test_a_finished_run_does_not_block(tmp_path):
+    repo, owner = _repo(tmp_path)
+    started = _run(repo, owner)
+    repo.checkpoint(
+        started.lease,
+        kind="terminal",
+        state="complete",
+        terminal_result={"status": "success"},
+        now=NOW,
+    )
+    assert drain.assess_drain(repo).status is drain.DrainStatus.READY
+
+
+# --- active work: wait ---------------------------------------------------
+
+
+def test_a_run_a_live_owner_is_working_makes_the_update_wait(tmp_path):
+    repo, owner = _repo(tmp_path)
+    _run(repo, owner)
+    assessment = drain.assess_drain(repo, now=NOW)
+    assert assessment.status is drain.DrainStatus.ACTIVE_WORK
+    assert assessment.may_wait
+    assert not assessment.ready
+
+
+def test_waiting_returns_ready_once_the_run_finishes(tmp_path):
+    repo, owner = _repo(tmp_path)
+    started = _run(repo, owner)
+    polls: list[float] = []
+
+    def sleep(seconds: float) -> None:
+        polls.append(seconds)
+        if len(polls) == 2:
+            repo.checkpoint(
+                started.lease,
+                kind="terminal",
+                state="complete",
+                terminal_result={"status": "success"},
+                now=NOW,
+            )
+
+    assessment = drain.wait_for_drain(
+        repo, timeout=30.0, poll=0.5, sleep=sleep, clock=_clock(), now=NOW
+    )
+    assert assessment.status is drain.DrainStatus.READY
+    assert polls, "the gate must actually have waited before reporting ready"
+
+
+def test_waiting_gives_up_and_refuses_rather_than_forcing(tmp_path):
+    repo, owner = _repo(tmp_path)
+    _run(repo, owner)
+    assessment = drain.wait_for_drain(
+        repo, timeout=2.0, poll=0.5, sleep=lambda _: None, clock=_clock(), now=NOW
+    )
+    assert assessment.status is drain.DrainStatus.ACTIVE_WORK
+    assert not assessment.ready
+
+
+# --- restart-safe continuation -------------------------------------------
+
+
+def test_a_run_parked_on_a_person_is_restart_safe_and_does_not_block(tmp_path):
+    repo, owner = _repo(tmp_path)
+    started = _run(repo, owner)
+    repo.checkpoint(
+        started.lease,
+        kind="waiting_approval",
+        state="waiting_approval",
+        payload={"approval_id": "appr-1"},
+        now=NOW,
+    )
+    assessment = drain.assess_drain(repo, now=NOW)
+    assert assessment.status is drain.DrainStatus.READY
+    assert started.run["run_id"] in assessment.continuable
+
+
+def test_a_crashed_run_with_no_external_effect_is_restart_safe(tmp_path):
+    repo, owner = _repo(tmp_path)
+    started = _run(repo, owner)
+    repo.release_lease(started.lease, now=NOW)
+    assessment = drain.assess_drain(repo, now=NOW + timedelta(hours=1))
+    assert assessment.status is drain.DrainStatus.READY
+    assert started.run["run_id"] in assessment.continuable
+
+
+# --- the effect that must never be killed and replayed -------------------
+
+
+def test_a_dispatched_send_with_no_outcome_stops_the_update(tmp_path):
+    repo, owner = _repo(tmp_path)
+    started = _run(repo, owner)
+    commit = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+    before = _snapshot(repo, started.run["run_id"])
+
+    assessment = drain.assess_drain(repo, now=NOW)
+
+    assert assessment.status is drain.DrainStatus.UNSETTLED_EFFECT
+    assert not assessment.ready
+    blocker = assessment.blockers[0]
+    assert blocker.run_id == started.run["run_id"]
+    assert blocker.effect_id == commit.effect["effect_id"]
+    assert blocker.tool_name == "gmail_send"
+    # The gate looked, and changed nothing.
+    assert _snapshot(repo, started.run["run_id"]) == before
+    assert (
+        repo.list_effects(started.run["run_id"])[0]["status"]
+        == EffectStatus.DISPATCHED
+    )
+
+
+def test_waiting_on_an_unsettled_send_never_quarantines_it(tmp_path):
+    """The gate may wait for the dispatching process to report. It may not decide."""
+    repo, owner = _repo(tmp_path)
+    started = _run(repo, owner)
+    repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+    before = _snapshot(repo, started.run["run_id"])
+
+    assessment = drain.wait_for_drain(
+        repo, timeout=5.0, poll=0.5, sleep=lambda _: None, clock=_clock(), now=NOW
+    )
+
+    assert assessment.status is drain.DrainStatus.UNSETTLED_EFFECT
+    assert _snapshot(repo, started.run["run_id"]) == before
+    assert repo.list_quarantined_effects() == []
+
+
+def test_waiting_clears_once_the_dispatching_process_reports(tmp_path):
+    repo, owner = _repo(tmp_path)
+    started = _run(repo, owner)
+    commit = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+    polls: list[float] = []
+
+    def sleep(seconds: float) -> None:
+        polls.append(seconds)
+        if len(polls) == 1:
+            settled = repo.record_effect_outcome(
+                commit.lease, commit.effect["effect_id"], ok=True, now=NOW
+            )
+            repo.checkpoint(
+                settled.lease,
+                kind="terminal",
+                state="complete",
+                terminal_result={"status": "success"},
+                now=NOW,
+            )
+
+    assessment = drain.wait_for_drain(
+        repo, timeout=30.0, poll=0.5, sleep=sleep, clock=_clock(), now=NOW
+    )
+    assert assessment.status is drain.DrainStatus.READY
+    assert polls
+
+
+# --- a quarantine is a person's, and waiting cannot help ------------------
+
+
+def test_a_quarantined_effect_stops_the_update_immediately(tmp_path):
+    repo, owner = _repo(tmp_path)
+    started = _run(repo, owner)
+    commit = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+    repo.quarantine_effect(
+        commit.lease,
+        commit.effect["effect_id"],
+        reason="the process died before the send reported",
+        now=NOW,
+    )
+    before = _snapshot(repo, started.run["run_id"])
+    polls: list[float] = []
+
+    assessment = drain.wait_for_drain(
+        repo,
+        timeout=60.0,
+        poll=0.5,
+        sleep=lambda seconds: polls.append(seconds),
+        clock=_clock(),
+        now=NOW,
+    )
+
+    assert assessment.status is drain.DrainStatus.QUARANTINED_EFFECT
+    assert not assessment.may_wait
+    assert polls == [], "no amount of waiting settles a quarantine; a person does"
+    assert _snapshot(repo, started.run["run_id"]) == before
+    assert (
+        repo.list_quarantined_effects()[0]["status"] == EffectStatus.AMBIGUOUS
+    ), "the update must not settle what a person owns"
+
+
+def test_a_quarantine_on_a_finished_run_still_stops_the_update(tmp_path):
+    """A quarantined effect outlives its run. The sweep is over effects, not runs."""
+    repo, owner = _repo(tmp_path)
+    started = _run(repo, owner)
+    commit = repo.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+    repo.quarantine_effect(
+        commit.lease, commit.effect["effect_id"], reason="unknown", now=NOW
+    )
+    lease = repo.acquire_lease(started.run["run_id"], owner, now=NOW)
+    repo.checkpoint(
+        lease,
+        kind="terminal",
+        state="partial",
+        terminal_result={"status": "partial"},
+        now=NOW,
+    )
+    assert repo.get_run(started.run["run_id"])["current_state"] == "partial"
+
+    assessment = drain.assess_drain(repo, now=NOW)
+    assert assessment.status is drain.DrainStatus.QUARANTINED_EFFECT
+
+
+def test_a_quarantine_outranks_active_work_in_the_reported_status(tmp_path):
+    repo, owner = _repo(tmp_path)
+    held = _run(repo, owner, session_id="sess-1")
+    commit = repo.dispatch_effect(
+        held.lease, tool_name="gmail_send", arguments=SEND_ARGS, now=NOW
+    )
+    repo.quarantine_effect(
+        commit.lease, commit.effect["effect_id"], reason="unknown", now=NOW
+    )
+    _run(repo, owner, session_id="sess-2")
+
+    assessment = drain.assess_drain(repo, now=NOW)
+    assert assessment.status is drain.DrainStatus.QUARANTINED_EFFECT
+    statuses = {blocker.status for blocker in assessment.blockers}
+    assert drain.DrainStatus.ACTIVE_WORK in statuses
+
+
+def _clock():
+    """A monotonic clock that advances one second per reading."""
+    ticks = iter(range(0, 10_000))
+    return lambda: float(next(ticks))

--- a/desktop/tests/test_update_exercises.py
+++ b/desktop/tests/test_update_exercises.py
@@ -1,0 +1,268 @@
+"""Criterion 6: the five exercises, run rather than described.
+
+Clean install, upgrade from the prior preview, a failed update, a rollback, and
+the person file surviving all of them. `docs/update-channel.md` describes these
+in prose; this file is what actually runs, and the doc points at it by name so
+the two cannot drift.
+
+The person-file exercise is the one a user would notice. An update that loses a
+person file is worse than an update that fails, because a failed update is
+visible and a lost person file is not. So every exercise below that touches
+state asserts the person file back afterwards, through the real `PersonStore`,
+not just through raw rows.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import update_fixtures as fx  # noqa: E402
+from coworker import doctor, migrations  # noqa: E402
+from coworker.agent_run_repository import AgentRunRepository  # noqa: E402
+from coworker.people import PersonStore  # noqa: E402
+from coworker.update_channel import UpdateStage, UpdateStatus, apply_update, rollback  # noqa: E402
+from state_fixtures import build_legacy_state  # noqa: E402
+
+PERSON_COLUMNS = (
+    "person_id",
+    "apollo_id",
+    "first_name",
+    "last_name",
+    "title",
+    "company",
+    "email",
+    "linkedin_url",
+    "sequence_state",
+    "target",
+)
+
+
+def _people_rows(root: Path) -> list[tuple]:
+    path = root / "people.db"
+    if not path.is_file():
+        return []
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute("SELECT * FROM people ORDER BY person_id").fetchall()
+        return [tuple(row[name] for name in PERSON_COLUMNS) for row in rows]
+    finally:
+        conn.close()
+
+
+def _events(root: Path) -> list[tuple]:
+    path = root / "people.db"
+    if not path.is_file():
+        return []
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT person_id, source, kind, summary FROM events "
+            "ORDER BY person_id, rowid"
+        ).fetchall()
+        return [tuple(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def _versions(root: Path) -> dict[str, int | None]:
+    return {
+        spec.store_id: migrations.read_version(root, spec)
+        for spec in migrations.REGISTRY
+        if migrations.store_present(root, spec)
+    }
+
+
+def _update(install, artifact, seed, public, **kwargs):
+    kwargs.setdefault("health_check", lambda _i: True)
+    opened = None
+    if "runs" not in kwargs and (install.state_root / "agent_runs.db").exists():
+        opened = AgentRunRepository(install.state_root)
+        kwargs["runs"] = opened
+    kwargs.setdefault("runs", None)
+    try:
+        return apply_update(
+            fx.document(artifact, seed, **kwargs.pop("manifest", {})),
+            installation=install,
+            artifact_path=artifact,
+            trust=fx.trust(public),
+            drain_timeout=0.0,
+            sleep=lambda _: None,
+            **kwargs,
+        )
+    finally:
+        if opened is not None:
+            try:
+                opened.close()
+            except Exception:
+                pass
+
+
+# --- exercise 1: clean install -------------------------------------------
+
+
+def test_exercise_clean_install(tmp_path):
+    """No previous application, no previous state. Nothing to back up or migrate."""
+    seed, public = fx.keypair()
+    artifact = fx.artifact(tmp_path, version="0.0.2")
+    install = fx.installation(tmp_path, version="0.0.0")
+    assert not install.bundle_path.exists()
+    assert not install.state_root.exists()
+
+    outcome = _update(
+        install,
+        artifact,
+        seed,
+        public,
+        manifest={"minimum_upgradable_version": "0.0.0"},
+    )
+
+    assert outcome.status is UpdateStatus.APPLIED, outcome.reason
+    assert outcome.stage is UpdateStage.DONE
+    assert fx.bundle_version(install.bundle_path) == "0.0.2"
+    assert outcome.backup_id is None
+    assert outcome.migrated == ()
+    assert not install.previous_path.exists()
+
+
+# --- exercise 2: upgrade from the prior preview --------------------------
+
+
+def test_exercise_upgrade_from_the_prior_preview(tmp_path):
+    """State written by the previous preview build, brought forward and kept."""
+    seed, public = fx.keypair()
+    artifact = fx.artifact(tmp_path, version="0.0.2")
+    install = fx.installation(tmp_path, version="0.0.1")
+    build_legacy_state(install.state_root)
+    fx.app_tree(install.bundle_path.parent, version="0.0.1")
+    people_before = _people_rows(install.state_root)
+    events_before = _events(install.state_root)
+    assert people_before, "the prior preview's state must contain a person file"
+
+    outcome = _update(install, artifact, seed, public)
+
+    assert outcome.status is UpdateStatus.APPLIED, outcome.reason
+    assert fx.bundle_version(install.bundle_path) == "0.0.2"
+    assert fx.bundle_version(install.previous_path) == "0.0.1"
+    assert "people_db" in outcome.migrated
+    assert outcome.backup_id is not None
+    assert migrations.plan_migrations(install.state_root).pending == ()
+    # The person file came forward with it.
+    assert _people_rows(install.state_root) == people_before
+    assert _events(install.state_root) == events_before
+
+
+# --- exercise 3: a failed update -----------------------------------------
+
+
+def test_exercise_failed_update_restores_the_last_usable_version(tmp_path):
+    seed, public = fx.keypair()
+    artifact = fx.artifact(tmp_path, version="0.0.2")
+    install = fx.installation(tmp_path, version="0.0.1")
+    build_legacy_state(install.state_root)
+    fx.app_tree(install.bundle_path.parent, version="0.0.1")
+    people_before = _people_rows(install.state_root)
+    events_before = _events(install.state_root)
+    versions_before = _versions(install.state_root)
+
+    outcome = _update(install, artifact, seed, public, health_check=lambda _i: False)
+
+    assert outcome.stage is UpdateStage.HEALTH, "the update must reach the launch check"
+    assert outcome.status is UpdateStatus.ROLLED_BACK
+    assert fx.bundle_version(install.bundle_path) == "0.0.1"
+    assert not install.previous_path.exists()
+    assert not install.staging_root.exists()
+    assert _versions(install.state_root) == versions_before
+    assert _people_rows(install.state_root) == people_before
+    assert _events(install.state_root) == events_before
+    assert "0.0.1" in outcome.guidance
+
+    # Doctor and the updater must not disagree about what is on this machine.
+    report = doctor.diagnose(install.state_root)
+    assert not report.blocked, [item.code for item in report.findings if item.blocking]
+    assert {item.store_id: item.status for item in report.stores}["people_db"] in {
+        "pending",
+        "current",
+    }
+
+
+# --- exercise 4: rollback -------------------------------------------------
+
+
+def test_exercise_rollback_after_a_successful_update(tmp_path):
+    seed, public = fx.keypair()
+    artifact = fx.artifact(tmp_path, version="0.0.2")
+    install = fx.installation(tmp_path, version="0.0.1")
+    build_legacy_state(install.state_root)
+    fx.app_tree(install.bundle_path.parent, version="0.0.1")
+    people_before = _people_rows(install.state_root)
+    versions_before = _versions(install.state_root)
+
+    applied = _update(install, artifact, seed, public)
+    assert applied.status is UpdateStatus.APPLIED, applied.reason
+    assert _versions(install.state_root) != versions_before
+
+    reverted = rollback(install, backup_id=applied.backup_id)
+
+    assert reverted.status is UpdateStatus.ROLLED_BACK, reverted.reason
+    assert fx.bundle_version(install.bundle_path) == "0.0.1"
+    assert not install.previous_path.exists()
+    assert _versions(install.state_root) == versions_before
+    assert _people_rows(install.state_root) == people_before
+    assert "people_db" in reverted.restored
+    assert not doctor.diagnose(install.state_root).blocked
+
+
+# --- exercise 5: the person file -----------------------------------------
+
+
+def test_exercise_the_person_file_reads_back_through_its_own_store(tmp_path):
+    """Rows surviving is not enough. The person file must still open."""
+    seed, public = fx.keypair()
+    artifact = fx.artifact(tmp_path, version="0.0.2")
+    install = fx.installation(tmp_path, version="0.0.1")
+    build_legacy_state(install.state_root)
+    fx.app_tree(install.bundle_path.parent, version="0.0.1")
+    person_id = _people_rows(install.state_root)[0][0]
+
+    outcome = _update(install, artifact, seed, public)
+    assert outcome.status is UpdateStatus.APPLIED, outcome.reason
+
+    store = PersonStore(install.state_root)
+    person = store.get(person_id, expand_sources=True)
+    assert person is not None, "the person file did not survive the update"
+    assert person["first_name"] == "Dana"
+    assert person["company"] == "Rippling"
+    assert person["email"] == "dana@example.com"
+    assert person["sequence_state"] == "open"
+    assert store.timeline(person_id), "the person's history did not survive"
+    assert person["person_id"] == person_id
+
+
+def test_exercise_the_person_file_survives_a_failed_update_and_a_rollback(tmp_path):
+    """The worst outcome in this issue, tested on the two paths that could cause it."""
+    seed, public = fx.keypair()
+    artifact = fx.artifact(tmp_path, version="0.0.2")
+    install = fx.installation(tmp_path, version="0.0.1")
+    build_legacy_state(install.state_root)
+    fx.app_tree(install.bundle_path.parent, version="0.0.1")
+    before = _people_rows(install.state_root)
+    person_id = before[0][0]
+
+    failed = _update(install, artifact, seed, public, health_check=lambda _i: False)
+    assert failed.status is UpdateStatus.ROLLED_BACK
+    assert _people_rows(install.state_root) == before
+
+    applied = _update(install, artifact, seed, public)
+    assert applied.status is UpdateStatus.APPLIED, applied.reason
+    reverted = rollback(install, backup_id=applied.backup_id)
+    assert reverted.status is UpdateStatus.ROLLED_BACK, reverted.reason
+
+    assert _people_rows(install.state_root) == before
+    store = PersonStore(install.state_root)
+    assert store.get(person_id) is not None

--- a/desktop/tests/test_update_health.py
+++ b/desktop/tests/test_update_health.py
@@ -1,0 +1,113 @@
+"""The launch check: does the version that was just installed actually come up?
+
+This is what makes criterion 4's "failed launch" a real branch rather than a
+callable somebody passes in. The check launches the sidecar that is inside the
+installed application, exactly as the shell does -- loopback, its own token, an
+isolated state directory -- and waits for the health handshake.
+
+The isolated state directory is the part worth stating twice. A launch check
+that opened the operator's real state would be a change the rollback could not
+undo, so it never does.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import update_fixtures as fx  # noqa: E402
+from coworker.update_channel.apply import SIDECAR_RELATIVE, sidecar_health_check  # noqa: E402
+
+STUB = '''#!{python}
+import argparse, json, os, sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+STATUS = os.environ.get("STUB_HEALTH", "ok")
+if STATUS == "crash":
+    sys.exit(3)
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+
+    def do_GET(self):
+        if self.headers.get("X-Club-Token") is None:
+            self.send_response(401)
+            self.end_headers()
+            return
+        # Prove the launch check gave us a throwaway state directory.
+        body = json.dumps({{
+            "status": STATUS,
+            "state_dir": os.environ.get("CLUB_STATE_DIR", ""),
+        }}).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--host", default="127.0.0.1")
+parser.add_argument("--port", type=int, required=True)
+args = parser.parse_args()
+HTTPServer((args.host, args.port), Handler).serve_forever()
+'''
+
+
+def _install_with_sidecar(tmp_path, *, health: str = "ok"):
+    install = fx.installation(tmp_path, version="0.0.2")
+    fx.app_tree(
+        install.bundle_path.parent,
+        version="0.0.2",
+        sidecar=STUB.format(python=sys.executable),
+    )
+    os.environ["STUB_HEALTH"] = health
+    return install
+
+
+def test_a_sidecar_that_answers_the_health_handshake_passes(tmp_path):
+    install = _install_with_sidecar(tmp_path)
+    try:
+        assert sidecar_health_check(install, timeout=25.0) is True
+    finally:
+        os.environ.pop("STUB_HEALTH", None)
+
+
+def test_a_sidecar_that_reports_an_unhealthy_status_fails(tmp_path):
+    install = _install_with_sidecar(tmp_path, health="degraded")
+    try:
+        assert sidecar_health_check(install, timeout=25.0) is False
+    finally:
+        os.environ.pop("STUB_HEALTH", None)
+
+
+def test_a_sidecar_that_exits_immediately_fails(tmp_path):
+    install = _install_with_sidecar(tmp_path, health="crash")
+    try:
+        assert sidecar_health_check(install, timeout=25.0) is False
+    finally:
+        os.environ.pop("STUB_HEALTH", None)
+
+
+def test_an_application_with_no_sidecar_in_it_fails(tmp_path):
+    install = fx.installation(tmp_path, version="0.0.2")
+    fx.app_tree(install.bundle_path.parent, version="0.0.2")
+    assert not (install.bundle_path / SIDECAR_RELATIVE).exists()
+    assert sidecar_health_check(install, timeout=5.0) is False
+
+
+def test_the_launch_check_never_opens_the_operators_state(tmp_path):
+    """The check runs against a throwaway directory, so a rollback stays complete."""
+    install = _install_with_sidecar(tmp_path)
+    install.state_root.mkdir(parents=True, exist_ok=True)
+    marker = install.state_root / "club.db"
+    marker.write_bytes(b"operator state")
+    try:
+        assert sidecar_health_check(install, timeout=25.0) is True
+    finally:
+        os.environ.pop("STUB_HEALTH", None)
+    assert marker.read_bytes() == b"operator state"
+    assert sorted(item.name for item in install.state_root.iterdir()) == ["club.db"]

--- a/desktop/tests/test_update_manifest.py
+++ b/desktop/tests/test_update_manifest.py
@@ -1,0 +1,377 @@
+"""The authenticated update manifest, and every way it must refuse.
+
+A manifest is the only thing standing between a signed preview build and an
+arbitrary directory someone dropped on the machine. So the property under test
+is not "a good manifest verifies"; it is that every single field it binds is
+load-bearing, and that changing any one of them alone turns a pass into a
+refusal with a named reason.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from coworker.update_channel import manifest as m
+
+PRODUCT = "sourcecado"
+KEY_ID = "test-preview-2026"
+
+
+def _keypair() -> tuple[bytes, str]:
+    """A signing seed and the base64 public key a client would trust."""
+    private = Ed25519PrivateKey.generate()
+    seed = private.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public = private.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
+    )
+    return seed, base64.b64encode(public).decode("ascii")
+
+
+def _artifact(tmp_path, payload: bytes = b"Sourcecado.app payload"):
+    path = tmp_path / "Sourcecado-0.0.2-macos-aarch64.zip"
+    path.write_bytes(payload)
+    return path
+
+
+def _installed(**overrides) -> m.BuildIdentity:
+    fields = {
+        "product": PRODUCT,
+        "channel": m.Channel.PREVIEW,
+        "version": "0.0.1",
+        "platform": "macos",
+        "arch": "aarch64",
+        "state_versions": {"people_db": 1, "conversation_db": 3},
+    }
+    fields.update(overrides)
+    return m.BuildIdentity(**fields)
+
+
+def _signed(artifact_path, **overrides) -> dict:
+    fields = {
+        "product": PRODUCT,
+        "channel": str(m.Channel.PREVIEW),
+        "version": "0.0.2",
+        "platform": "macos",
+        "arch": "aarch64",
+        "artifact_name": artifact_path.name,
+        "artifact_size": artifact_path.stat().st_size,
+        "artifact_sha256": m.sha256_file(artifact_path),
+        "minimum_upgradable_version": "0.0.1",
+        "state_versions": {"people_db": 1, "conversation_db": 3},
+        "released_at": "2026-08-27T12:00:00+00:00",
+        "commit": "0" * 40,
+    }
+    fields.update(overrides)
+    return m.build_manifest(**fields)
+
+
+def _document(artifact_path, seed, **overrides) -> dict:
+    return m.sign_manifest(_signed(artifact_path, **overrides), seed=seed, key_id=KEY_ID)
+
+
+def _trust(public_b64: str, channel=m.Channel.PREVIEW) -> dict:
+    return {str(channel): {KEY_ID: public_b64}}
+
+
+def _verify(document, artifact_path, public_b64, **overrides):
+    return m.verify_manifest(
+        document,
+        installed=_installed(**overrides.pop("installed", {})),
+        artifact_path=artifact_path,
+        trust=overrides["trust"] if "trust" in overrides else _trust(public_b64),
+    )
+
+
+# --- the happy path, so every refusal below is a real difference ----------
+
+
+def test_a_signed_manifest_verifies_and_reports_what_it_binds(tmp_path):
+    seed, public = _keypair()
+    artifact = _artifact(tmp_path)
+    outcome = _verify(_document(artifact, seed), artifact, public)
+
+    assert outcome.ok, outcome.detail
+    assert outcome.refusal is None
+    bound = outcome.manifest
+    assert bound is not None
+    assert bound.version == "0.0.2"
+    assert bound.channel == str(m.Channel.PREVIEW)
+    assert bound.platform == "macos"
+    assert bound.arch == "aarch64"
+    assert bound.artifact_sha256 == m.sha256_file(artifact)
+    assert bound.key_id == KEY_ID
+
+
+def test_the_manifest_binds_exactly_the_declared_field_set(tmp_path):
+    seed, _ = _keypair()
+    artifact = _artifact(tmp_path)
+    document = _document(artifact, seed)
+    assert set(document["signed"]) == set(m.SIGNED_FIELDS)
+    # Version, platform, architecture, checksum, and the signature itself.
+    for required in (
+        "version",
+        "platform",
+        "arch",
+        "artifact_sha256",
+        "channel",
+    ):
+        assert required in m.SIGNED_FIELDS
+    assert document["signature"]["algorithm"] == m.SIGNATURE_ALGORITHM
+
+
+# --- one changed field at a time -----------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "refusal"),
+    [
+        ("version", "0.0.1", m.Refusal.NOT_AN_UPGRADE),
+        ("channel", "stable", m.Refusal.CHANNEL_MISMATCH),
+        ("platform", "windows", m.Refusal.PLATFORM_MISMATCH),
+        ("arch", "x86_64", m.Refusal.ARCH_MISMATCH),
+        ("product", "not-sourcecado", m.Refusal.PRODUCT_MISMATCH),
+        ("artifact_sha256", "f" * 64, m.Refusal.ARTIFACT_DIGEST_MISMATCH),
+        ("artifact_size", 999999, m.Refusal.ARTIFACT_SIZE_MISMATCH),
+        ("minimum_upgradable_version", "9.9.9", m.Refusal.UNSUPPORTED_UPGRADE_PATH),
+    ],
+)
+def test_changing_one_bound_field_refuses_with_its_own_reason(
+    tmp_path, field, value, refusal
+):
+    seed, public = _keypair()
+    artifact = _artifact(tmp_path)
+    # Signed correctly. The signature is valid; the binding is what fails.
+    outcome = _verify(_document(artifact, seed, **{field: value}), artifact, public)
+    assert not outcome.ok
+    assert outcome.refusal is refusal
+
+
+def test_a_tampered_field_after_signing_breaks_the_signature(tmp_path):
+    seed, public = _keypair()
+    artifact = _artifact(tmp_path)
+    document = _document(artifact, seed)
+    document["signed"]["version"] = "9.9.9"
+    outcome = _verify(document, artifact, public)
+    assert not outcome.ok
+    assert outcome.refusal is m.Refusal.BAD_SIGNATURE
+
+
+def test_a_replaced_artifact_refuses_even_with_a_valid_signature(tmp_path):
+    seed, public = _keypair()
+    artifact = _artifact(tmp_path)
+    document = _document(artifact, seed)
+    artifact.write_bytes(b"Sourcecado.app payload plus something else")
+    outcome = _verify(document, artifact, public)
+    assert not outcome.ok
+    # Size changed too; either refusal is a refusal, but it must be one of them.
+    assert outcome.refusal in {
+        m.Refusal.ARTIFACT_DIGEST_MISMATCH,
+        m.Refusal.ARTIFACT_SIZE_MISMATCH,
+    }
+
+
+def test_a_missing_artifact_refuses(tmp_path):
+    seed, public = _keypair()
+    artifact = _artifact(tmp_path)
+    document = _document(artifact, seed)
+    artifact.unlink()
+    outcome = _verify(document, artifact, public)
+    assert not outcome.ok
+    assert outcome.refusal is m.Refusal.ARTIFACT_MISSING
+
+
+# --- the signature itself ------------------------------------------------
+
+
+def test_a_key_that_is_not_trusted_for_this_channel_refuses(tmp_path):
+    seed, _ = _keypair()
+    _, other_public = _keypair()
+    artifact = _artifact(tmp_path)
+    outcome = _verify(_document(artifact, seed), artifact, other_public)
+    assert not outcome.ok
+    assert outcome.refusal is m.Refusal.BAD_SIGNATURE
+
+
+def test_a_key_trusted_only_for_stable_cannot_sign_a_preview_manifest(tmp_path):
+    seed, public = _keypair()
+    artifact = _artifact(tmp_path)
+    outcome = _verify(
+        _document(artifact, seed),
+        artifact,
+        public,
+        trust=_trust(public, channel=m.Channel.STABLE),
+    )
+    assert not outcome.ok
+    assert outcome.refusal is m.Refusal.UNTRUSTED_KEY
+
+
+def test_an_empty_trust_store_refuses_everything(tmp_path):
+    seed, public = _keypair()
+    artifact = _artifact(tmp_path)
+    outcome = _verify(_document(artifact, seed), artifact, public, trust={})
+    assert not outcome.ok
+    assert outcome.refusal is m.Refusal.UNTRUSTED_KEY
+
+
+def test_an_unsigned_document_refuses(tmp_path):
+    seed, public = _keypair()
+    artifact = _artifact(tmp_path)
+    document = _document(artifact, seed)
+    document.pop("signature")
+    outcome = _verify(document, artifact, public)
+    assert not outcome.ok
+    assert outcome.refusal is m.Refusal.MALFORMED
+
+
+def test_an_unknown_signature_algorithm_refuses(tmp_path):
+    seed, public = _keypair()
+    artifact = _artifact(tmp_path)
+    document = _document(artifact, seed)
+    document["signature"]["algorithm"] = "none"
+    outcome = _verify(document, artifact, public)
+    assert not outcome.ok
+    assert outcome.refusal is m.Refusal.UNKNOWN_ALGORITHM
+
+
+def test_signature_bytes_are_not_reinterpreted_as_text(tmp_path):
+    seed, public = _keypair()
+    artifact = _artifact(tmp_path)
+    document = _document(artifact, seed)
+    document["signature"]["value"] = "not base64 at all !!!"
+    outcome = _verify(document, artifact, public)
+    assert not outcome.ok
+    assert outcome.refusal is m.Refusal.MALFORMED
+
+
+# --- the closed field set ------------------------------------------------
+
+
+def test_an_extra_field_in_a_signed_manifest_refuses(tmp_path):
+    seed, public = _keypair()
+    artifact = _artifact(tmp_path)
+    document = _document(artifact, seed)
+    document["signed"]["install_command"] = "curl | sh"
+    outcome = _verify(document, artifact, public)
+    assert not outcome.ok
+    # An unknown field is caught before the signature is even considered, so a
+    # future manifest cannot smuggle a field this build would ignore.
+    assert outcome.refusal is m.Refusal.UNKNOWN_FIELD
+
+
+def test_a_missing_field_refuses(tmp_path):
+    seed, public = _keypair()
+    artifact = _artifact(tmp_path)
+    document = _document(artifact, seed)
+    document["signed"].pop("arch")
+    outcome = _verify(document, artifact, public)
+    assert not outcome.ok
+    assert outcome.refusal is m.Refusal.MISSING_FIELD
+
+
+def test_a_future_manifest_version_refuses(tmp_path):
+    seed, public = _keypair()
+    artifact = _artifact(tmp_path)
+    document = _document(artifact, seed, manifest_version=m.MANIFEST_VERSION + 1)
+    outcome = _verify(document, artifact, public)
+    assert not outcome.ok
+    assert outcome.refusal is m.Refusal.UNSUPPORTED_MANIFEST_VERSION
+
+
+def test_build_manifest_rejects_an_unknown_field_at_generation_time(tmp_path):
+    artifact = _artifact(tmp_path)
+    with pytest.raises(ValueError, match="install_command"):
+        _signed(artifact, install_command="curl | sh")
+
+
+# --- state compatibility is bound too ------------------------------------
+
+
+def test_a_manifest_expecting_a_state_version_this_build_cannot_reach_refuses(
+    tmp_path,
+):
+    seed, public = _keypair()
+    artifact = _artifact(tmp_path)
+    document = _document(artifact, seed, state_versions={"people_db": 9})
+    outcome = _verify(document, artifact, public)
+    assert not outcome.ok
+    assert outcome.refusal is m.Refusal.STATE_AHEAD_OF_MIGRATOR
+
+
+def test_a_manifest_expecting_older_state_than_is_on_disk_refuses(tmp_path):
+    seed, public = _keypair()
+    artifact = _artifact(tmp_path)
+    document = _document(artifact, seed, state_versions={"conversation_db": 2})
+    outcome = _verify(document, artifact, public)
+    assert not outcome.ok
+    assert outcome.refusal is m.Refusal.STATE_DOWNGRADE
+
+
+def test_a_manifest_naming_a_store_this_build_has_never_heard_of_refuses(tmp_path):
+    seed, public = _keypair()
+    artifact = _artifact(tmp_path)
+    document = _document(artifact, seed, state_versions={"ledger_of_the_future": 1})
+    outcome = _verify(document, artifact, public)
+    assert not outcome.ok
+    assert outcome.refusal is m.Refusal.UNKNOWN_STORE
+
+
+# --- the shipped trust store ---------------------------------------------
+
+
+def test_no_signing_key_is_shipped_yet_so_nothing_verifies_in_production(tmp_path):
+    """A tripwire, not a preference.
+
+    Sourcecado ships no update signing key, because no authorized Apple or
+    Sourcecado identity has been issued yet. The trust store is therefore empty
+    and every real manifest is refused. When a key is added, this test goes red
+    and whoever added it must say so here.
+    """
+    assert m.TRUSTED_KEYS == {}
+    seed, public = _keypair()
+    artifact = _artifact(tmp_path)
+    outcome = m.verify_manifest(
+        _document(artifact, seed), installed=_installed(), artifact_path=artifact
+    )
+    assert not outcome.ok
+    assert outcome.refusal is m.Refusal.UNTRUSTED_KEY
+
+
+def test_registry_state_versions_reads_the_migration_registry():
+    versions = m.registry_state_versions()
+    from coworker import migrations
+
+    assert versions == {
+        spec.store_id: spec.current_version for spec in migrations.REGISTRY
+    }
+    assert versions["people_db"] >= 1
+
+
+# --- canonical bytes -----------------------------------------------------
+
+
+def test_key_order_does_not_change_what_was_signed(tmp_path):
+    seed, public = _keypair()
+    artifact = _artifact(tmp_path)
+    document = _document(artifact, seed)
+    shuffled = dict(reversed(list(document["signed"].items())))
+    assert m.canonical_bytes(shuffled) == m.canonical_bytes(document["signed"])
+    document["signed"] = shuffled
+    assert _verify(document, artifact, public).ok
+
+
+def test_canonical_bytes_are_domain_separated(tmp_path):
+    artifact = _artifact(tmp_path)
+    signed = _signed(artifact)
+    assert m.canonical_bytes(signed).startswith(m.SIGNING_CONTEXT)
+    assert json.loads(
+        m.canonical_bytes(signed)[len(m.SIGNING_CONTEXT) + 1 :].decode("utf-8")
+    ) == signed

--- a/desktop/tests/test_update_secrets.py
+++ b/desktop/tests/test_update_secrets.py
@@ -1,0 +1,282 @@
+"""Criterion 7: the four surfaces an update can leak a credential through.
+
+Artifacts, logs, manifests, and diagnostic bundles. The manifest is the new one
+and the most likely to leak, because it is assembled from build metadata --
+a commit, a file name, whatever a workflow passes -- and build metadata is
+exactly where a runner path or a pasted token ends up.
+
+Every test here plants a credential and then proves it did not arrive. The
+matcher is `coworker/bundle_redaction.py` in all four cases, because a second
+matcher drifts and the one that drifts is the one that misses.
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+import update_fixtures as fx  # noqa: E402
+from coworker import bundle_redaction  # noqa: E402
+from coworker.update_channel import UpdateStatus, apply_update  # noqa: E402
+from state_fixtures import (  # noqa: E402
+    PLANTED_API_KEY,
+    PLANTED_BEARER,
+    PLANTED_CANARIES,
+)
+
+KEY_ENV = "SOURCECADO_UPDATE_SIGNING_KEY"
+KEY_ID = "test-preview-2026"
+
+
+def _cli():
+    """Load packaging/update_manifest.py the way a workflow runs it."""
+    path = Path(__file__).resolve().parents[1] / "packaging" / "update_manifest.py"
+    spec = importlib.util.spec_from_file_location("sourcecado_update_manifest", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def signing_key(monkeypatch):
+    private = Ed25519PrivateKey.generate()
+    seed = private.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public = private.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
+    )
+    encoded = base64.b64encode(seed).decode("ascii")
+    monkeypatch.setenv(KEY_ENV, encoded)
+    return encoded, base64.b64encode(public).decode("ascii")
+
+
+def _generate_argv(artifact: Path, output: Path, **overrides) -> list[str]:
+    fields = {
+        "--artifact": str(artifact),
+        "--output": str(output),
+        "--version": "0.0.2",
+        "--minimum-from": "0.0.1",
+        "--released-at": "2026-08-27T12:00:00+00:00",
+        "--commit": "0" * 40,
+        "--key-id": KEY_ID,
+    }
+    fields.update(overrides)
+    argv = ["generate"]
+    for name, value in fields.items():
+        argv += [name, str(value)]
+    return argv
+
+
+# --- surface 1: the manifest ---------------------------------------------
+
+
+def test_a_credential_in_build_metadata_never_reaches_a_manifest(
+    tmp_path, signing_key, capsys
+):
+    cli = _cli()
+    artifact = fx.artifact(tmp_path, version="0.0.2")
+    output = tmp_path / "update.json"
+
+    code = cli.main(_generate_argv(artifact, output, **{"--commit": PLANTED_API_KEY}))
+
+    assert code == cli.EXIT_LEAK
+    assert not output.exists(), "a manifest that matched the scan was written anyway"
+    error = capsys.readouterr().err
+    assert "issued_credential" in error
+    assert PLANTED_API_KEY not in error, "the refusal repeated the value it caught"
+
+
+def test_a_home_path_in_build_metadata_never_reaches_a_manifest(
+    tmp_path, signing_key, capsys
+):
+    cli = _cli()
+    artifact = fx.artifact(tmp_path, version="0.0.2")
+    output = tmp_path / "update.json"
+
+    code = cli.main(
+        _generate_argv(
+            artifact,
+            output,
+            **{"--artifact-name": "/Users/releasebot/build/Sourcecado.zip"},
+        )
+    )
+
+    assert code == cli.EXIT_LEAK
+    assert not output.exists()
+    assert "home_path" in capsys.readouterr().err
+
+
+def test_the_signing_key_itself_cannot_be_copied_into_a_manifest(
+    tmp_path, signing_key, capsys
+):
+    """The registered scan catches the build's own environment, not just patterns."""
+    cli = _cli()
+    encoded, _public = signing_key
+    artifact = fx.artifact(tmp_path, version="0.0.2")
+    output = tmp_path / "update.json"
+
+    code = cli.main(_generate_argv(artifact, output, **{"--commit": encoded}))
+
+    assert code == cli.EXIT_LEAK
+    assert not output.exists()
+    error = capsys.readouterr().err
+    assert "registered_secret" in error
+    assert encoded not in error
+
+
+def test_a_clean_manifest_is_written_and_then_verifies(tmp_path, signing_key, capsys):
+    cli = _cli()
+    _encoded, public = signing_key
+    artifact = fx.artifact(tmp_path, version="0.0.2")
+    output = tmp_path / "update.json"
+
+    assert cli.main(_generate_argv(artifact, output)) == cli.EXIT_OK
+    assert output.is_file()
+
+    code = cli.main(
+        [
+            "verify",
+            "--manifest",
+            str(output),
+            "--artifact",
+            str(artifact),
+            "--installed-version",
+            "0.0.1",
+            "--trust",
+            f"{KEY_ID}={public}",
+        ]
+    )
+    assert code == cli.EXIT_OK
+    assert "OK" in capsys.readouterr().out
+
+
+def test_a_written_manifest_passes_the_bundle_scan(tmp_path, signing_key):
+    cli = _cli()
+    artifact = fx.artifact(tmp_path, version="0.0.2")
+    output = tmp_path / "update.json"
+    assert cli.main(_generate_argv(artifact, output)) == cli.EXIT_OK
+
+    matches = bundle_redaction.scan_text(
+        output.read_text(encoding="utf-8"),
+        registered=PLANTED_CANARIES,
+        home=tmp_path / "home",
+        state_root=tmp_path / "state",
+        location="update.json",
+    )
+    assert matches == ()
+
+
+# --- surface 2: the artifact and what ships beside it --------------------
+
+
+def test_a_credential_in_an_attestation_file_stops_the_manifest(
+    tmp_path, signing_key, capsys
+):
+    cli = _cli()
+    artifact = fx.artifact(tmp_path, version="0.0.2")
+    provenance = tmp_path / "provenance.txt"
+    provenance.write_text(
+        f"commit: abc123\nrunner_token: {PLANTED_BEARER}\n", encoding="utf-8"
+    )
+    output = tmp_path / "update.json"
+
+    code = cli.main(
+        _generate_argv(artifact, output) + ["--attest", str(provenance)]
+    )
+
+    assert code == cli.EXIT_LEAK
+    assert not output.exists()
+    error = capsys.readouterr().err
+    assert "artifact:provenance.txt" in error
+    assert PLANTED_BEARER not in error
+
+
+def test_a_clean_attestation_file_does_not_stop_the_manifest(tmp_path, signing_key):
+    cli = _cli()
+    artifact = fx.artifact(tmp_path, version="0.0.2")
+    provenance = tmp_path / "provenance.txt"
+    provenance.write_text("commit: abc123\nrunner: macOS 15 arm64\n", encoding="utf-8")
+    output = tmp_path / "update.json"
+
+    code = cli.main(_generate_argv(artifact, output) + ["--attest", str(provenance)])
+    assert code == cli.EXIT_OK
+
+
+# --- surface 3: what the updater tells the operator -----------------------
+
+
+def _rolled_back_with(tmp_path, message: str):
+    seed, public = fx.keypair()
+    artifact = fx.artifact(tmp_path, version="0.0.2")
+    install = fx.installation(tmp_path, version="0.0.1")
+    fx.app_tree(install.bundle_path.parent, version="0.0.1")
+
+    def explode(_installation):
+        raise RuntimeError(message)
+
+    return apply_update(
+        fx.document(artifact, seed),
+        installation=install,
+        artifact_path=artifact,
+        trust=fx.trust(public),
+        runs=None,
+        health_check=explode,
+        drain_timeout=0.0,
+        sleep=lambda _: None,
+    )
+
+
+def test_a_credential_in_a_failure_message_is_withheld_from_guidance(tmp_path):
+    outcome = _rolled_back_with(
+        tmp_path, f"the sidecar rejected X-Club-Token: {PLANTED_API_KEY}"
+    )
+
+    assert outcome.status is UpdateStatus.ROLLED_BACK
+    assert PLANTED_API_KEY not in outcome.guidance
+    assert "withheld" in outcome.guidance
+    # The sentence the operator needs still survives the withholding.
+    assert "0.0.1" in outcome.guidance
+
+
+def test_a_home_path_in_a_failure_message_is_anchored_not_printed(tmp_path):
+    outcome = _rolled_back_with(
+        tmp_path, "could not execute /Users/operator/Library/Sourcecado/sidecar"
+    )
+    assert "/Users/operator" not in outcome.guidance
+    assert "<home>" in outcome.guidance
+
+
+# --- surface 4: what a diagnostic bundle could pick up --------------------
+
+
+def test_the_whole_update_outcome_passes_the_scan_a_bundle_would_apply(tmp_path):
+    outcome = _rolled_back_with(
+        tmp_path, f"the sidecar rejected X-Club-Token: {PLANTED_API_KEY}"
+    )
+
+    matches = bundle_redaction.scan(
+        outcome.to_dict(),
+        registered=PLANTED_CANARIES,
+        home=Path("/Users/operator"),
+        state_root=tmp_path / "state",
+        location="update",
+    )
+    assert matches == (), f"an update outcome would refuse a bundle: {matches}"
+
+
+def test_the_outcome_is_plain_json_so_a_bundle_can_carry_it(tmp_path):
+    outcome = _rolled_back_with(tmp_path, "the sidecar exited immediately")
+    assert json.loads(json.dumps(outcome.to_dict()))["status"] == "rolled_back"

--- a/desktop/tests/update_fixtures.py
+++ b/desktop/tests/update_fixtures.py
@@ -1,0 +1,124 @@
+"""Shared scaffolding for the update-channel tests.
+
+Everything here builds a *real* update: a real Ed25519 keypair, a real zip of a
+real directory tree shaped like `Sourcecado.app`, and a real signed manifest
+over that artifact's actual digest. Nothing is stubbed at the boundary the
+production code checks, so a test that passes here would pass against a
+publisher's artifact.
+"""
+
+from __future__ import annotations
+
+import base64
+import shutil
+from pathlib import Path
+from typing import Any
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from coworker.update_channel import manifest as m
+from coworker.update_channel.apply import Installation
+
+KEY_ID = "test-preview-2026"
+PRODUCT = "sourcecado"
+SIDECAR_RELATIVE = "Contents/Resources/resources/sourcecado-sidecar/sourcecado-sidecar"
+
+
+def keypair() -> tuple[bytes, str]:
+    private = Ed25519PrivateKey.generate()
+    seed = private.private_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PrivateFormat.Raw,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    public = private.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw, format=serialization.PublicFormat.Raw
+    )
+    return seed, base64.b64encode(public).decode("ascii")
+
+
+def trust(public_b64: str, channel: str = str(m.Channel.PREVIEW)) -> dict:
+    return {str(channel): {KEY_ID: public_b64}}
+
+
+def app_tree(root: Path, *, version: str, sidecar: str | None = None) -> Path:
+    """A directory shaped like the packaged app, with a readable version marker."""
+    bundle = root / "Sourcecado.app"
+    contents = bundle / "Contents"
+    (contents / "MacOS").mkdir(parents=True, exist_ok=True)
+    (contents / "Info.plist").write_text(
+        "<plist><dict><key>CFBundleShortVersionString</key>"
+        f"<string>{version}</string></dict></plist>",
+        encoding="utf-8",
+    )
+    (contents / "MacOS" / "Sourcecado").write_text(f"binary {version}", encoding="utf-8")
+    if sidecar is not None:
+        path = bundle / SIDECAR_RELATIVE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(sidecar, encoding="utf-8")
+        path.chmod(0o755)
+    return bundle
+
+
+def artifact(tmp_path: Path, *, version: str, sidecar: str | None = None) -> Path:
+    """Zip an app tree the way a publisher would, and return the archive path."""
+    staging = tmp_path / f"artifact-{version}"
+    staging.mkdir(parents=True, exist_ok=True)
+    app_tree(staging, version=version, sidecar=sidecar)
+    archive = shutil.make_archive(
+        str(tmp_path / f"Sourcecado-{version}-macos-aarch64"), "zip", root_dir=staging
+    )
+    return Path(archive)
+
+
+def identity(**overrides: Any) -> m.BuildIdentity:
+    fields = {
+        "product": PRODUCT,
+        "channel": str(m.Channel.PREVIEW),
+        "version": "0.0.1",
+        "platform": "macos",
+        "arch": "aarch64",
+        "state_versions": m.registry_state_versions(),
+    }
+    fields.update(overrides)
+    return m.BuildIdentity(**fields)
+
+
+def installation(tmp_path: Path, **overrides: Any) -> Installation:
+    bundle = overrides.pop("bundle_path", tmp_path / "Applications" / "Sourcecado.app")
+    state = overrides.pop("state_root", tmp_path / "state")
+    Path(bundle).parent.mkdir(parents=True, exist_ok=True)
+    return Installation(
+        identity=identity(**overrides), bundle_path=Path(bundle), state_root=Path(state)
+    )
+
+
+def document(artifact_path: Path, seed: bytes, **overrides: Any) -> dict:
+    fields = {
+        "product": PRODUCT,
+        "channel": str(m.Channel.PREVIEW),
+        "version": "0.0.2",
+        "platform": "macos",
+        "arch": "aarch64",
+        "artifact_name": artifact_path.name,
+        "artifact_size": artifact_path.stat().st_size,
+        "artifact_sha256": m.sha256_file(artifact_path),
+        "minimum_upgradable_version": "0.0.1",
+        "state_versions": m.registry_state_versions(),
+        "released_at": "2026-08-27T12:00:00+00:00",
+        "commit": "0" * 40,
+    }
+    fields.update(overrides)
+    return m.sign_manifest(m.build_manifest(**fields), seed=seed, key_id=KEY_ID)
+
+
+def bundle_version(bundle: Path) -> str | None:
+    """Read the version marker out of an installed tree, or None if it is gone."""
+    plist = bundle / "Contents" / "Info.plist"
+    if not plist.is_file():
+        return None
+    text = plist.read_text(encoding="utf-8")
+    start = text.find("<string>")
+    end = text.find("</string>")
+    return text[start + len("<string>") : end] if 0 <= start < end else None


### PR DESCRIPTION
Addresses seven of nine criteria in #77. **The two requiring Apple credentials are authored but unrun** — see the end. This does not close the issue.

## Domain words

- **Manifest** — the signed metadata describing an update: version, platform, architecture, checksum, signature.
- **Drain** — waiting for active work to finish before applying an update.
- **Unsettled effect** — an external action that was dispatched but whose outcome is not yet known.

## Problem

There was no update path. There was also no safe one available by default: the natural implementation is *stop the app, swap the bundle, restart*, and that is dangerous here.

## Criterion 3 is the one that could cause real harm

If a run has dispatched a Gmail send and does not yet know the outcome, killing the process makes that outcome permanently ambiguous — and a restart that "resumes" it can send a **second real email to a real person**. The #63 fence exists so that state is quarantined for a human to settle.

So an update must never turn a resolvable situation into an ambiguous one, **and must never resolve an existing ambiguity by retrying**. Both halves are tested:

| Test | Proves |
|---|---|
| `test_a_dispatched_send_with_no_outcome_stops_the_update` | The update does not proceed |
| `test_waiting_on_an_unsettled_send_never_quarantines_it` | It also does not resolve it — the state is left exactly as found |
| `test_waiting_gives_up_and_refuses_rather_than_forcing` | On timeout it refuses; it never forces |
| `test_a_run_a_live_owner_is_working_makes_the_update_wait` | A live `flock`-holding owner blocks |
| `test_a_run_parked_on_a_person_is_restart_safe_and_does_not_block` | Waiting-for-a-human is not "active work" |
| `test_a_crashed_run_with_no_external_effect_is_restart_safe` | A crash with nothing dispatched does not block |
| `test_waiting_clears_once_the_dispatching_process_reports` | It unblocks correctly, so this is not a permanent stall |

The distinction in rows 5 and 6 matters: an update that blocked on *any* incomplete run would never apply, and an update that blocked on *none* would be unsafe. Only an unsettled external effect is a reason to stop.

## Composed, not rebuilt

This issue sits on top of most of the sprint, and reusing rather than duplicating was the design constraint:

| Criterion | Delegates to |
|---|---|
| 2 — state compatibility and backup | `migrations.py` (#73) — its registry already does versioning, backup, rollback, and fail-closed |
| 3 — never replay an ambiguous effect | `agent_run_approval.py` / `agent_run_resume.py` (#63 slices 3–4) |
| 7 — no credential in any artifact | `bundle_redaction.py` (#75) — one matcher, not a second that could drift |

## Criterion 7: four surfaces, and the manifest is the new one

Artifacts, logs, manifests, and diagnostic bundles. The bundle already fails closed (#75). The **manifest** is new and the most likely to leak, because it is generated from build metadata that can carry paths, environment, or CI variables.

| Test | Attacks |
|---|---|
| `test_a_credential_in_build_metadata_never_reaches_a_manifest` | The obvious path |
| `test_a_home_path_in_build_metadata_never_reaches_a_manifest` | `/Users/<name>/…` identifies a real person |
| `test_the_signing_key_itself_cannot_be_copied_into_a_manifest` | The worst case |
| `test_a_credential_in_an_attestation_file_stops_the_manifest` | Fails closed on upstream input |
| `test_a_credential_in_a_failure_message_is_withheld_from_guidance` | Error paths, which are usually forgotten |
| `test_a_written_manifest_passes_the_bundle_scan` | End-to-end against #75's scanner |

`test_a_clean_attestation_file_does_not_stop_the_manifest` is the control — a checker that refuses everything is useless.

## Mutations use explicit control/mutant pairs

`test_update_channel_mutations.py` pairs each mutation with a control that proves the guard holds first, so a mutant "caught" by an already-broken test cannot be mistaken for evidence:

```
test_control_the_digest_guard_holds
test_mutant_a_manifest_that_verifies_a_wrong_digest_is_caught
test_control_the_drain_gate_holds
test_mutant_an_update_that_proceeds_during_an_unsettled_effect_is_caught
test_mutant_a_gate_that_only_misreads_the_effect_is_still_caught
test_control_the_rollback_guard_holds
```

The third mutant is the subtle one: a gate that reads the effect state *wrongly* rather than skipping the check entirely is still caught.

## Measurements

```
1723 passed, 3 skipped, 1 warning in 66.63s
 Test Files  53 passed (53)
      Tests  476 passed (476)
tsc --noEmit && vite build   clean
```

Skip count held at 3 — the pre-existing environmental ones. Re-run independently by the reviewing session on the pushed commit.

## NOT DONE: the two criteria needing Apple credentials

1. **Fisher provides or selects the authorized Apple signing/notarization identity through protected CI secrets.**
2. **Preview builds are signed, notarized, stapled, and independently verified before publication.**

The CI steps are **written** so that supplying the identity is the only remaining action. They have not run, and no build produced here is signed or notarized. Do not read the green checks as evidence of either.

#77 should stay open until those are done.

## Boundary

`migrations.py`, `doctor.py`, `bundle_redaction.py`, `diagnostic_bundle.py`, the `agent_run_*` modules, `turn.py`, `store.py`, `server.py`, `people.py`, `permissions.py`, `run_ledger*`, `compaction.py`, and every connector module are called and never modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjAD6SVox1gvF4sV3jTnJy
