### PR TITLE
feat(desktop): activate bounded context projection for saved memory

### DIFF
--- a/desktop/coworker/context_projection.py
+++ b/desktop/coworker/context_projection.py
@@ -1,7 +1,10 @@
-"""Inactive proposal contract for bounded Sourcecado context projection.
+"""The approved contract for bounded Sourcecado context projection.
 
-The active prompt runtime does not import this module. Category rules and store
-adapters remain subject to Fisher's issue #58 approval.
+The active prompt runtime imports this module. `brief.py` builds the person-file
+section from it (#70), and `server.py` builds the saved-memory section from it
+under the `context-projection-v1` category rules Fisher approved on issue #58.
+A change to selection, bounding, or scope-mismatch behaviour here changes what
+the model sees on the next request.
 """
 
 from __future__ import annotations

--- a/desktop/coworker/migrations.py
+++ b/desktop/coworker/migrations.py
@@ -436,6 +436,22 @@ _CONVERSATION_ADDED_TABLES = {
     """,
 }
 
+# The context-projection-v1 metadata a memory row needs (issue #58): its
+# category, its scope, its Source Reference, when it changed, its freshness
+# window, its sensitivity, and the claim it competes on. Restated here because
+# the registry, not the constructor, is the release contract for version 2.
+_MEMORY_CLASSIFICATION_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("category", "TEXT"),
+    ("classification_status", "TEXT"),
+    ("person_id", "TEXT"),
+    ("session_id", "TEXT"),
+    ("source_ref", "TEXT"),
+    ("updated_at", "TEXT"),
+    ("fresh_until", "TEXT"),
+    ("sensitivity", "TEXT"),
+    ("claim_key", "TEXT"),
+)
+
 _PEOPLE_ADDED_COLUMNS: tuple[tuple[str, str, str], ...] = (
     ("people", "version", "INTEGER NOT NULL DEFAULT 1"),
     ("people", "outcome", "TEXT"),
@@ -556,6 +572,60 @@ def _count_conversation_db(context: MigrationContext) -> int:
     return _sqlite_adoption_count(
         context, _CONVERSATION_ADDED_COLUMNS, _CONVERSATION_ADDED_TABLES
     )
+
+
+def _count_memory_classification(context: MigrationContext) -> int:
+    """How many memory rows still have no classification of their own."""
+    conn = context.connection
+    assert conn is not None
+    if "memories" not in table_names(conn):
+        return 0
+    if "classification_status" not in column_names(conn, "memories"):
+        return _row_count(conn, "memories")
+    return int(
+        conn.execute(
+            "SELECT COUNT(*) FROM memories WHERE classification_status IS NULL"
+        ).fetchone()[0]
+    )
+
+
+def _classify_legacy_memories(context: MigrationContext) -> int:
+    """Move every memory row written before context-projection-v1 to review.
+
+    The category is assigned by where the row came from, never by what it says.
+    A row worded like a global preference and a row stating a fact about one
+    Person are indistinguishable as text, so both land in `legacy_unclassified`
+    with `classification_status = needs_review` and stay out of model context
+    until the director says which is which.
+
+    Ids, content, and `created_at` are untouched, and `MEMORY.md` and the
+    per-row Markdown files are left exactly as they are.
+
+    Executed one statement at a time, never through `executescript`, which
+    issues a COMMIT before it runs. Inside the transaction `_apply_store` opens,
+    that COMMIT would end the transaction and leave the rollback with nothing to
+    undo -- silently, and with the store half migrated.
+    """
+    conn = context.connection
+    assert conn is not None
+    touched = _count_memory_classification(context)
+    present = column_names(conn, "memories")
+    for column, definition in _MEMORY_CLASSIFICATION_COLUMNS:
+        if column in present:
+            continue
+        conn.execute(f"ALTER TABLE memories ADD COLUMN {column} {definition}")
+    conn.execute(
+        """
+        UPDATE memories SET
+            category = 'legacy_unclassified',
+            classification_status = 'needs_review',
+            source_ref = 'sourcecado:memory/' || id,
+            updated_at = COALESCE(updated_at, created_at),
+            sensitivity = COALESCE(sensitivity, 'standard')
+        WHERE classification_status IS NULL
+        """
+    )
+    return touched
 
 
 def _adopt_people_db(context: MigrationContext) -> int:
@@ -757,6 +827,19 @@ REGISTRY: tuple[StoreSpec, ...] = (
             "Adopt the conversation schema shipped before the registry existed.",
             _count_conversation_db,
             _adopt_conversation_db,
+        )
+        + (
+            Migration(
+                from_version=1,
+                to_version=2,
+                description=(
+                    "Give every memory row a category, a scope, a Source "
+                    "Reference, and a freshness window, and withhold the "
+                    "unclassified ones from model context."
+                ),
+                count=_count_memory_classification,
+                apply=_classify_legacy_memories,
+            ),
         ),
         json_columns=(
             ("inbox", "arguments"),

--- a/desktop/coworker/server.py
+++ b/desktop/coworker/server.py
@@ -55,6 +55,10 @@ from coworker.connectors.google_oauth import (
     merge_scopes,
     save_google,
 )
+from coworker.context_projection import (
+    ProjectionIdentity,
+    prepare_context_projection,
+)
 from coworker.diagnostic_bundle import (
     HEALTH_WINDOW_RUNS,
     BundleScanFailed,
@@ -118,7 +122,11 @@ from coworker.provider_retry import verified_provider_chain
 from coworker.run_ledger import RunLedger
 from coworker.run_ledger_api import run_ledger_router
 from coworker.secrets import SecretStore
-from coworker.store import ConversationStore, valid_session_id
+from coworker.store import (
+    MEMORY_CATEGORY_PREFERENCE,
+    ConversationStore,
+    valid_session_id,
+)
 from coworker.telemetry import (
     AgentTurnSpan,
     ErrorKind,
@@ -174,6 +182,35 @@ def _bounded_context(text: str, budget_chars: int) -> str:
     return text if len(text) <= budget_chars else text[:budget_chars]
 
 
+def _saved_memory_body(
+    store: ConversationStore,
+    *,
+    identity: ProjectionIdentity,
+    budget_chars: int,
+) -> str:
+    """The classified operator preferences, under context-projection-v1.
+
+    Two caps apply and the first one reached wins: the approved 256-token
+    operator-preference category budget, with no borrowing from another
+    category, and the existing character envelope for this section. Selection
+    is whole items in both cases, so a preference is never cut in half and its
+    Source Reference is never cut off (issue #58).
+    """
+    candidates = store.memory_projection_items()
+    if not candidates:
+        return ""
+    projection = prepare_context_projection(identity=identity, items=candidates)
+    lines: list[str] = []
+    used = 0
+    for item in projection.items:
+        extra = len(item.text) + (1 if lines else 0)
+        if used + extra > budget_chars:
+            break
+        lines.append(item.text)
+        used += extra
+    return "\n".join(lines)
+
+
 def system_prompt_assembly(
     store: ConversationStore,
     persona: Persona | None = None,
@@ -184,16 +221,26 @@ def system_prompt_assembly(
 ) -> AssembledSystemPrompt:
     definition = _runtime_prompt_definition(persona)
     dynamic: list[PromptSection] = []
-    items = store.list_memories()
-    if items:
-        memory = "\n".join(f"[#{item['id']}] {item['content']}" for item in items)
-        dynamic.append(
-            PromptSection(
-                "saved_memory",
-                "Saved memory",
-                _bounded_context(memory, 4_000),
-            )
-        )
+    bound_person_id: str | None = None
+    bound_person: dict[str, Any] | None = None
+    if people is not None and session_id:
+        bound_person_id = people.person_for_session(session_id)
+        if bound_person_id is not None:
+            bound_person = people.get(bound_person_id)
+    memory = _saved_memory_body(
+        store,
+        identity=ProjectionIdentity(
+            persona_id=persona.id if persona is not None else "sourcing",
+            session_id=session_id or "",
+            person_id=bound_person_id if bound_person is not None else None,
+            target=(bound_person or {}).get("target"),
+            prompt_version=definition.version,
+            effective_tools_hash="",
+        ),
+        budget_chars=definition.dynamic_budgets["saved_memory"],
+    )
+    if memory:
+        dynamic.append(PromptSection("saved_memory", "Saved memory", memory))
     if skills is not None:
         catalog = catalog_text(skills)
         if catalog:
@@ -204,23 +251,21 @@ def system_prompt_assembly(
                     _bounded_context(catalog, 3_000),
                 )
             )
-    if people is not None and session_id:
-        person_id = people.person_for_session(session_id)
-        if person_id is not None and people.get(person_id) is not None:
-            # The model reads the same bounded projection the person view
-            # renders. Assembling person facts here instead would be the
-            # second summary that silently drifts from the one a director
-            # reads (issue #70, criterion 6).
-            dynamic.append(
-                PromptSection(
-                    "person_file",
-                    "Person File context",
-                    prompt_context(
-                        person_brief(people, person_id, session_id=session_id),
-                        budget_chars=definition.dynamic_budgets["person_file"],
-                    ),
-                )
+    if people is not None and bound_person is not None and bound_person_id is not None:
+        # The model reads the same bounded projection the person view
+        # renders. Assembling person facts here instead would be the
+        # second summary that silently drifts from the one a director
+        # reads (issue #70, criterion 6).
+        dynamic.append(
+            PromptSection(
+                "person_file",
+                "Person File context",
+                prompt_context(
+                    person_brief(people, bound_person_id, session_id=session_id),
+                    budget_chars=definition.dynamic_budgets["person_file"],
+                ),
             )
+        )
     return assemble_system_prompt(
         definition=definition,
         dynamic_sections=tuple(dynamic),
@@ -1089,6 +1134,45 @@ def create_app(
     @app.get("/v1/skills")
     def skills():
         return {"skills": app.state.skills.catalog()}
+
+    @app.get("/v1/memory/classification")
+    def memory_classification():
+        """What the director still has to classify before it can be used again.
+
+        Migrating to context-projection-v1 withholds every memory row written
+        before the contract until it is classified, so this count is how a
+        director sees that Sourcecado has not lost anything -- it is waiting.
+        """
+        return app.state.store.memory_backlog()
+
+    @app.post("/v1/memory/{memory_id}/classification")
+    async def memory_classify(memory_id: int, request: Request):
+        payload = await request.json()
+        category = str(payload.get("category") or "").strip()
+        if category != MEMORY_CATEGORY_PREFERENCE:
+            return JSONResponse(
+                {
+                    "error": (
+                        "only a person-independent operator preference can be "
+                        "classified here"
+                    )
+                },
+                status_code=400,
+            )
+        claim_key = str(payload.get("claim_key") or "").strip() or None
+        try:
+            item = app.state.store.memory_classify(memory_id, claim_key=claim_key)
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        if item is None:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        return {"memory": item}
+
+    @app.delete("/v1/memory/{memory_id}")
+    def memory_delete(memory_id: int):
+        if not app.state.store.memory_forget(memory_id):
+            return JSONResponse({"error": "not found"}, status_code=404)
+        return {"forgotten": True, "id": memory_id}
 
     @app.get("/v1/settings")
     def settings():

--- a/desktop/coworker/store.py
+++ b/desktop/coworker/store.py
@@ -12,12 +12,115 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
+from coworker.context_projection import (
+    ContextAuthority,
+    ContextCategory,
+    ContextSensitivity,
+    ContextSourceRef,
+    ContextState,
+    ProjectionItem,
+)
+
 _SID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 # Declared schema version for club.db and the transcript log, read by the
 # migration registry in coworker.migrations. Reporting only: this module
 # does not stamp or check it.
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 TRANSCRIPT_VERSION = 1
+
+# context-projection-v1 (issue #58). A memory row is model context only after
+# the director classifies it as a person-independent operator preference.
+# Everything else -- a row migrated from before the contract, and every new
+# ambiguous `remember` write -- waits for review and is withheld.
+MEMORY_CATEGORY_LEGACY = "legacy_unclassified"
+MEMORY_CATEGORY_UNCLASSIFIED = "unclassified"
+MEMORY_CATEGORY_PREFERENCE = "operator_preference"
+MEMORY_NEEDS_REVIEW = "needs_review"
+MEMORY_CLASSIFIED = "classified"
+MEMORY_SENSITIVITY_STANDARD = "standard"
+
+# The columns that carry that contract. They are added to an existing database
+# without a default on purpose: the registry step in coworker/migrations.py is
+# what writes every existing row to legacy_unclassified/needs_review, with a
+# backup taken first. A default here would do that work silently on the first
+# open and leave the registered migration with nothing left to migrate.
+_MEMORY_CONTEXT_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("category", "TEXT"),
+    ("classification_status", "TEXT"),
+    ("person_id", "TEXT"),
+    ("session_id", "TEXT"),
+    ("source_ref", "TEXT"),
+    ("updated_at", "TEXT"),
+    ("fresh_until", "TEXT"),
+    ("sensitivity", "TEXT"),
+    ("claim_key", "TEXT"),
+)
+
+_MEMORY_COLUMNS = "id, content, created_at, " + ", ".join(
+    column for column, _definition in _MEMORY_CONTEXT_COLUMNS
+)
+
+# Per-item cap for the operator-preference category in DEFAULT_PROJECTION_POLICY.
+# The adapter clips to it; the projector omits anything still over it.
+_MEMORY_ITEM_TOKENS = 64
+
+
+def projection_tokens(text: str) -> int:
+    """The versioned budget unit for context-projection-v1.
+
+    `ceil(len(utf-8 bytes) / 3)`: provider-independent and conservative. It is
+    an explicit budget unit, not a claim about any provider's billed tokens.
+    """
+    return -(-len(text.encode("utf-8")) // 3)
+
+
+def _memory_source_ref(memory_id: int) -> str:
+    return f"sourcecado:memory/{memory_id}"
+
+
+def _memory_source_ref_record(row: sqlite3.Row) -> ContextSourceRef:
+    return ContextSourceRef(
+        id=_memory_source_ref(row["id"]),
+        provider="sourcecado",
+        locator=f"memory/{row['id']}",
+        observed_at=row["created_at"],
+        modified_at=row["updated_at"],
+        fresh_until=row["fresh_until"],
+    )
+
+
+def _is_past(value: str | None, moment: datetime) -> bool:
+    if not value:
+        return False
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return False
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed <= moment
+
+
+def _memory_line(memory_id: int, excerpt: str, state: str) -> str:
+    return f"[#{memory_id}] {excerpt} ({_memory_source_ref(memory_id)}, {state})"
+
+
+def _clip_memory_line(row: sqlite3.Row, state: ContextState) -> tuple[str, bool]:
+    """Render one preference, clipped at a word boundary to the per-item cap.
+
+    The Source Reference and the evidence state are outside the clipped span,
+    so shortening an excerpt never cuts either in half.
+    """
+    line = _memory_line(row["id"], row["content"], state.value)
+    if projection_tokens(line) <= _MEMORY_ITEM_TOKENS:
+        return line, False
+    words = row["content"].split()
+    while words:
+        words.pop()
+        candidate = _memory_line(row["id"], " ".join(words) + "…", state.value)
+        if projection_tokens(candidate) <= _MEMORY_ITEM_TOKENS:
+            return candidate, True
+    return _memory_line(row["id"], "…", state.value), True
 _INTERRUPTED_APPROVAL_ERROR = (
     "Outcome is unknown after Sourcecado restarted. "
     "Verify the external resource before retrying."
@@ -116,7 +219,16 @@ class ConversationStore:
             CREATE TABLE IF NOT EXISTS memories (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 content TEXT NOT NULL,
-                created_at TEXT DEFAULT CURRENT_TIMESTAMP
+                created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+                category TEXT NOT NULL DEFAULT 'unclassified',
+                classification_status TEXT NOT NULL DEFAULT 'needs_review',
+                person_id TEXT,
+                session_id TEXT,
+                source_ref TEXT,
+                updated_at TEXT,
+                fresh_until TEXT,
+                sensitivity TEXT NOT NULL DEFAULT 'standard',
+                claim_key TEXT
             );
             CREATE TABLE IF NOT EXISTS jobs (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -196,6 +308,13 @@ class ConversationStore:
                 ON chat_queue(session_id, position);
             """
         )
+        for column, definition in _MEMORY_CONTEXT_COLUMNS:
+            try:
+                self._conn.execute(
+                    f"ALTER TABLE memories ADD COLUMN {column} {definition}"
+                )
+            except sqlite3.OperationalError:
+                pass
         try:
             self._conn.execute("ALTER TABLE jobs ADD COLUMN next_run_at TEXT")
         except sqlite3.OperationalError:
@@ -631,15 +750,52 @@ class ConversationStore:
             self._conn.commit()
         self.set_setting("open_session_id", sid)
 
-    def remember(self, content: str) -> dict[str, Any]:
+    def remember(
+        self,
+        content: str,
+        *,
+        person_id: str | None = None,
+        session_id: str | None = None,
+        sensitivity: str = MEMORY_SENSITIVITY_STANDARD,
+        fresh_until: str | None = None,
+    ) -> dict[str, Any]:
+        """Save a memory row. It is never model context until classified.
+
+        A write becomes a global operator preference only when the director
+        explicitly asks for one, which is `memory_classify`. Nothing here reads
+        the content to guess a category: a row saying "prefer short drafts" and
+        a row saying "Ada moved to Analytic" both land in the same waiting
+        state, because the words alone cannot tell them apart.
+        """
+        now = datetime.now(UTC).isoformat()
         with self._lock:
             cursor = self._conn.execute(
-                "INSERT INTO memories (content) VALUES (?)", (content,)
+                """
+                INSERT INTO memories
+                    (content, category, classification_status, person_id,
+                     session_id, updated_at, fresh_until, sensitivity)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    content,
+                    MEMORY_CATEGORY_UNCLASSIFIED,
+                    MEMORY_NEEDS_REVIEW,
+                    person_id,
+                    session_id,
+                    now,
+                    fresh_until,
+                    sensitivity,
+                ),
+            )
+            memory_id = cursor.lastrowid
+            self._conn.execute(
+                "UPDATE memories SET source_ref = ? WHERE id = ?",
+                (_memory_source_ref(memory_id), memory_id),
             )
             self._conn.commit()
             row = self._conn.execute(
-                "SELECT id, content, created_at FROM memories WHERE id = ?",
-                (cursor.lastrowid,),
+                f"SELECT {_MEMORY_COLUMNS} FROM memories WHERE id = ?",
+                (memory_id,),
             ).fetchone()
         item = dict(row)
         self._write_memory_md(item)
@@ -649,20 +805,40 @@ class ConversationStore:
     def list_memories(self) -> list[dict[str, Any]]:
         with self._lock:
             rows = self._conn.execute(
-                "SELECT id, content, created_at FROM memories ORDER BY id"
+                f"SELECT {_MEMORY_COLUMNS} FROM memories ORDER BY id"
             ).fetchall()
         return [dict(row) for row in rows]
 
     def memory_update(self, memory_id: int, content: str) -> dict[str, Any] | None:
+        """Rewrite a memory's content, which sends it back for review.
+
+        Rewritten text is text the director has not classified. Keeping the old
+        classification would let a rewrite change model context without anyone
+        approving what it now says.
+        """
         with self._lock:
             cursor = self._conn.execute(
-                "UPDATE memories SET content = ? WHERE id = ?", (content, memory_id)
+                """
+                UPDATE memories SET
+                    content = ?,
+                    category = ?,
+                    classification_status = ?,
+                    updated_at = ?
+                WHERE id = ?
+                """,
+                (
+                    content,
+                    MEMORY_CATEGORY_UNCLASSIFIED,
+                    MEMORY_NEEDS_REVIEW,
+                    datetime.now(UTC).isoformat(),
+                    memory_id,
+                ),
             )
             self._conn.commit()
             if cursor.rowcount == 0:
                 return None
             row = self._conn.execute(
-                "SELECT id, content, created_at FROM memories WHERE id = ?",
+                f"SELECT {_MEMORY_COLUMNS} FROM memories WHERE id = ?",
                 (memory_id,),
             ).fetchone()
         if row is None:
@@ -671,6 +847,136 @@ class ConversationStore:
         self._write_memory_md(item)
         self._write_memory_index()
         return item
+
+    def memory_classify(
+        self, memory_id: int, *, claim_key: str | None = None
+    ) -> dict[str, Any] | None:
+        """Record the director's explicit decision that a row is a preference.
+
+        Refuses a row that carries a Person or session scope. A fact about one
+        Person belongs on that Person File through the existing Board contract,
+        and promoting it here is exactly the silent widening the migration
+        default exists to prevent.
+        """
+        with self._lock:
+            row = self._conn.execute(
+                f"SELECT {_MEMORY_COLUMNS} FROM memories WHERE id = ?",
+                (memory_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            if row["person_id"] or row["session_id"]:
+                raise ValueError(
+                    "a Person- or session-scoped memory cannot become a global "
+                    "operator preference; file it on the Person File instead"
+                )
+            self._conn.execute(
+                """
+                UPDATE memories SET
+                    category = ?,
+                    classification_status = ?,
+                    claim_key = ?,
+                    source_ref = ?,
+                    updated_at = ?
+                WHERE id = ?
+                """,
+                (
+                    MEMORY_CATEGORY_PREFERENCE,
+                    MEMORY_CLASSIFIED,
+                    claim_key,
+                    _memory_source_ref(memory_id),
+                    datetime.now(UTC).isoformat(),
+                    memory_id,
+                ),
+            )
+            self._conn.commit()
+            updated = self._conn.execute(
+                f"SELECT {_MEMORY_COLUMNS} FROM memories WHERE id = ?",
+                (memory_id,),
+            ).fetchone()
+        return dict(updated)
+
+    def memory_backlog(self) -> dict[str, Any]:
+        """What the director still has to classify, and what is already live."""
+        with self._lock:
+            rows = self._conn.execute(
+                f"SELECT {_MEMORY_COLUMNS} FROM memories ORDER BY id"
+            ).fetchall()
+        waiting = [
+            dict(row)
+            for row in rows
+            if (row["classification_status"] or MEMORY_NEEDS_REVIEW)
+            != MEMORY_CLASSIFIED
+        ]
+        return {
+            "needs_review": len(waiting),
+            "classified": len(rows) - len(waiting),
+            "items": waiting,
+        }
+
+    def memory_projection_items(
+        self, *, now: datetime | None = None
+    ) -> tuple[ProjectionItem, ...]:
+        """The classified operator preferences, as already-scoped projection items.
+
+        Eligibility is decided in SQL before any ranking: unclassified rows,
+        Person- or session-scoped rows, and restricted rows never leave this
+        method, so they cannot reach a prompt.
+        """
+        moment = now or datetime.now(UTC)
+        with self._lock:
+            rows = self._conn.execute(
+                f"""
+                SELECT {_MEMORY_COLUMNS} FROM memories
+                WHERE classification_status = ?
+                  AND category = ?
+                  AND person_id IS NULL
+                  AND session_id IS NULL
+                  AND COALESCE(sensitivity, ?) = ?
+                ORDER BY id
+                """,
+                (
+                    MEMORY_CLASSIFIED,
+                    MEMORY_CATEGORY_PREFERENCE,
+                    MEMORY_SENSITIVITY_STANDARD,
+                    MEMORY_SENSITIVITY_STANDARD,
+                ),
+            ).fetchall()
+        contested: dict[str, list[sqlite3.Row]] = {}
+        for row in rows:
+            if row["claim_key"]:
+                contested.setdefault(row["claim_key"], []).append(row)
+        items: list[ProjectionItem] = []
+        for row in rows:
+            group = contested.get(row["claim_key"] or "", [])
+            conflicting = len(group) > 1
+            if conflicting:
+                state = ContextState.CONFLICTING
+            elif _is_past(row["fresh_until"], moment):
+                state = ContextState.STALE
+            else:
+                state = ContextState.CURRENT
+            refs = tuple(
+                _memory_source_ref_record(member)
+                for member in (group if conflicting else [row])
+            )
+            text, truncated = _clip_memory_line(row, state)
+            items.append(
+                ProjectionItem(
+                    id=f"memory:{row['id']}",
+                    category=ContextCategory.OPERATOR_PREFERENCE,
+                    text=text,
+                    tokens=projection_tokens(text),
+                    state=state,
+                    authority=ContextAuthority.DIRECTOR,
+                    updated_at=row["updated_at"] or row["created_at"],
+                    source_refs=refs,
+                    claim_key=row["claim_key"],
+                    truncated=truncated,
+                    sensitivity=ContextSensitivity.STANDARD,
+                )
+            )
+        return tuple(items)
 
     def add_job(
         self,

--- a/desktop/coworker/store.py
+++ b/desktop/coworker/store.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any
 
 from coworker.context_projection import (
+    DEFAULT_PROJECTION_POLICY,
     ContextAuthority,
     ContextCategory,
     ContextSensitivity,
@@ -30,9 +31,9 @@ TRANSCRIPT_VERSION = 1
 
 # context-projection-v1 (issue #58). A memory row is model context only after
 # the director classifies it as a person-independent operator preference.
-# Everything else -- a row migrated from before the contract, and every new
-# ambiguous `remember` write -- waits for review and is withheld.
-MEMORY_CATEGORY_LEGACY = "legacy_unclassified"
+# Everything else waits for review and is withheld: a new ambiguous `remember`
+# write as "unclassified", and a row migrated from before the contract as
+# "legacy_unclassified", which coworker/migrations.py writes.
 MEMORY_CATEGORY_UNCLASSIFIED = "unclassified"
 MEMORY_CATEGORY_PREFERENCE = "operator_preference"
 MEMORY_NEEDS_REVIEW = "needs_review"
@@ -60,9 +61,13 @@ _MEMORY_COLUMNS = "id, content, created_at, " + ", ".join(
     column for column, _definition in _MEMORY_CONTEXT_COLUMNS
 )
 
-# Per-item cap for the operator-preference category in DEFAULT_PROJECTION_POLICY.
-# The adapter clips to it; the projector omits anything still over it.
-_MEMORY_ITEM_TOKENS = 64
+# Read from the approved policy rather than restated, so the adapter clips to
+# exactly the cap the projector enforces and the two cannot drift apart.
+_MEMORY_ITEM_TOKENS = next(
+    budget.max_item_tokens
+    for budget in DEFAULT_PROJECTION_POLICY.category_budgets
+    if budget.category is ContextCategory.OPERATOR_PREFERENCE
+)
 
 
 def projection_tokens(text: str) -> int:

--- a/desktop/docs/context-projection.md
+++ b/desktop/docs/context-projection.md
@@ -1,0 +1,118 @@
+# Bounded context projection
+
+Status: active-stack engineering reference for issue #58.
+
+Fisher approved `context-projection-v1` on 2026-08-27. The packet is
+`docs/superpowers/plans/2026-08-27-context-projection-coauthoring.md`. This page
+describes what the activation actually does.
+
+## What changed in the prompt
+
+The `saved_memory` section used to be a bounded full-store dump. Every row from
+`list_memories()` was joined oldest first and the joined string clipped at 4,000
+characters. That favoured the oldest rows, could cut a row in half, and could
+not tell a preference of the director's from a fact about one person.
+
+It is now a projection. `ConversationStore.memory_projection_items()` emits
+already-scoped `ProjectionItem` values for the classified operator preferences,
+and `server._saved_memory_body` selects from them through
+`prepare_context_projection` under `DEFAULT_PROJECTION_POLICY`.
+
+Two caps apply and the first one reached wins:
+
+- the 256-token `operator_preference` category budget, 64 tokens per item, with
+  no borrowing from any other category;
+- the existing 4,000-character envelope for this section, which together with
+  the person file's 2,000 is the approved 6,000-character combined envelope.
+
+Selection is whole items under both caps, so a preference is never cut in half
+and its Source Reference is never cut off. Tokens are counted with
+`store.projection_tokens`: `ceil(len(utf-8 bytes) / 3)`. That is an explicit
+budget unit, not a claim about any provider's billed tokens.
+
+## What a memory row carries
+
+`club.db` schema version 2 adds nine columns to `memories`: `category`,
+`classification_status`, `person_id`, `session_id`, `source_ref`, `updated_at`,
+`fresh_until`, `sensitivity`, and `claim_key`.
+
+Only one predicate lets a row into the prompt:
+
+```sql
+classification_status = 'classified' AND category = 'operator_preference'
+AND person_id IS NULL AND session_id IS NULL AND sensitivity = 'standard'
+```
+
+It is a positive allowlist, so any state the code does not recognise is withheld
+rather than leaked.
+
+Evidence state is derived at projection time, not stored:
+
+- `conflicting` — two or more classified rows share one `claim_key`. Both are
+  projected, and each carries both Source References, so the projection never
+  silently picks a winner.
+- `stale` — the row's `fresh_until` has passed. Preferences have none by
+  default; they go stale only when the director changes one.
+- `current` — everything else.
+
+## The migration
+
+`SCHEMA_VERSION` in `coworker/store.py` is 2, and `coworker/migrations.py`
+registers the 1 to 2 step for `conversation_db`. Doctor plans it, backs the
+store up first, and rolls it back if it raises.
+
+Every memory row already on disk becomes `category = 'legacy_unclassified'` with
+`classification_status = 'needs_review'`. Ids, content, `created_at`, the
+per-row Markdown files, and `MEMORY.md` are untouched.
+
+The step never reads a row's text. A row worded like a global preference and a
+row stating a fact about one person are indistinguishable as text, so both wait.
+That temporarily withholds well-worded rows, and it is the point: it stops an
+existing person fact from silently becoming a global preference.
+
+The step runs its statements one at a time. `sqlite3.Connection.executescript`
+issues a COMMIT before it runs, which would end the transaction `_apply_store`
+opens and leave the rollback with nothing to undo.
+
+The store's constructor adds the same columns to an existing database so the app
+never opens a database it cannot query, but it adds them without defaults. The
+registry step is what writes the classification, so the backup covers the real
+change.
+
+## New writes
+
+`store.remember()` records `category = 'unclassified'`,
+`classification_status = 'needs_review'`. Nothing infers a category from the
+content. `store.memory_update()` sends a rewritten row back for review, because
+rewritten text is text nobody has classified.
+
+A row becomes a global preference only through `store.memory_classify()`, which
+is reached only by `POST /v1/memory/{id}/classification` — a director action in
+the UI. It refuses any row carrying a `person_id` or `session_id`: a fact about
+one person belongs on that Person File through the existing Board contract.
+
+The `remember` tool passes no scope, so every model-driven write is ambiguous
+and waits. `coworker/tools.py` is where a director's explicit "remember this as
+a standing preference" would have to be carried; that parameter does not exist
+yet.
+
+## The backlog is visible
+
+Withholding is user-visible: rows the director saved stop appearing until they
+are classified. It reads as Sourcecado having forgotten things, so the count is
+deliberately in front of the operator.
+
+- `GET /v1/memory/classification` returns `needs_review`, `classified`, and the
+  waiting rows.
+- The global rail carries a **Memory** destination with a badge showing the
+  waiting count, refreshed on navigation and on window focus.
+- `#/memory` lists each waiting row with two actions: keep it as a global
+  preference, or delete it. The page says where a fact about one person belongs
+  instead.
+
+## Known bound to watch
+
+The 1,024-token person-evidence cap is the number most likely to need
+revisiting. At 160 tokens per item that is roughly six evidence items for a
+director working one person deeply. It ships as specified. The no-borrow design
+means raising it later is a contained change; do not raise it preemptively.

--- a/desktop/surfaces/gui/src/api.ts
+++ b/desktop/surfaces/gui/src/api.ts
@@ -1019,6 +1019,45 @@ export async function getSkills(): Promise<{ skills: SkillInfo[] }> {
   return res.json();
 }
 
+export type MemoryRow = {
+  id: number;
+  content: string;
+  category: string;
+  classification_status: string | null;
+  created_at: string;
+};
+
+export type MemoryBacklog = {
+  needs_review: number;
+  classified: number;
+  items: MemoryRow[];
+};
+
+export async function getMemoryBacklog(): Promise<MemoryBacklog> {
+  const res = await get("/v1/memory/classification");
+  if (!res.ok) throw new Error(`memory ${res.status}`);
+  return res.json();
+}
+
+export async function classifyMemory(id: number): Promise<{ memory: MemoryRow }> {
+  const res = await fetch(`${httpBase()}/v1/memory/${id}/classification`, {
+    method: "POST",
+    headers: { "X-Club-Token": apiToken(), "Content-Type": "application/json" },
+    body: JSON.stringify({ category: "operator_preference" }),
+  });
+  if (!res.ok) throw new Error(`memory classify ${res.status}`);
+  return res.json();
+}
+
+export async function forgetMemory(id: number): Promise<{ forgotten: boolean; id: number }> {
+  const res = await fetch(`${httpBase()}/v1/memory/${id}`, {
+    method: "DELETE",
+    headers: { "X-Club-Token": apiToken() },
+  });
+  if (!res.ok) throw new Error(`memory forget ${res.status}`);
+  return res.json();
+}
+
 const SCHEDULE_RUN_STATUSES = new Set<ScheduleRunStatus>([
   "running",
   "success",

--- a/desktop/surfaces/gui/src/app/AppShell.tsx
+++ b/desktop/surfaces/gui/src/app/AppShell.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import {
   createSession,
   getInbox,
+  getMemoryBacklog,
   getSessions,
   pinSession,
   renameSession,
@@ -13,6 +14,7 @@ import { BoardView } from "../Board";
 import { PersonFileView } from "../PersonFile";
 import { ChatPage } from "../routes/ChatPage";
 import { ConnectionsPage } from "../routes/ConnectionsPage";
+import { MemoryPage } from "../routes/MemoryPage";
 import { ScheduledPage } from "../routes/ScheduledPage";
 import { SettingsPage } from "../routes/SettingsPage";
 import { SkillsPage } from "../routes/SkillsPage";
@@ -34,6 +36,7 @@ export function AppShell() {
   const [stale, setStale] = useState(Boolean(cachedListing));
   const [railOpen, setRailOpen] = useState(false);
   const [scheduledApprovalCount, setScheduledApprovalCount] = useState(0);
+  const [memoryReviewCount, setMemoryReviewCount] = useState(0);
   const railTriggerRef = useRef<HTMLButtonElement>(null);
   const railFocusTimerRef = useRef<number | null>(null);
   const railWasOpenedRef = useRef(false);
@@ -117,6 +120,26 @@ export function AppShell() {
       window.removeEventListener("sourcecado:inbox-changed", refreshInbox);
     };
   }, []);
+  useEffect(() => {
+    let active = true;
+    // Migrating to context-projection-v1 withholds every unclassified memory
+    // row from the model. The count is how a director sees that Sourcecado is
+    // waiting on them rather than that it forgot (issue #58).
+    const refreshMemory = () => {
+      getMemoryBacklog().then(
+        ({ needs_review }) => {
+          if (active) setMemoryReviewCount(needs_review);
+        },
+        () => {},
+      );
+    };
+    refreshMemory();
+    window.addEventListener("focus", refreshMemory);
+    return () => {
+      active = false;
+      window.removeEventListener("focus", refreshMemory);
+    };
+  }, [route]);
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
@@ -239,6 +262,8 @@ export function AppShell() {
     outlet = <PersonFileView personId={route.personId} />;
   } else if (route.kind === "skills") {
     outlet = <SkillsPage />;
+  } else if (route.kind === "memory") {
+    outlet = <MemoryPage />;
   } else if (route.kind === "scheduled") {
     outlet = <ScheduledPage />;
   } else if (route.kind === "connections") {
@@ -280,6 +305,7 @@ export function AppShell() {
         route={route}
         sessions={sessions}
         scheduledApprovalCount={scheduledApprovalCount}
+        memoryReviewCount={memoryReviewCount}
         onNewChat={() => void handleNewChat()}
         onOpenSession={handleOpenSession}
         onPin={(session) => void handlePin(session)}

--- a/desktop/surfaces/gui/src/app/CommandSearch.tsx
+++ b/desktop/surfaces/gui/src/app/CommandSearch.tsx
@@ -7,6 +7,7 @@ const DESTINATIONS = [
   { label: "Scheduled", hash: "#/scheduled" },
   { label: "Connections", hash: "#/connections" },
   { label: "Skills", hash: "#/skills" },
+  { label: "Memory", hash: "#/memory" },
   { label: "Settings", hash: "#/settings" },
 ];
 

--- a/desktop/surfaces/gui/src/app/GlobalRail.tsx
+++ b/desktop/surfaces/gui/src/app/GlobalRail.tsx
@@ -49,6 +49,7 @@ type Props = {
   route: AppRoute;
   sessions: SessionRow[] | null;
   scheduledApprovalCount: number;
+  memoryReviewCount: number;
   onNewChat: () => void;
   onOpenSession: (session: SessionRow) => void;
   onPin: (session: SessionRow) => void;
@@ -57,7 +58,7 @@ type Props = {
   onClose: () => void;
 };
 
-export function GlobalRail({ open, route, sessions, scheduledApprovalCount, onNewChat, onOpenSession, onPin, onRename, onSearch, onClose }: Props) {
+export function GlobalRail({ open, route, sessions, scheduledApprovalCount, memoryReviewCount, onNewChat, onOpenSession, onPin, onRename, onSearch, onClose }: Props) {
   const pinned = sessions?.filter((session) => session.pinned) || [];
   const recent = sessions?.filter((session) => !session.pinned) || [];
   const railRef = useRef<HTMLElement>(null);
@@ -132,6 +133,14 @@ export function GlobalRail({ open, route, sessions, scheduledApprovalCount, onNe
           </RailLink>
           <RailLink href="#/connections" current={route.kind === "connections"}>Connections</RailLink>
           <RailLink href="#/skills" current={route.kind === "skills"}>Skills</RailLink>
+          <RailLink
+            href="#/memory"
+            current={route.kind === "memory"}
+            badge={memoryReviewCount}
+            badgeLabel={`Saved memory: ${memoryReviewCount} waiting for review`}
+          >
+            Memory
+          </RailLink>
         </div>
         <div className="thread-groups">
           {pinned.length > 0 && (
@@ -265,11 +274,13 @@ function RailLink({
   current,
   children,
   badge = 0,
+  badgeLabel,
 }: {
   href: string;
   current: boolean;
   children: string;
   badge?: number;
+  badgeLabel?: string;
 }) {
   return (
     <a
@@ -282,7 +293,7 @@ function RailLink({
       {badge > 0 && (
         <span
           className="rail-inbox-badge"
-          aria-label={`Inbox: ${badge} waiting approval${badge === 1 ? "" : "s"}`}
+          aria-label={badgeLabel || `Inbox: ${badge} waiting approval${badge === 1 ? "" : "s"}`}
         >
           {badge}
         </span>

--- a/desktop/surfaces/gui/src/app/route.ts
+++ b/desktop/surfaces/gui/src/app/route.ts
@@ -5,6 +5,7 @@ export type AppRoute =
   | { kind: "scheduled" }
   | { kind: "settings" }
   | { kind: "skills" }
+  | { kind: "memory" }
   | { kind: "chat"; sessionId?: string; personId?: string };
 
 export function parseHash(hash: string): AppRoute {
@@ -33,6 +34,7 @@ export function parseHash(hash: string): AppRoute {
   if (hash === "#/scheduled") return { kind: "scheduled" };
   if (hash === "#/settings") return { kind: "settings" };
   if (hash === "#/skills") return { kind: "skills" };
+  if (hash === "#/memory") return { kind: "memory" };
   if (hash.startsWith("#/chat/") && hash.includes("/person/")) {
     const [sessionId, personId] = hash.slice("#/chat/".length).split("/person/", 2);
     if (sessionId && personId) {

--- a/desktop/surfaces/gui/src/routes/MemoryPage.tsx
+++ b/desktop/surfaces/gui/src/routes/MemoryPage.tsx
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { classifyMemory, forgetMemory, getMemoryBacklog, type MemoryBacklog } from "../api";
+
+type BacklogState =
+  | { status: "loading" }
+  | { status: "loaded"; backlog: MemoryBacklog }
+  | { status: "failed" };
+
+export function MemoryPage() {
+  const [state, setState] = useState<BacklogState>({ status: "loading" });
+  const [attempt, setAttempt] = useState(0);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    setState({ status: "loading" });
+    getMemoryBacklog()
+      .then((backlog) => {
+        if (active) setState({ status: "loaded", backlog });
+      })
+      .catch(() => {
+        if (active) setState({ status: "failed" });
+      });
+    return () => {
+      active = false;
+    };
+  }, [attempt]);
+
+  const refresh = useCallback(async () => {
+    const backlog = await getMemoryBacklog();
+    setState({ status: "loaded", backlog });
+  }, []);
+
+  async function run(action: () => Promise<unknown>, failure: string) {
+    setActionError(null);
+    try {
+      await action();
+      await refresh();
+    } catch {
+      setActionError(failure);
+    }
+  }
+
+  if (state.status === "loading") {
+    return (
+      <main className="route-page memory-page">
+        <h1>Saved memory</h1>
+        <p role="status">Loading saved memory…</p>
+      </main>
+    );
+  }
+
+  if (state.status === "failed") {
+    return (
+      <main className="route-page memory-page">
+        <h1>Saved memory</h1>
+        <section className="route-error" role="alert">
+          <h2>Saved memory couldn’t be loaded</h2>
+          <p>Check that Sourcecado is available, then try again.</p>
+          <button type="button" onClick={() => setAttempt((value) => value + 1)}>
+            Retry loading saved memory
+          </button>
+        </section>
+      </main>
+    );
+  }
+
+  const { backlog } = state;
+  return (
+    <main className="route-page memory-page">
+      <h1>Saved memory</h1>
+      <p className="memory-counts">
+        <strong>{backlog.needs_review} waiting for review</strong>
+        <span>{backlog.classified} in use</span>
+      </p>
+      <p className="memory-explainer">
+        Sourcecado still has every one of these. They are not being used until you
+        say what each one is. Keep the ones that are a standing preference of
+        yours, whoever you are working. A fact about one person belongs on that
+        Person File, so file it there and delete the note here.
+      </p>
+      {actionError && (
+        <section className="route-error" role="alert">
+          <h2>{actionError}</h2>
+          <p>Nothing changed. Try again, or delete the note instead.</p>
+        </section>
+      )}
+      {backlog.items.length === 0 ? (
+        <section className="route-empty" role="status">
+          <h2>Nothing waiting for review</h2>
+          <p>New notes appear here until you say what they are.</p>
+        </section>
+      ) : (
+        <ul className="memory-list" aria-label="Memory waiting for review">
+          {backlog.items.map((item) => (
+            <li key={item.id} aria-label={`Saved memory ${item.id}`}>
+              <article className="memory-card">
+                <p className="memory-content">{item.content}</p>
+                <p className="memory-meta">
+                  <span className="memory-id">#{item.id}</span>
+                  <span>Saved {item.created_at.slice(0, 10)}</span>
+                </p>
+                <div className="memory-actions">
+                  <button
+                    type="button"
+                    className="memory-keep"
+                    aria-label={`Keep memory ${item.id} as a global preference`}
+                    onClick={() =>
+                      void run(
+                        () => classifyMemory(item.id),
+                        "That memory couldn’t be classified",
+                      )
+                    }
+                  >
+                    Keep as global preference
+                  </button>
+                  <button
+                    type="button"
+                    className="memory-delete"
+                    aria-label={`Delete memory ${item.id}`}
+                    onClick={() =>
+                      void run(
+                        () => forgetMemory(item.id),
+                        "That memory couldn’t be deleted",
+                      )
+                    }
+                  >
+                    Delete
+                  </button>
+                </div>
+              </article>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/desktop/surfaces/gui/src/styles/route.css
+++ b/desktop/surfaces/gui/src/styles/route.css
@@ -14,7 +14,8 @@
 }
 
 .skills-page,
-.settings-page {
+.settings-page,
+.memory-page {
   width: 100%;
   max-width: 1040px;
   margin: 0 auto;
@@ -23,6 +24,97 @@
 .skills-page > [role="status"],
 .settings-page > [role="status"] {
   margin-top: 18px;
+}
+
+/* Saved-memory review. A backlog to drain is a low-density moment, so the
+   count carries the warmth and the rows stay quiet and scannable. */
+.memory-counts {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin: 16px 0 0;
+}
+
+.memory-counts strong {
+  padding: 4px 10px;
+  border-radius: 9999px;
+  background: var(--accent-tint);
+  color: var(--accent-deep);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.memory-counts span {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.memory-explainer {
+  max-width: 620px;
+  margin: 12px 0 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.memory-list {
+  display: grid;
+  gap: 8px;
+  margin: 24px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.memory-card {
+  display: grid;
+  gap: 8px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.memory-content {
+  margin: 0;
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.memory-meta {
+  display: flex;
+  gap: 12px;
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.memory-id {
+  font-family: "Geist Mono", ui-monospace, monospace;
+}
+
+.memory-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.memory-actions button {
+  min-height: 36px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.memory-keep {
+  border-color: var(--accent);
+  color: var(--accent-deep);
+}
+
+.memory-actions button:hover {
+  background: var(--raised);
 }
 
 .skill-list {
@@ -481,6 +573,15 @@
   .persona-options button,
   .route-error button {
     min-height: 44px;
+  }
+
+  .memory-actions {
+    flex-direction: column;
+  }
+
+  .memory-actions button {
+    min-height: 44px;
+    min-width: 44px;
   }
 
   .workspace-add-form,

--- a/desktop/surfaces/gui/tests/globalRail.test.tsx
+++ b/desktop/surfaces/gui/tests/globalRail.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { GlobalRail } from "../src/app/GlobalRail";
@@ -6,13 +6,14 @@ import type { AppRoute } from "../src/app/route";
 
 const route: AppRoute = { kind: "skills" };
 
-function renderRail(open: boolean) {
+function renderRail(open: boolean, memoryReviewCount = 0) {
   return render(
     <GlobalRail
       open={open}
       route={route}
       sessions={[]}
       scheduledApprovalCount={0}
+      memoryReviewCount={memoryReviewCount}
       onNewChat={vi.fn()}
       onOpenSession={vi.fn()}
       onPin={vi.fn()}
@@ -55,6 +56,7 @@ describe("GlobalRail off-screen focus containment", () => {
         route={route}
         sessions={[]}
         scheduledApprovalCount={0}
+        memoryReviewCount={0}
         onNewChat={vi.fn()}
         onOpenSession={vi.fn()}
         onPin={vi.fn()}
@@ -81,5 +83,26 @@ describe("GlobalRail off-screen focus containment", () => {
     renderRail(false);
 
     expect(document.getElementById("app-rail")).not.toHaveAttribute("inert");
+  });
+});
+
+describe("GlobalRail saved-memory backlog", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("shows how many saved memories are waiting for review", () => {
+    renderRail(false, 12);
+
+    const badge = screen.getByLabelText("Saved memory: 12 waiting for review");
+    expect(badge).toHaveTextContent("12");
+    expect(screen.getByRole("link", { name: "Memory" })).toHaveAttribute("href", "#/memory");
+  });
+
+  it("shows no badge once the backlog is drained", () => {
+    renderRail(false, 0);
+
+    expect(screen.queryByLabelText(/waiting for review/)).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Memory" })).toBeInTheDocument();
   });
 });

--- a/desktop/surfaces/gui/tests/memoryPage.test.tsx
+++ b/desktop/surfaces/gui/tests/memoryPage.test.tsx
@@ -1,0 +1,148 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MemoryPage } from "../src/routes/MemoryPage";
+
+const api = vi.hoisted(() => ({
+  getMemoryBacklog: vi.fn(),
+  classifyMemory: vi.fn(),
+  forgetMemory: vi.fn(),
+}));
+
+vi.mock("../src/api", () => ({
+  getMemoryBacklog: api.getMemoryBacklog,
+  classifyMemory: api.classifyMemory,
+  forgetMemory: api.forgetMemory,
+}));
+
+const WAITING = {
+  needs_review: 2,
+  classified: 1,
+  items: [
+    {
+      id: 1,
+      content: "Codeology sources design-adjacent engineers first.",
+      category: "legacy_unclassified",
+      classification_status: "needs_review",
+      created_at: "2026-08-01T09:12:00+00:00",
+    },
+    {
+      id: 4,
+      content: "Ada moved to Analytic in June.",
+      category: "unclassified",
+      classification_status: "needs_review",
+      created_at: "2026-08-20T09:12:00+00:00",
+    },
+  ],
+};
+
+describe("MemoryPage", () => {
+  beforeEach(() => {
+    api.getMemoryBacklog.mockReset();
+    api.classifyMemory.mockReset();
+    api.forgetMemory.mockReset();
+  });
+
+  it("announces that the backlog is loading", () => {
+    api.getMemoryBacklog.mockReturnValue(new Promise(() => {}));
+
+    render(<MemoryPage />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Loading saved memory");
+  });
+
+  it("leads with how many rows are waiting and why they are withheld", async () => {
+    api.getMemoryBacklog.mockResolvedValue(WAITING);
+
+    render(<MemoryPage />);
+
+    expect(await screen.findByText("2 waiting for review")).toBeInTheDocument();
+    expect(screen.getByText(/1 in use/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/not being used until you say what each one is/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Codeology sources design-adjacent engineers first.")).toBeInTheDocument();
+    expect(screen.getByText("Ada moved to Analytic in June.")).toBeInTheDocument();
+  });
+
+  it("says where a fact about one person belongs instead", async () => {
+    api.getMemoryBacklog.mockResolvedValue(WAITING);
+
+    render(<MemoryPage />);
+
+    expect(await screen.findByText(/Person File/)).toBeInTheDocument();
+  });
+
+  it("keeps a row as a global preference and refreshes the backlog", async () => {
+    api.getMemoryBacklog
+      .mockResolvedValueOnce(WAITING)
+      .mockResolvedValueOnce({ needs_review: 1, classified: 2, items: [WAITING.items[1]] });
+    api.classifyMemory.mockResolvedValue({ memory: { id: 1 } });
+
+    render(<MemoryPage />);
+
+    const row = await screen.findByRole("listitem", { name: "Saved memory 1" });
+    fireEvent.click(within(row).getByRole("button", { name: "Keep memory 1 as a global preference" }));
+
+    await waitFor(() => expect(api.classifyMemory).toHaveBeenCalledWith(1));
+    expect(await screen.findByText("1 waiting for review")).toBeInTheDocument();
+  });
+
+  it("deletes a row the director does not want kept", async () => {
+    api.getMemoryBacklog
+      .mockResolvedValueOnce(WAITING)
+      .mockResolvedValueOnce({ needs_review: 1, classified: 1, items: [WAITING.items[0]] });
+    api.forgetMemory.mockResolvedValue({ forgotten: true, id: 4 });
+
+    render(<MemoryPage />);
+
+    const row = await screen.findByRole("listitem", { name: "Saved memory 4" });
+    fireEvent.click(within(row).getByRole("button", { name: "Delete memory 4" }));
+
+    await waitFor(() => expect(api.forgetMemory).toHaveBeenCalledWith(4));
+    expect(await screen.findByText("1 waiting for review")).toBeInTheDocument();
+  });
+
+  it("reports a refused classification without leaking internals", async () => {
+    api.getMemoryBacklog.mockResolvedValue(WAITING);
+    api.classifyMemory.mockRejectedValue(
+      new Error("memory classify 400 /Users/private/club.db"),
+    );
+
+    const { container } = render(<MemoryPage />);
+
+    const row = await screen.findByRole("listitem", { name: "Saved memory 1" });
+    fireEvent.click(within(row).getByRole("button", { name: "Keep memory 1 as a global preference" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("That memory couldn’t be classified");
+    expect(container).not.toHaveTextContent("/Users/private");
+  });
+
+  it("says so plainly when nothing is waiting", async () => {
+    api.getMemoryBacklog.mockResolvedValue({ needs_review: 0, classified: 3, items: [] });
+
+    render(<MemoryPage />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("status")).toHaveTextContent("Nothing waiting for review"),
+    );
+    expect(screen.queryByRole("list", { name: "Memory waiting for review" })).not.toBeInTheDocument();
+  });
+
+  it("shows a contextual failure and retries the backlog", async () => {
+    api.getMemoryBacklog
+      .mockRejectedValueOnce(new Error("memory 500 /Users/private/club.db"))
+      .mockResolvedValueOnce(WAITING);
+
+    const { container } = render(<MemoryPage />);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Saved memory couldn’t be loaded");
+    expect(container).not.toHaveTextContent("/Users/private");
+
+    fireEvent.click(within(alert).getByRole("button", { name: "Retry loading saved memory" }));
+
+    expect(await screen.findByText("2 waiting for review")).toBeInTheDocument();
+  });
+});

--- a/desktop/surfaces/gui/tests/memoryStyles.test.ts
+++ b/desktop/surfaces/gui/tests/memoryStyles.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { styles } from "./cssBundle";
+
+describe("Saved memory review styles", () => {
+  it("puts the waiting count on the warm accent tint rather than a raw colour", () => {
+    expect(styles).toMatch(
+      /\.memory-counts strong\s*\{[^}]*background:\s*var\(--accent-tint\);[^}]*color:\s*var\(--accent-deep\);/,
+    );
+  });
+
+  it("keeps review rows as quiet hairline surfaces", () => {
+    expect(styles).toMatch(
+      /\.memory-card\s*\{[^}]*border:\s*1px solid var\(--border\);[^}]*background:\s*var\(--surface\);/,
+    );
+  });
+
+  it("keeps the keep and delete controls touch sized on narrow viewports", () => {
+    expect(styles).toMatch(
+      /@media \(max-width: 767px\)[\s\S]*?\.memory-actions button\s*\{[^}]*min-height:\s*44px;[^}]*min-width:\s*44px;/,
+    );
+  });
+});

--- a/desktop/surfaces/gui/tests/route.test.ts
+++ b/desktop/surfaces/gui/tests/route.test.ts
@@ -11,6 +11,10 @@ describe("app route parser", () => {
     });
   });
 
+  it("parses the saved-memory classification destination", () => {
+    expect(parseHash("#/memory")).toEqual({ kind: "memory" });
+  });
+
   it("falls back safely when a person id is malformed", () => {
     expect(parseHash("#/people/%E0%A4%A")).toEqual({ kind: "board" });
   });

--- a/desktop/surfaces/gui/tests/shell.test.tsx
+++ b/desktop/surfaces/gui/tests/shell.test.tsx
@@ -23,6 +23,7 @@ const api = vi.hoisted(() => ({
   getGmail: vi.fn(),
   getHealth: vi.fn(),
   getInbox: vi.fn(),
+  getMemoryBacklog: vi.fn(),
   getPersona: vi.fn(),
   getPerson: vi.fn(),
   getSchedule: vi.fn(),
@@ -53,6 +54,7 @@ vi.mock("../src/api", () => ({
   getGmail: api.getGmail,
   getHealth: api.getHealth,
   getInbox: api.getInbox,
+  getMemoryBacklog: api.getMemoryBacklog,
   getPersona: api.getPersona,
   getPerson: api.getPerson,
   getSchedule: api.getSchedule,
@@ -87,6 +89,7 @@ describe("App shell routing", () => {
     api.getGmail.mockResolvedValue({ connected: false, email: null });
     api.getHealth.mockResolvedValue({ status: "ok", piece: "test", slice: 1, model: "test" });
     api.getInbox.mockResolvedValue({ items: [] });
+    api.getMemoryBacklog.mockResolvedValue({ needs_review: 0, classified: 0, items: [] });
     api.getPersona.mockResolvedValue({ id: "sourcing", name: "Sourcing Director", tools: [] });
     api.getPerson.mockResolvedValue({
       person: { person_id: "person-1", sequence_state: "open" },

--- a/desktop/tests/test_chat.py
+++ b/desktop/tests/test_chat.py
@@ -1580,8 +1580,21 @@ def test_ws_remember_survives_new_sidecar(tmp_path):
         ws.send_json({"type": "chat", "text": "what do I drink?"})
         _drain(ws)
     system = second.calls[0][0]["content"]
-    assert "oat lattes" in system
-    assert "[#1]" in system
+    # A model `remember` write is not the director explicitly asking for a
+    # person-independent preference to persist, so the row waits for
+    # classification instead of returning to the prompt (issue #58). It is
+    # durable and visible in the backlog the whole time.
+    assert "oat lattes" not in system
+
+    from coworker.server import system_prompt
+    from coworker.store import ConversationStore
+
+    store = ConversationStore(tmp_path)
+    assert store.memory_backlog()["needs_review"] == 1
+    store.memory_classify(1)
+    classified_prompt = system_prompt(store)
+    assert "oat lattes" in classified_prompt
+    assert "[#1]" in classified_prompt
 
 
 def test_close_open_tool_calls_inserts_missing_results():

--- a/desktop/tests/test_context_projection_prompt.py
+++ b/desktop/tests/test_context_projection_prompt.py
@@ -1,0 +1,162 @@
+"""The saved-memory prompt section is a bounded projection, not a store dump.
+
+Before context-projection-v1 every memory row was joined oldest-first and the
+whole string clipped at 4,000 characters, which could cut a row in half and
+could not tell an operator preference from a fact about one Person. The section
+now carries only classified operator preferences, selected under
+`DEFAULT_PROJECTION_POLICY`.
+"""
+
+from coworker import server
+from coworker.context_projection import DEFAULT_PROJECTION_POLICY, ContextCategory
+from coworker.persona import load_persona
+from coworker.store import ConversationStore, projection_tokens
+
+
+def _saved_memory(assembled) -> str | None:
+    marker = "## Saved memory\n\n"
+    if marker not in assembled.text:
+        return None
+    return assembled.text.split(marker, 1)[1].split("\n\n##", 1)[0]
+
+
+def _preference_budget():
+    return next(
+        budget
+        for budget in DEFAULT_PROJECTION_POLICY.category_budgets
+        if budget.category is ContextCategory.OPERATOR_PREFERENCE
+    )
+
+
+def test_an_unclassified_row_never_reaches_the_prompt(tmp_path):
+    store = ConversationStore(tmp_path)
+    store.remember("WITHHELD LEGACY SENTINEL")
+    store.remember("Keep outreach drafts under 140 words.")
+    store.memory_classify(2)
+
+    assembled = server.system_prompt_assembly(store, load_persona("sourcing"))
+
+    section = _saved_memory(assembled)
+    # Non-vacuous: the classified preference is there, the unclassified one is not.
+    assert section is not None
+    assert "Keep outreach drafts under 140 words." in section
+    assert "WITHHELD LEGACY SENTINEL" not in assembled.text
+
+
+def test_the_section_is_absent_when_nothing_is_classified(tmp_path):
+    store = ConversationStore(tmp_path)
+    store.remember("Codeology sources design-adjacent engineers first.")
+
+    assembled = server.system_prompt_assembly(store, load_persona("sourcing"))
+
+    assert _saved_memory(assembled) is None
+    assert "saved_memory" not in [
+        item.section_id for item in assembled.diagnostics.dynamic_context_sections
+    ]
+
+
+def test_the_preference_category_never_borrows_another_categorys_budget(tmp_path):
+    store = ConversationStore(tmp_path)
+    for index in range(40):
+        store.remember(f"Preference {index}: " + "w" * 120)
+        store.memory_classify(index + 1)
+    budget = _preference_budget()
+
+    assembled = server.system_prompt_assembly(store, load_persona("sourcing"))
+
+    section = _saved_memory(assembled)
+    assert section is not None
+    used = sum(projection_tokens(line) for line in section.splitlines())
+    assert used <= budget.max_tokens
+    # The whole-projection budget is eight times the category cap. Staying under
+    # the category cap is the claim; staying under 2,048 alone would not be.
+    assert budget.max_tokens < DEFAULT_PROJECTION_POLICY.total_tokens
+
+
+def test_every_projected_preference_is_a_whole_item(tmp_path):
+    store = ConversationStore(tmp_path)
+    for index in range(12):
+        store.remember(f"Preference {index}: " + "w" * 60)
+        store.memory_classify(index + 1)
+
+    assembled = server.system_prompt_assembly(store, load_persona("sourcing"))
+
+    section = _saved_memory(assembled)
+    assert section is not None
+    lines = section.splitlines()
+    assert lines
+    for line in lines:
+        assert line.startswith("[#")
+        assert "sourcecado:memory/" in line
+        assert line.endswith(")")
+        assert projection_tokens(line) <= _preference_budget().max_item_tokens
+
+
+def test_the_combined_memory_and_person_envelope_is_still_six_thousand_chars(tmp_path):
+    from coworker.people import PersonStore
+
+    store = ConversationStore(tmp_path)
+    for index in range(40):
+        store.remember(f"Preference {index}: " + "w" * 120)
+        store.memory_classify(index + 1)
+    people = PersonStore(tmp_path)
+    person = people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+        target="research dinner",
+    )
+    people.bind_session("session-ada", person["person_id"])
+    for index in range(12):
+        people.append_event(
+            person["person_id"],
+            source="gmail",
+            kind="mail",
+            summary=f"event-{index}-" + "p" * 300,
+        )
+
+    assembled = server.system_prompt_assembly(
+        store,
+        load_persona("sourcing"),
+        people=people,
+        session_id="session-ada",
+    )
+
+    sections = {
+        item.section_id: item for item in assembled.diagnostics.dynamic_context_sections
+    }
+    assert "saved_memory" in sections
+    assert "person_file" in sections
+    combined = sections["saved_memory"].chars + sections["person_file"].chars
+    assert combined <= 6_000
+
+
+def test_a_person_bound_session_still_gets_only_global_preferences(tmp_path):
+    from coworker.people import PersonStore
+
+    store = ConversationStore(tmp_path)
+    store.remember("Keep outreach drafts under 140 words.")
+    store.memory_classify(1)
+    people = PersonStore(tmp_path)
+    person = people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L",
+        title="Founder",
+        company="Analytic",
+        target="research dinner",
+    )
+    people.bind_session("session-ada", person["person_id"])
+
+    assembled = server.system_prompt_assembly(
+        store,
+        load_persona("sourcing"),
+        people=people,
+        session_id="session-ada",
+    )
+
+    section = _saved_memory(assembled)
+    assert section is not None
+    assert "Keep outreach drafts under 140 words." in section

--- a/desktop/tests/test_memory_classification.py
+++ b/desktop/tests/test_memory_classification.py
@@ -1,0 +1,196 @@
+"""Memory rows carry the approved context-projection category contract.
+
+`context-projection-v1` (issue #58) gives every memory row a category, a scope,
+a Source Reference, an updated time, a freshness window, a sensitivity, and a
+conflict key. Only a row the director explicitly classified as a global operator
+preference may become model context; everything else is withheld.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from coworker.context_projection import (
+    ContextAuthority,
+    ContextCategory,
+    ContextSensitivity,
+    ContextState,
+)
+from coworker.store import (
+    MEMORY_CATEGORY_PREFERENCE,
+    MEMORY_CATEGORY_UNCLASSIFIED,
+    MEMORY_CLASSIFIED,
+    MEMORY_NEEDS_REVIEW,
+    ConversationStore,
+    projection_tokens,
+)
+
+
+def test_a_new_remember_write_is_ambiguous_and_waits_for_review(tmp_path):
+    store = ConversationStore(tmp_path)
+
+    item = store.remember("Prefer outreach drafts under 140 words.")
+
+    assert item["category"] == MEMORY_CATEGORY_UNCLASSIFIED
+    assert item["classification_status"] == MEMORY_NEEDS_REVIEW
+    assert item["person_id"] is None
+    assert item["session_id"] is None
+    assert item["sensitivity"] == "standard"
+    assert item["source_ref"] == "sourcecado:memory/1"
+    assert item["updated_at"]
+
+
+def test_an_ambiguous_write_never_reaches_model_context(tmp_path):
+    store = ConversationStore(tmp_path)
+    store.remember("Prefer outreach drafts under 140 words.")
+
+    assert store.memory_projection_items() == ()
+
+
+def test_the_director_classifying_a_preference_puts_it_in_context(tmp_path):
+    store = ConversationStore(tmp_path)
+    store.remember("Prefer outreach drafts under 140 words.")
+
+    classified = store.memory_classify(1)
+
+    assert classified is not None
+    assert classified["category"] == MEMORY_CATEGORY_PREFERENCE
+    assert classified["classification_status"] == MEMORY_CLASSIFIED
+    items = store.memory_projection_items()
+    assert len(items) == 1
+    projected = items[0]
+    assert projected.category is ContextCategory.OPERATOR_PREFERENCE
+    assert projected.authority is ContextAuthority.DIRECTOR
+    assert projected.state is ContextState.CURRENT
+    assert projected.sensitivity is ContextSensitivity.STANDARD
+    assert projected.person_id is None
+    assert projected.session_id is None
+    assert "Prefer outreach drafts under 140 words." in projected.text
+    assert projected.source_refs[0].id == "sourcecado:memory/1"
+    assert projected.source_refs[0].provider == "sourcecado"
+
+
+def test_classifying_a_missing_row_reports_nothing_to_classify(tmp_path):
+    store = ConversationStore(tmp_path)
+
+    assert store.memory_classify(9) is None
+
+
+def test_a_person_scoped_row_cannot_become_a_global_preference(tmp_path):
+    store = ConversationStore(tmp_path)
+    store.remember("Ada moved to Analytic in June.", person_id="per_ada")
+
+    with pytest.raises(ValueError, match="scoped"):
+        store.memory_classify(1)
+    assert store.memory_projection_items() == ()
+
+
+def test_a_session_scoped_row_cannot_become_a_global_preference(tmp_path):
+    store = ConversationStore(tmp_path)
+    store.remember("Working the Rippling list this session.", session_id="main")
+
+    with pytest.raises(ValueError, match="scoped"):
+        store.memory_classify(1)
+    assert store.memory_projection_items() == ()
+
+
+def test_a_restricted_row_is_withheld_even_once_classified(tmp_path):
+    store = ConversationStore(tmp_path)
+    store.remember("Prefer outreach drafts under 140 words.")
+    store.remember("Restricted note.", sensitivity="restricted")
+    store.memory_classify(1)
+    store.memory_classify(2)
+
+    projected = store.memory_projection_items()
+
+    # Non-vacuous: the standard preference is present, the restricted one is not.
+    assert [item.id for item in projected] == ["memory:1"]
+
+
+def test_two_preferences_on_one_claim_key_are_conflicting_with_both_sources(tmp_path):
+    store = ConversationStore(tmp_path)
+    store.remember("Keep outreach drafts under 140 words.")
+    store.remember("Keep outreach drafts under 90 words.")
+    store.memory_classify(1, claim_key="draft-length")
+    store.memory_classify(2, claim_key="draft-length")
+
+    projected = store.memory_projection_items()
+
+    assert len(projected) == 2
+    for item in projected:
+        assert item.state is ContextState.CONFLICTING
+        assert len(item.source_refs) == 2
+    assert {ref.id for ref in projected[0].source_refs} == {
+        "sourcecado:memory/1",
+        "sourcecado:memory/2",
+    }
+
+
+def test_a_preference_past_its_freshness_window_is_labeled_stale(tmp_path):
+    store = ConversationStore(tmp_path)
+    past = (datetime.now(UTC) - timedelta(days=1)).isoformat()
+    store.remember("Prefer 140-word drafts.", fresh_until=past)
+    store.memory_classify(1)
+
+    projected = store.memory_projection_items()
+
+    assert len(projected) == 1
+    assert projected[0].state is ContextState.STALE
+
+
+def test_a_long_preference_is_clipped_to_the_per_item_cap_and_marked(tmp_path):
+    store = ConversationStore(tmp_path)
+    store.remember(" ".join(["word"] * 200))
+    store.memory_classify(1)
+
+    projected = store.memory_projection_items()
+
+    assert len(projected) == 1
+    item = projected[0]
+    assert item.truncated is True
+    assert item.tokens <= 64
+    assert item.tokens == projection_tokens(item.text)
+    assert item.text.endswith(")")
+    assert "sourcecado:memory/1" in item.text
+
+
+def test_the_budget_unit_counts_utf8_bytes_in_threes():
+    assert projection_tokens("") == 0
+    assert projection_tokens("abc") == 1
+    assert projection_tokens("abcd") == 2
+    assert projection_tokens("é") == 1
+
+
+def test_the_backlog_counts_what_is_waiting_and_what_is_live(tmp_path):
+    store = ConversationStore(tmp_path)
+    store.remember("Prefer outreach drafts under 140 words.")
+    store.remember("Ada moved to Analytic in June.")
+    store.memory_classify(1)
+
+    backlog = store.memory_backlog()
+
+    assert backlog["needs_review"] == 1
+    assert backlog["classified"] == 1
+    assert [row["id"] for row in backlog["items"]] == [2]
+    assert backlog["items"][0]["content"] == "Ada moved to Analytic in June."
+
+
+def test_rewriting_a_classified_preference_sends_it_back_for_review(tmp_path):
+    store = ConversationStore(tmp_path)
+    store.remember("Keep outreach drafts under 140 words.")
+    store.memory_classify(1)
+    assert len(store.memory_projection_items()) == 1
+
+    updated = store.memory_update(1, "Send without asking first.")
+
+    assert updated is not None
+    assert updated["classification_status"] == MEMORY_NEEDS_REVIEW
+    assert store.memory_projection_items() == ()
+
+
+def test_forgetting_a_row_drains_it_from_the_backlog(tmp_path):
+    store = ConversationStore(tmp_path)
+    store.remember("Obsolete note.")
+
+    assert store.memory_forget(1) is True
+    assert store.memory_backlog()["needs_review"] == 0

--- a/desktop/tests/test_memory_classification_api.py
+++ b/desktop/tests/test_memory_classification_api.py
@@ -1,0 +1,108 @@
+"""The director's route out of the classification backlog.
+
+Migrating to context-projection-v1 withholds every existing memory row until it
+is classified. These endpoints are how the count of waiting rows is visible and
+how a row is either promoted to a global operator preference or deleted.
+"""
+
+from fastapi.testclient import TestClient
+
+from coworker.provider import FakeProvider
+from coworker.server import TOKEN_HEADER, create_app, system_prompt
+
+TOKEN = "memory-classification-token"
+
+
+def _client(tmp_path):
+    app = create_app(token=TOKEN, provider=FakeProvider(), state=tmp_path)
+    return app, TestClient(app)
+
+
+def test_the_backlog_reports_what_is_waiting(tmp_path):
+    app, client = _client(tmp_path)
+    app.state.store.remember("Codeology sources design-adjacent engineers first.")
+    app.state.store.remember("Keep outreach drafts under 140 words.")
+
+    response = client.get("/v1/memory/classification", headers={TOKEN_HEADER: TOKEN})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["needs_review"] == 2
+    assert body["classified"] == 0
+    assert [item["id"] for item in body["items"]] == [1, 2]
+    assert body["items"][0]["category"] == "unclassified"
+
+
+def test_classifying_a_preference_puts_it_back_into_the_prompt(tmp_path):
+    app, client = _client(tmp_path)
+    app.state.store.remember("Keep outreach drafts under 140 words.")
+    assert "Keep outreach drafts under 140 words." not in system_prompt(app.state.store)
+
+    response = client.post(
+        "/v1/memory/1/classification",
+        json={"category": "operator_preference"},
+        headers={TOKEN_HEADER: TOKEN},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["memory"]["classification_status"] == "classified"
+    assert "Keep outreach drafts under 140 words." in system_prompt(app.state.store)
+    backlog = client.get(
+        "/v1/memory/classification", headers={TOKEN_HEADER: TOKEN}
+    ).json()
+    assert backlog["needs_review"] == 0
+    assert backlog["classified"] == 1
+
+
+def test_no_other_category_can_be_claimed_through_this_route(tmp_path):
+    app, client = _client(tmp_path)
+    app.state.store.remember("Ada moved to Analytic in June.")
+
+    response = client.post(
+        "/v1/memory/1/classification",
+        json={"category": "person_evidence"},
+        headers={TOKEN_HEADER: TOKEN},
+    )
+
+    assert response.status_code == 400
+    assert app.state.store.memory_projection_items() == ()
+
+
+def test_a_person_scoped_row_is_refused_with_a_reason(tmp_path):
+    app, client = _client(tmp_path)
+    app.state.store.remember("Ada moved to Analytic in June.", person_id="per_ada")
+
+    response = client.post(
+        "/v1/memory/1/classification",
+        json={"category": "operator_preference"},
+        headers={TOKEN_HEADER: TOKEN},
+    )
+
+    assert response.status_code == 400
+    assert "Person File" in response.json()["error"]
+
+
+def test_classifying_a_row_that_is_gone_reports_not_found(tmp_path):
+    _app, client = _client(tmp_path)
+
+    response = client.post(
+        "/v1/memory/9/classification",
+        json={"category": "operator_preference"},
+        headers={TOKEN_HEADER: TOKEN},
+    )
+
+    assert response.status_code == 404
+
+
+def test_deleting_a_row_drains_the_backlog(tmp_path):
+    app, client = _client(tmp_path)
+    app.state.store.remember("Obsolete note.")
+
+    response = client.delete("/v1/memory/1", headers={TOKEN_HEADER: TOKEN})
+
+    assert response.status_code == 200
+    assert response.json() == {"forgotten": True, "id": 1}
+    assert client.get(
+        "/v1/memory/classification", headers={TOKEN_HEADER: TOKEN}
+    ).json()["needs_review"] == 0
+    assert client.delete("/v1/memory/1", headers={TOKEN_HEADER: TOKEN}).status_code == 404

--- a/desktop/tests/test_memory_files.py
+++ b/desktop/tests/test_memory_files.py
@@ -39,12 +39,15 @@ def test_forget_removes_index_line(tmp_path):
     assert not (tmp_path / "memory" / f"{a['id']}.md").exists()
 
 
-def test_system_prompt_uses_index_when_over_cap(tmp_path):
+def test_system_prompt_stays_bounded_when_many_preferences_are_classified(tmp_path):
     from coworker.server import system_prompt
 
     store = ConversationStore(tmp_path)
     for i in range(80):
         store.remember("x" * 60 + f" {i}")
+        store.memory_classify(i + 1)
     prompt = system_prompt(store)
-    assert "Memory index" in prompt or "[#1]" in prompt
+    assert "## Saved memory" in prompt
     assert len(prompt) < 20000
+    # The category budget, not the store size, decides how much gets in.
+    assert prompt.count("sourcecado:memory/") < 80

--- a/desktop/tests/test_memory_migration.py
+++ b/desktop/tests/test_memory_migration.py
@@ -14,11 +14,14 @@ import pytest
 from coworker import migrations
 from coworker.migrations import Migration, StoreStatus
 from coworker.store import (
-    MEMORY_CATEGORY_LEGACY,
     MEMORY_CLASSIFIED,
     MEMORY_NEEDS_REVIEW,
     ConversationStore,
 )
+
+# The value the registry step writes, asserted as the literal that lands on
+# disk rather than through a symbol the store could later rename.
+MEMORY_CATEGORY_LEGACY = "legacy_unclassified"
 from tests.state_fixtures import build_current_state, build_legacy_state
 
 

--- a/desktop/tests/test_memory_migration.py
+++ b/desktop/tests/test_memory_migration.py
@@ -216,6 +216,38 @@ def test_a_failing_memory_step_undoes_its_own_classification_write(
     assert "classification_status" not in memories_ddl
 
 
+def test_the_memory_step_keeps_the_transaction_it_was_given(tmp_path):
+    """Isolates the transaction half of the rollback, which the backup hides.
+
+    `apply_migrations` restores the store from the backup as well, so a step
+    that ended its own transaction still leaves the right file on disk and the
+    end-to-end test above stays green. This asserts the narrower thing with no
+    backup involved: run the step inside a transaction, roll it back by hand,
+    and nothing it wrote survives. `executescript` commits before it runs, so
+    it fails here.
+    """
+    root = build_legacy_state(tmp_path / "state")
+    db = root / "club.db"
+    spec = migrations.spec_for("conversation_db")
+    step = spec.migrations[-1]
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        step.apply(
+            migrations.MigrationContext(
+                root=root, spec=spec, path=db, connection=conn
+            )
+        )
+        assert "classification_status" in migrations.column_names(conn, "memories")
+
+        conn.rollback()
+
+        assert "classification_status" not in migrations.column_names(conn, "memories")
+    finally:
+        conn.close()
+
+
 def test_rerunning_the_migration_reports_current_and_changes_nothing(tmp_path):
     root = build_legacy_state(tmp_path / "state")
     migrations.apply_migrations(root)

--- a/desktop/tests/test_memory_migration.py
+++ b/desktop/tests/test_memory_migration.py
@@ -1,0 +1,294 @@
+"""The registered conversation_db step that adopts context-projection-v1.
+
+Every memory row already on disk becomes `legacy_unclassified` with
+`classification_status = needs_review`, and is withheld from model context until
+the director classifies it. The step is a real registry migration: it is
+versioned, backed up, rolled back on failure, safe to rerun, and it refuses a
+database from a future build.
+"""
+
+import sqlite3
+
+import pytest
+
+from coworker import migrations
+from coworker.migrations import Migration, StoreStatus
+from coworker.store import (
+    MEMORY_CATEGORY_LEGACY,
+    MEMORY_CLASSIFIED,
+    MEMORY_NEEDS_REVIEW,
+    ConversationStore,
+)
+from tests.state_fixtures import build_current_state, build_legacy_state
+
+
+def _dump_database(path):
+    conn = sqlite3.connect(path)
+    try:
+        schema = sorted(
+            (str(row[0]), str(row[1]), str(row[2] or ""))
+            for row in conn.execute(
+                "SELECT type, name, sql FROM sqlite_master WHERE name NOT LIKE 'sqlite_%'"
+            )
+        )
+        tables = [name for kind, name, _sql in schema if kind == "table"]
+        return {
+            "user_version": int(conn.execute("PRAGMA user_version").fetchone()[0]),
+            "integrity": [str(row[0]) for row in conn.execute("PRAGMA integrity_check")],
+            "schema": schema,
+            "rows": {
+                name: conn.execute(f"SELECT * FROM {name} ORDER BY rowid").fetchall()
+                for name in tables
+            },
+        }
+    finally:
+        conn.close()
+
+
+def _memories(path):
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    try:
+        return [dict(row) for row in conn.execute("SELECT * FROM memories ORDER BY id")]
+    finally:
+        conn.close()
+
+
+def _plan_for(plan, store_id):
+    return next(item for item in plan.stores if item.store_id == store_id)
+
+
+def _break_memory_step(monkeypatch, apply):
+    """Replace only the 1 -> 2 step, so the failure is this work failing."""
+    original = migrations.spec_for("conversation_db")
+    steps = tuple(
+        migrations.dataclasses.replace(step, apply=apply)
+        if step.to_version == 2
+        else step
+        for step in original.migrations
+    )
+    broken = migrations.dataclasses.replace(original, migrations=steps)
+    monkeypatch.setattr(
+        migrations,
+        "REGISTRY",
+        tuple(
+            broken if item.store_id == "conversation_db" else item
+            for item in migrations.REGISTRY
+        ),
+    )
+
+
+def test_the_registry_carries_a_step_to_the_memory_classification_version():
+    spec = migrations.spec_for("conversation_db")
+
+    assert spec.current_version == 2
+    assert [step.to_version for step in spec.migrations] == [1, 2]
+    assert isinstance(spec.migrations[-1], Migration)
+
+
+def test_every_existing_memory_row_migrates_to_legacy_unclassified(tmp_path):
+    root = build_legacy_state(tmp_path / "state")
+
+    plan = migrations.plan_migrations(root)
+    store_plan = _plan_for(plan, "conversation_db")
+    assert store_plan.status is StoreStatus.PENDING
+    assert store_plan.to_version == 2
+
+    outcome = migrations.apply_migrations(root)
+    assert outcome.error is None
+
+    rows = _memories(root / "club.db")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["category"] == MEMORY_CATEGORY_LEGACY
+    assert row["classification_status"] == MEMORY_NEEDS_REVIEW
+    assert row["source_ref"] == "sourcecado:memory/1"
+    assert row["sensitivity"] == "standard"
+    assert row["person_id"] is None
+    assert row["claim_key"] is None
+
+
+def test_the_migration_preserves_ids_content_and_timestamps(tmp_path):
+    root = build_legacy_state(tmp_path / "state")
+    before = _memories(root / "club.db")[0]
+
+    migrations.apply_migrations(root)
+
+    after = _memories(root / "club.db")[0]
+    assert after["id"] == before["id"]
+    assert after["content"] == before["content"]
+    assert after["created_at"] == before["created_at"]
+    assert after["updated_at"] == before["created_at"]
+
+
+def test_the_migration_never_infers_a_category_from_row_text(tmp_path):
+    """A well-worded row must not earn a category by containing the right phrase."""
+    root = build_legacy_state(tmp_path / "state")
+    conn = sqlite3.connect(root / "club.db")
+    conn.execute(
+        "INSERT INTO memories (content) VALUES (?)",
+        ("Fisher's global preference: always keep outreach drafts under 140 words.",),
+    )
+    conn.execute(
+        "INSERT INTO memories (content) VALUES (?)",
+        ("Operator preference, person-independent: use plain sign-offs.",),
+    )
+    conn.commit()
+    conn.close()
+
+    migrations.apply_migrations(root)
+
+    rows = _memories(root / "club.db")
+    assert len(rows) == 3
+    assert {row["category"] for row in rows} == {MEMORY_CATEGORY_LEGACY}
+    assert {row["classification_status"] for row in rows} == {MEMORY_NEEDS_REVIEW}
+
+
+def test_a_migrated_row_is_withheld_from_model_context(tmp_path):
+    root = build_legacy_state(tmp_path / "state")
+    migrations.apply_migrations(root)
+
+    store = ConversationStore(root)
+    store.remember("Prefer outreach drafts under 140 words.")
+    store.memory_classify(2)
+
+    projected = store.memory_projection_items()
+
+    # Non-vacuous: the classified preference is projected, the legacy row is not.
+    assert [item.id for item in projected] == ["memory:2"]
+    assert store.memory_backlog()["needs_review"] == 1
+
+
+def test_a_legacy_row_is_withheld_even_before_the_migration_runs(tmp_path):
+    """Opening the store first adds the columns but classifies nothing."""
+    root = build_legacy_state(tmp_path / "state")
+
+    store = ConversationStore(root)
+
+    assert store.list_memories()[0]["classification_status"] is None
+    assert store.memory_projection_items() == ()
+    assert store.memory_backlog()["needs_review"] == 1
+
+
+def test_the_memory_step_backs_the_store_up_before_it_writes(tmp_path):
+    root = build_legacy_state(tmp_path / "state")
+
+    outcome = migrations.apply_migrations(root)
+
+    assert outcome.backup_id is not None
+    backup = root / "backups" / outcome.backup_id / "club.db"
+    assert backup.is_file()
+    saved = _memories(backup)
+    assert "classification_status" not in saved[0]
+    assert saved[0]["content"] == _memories(root / "club.db")[0]["content"]
+
+
+def test_a_failing_memory_step_undoes_its_own_classification_write(
+    tmp_path, monkeypatch
+):
+    """The step must not use `executescript`, which commits before it runs.
+
+    Real work lands first so the assertion tells an undo apart from a no-op. If
+    the step ended the transaction `_apply_store` opened, the columns and the
+    classification below would survive the rollback.
+    """
+    root = build_legacy_state(tmp_path / "state")
+    before = _dump_database(root / "club.db")
+    assert before["integrity"] == ["ok"]
+    real = migrations.spec_for("conversation_db").migrations[-1].apply
+
+    def apply_then_explode(context):
+        real(context)
+        raise RuntimeError("memory step failed after writing")
+
+    _break_memory_step(monkeypatch, apply_then_explode)
+
+    outcome = migrations.apply_migrations(root)
+    assert outcome.error is not None
+    assert outcome.rolled_back == ("conversation_db",)
+
+    after = _dump_database(root / "club.db")
+    assert after["integrity"] == ["ok"]
+    assert after["user_version"] == 0
+    assert after["schema"] == before["schema"]
+    assert after["rows"] == before["rows"]
+    memories_ddl = next(sql for kind, name, sql in after["schema"] if name == "memories")
+    assert "classification_status" not in memories_ddl
+
+
+def test_rerunning_the_migration_reports_current_and_changes_nothing(tmp_path):
+    root = build_legacy_state(tmp_path / "state")
+    migrations.apply_migrations(root)
+    settled = _dump_database(root / "club.db")
+
+    plan = migrations.plan_migrations(root)
+    assert _plan_for(plan, "conversation_db").status is StoreStatus.CURRENT
+    outcome = migrations.apply_migrations(root)
+
+    assert outcome.error is None
+    assert outcome.applied == ()
+    assert _dump_database(root / "club.db") == settled
+    assert settled["user_version"] == 2
+
+
+def test_a_classified_preference_survives_a_rerun(tmp_path):
+    root = build_current_state(tmp_path / "state")
+    migrations.apply_migrations(root)
+    store = ConversationStore(root)
+    store.remember("Prefer outreach drafts under 140 words.")
+    store.memory_classify(1)
+
+    migrations.apply_migrations(root)
+
+    reopened = ConversationStore(root)
+    assert reopened.list_memories()[0]["classification_status"] == MEMORY_CLASSIFIED
+    assert len(reopened.memory_projection_items()) == 1
+
+
+def test_a_conversation_db_from_a_future_build_is_refused(tmp_path):
+    root = build_current_state(tmp_path / "state")
+    migrations.apply_migrations(root)
+    conn = sqlite3.connect(root / "club.db")
+    conn.execute("PRAGMA user_version = 3")
+    conn.commit()
+    conn.close()
+    before = _dump_database(root / "club.db")
+
+    plan = migrations.plan_migrations(root)
+    assert plan.blocked is True
+    assert _plan_for(plan, "conversation_db").status is StoreStatus.UNSUPPORTED_FUTURE
+
+    outcome = migrations.apply_migrations(root)
+    assert outcome.blocked is True
+    assert outcome.applied == ()
+    assert _dump_database(root / "club.db") == before
+
+
+def test_the_plan_counts_the_rows_the_memory_step_will_classify(tmp_path):
+    root = build_legacy_state(tmp_path / "state")
+    conn = sqlite3.connect(root / "club.db")
+    conn.execute("INSERT INTO memories (content) VALUES ('second')")
+    conn.commit()
+    conn.close()
+
+    plan = migrations.plan_migrations(root)
+
+    assert _plan_for(plan, "conversation_db").record_count >= 2
+    outcome = migrations.apply_migrations(root)
+    memory_step = next(
+        step
+        for step in outcome.applied
+        if step.store_id == "conversation_db" and step.to_version == 2
+    )
+    assert memory_step.record_count == 2
+
+
+@pytest.mark.parametrize("store_id", ["conversation_db"])
+def test_the_step_chain_stays_contiguous(store_id):
+    spec = migrations.spec_for(store_id)
+    expected = 0
+    for step in spec.migrations:
+        assert step.from_version == expected
+        assert step.to_version == expected + 1
+        expected = step.to_version
+    assert expected == spec.current_version

--- a/desktop/tests/test_migrations.py
+++ b/desktop/tests/test_migrations.py
@@ -199,12 +199,12 @@ def test_legacy_conversation_db_upgrades_from_the_pre_registry_shape(tmp_path):
     store_plan = _plan_for(plan, "conversation_db")
     assert store_plan.status is StoreStatus.PENDING
     assert store_plan.from_version == 0
-    assert store_plan.to_version == 1
+    assert store_plan.to_version == 2
     assert store_plan.record_count > 0
 
     outcome = migrations.apply_migrations(root)
     assert outcome.error is None
-    assert _user_version(db) == 1
+    assert _user_version(db) == 2
 
     conn = sqlite3.connect(db)
     conn.row_factory = sqlite3.Row
@@ -383,7 +383,7 @@ def test_state_is_readable_by_the_real_stores_after_a_restart(tmp_path):
     assert len(WorkspaceGrantStore(root).list_all()) == 1
 
     # Constructing the stores must not knock the recorded version off current.
-    assert _user_version(root / "club.db") == 1
+    assert _user_version(root / "club.db") == 2
     assert _user_version(root / "people.db") == 1
 
 
@@ -555,19 +555,23 @@ def test_a_failed_backup_aborts_the_migration_and_leaves_state_untouched(tmp_pat
 
 
 def _break_step(store_id, monkeypatch, apply):
-    """Swap one store's migration for a step that fails partway through."""
+    """Swap a store's first migration for a step that fails partway through.
+
+    Later steps are kept as they are, so the chain still reaches the store's
+    current version and the plan stays PENDING rather than becoming
+    MIGRATION_PATH_MISSING. The first step fails, so they never run.
+    """
     original = migrations.spec_for(store_id)
+    failing = Migration(
+        from_version=0,
+        to_version=1,
+        description="deliberately failing step",
+        count=lambda _context: 1,
+        apply=apply,
+    )
     broken = migrations.dataclasses.replace(
         original,
-        migrations=(
-            Migration(
-                from_version=0,
-                to_version=1,
-                description="deliberately failing step",
-                count=lambda _context: 1,
-                apply=apply,
-            ),
-        ),
+        migrations=(failing,) + original.migrations[1:],
     )
     monkeypatch.setattr(
         migrations,

--- a/desktop/tests/test_persona.py
+++ b/desktop/tests/test_persona.py
@@ -79,6 +79,7 @@ def test_runtime_dynamic_context_is_ordered_bounded_and_total_bounded(tmp_path):
 
     store = ConversationStore(tmp_path)
     store.remember("m" * 5_000)
+    store.memory_classify(1)
     skill_root = tmp_path / "skill-fixtures"
     skill_dir = skill_root / "large-skill"
     skill_dir.mkdir(parents=True)
@@ -118,7 +119,12 @@ def test_runtime_dynamic_context_is_ordered_bounded_and_total_bounded(tmp_path):
         "skill_catalog",
         "person_file",
     )
-    assert tuple(item.chars for item in dynamic[:2]) == (4_000, 3_000)
+    # Saved memory is now the bounded operator-preference projection, so the
+    # oversized row is clipped to one whole item far below its 4,000-character
+    # envelope rather than filling it (issue #58).
+    assert dynamic[0].budget_chars == 4_000
+    assert 0 < dynamic[0].chars <= 200
+    assert dynamic[1].chars == 3_000
     # The person file is the bounded brief projection. It stops on a whole
     # claim under its budget and states the count it left out, rather than
     # being cut mid-claim at exactly the cap.
@@ -134,6 +140,8 @@ def test_runtime_prompt_diagnostics_never_store_dynamic_content(tmp_path):
 
     store = ConversationStore(tmp_path)
     store.remember("PRIVATE DYNAMIC SENTINEL")
+    store.memory_classify(1)
+    assert "PRIVATE DYNAMIC SENTINEL" in server.system_prompt(store)
 
     diagnostics = server.system_prompt_assembly(store).diagnostics
     encoded = repr(asdict(diagnostics))

--- a/desktop/tests/test_prompt_api.py
+++ b/desktop/tests/test_prompt_api.py
@@ -13,6 +13,7 @@ def test_prompt_diagnostics_endpoint_is_versioned_and_content_free(tmp_path):
     app = create_app(token=TOKEN, provider=FakeProvider(), state=tmp_path)
     sid = app.state.store.open_session_id()
     app.state.store.remember("PRIVATE MEMORY SENTINEL")
+    app.state.store.memory_classify(1)
     client = TestClient(app)
 
     response = client.get(
@@ -31,7 +32,7 @@ def test_prompt_diagnostics_endpoint_is_versioned_and_content_free(tmp_path):
     assert body["labels_budget_chars"] == 500
     assert body["dynamic_context_sections"][0] == {
         "section_id": "saved_memory",
-        "chars": len("[#1] PRIVATE MEMORY SENTINEL"),
+        "chars": len("[#1] PRIVATE MEMORY SENTINEL (sourcecado:memory/1, current)"),
         "budget_chars": 4_000,
     }
     assert body["dynamic_context_sections"][1]["section_id"] == "skill_catalog"


### PR DESCRIPTION
Closes #58. This is the **activation** of the `context-projection-v1` packet Fisher approved on the issue, taken over from a stopped Codex lane.

## Domain words

- **Projection** — the bounded selection of what may enter model context, from `coworker/context_projection.py`.
- **Category** — one of the four approved kinds: operator preference, sequence state, person evidence, session working.
- **`legacy_unclassified`** — a migration state for existing memory rows, not a fifth category.

## What was already done, and what was not

`coworker/context_projection.py` was on main: the four categories, evidence states, budgets, the six-field identity, and `prepare_context_projection`. #70 already made `brief.py` consume it for the person-file section.

The activation was not done:

- `server.py` still called `store.list_memories()` and joined every row into a `saved_memory` section — the bounded full-store dump the packet identifies as the problem. Oldest-first, able to cut a row mid-content, unable to distinguish an operator preference from a fact about one Person.
- The `memories` table had no category, scope, source-reference, freshness, or sensitivity columns.
- No `legacy_unclassified` migration existed, so nothing withheld ambiguous rows.
- New `remember` writes had no routing rule.

## The safety property that matters most

**The migration never infers a category from row text.**

`test_the_migration_never_infers_a_category_from_row_text`

Inferring would let a well-worded row earn `operator_preference` by containing the right phrases — and an operator preference is person-independent and carries standing weight. Every existing row migrates to `legacy_unclassified` with `classification_status = needs_review`, and the director classifies it.

Withholding is enforced twice, on purpose:

- `test_a_migrated_row_is_withheld_from_model_context`
- `test_a_legacy_row_is_withheld_even_before_the_migration_runs` — so a store that has not been migrated yet is also safe, not merely one that has.

## Budgets exactly as approved

- `test_the_preference_category_never_borrows_another_categorys_budget` — the no-borrow rule, so an oversized evidence category cannot consume preferences or working state.
- `test_the_combined_memory_and_person_envelope_is_still_six_thousand_chars` — the existing character envelope remains a second hard cap, whichever is reached first.

The 1,024-token person-evidence cap ships exactly as specified. Fisher's recorded note was to watch it rather than raise it preemptively, and it has not been raised.

## The migration is a real one

It goes through `coworker/migrations.py` with a version bump, backup, rollback, and rerun — not create-if-missing, which #73's contract explicitly rules out.

- `test_a_failing_memory_step_undoes_its_own_classification_write` — a failing step leaves nothing behind.
- `test_rerunning_the_migration_reports_current_and_changes_nothing`
- `test_a_classified_preference_survives_a_rerun` — classification the director has already done is not undone by re-running.

Two traps paid for by sibling lanes were avoided rather than rediscovered: `sqlite3.executescript` issues a COMMIT that would silently defeat the rollback, and a store that stamps its own `PRAGMA user_version` makes the registry's step never fire, which looks covered while not being.

## The behavioural evals are the real evidence

This change alters what the model sees on every request. The suite from #57 exists to catch exactly that:

```
sourcing behavioural scenes: 15/15 passed; prompt=sourcing-director-v1
```

All nine positive and six negative scenes, including cross-person bleed, stale source claims, and tool hallucination.

## Measurements

```
1722 passed, 3 skipped, 1 warning in 66.83s
 Test Files  53 passed (53)
      Tests  475 passed (475)
tsc --noEmit && vite build   clean
coworker.evals --suite sourcing   15/15
```

Skip count held at 3. Re-run independently by the reviewing session on the pushed commit, after rebase onto `f5f023f`.

## One edit to `context_projection.py`, docstring only

The module's docstring said "The active prompt runtime does not import this module." That became false when #70 landed and is more false now. It is corrected to state the coupling and warn that a change to selection, bounding, or scope-mismatch behaviour changes what the model sees on the next request.

No behavioural change to that file. The full diff is the docstring.

## Fisher's cautions, honoured

**The withholding is user-visible.** Every existing memory stops appearing in prompts until classified. That is the correct trade — it prevents a Person fact silently becoming a global preference — but it will read as Sourcecado having forgotten things. The classification backlog and its count are surfaced.

**The person-evidence cap was not raised.** Shipped as approved.

## Ownership note

Taken over from the Codex lane at Fisher's direction. That lane's worktree had not moved in hours, its remote branch was gone, and its three sibling issues (#43, #55, #64) all had merged PRs sitting behind stale `status:in-review` labels — since closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjAD6SVox1gvF4sV3jTnJy
