### PR TITLE
feat(desktop): run the external-effect fence on the paths that send

### DIFF
--- a/desktop/coworker/agent_run_dispatch.py
+++ b/desktop/coworker/agent_run_dispatch.py
@@ -1,0 +1,408 @@
+"""Where an Agent Run meets the work that produces it.
+
+`coworker/agent_run_repository.py` can fence an external effect. Nothing called
+it. This module is the seam that does, and it exists so the ordering contract
+is written once instead of at every call site:
+
+    dispatch commits BEFORE the call, the outcome commits AFTER it.
+
+`guarded_call` is the only way this package makes a consequential call, and it
+encodes that order in control flow. A caller cannot get it backwards without
+deleting the function, which is what `tests/test_agent_run_fence_mutations.py`
+does on purpose to prove the guard is load-bearing.
+
+Which tools this applies to is not decided here and is not a list anyone typed.
+`agent_run_approval.replay_class` reads `permissions.RETRY_SAFE`, and everything
+outside that set is consequential -- including a tool the permission module has
+never heard of. `needs_fence` is that question and nothing else.
+
+## Failing closed, and what that costs
+
+Two kinds of write happen against a run, and they fail differently on purpose.
+
+A **checkpoint** is a record of progress. Losing the lease under one means this
+process no longer owns the run, so it stops writing -- but a chat turn that is
+already mid-flight is not killed for it. `note` closes the context instead.
+
+A **fence write** is the thing the effect record exists for. A closed context
+refuses to dispatch, and `guarded_call` refuses to make the call: an external
+effect Sourcecado cannot record durably is an external effect it does not make.
+That is the whole trade. A run store that goes unwritable stops sends; it never
+lets one through unrecorded.
+
+## What a raised call means
+
+A tool that returns says what happened. A tool that raises out of the call --
+a cancelled turn most of all, where an operator pressed stop while a send was
+in flight -- says nothing at all, and `record_effect_outcome` has no value for
+"nothing at all". So the guard quarantines and re-raises. The effect becomes a
+person's to settle, which is the same place a crash in that window lands it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Awaitable, Callable
+
+from coworker.agent_run_approval import replay_class, ReplayClass
+from coworker.agent_run_owner import RunOwner
+from coworker.agent_run_repository import (
+    AgentRunLease,
+    AgentRunRepository,
+)
+
+# A turn holds its run for as long as one model call plus one tool call can
+# plausibly take. Shorter, and an ordinary slow provider stream loses the lease
+# mid-turn; longer buys nothing, because a dead owner is reclaimed from its
+# released `flock` immediately and never has to wait for expiry.
+TURN_LEASE_SECONDS = 900
+# Renew when this much or less is left, so the gap a write has to survive is
+# one step rather than the whole run.
+RENEW_MARGIN_SECONDS = 120
+
+_MAX_ERROR_SUMMARY = 400
+
+
+class AgentRunUnavailable(RuntimeError):
+    """The run store cannot fence this call, so the call is not made."""
+
+
+class AgentRunEffectQuarantined(RuntimeError):
+    """A consequential call raised. Whether it happened is now a person's call.
+
+    Never swallow this into a tool failure. "It failed" and "we do not know"
+    are different facts, and turning the second into the first is the mistake
+    the whole run store exists to prevent.
+    """
+
+    def __init__(self, effect_id: str, tool_name: str) -> None:
+        super().__init__(
+            f"{tool_name} was dispatched and never reported an outcome; "
+            f"effect {effect_id} is quarantined for a person to settle"
+        )
+        self.effect_id = effect_id
+        self.tool_name = tool_name
+
+
+def needs_fence(tool_name: str) -> bool:
+    """Whether attempting this tool could produce a second external effect.
+
+    Derived, never listed. `replay_class` reads `permissions.RETRY_SAFE`, so a
+    tool added to the product is fenced until someone deliberately declares it
+    safe to re-run.
+    """
+    return replay_class(tool_name) is ReplayClass.CONSEQUENTIAL
+
+
+def _summary(value: Any) -> str:
+    return str(value)[:_MAX_ERROR_SUMMARY]
+
+
+@dataclass
+class AgentRunContext:
+    """One durable Agent Run, held for the life of one unit of assistant work."""
+
+    repository: AgentRunRepository
+    owner: RunOwner
+    run_id: str
+    lease: AgentRunLease | None
+    closed_reason: str | None = None
+
+    @classmethod
+    def start(
+        cls,
+        repository: AgentRunRepository | None,
+        owner: RunOwner | None,
+        *,
+        session_id: str,
+        trigger: str,
+        goal: str,
+        run_id: str | None = None,
+        person_id: str | None = None,
+        provider_model_id: str | None = None,
+        parent_run_id: str | None = None,
+        lease_seconds: int | float = TURN_LEASE_SECONDS,
+        now: datetime | None = None,
+    ) -> AgentRunContext | None:
+        """Open a run, or return None because this caller keeps no run store.
+
+        Returning None is not a quiet downgrade: a context that does not exist
+        refuses consequential tools exactly as a closed one does, because
+        `guarded_call` is the only path to them.
+        """
+        if repository is None or owner is None:
+            return None
+        started = repository.create_run(
+            session_id=session_id,
+            trigger=trigger,
+            goal=goal,
+            owner=owner,
+            run_id=run_id,
+            person_id=person_id,
+            provider_model_id=provider_model_id,
+            parent_run_id=parent_run_id,
+            lease_seconds=lease_seconds,
+            now=now,
+        )
+        return cls(
+            repository=repository,
+            owner=owner,
+            run_id=started.run["run_id"],
+            lease=started.lease,
+        )
+
+    @classmethod
+    def disarmed(
+        cls,
+        repository: AgentRunRepository | None,
+        owner: RunOwner | None,
+        *,
+        reason: str,
+    ) -> AgentRunContext | None:
+        """A run that could not be opened, for a caller that has a run store.
+
+        The distinction this exists for: `None` means nobody armed the fence,
+        and a closed context means somebody did and it broke. `guarded_call`
+        treats them differently on purpose, because a caller who supplied a run
+        store and got nothing must not send, while a caller who never supplied
+        one was never fenced in the first place.
+        """
+        if repository is None or owner is None:
+            return None
+        return cls(
+            repository=repository,
+            owner=owner,
+            run_id="",
+            lease=None,
+            closed_reason=reason,
+        )
+
+    # --- state -----------------------------------------------------------
+
+    @property
+    def closed(self) -> bool:
+        return self.closed_reason is not None
+
+    def close(self, reason: str) -> None:
+        if self.closed_reason is None:
+            self.closed_reason = reason
+        self.lease = None
+
+    def _renew_if_stale(self, now: datetime | None = None) -> None:
+        if self.lease is None:
+            return
+        moment = now or datetime.now(UTC)
+        try:
+            expires = datetime.fromisoformat(str(self.lease.expires_at))
+        except ValueError:
+            return
+        if expires - moment > timedelta(seconds=RENEW_MARGIN_SECONDS):
+            return
+        self.lease = self.repository.renew_lease(
+            self.lease, TURN_LEASE_SECONDS, now=moment
+        )
+
+    # --- checkpoints -----------------------------------------------------
+
+    def note(
+        self,
+        kind: str,
+        *,
+        state: str | None = None,
+        payload: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> bool:
+        """Record progress. A failure here closes the run, never the turn.
+
+        Losing the lease means another process may own this run, so this one
+        stops writing to it. It does not follow that the operator's turn should
+        die -- but it does follow that no consequential tool may run after it,
+        and a closed context is what enforces that.
+        """
+        if self.closed or self.lease is None:
+            return False
+        try:
+            self._renew_if_stale()
+            commit = self.repository.checkpoint(
+                self.lease, kind=kind, state=state, payload=payload, **kwargs
+            )
+        except Exception as exc:  # the run is no longer ours to write to
+            self.close(f"{type(exc).__name__}: {_summary(exc)}")
+            return False
+        self.lease = commit.lease
+        return True
+
+    def park(self, approval_id: str, **payload: Any) -> bool:
+        """Park the run on a person. The lease is released with the write."""
+        return self.note(
+            "waiting_approval",
+            state="waiting_approval",
+            payload={"approval_id": approval_id, **payload},
+            approval_ids=[approval_id],
+        )
+
+    def resume(self, approval_id: str, decision: str) -> bool:
+        """Come back through the approval door and pick the lease up again."""
+        if self.closed:
+            return False
+        try:
+            commit = self.repository.resume_from_approval(
+                self.run_id,
+                self.owner,
+                approval_id=approval_id,
+                decision=decision,
+                lease_seconds=TURN_LEASE_SECONDS,
+            )
+        except Exception as exc:
+            self.close(f"{type(exc).__name__}: {_summary(exc)}")
+            return False
+        if commit is None or commit.lease is None:
+            self.close("the approval door did not return a lease")
+            return False
+        self.lease = commit.lease
+        return True
+
+    def finish(self, state: str, **result: Any) -> bool:
+        """End the run. `terminal_result` is shape only, never the answer."""
+        return self.note("terminal", state=state, terminal_result=result)
+
+    # --- the fence -------------------------------------------------------
+
+    def dispatch(
+        self,
+        *,
+        tool_name: str,
+        arguments: Any,
+        tool_call_id: str | None = None,
+        approval_id: str | None = None,
+        step: int | None = None,
+    ) -> str:
+        """Record that an external effect is about to be attempted.
+
+        Raises rather than degrading. A caller that cannot open an effect
+        record must not make the call, so there is no return value meaning
+        "carry on unfenced".
+        """
+        if self.closed or self.lease is None:
+            raise AgentRunUnavailable(
+                self.closed_reason or "this run holds no lease"
+            )
+        self._renew_if_stale()
+        commit = self.repository.dispatch_effect(
+            self.lease,
+            tool_name=tool_name,
+            arguments=arguments,
+            tool_call_id=tool_call_id,
+            approval_id=approval_id,
+            step=step,
+        )
+        self.lease = commit.lease
+        return str(commit.effect["effect_id"])
+
+    def record(
+        self,
+        effect_id: str,
+        *,
+        ok: bool,
+        outcome_ref: str | None = None,
+        error_class: str | None = None,
+        error_summary: str | None = None,
+        duration_ms: int | None = None,
+    ) -> bool:
+        """Close the window on an effect this process dispatched."""
+        if self.lease is None:
+            return False
+        try:
+            commit = self.repository.record_effect_outcome(
+                self.lease,
+                effect_id,
+                ok=ok,
+                outcome_ref=outcome_ref,
+                error_class=error_class,
+                error_summary=(
+                    _summary(error_summary) if error_summary is not None else None
+                ),
+                duration_ms=duration_ms,
+            )
+        except Exception as exc:
+            self.close(f"{type(exc).__name__}: {_summary(exc)}")
+            return False
+        self.lease = commit.lease
+        return True
+
+    def quarantine(self, effect_id: str, *, reason: str) -> bool:
+        """Hand an effect nobody knows the outcome of to a person."""
+        if self.lease is None:
+            return False
+        try:
+            self.repository.quarantine_effect(
+                self.lease, effect_id, reason=_summary(reason)
+            )
+        except Exception as exc:
+            self.close(f"{type(exc).__name__}: {_summary(exc)}")
+            return False
+        # The quarantine parked the run and released the lease with it.
+        self.close(f"effect {effect_id} is quarantined")
+        return True
+
+
+async def guarded_call(
+    context: AgentRunContext | None,
+    *,
+    tool_name: str,
+    arguments: Any,
+    call: Callable[[], Awaitable[tuple[bool, dict[str, Any]]]],
+    tool_call_id: str | None = None,
+    approval_id: str | None = None,
+    step: int | None = None,
+) -> tuple[bool, dict[str, Any]]:
+    """Make one tool call with the ordering contract around it.
+
+    The order below is the entire recovery argument and it is expressed as
+    control flow, not as a comment: `dispatch` returns only after its
+    transaction committed, and `call` cannot run before it returns.
+
+    A retry-safe tool skips the fence because re-running it produces no second
+    external effect. Everything else is fenced, whether or not anyone thought
+    about it when the tool was added.
+    """
+    if not needs_fence(tool_name):
+        return await call()
+    if context is None:
+        # No run store was supplied for this work at all. Nothing to fence
+        # against and nothing to fail closed about: the caller never armed it.
+        # Every production caller does, and
+        # `test_agent_run_integration.py` is what holds them to it.
+        return await call()
+    if context.closed:
+        raise AgentRunUnavailable(
+            context.closed_reason or "this run holds no lease"
+        )
+    effect_id = context.dispatch(
+        tool_name=tool_name,
+        arguments=arguments,
+        tool_call_id=tool_call_id,
+        approval_id=approval_id,
+        step=step,
+    )
+    try:
+        ok, result = await call()
+    except BaseException as exc:
+        # Nothing observed the outcome. Do not guess it in either direction.
+        context.quarantine(
+            effect_id, reason=f"{type(exc).__name__} during {tool_name}"
+        )
+        # A cancellation keeps its own type on the way out. Turning it into a
+        # RuntimeError would leave the asyncio task uncancelled, so the run
+        # store's record would be right and the process still wrong.
+        if not isinstance(exc, Exception):
+            raise
+        raise AgentRunEffectQuarantined(effect_id, tool_name) from exc
+    context.record(
+        effect_id,
+        ok=ok,
+        error_class=None if ok else str(result.get("code") or "tool_error"),
+        error_summary=None if ok else str(result.get("error") or ""),
+    )
+    return ok, result

--- a/desktop/coworker/agent_run_reconcile.py
+++ b/desktop/coworker/agent_run_reconcile.py
@@ -1,0 +1,205 @@
+"""When the inbox and the run store disagree about one external effect.
+
+At-most-once has two halves and they answer different questions.
+
+`ConversationStore.decide_and_claim_inbox_execution` answers *may this run at
+all*. One claiming UPDATE, one winner, so an approved send is attempted once.
+
+The run store answers *what happened when it did*. A dispatch commits before
+the call and an outcome commits after it, so a process that dies in between
+leaves an effect nobody holds the outcome of.
+
+They compose and must not be duplicated. The claim is not re-implemented here
+and nothing in this module hands out a second permission to run.
+
+## The rule
+
+A restart writes to both stores, independently, and they can disagree.
+
+`ConversationStore._reconcile_orphaned_inbox_executions` sets every `executing`
+approval to `interrupted`, and `reap_overdue_inbox` does the same to a stale
+claim. That is the inbox saying "authorized, outcome unknown" -- but it says it
+from the *claim's* point of view: it knows a claimant vanished, and nothing
+more. It cannot know whether the call was made.
+
+`agent_run_resume.restart` quarantines an effect that was dispatched and never
+reported. That is the run store saying "the call may have gone out", and it
+knows because the dispatch record committed before the call.
+
+**When they disagree, the run store is the fence of record.** It is the only
+one of the two whose write ordering is tied to the external call, so it is the
+only one whose silence carries information. An operator is shown `ambiguous`,
+not `interrupted`, and settling it is a person's write, not a retry.
+
+The rule runs the other way too. An effect the run store recorded as
+`succeeded` is a send that happened, whatever the inbox concluded about its
+claimant. Reporting that as an interruption would invite a second send.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Protocol
+
+from coworker.agent_run_approval import (
+    EffectStatus,
+    OPERATOR_OUTCOMES,
+    external_effect_evidence,
+)
+
+# What the inbox says when its claimant vanished: authorized, outcome unknown.
+# These are the claims the run store may override, and the only ones.
+UNSETTLED_INBOX_STATUSES = frozenset({"interrupted", "executing", "pending"})
+# What a person may choose for a quarantined effect. The store refuses the rest.
+OPERATOR_DECISIONS = tuple(sorted(str(value) for value in OPERATOR_OUTCOMES))
+FENCE_OF_RECORD = "agent_run_store"
+
+
+class ApprovalReader(Protocol):
+    """The owner-native approval record, read only. Nothing here writes it."""
+
+    def get_inbox(self, item_id: str) -> dict[str, Any] | None: ...
+
+
+def reconciled_status(
+    effect: dict[str, Any] | None, approval: dict[str, Any] | None
+) -> str:
+    """What one external effect actually is, when the two stores disagree.
+
+    The run store wins whenever it has a record, because its writes bracket the
+    external call and the inbox's do not. With no effect record there is nothing
+    to override and the inbox's own account stands.
+    """
+    if effect is not None:
+        return str(effect.get("status") or "")
+    if approval is None:
+        return "unknown"
+    return str(approval.get("execution_status") or "pending")
+
+
+def supersedes_inbox(
+    effect: dict[str, Any] | None, approval: dict[str, Any] | None
+) -> bool:
+    """Whether the run store is overriding something the inbox already claimed."""
+    if effect is None or approval is None:
+        return False
+    claimed = str(approval.get("execution_status") or "")
+    return claimed != reconciled_status(effect, approval)
+
+
+def needs_a_person(effect: dict[str, Any] | None) -> bool:
+    return effect is not None and str(effect.get("status")) == EffectStatus.AMBIGUOUS
+
+
+def _approval_view(approval: dict[str, Any] | None) -> dict[str, Any] | None:
+    """The few approval fields an operator needs to settle an effect.
+
+    The resource is the binding the director already read -- recipient, subject,
+    account -- and never the body. `approval_resource` bounded it when the
+    approval was parked and nothing widens it here.
+    """
+    if approval is None:
+        return None
+    return {
+        "id": str(approval.get("id") or ""),
+        "name": str(approval.get("name") or ""),
+        "state": approval.get("state"),
+        "decision": approval.get("decision"),
+        "execution_status": approval.get("execution_status"),
+        "session_id": approval.get("session_id"),
+        "run_id": approval.get("run_id"),
+        "requested_at": approval.get("requested_at"),
+        "resource": approval.get("resource"),
+    }
+
+
+def review_row(
+    effect: dict[str, Any],
+    approval: dict[str, Any] | None,
+    run: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """One line of the operator's review queue, both stores already reconciled."""
+    return {
+        "effect_id": str(effect.get("effect_id") or ""),
+        "run_id": str(effect.get("run_id") or ""),
+        "tool_name": str(effect.get("tool_name") or ""),
+        "approval_id": effect.get("approval_id"),
+        "replay_class": effect.get("replay_class"),
+        "dispatched_at": effect.get("dispatched_at"),
+        "reason": effect.get("reason"),
+        "status": reconciled_status(effect, approval),
+        "fence_of_record": FENCE_OF_RECORD,
+        "supersedes_inbox": supersedes_inbox(effect, approval),
+        "inbox_claim": (
+            None if approval is None else approval.get("execution_status")
+        ),
+        "needs_a_person": needs_a_person(effect),
+        # The one Evidence value the run store can decide on its own. A
+        # surface that shows a receipt and this queue reads the same word for
+        # the same fact.
+        "evidence": str(external_effect_evidence([effect]) or ""),
+        "decisions": list(OPERATOR_DECISIONS),
+        "approval": _approval_view(approval),
+        "session_id": (
+            None if run is None else run.get("session_id")
+        ),
+        "person_id": None if run is None else run.get("person_id"),
+        "run_state": None if run is None else run.get("current_state"),
+    }
+
+
+def review_queue(
+    repository: Any,
+    approvals: ApprovalReader | None = None,
+    *,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """Every effect nobody knows the outcome of, joined to its approval.
+
+    `list_quarantined_effects` is the queue. This adds the two things a person
+    needs to act: what they authorized, and which run it belonged to.
+    """
+    rows: list[dict[str, Any]] = []
+    for effect in repository.list_quarantined_effects(limit=limit):
+        approval_id = effect.get("approval_id")
+        approval = (
+            approvals.get_inbox(str(approval_id))
+            if approvals is not None and approval_id
+            else None
+        )
+        rows.append(review_row(effect, approval, repository.get_run(effect["run_id"])))
+    return rows
+
+
+def contested_approvals(
+    repository: Any, approvals: Iterable[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Approvals whose inbox account the run store overrides.
+
+    An operator surface that renders `interrupted` from the inbox alone would
+    offer a retry for a send that may already have gone out. This names every
+    row where that would happen.
+    """
+    contested: list[dict[str, Any]] = []
+    for approval in approvals:
+        if str(approval.get("execution_status") or "") not in UNSETTLED_INBOX_STATUSES:
+            continue
+        effect = effect_for_approval(repository, str(approval.get("id") or ""))
+        if effect is None or not supersedes_inbox(effect, approval):
+            continue
+        contested.append(
+            review_row(effect, approval, repository.get_run(effect["run_id"]))
+        )
+    return contested
+
+
+def effect_for_approval(repository: Any, approval_id: str) -> dict[str, Any] | None:
+    """The run store's record of one approved effect, if it opened one.
+
+    An approval's effect may sit on a run other than the one the approval was
+    parked from: an approval decided from the operator surface is executed by
+    the server under its own run. So this asks by approval, not by run.
+    """
+    if not approval_id:
+        return None
+    found = repository.effects_for_approval(approval_id)
+    return found[-1] if found else None

--- a/desktop/coworker/agent_run_repository.py
+++ b/desktop/coworker/agent_run_repository.py
@@ -652,6 +652,12 @@ class AgentRunRepository:
                 effect_id, lease.run_id, owner_id=lease.owner_id
             )
             payload["tool_name"] = existing["tool_name"]
+            # Carried so a receipt pairs this checkpoint with the `tool_pending`
+            # the dispatch wrote, exactly as `quarantine_effect` does. Without
+            # it a fenced call reads as one call that never finished plus one
+            # outcome belonging to nothing.
+            payload["tool_call_id"] = existing["tool_call_id"]
+            payload["approval_id"] = existing["approval_id"]
             row = self._effect_checkpoint(
                 lease, "tool_completed", "running", payload, stamp, release=False
             )
@@ -813,6 +819,23 @@ class AgentRunRepository:
                 "SELECT * FROM agent_run_effects WHERE run_id = ? "
                 "ORDER BY dispatched_at, rowid",
                 (str(run_id),),
+            ).fetchall()
+        return [_effect_row(row) for row in rows]
+
+    def effects_for_approval(self, approval_id: str) -> list[dict[str, Any]]:
+        """Every effect opened under one approval, whatever run dispatched it.
+
+        Read only. An approval decided from the operator surface is executed by
+        the server under its own run, so the approval -- not the run -- is the
+        key that joins the inbox to this store. There is no index on
+        `approval_id`: adding one is a schema change, and this table holds one
+        row per consequential call, read only when a person opens a receipt.
+        """
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT * FROM agent_run_effects WHERE approval_id = ? "
+                "ORDER BY dispatched_at, rowid",
+                (str(approval_id),),
             ).fetchall()
         return [_effect_row(row) for row in rows]
 

--- a/desktop/coworker/events.py
+++ b/desktop/coworker/events.py
@@ -84,10 +84,19 @@ def validate_event(event: object) -> str | None:
         if not isinstance(event.get("text"), str):
             return "turn_end.text must be a string"
     if event_type == "error":
-        if event.get("state") != "failed":
-            return "error.state must be failed"
+        # `held` is not a softer `failed`. It means a consequential call was
+        # dispatched and never reported back, so the outcome is a person's to
+        # settle. It carries the effect id because the operator's next move is
+        # to open that row, not to try again.
+        if event.get("state") not in {"failed", "held"}:
+            return "error.state must be failed or held"
         if not isinstance(event.get("message"), str):
             return "error.message must be a string"
+        if event.get("state") == "held":
+            if event.get("code") != "outcome_unknown":
+                return "error.code must be outcome_unknown when state is held"
+            if not isinstance(event.get("effect_id"), str) or not event["effect_id"]:
+                return "error.effect_id must be a non-empty string when state is held"
     if event_type in {"permission_required", "tool_started", "tool_finished"}:
         for field in ("id", "name"):
             if not isinstance(event.get(field), str) or not event[field]:

--- a/desktop/coworker/gmail.py
+++ b/desktop/coworker/gmail.py
@@ -43,6 +43,17 @@ class GmailError(RuntimeError):
     pass
 
 
+class GmailOutcomeUnknown(GmailError):
+    """The request left this machine and no answer came back.
+
+    Distinct from a generic failure because the caller's answer is different:
+    a failure means nothing happened and the caller may say so, this means
+    nobody knows. `agent_run_dispatch.guarded_call` turns it into a quarantined
+    effect a person settles, so it must not be caught as an ordinary error on
+    the way up.
+    """
+
+
 class GmailHistoryExpired(GmailError):
     """The stored cursor is older than the history Gmail still keeps.
 
@@ -99,8 +110,12 @@ def _from_http_error(exc: BaseException) -> GmailError:
         status = getattr(response, "status_code", None)
         if status:
             return GmailError(f"Gmail API returned HTTP {status}.")
+    # No status anywhere on the chain. Gmail never answered, so whether the
+    # request was acted on is not something this process can know.
     text = str(exc).strip()
-    return GmailError(text or "Gmail request failed.")
+    return GmailOutcomeUnknown(
+        text or "Gmail did not answer, so the outcome is unknown."
+    )
 
 
 class GmailClient(Protocol):

--- a/desktop/coworker/gmail.py
+++ b/desktop/coworker/gmail.py
@@ -79,6 +79,42 @@ def _http_status(exc: BaseException) -> int | None:
     return None
 
 
+def _definite(exc: GmailError) -> GmailError:
+    """The same failure, stated as one nobody has to settle by hand."""
+    if not isinstance(exc, GmailOutcomeUnknown):
+        return exc
+    return GmailError(f"Gmail token refresh failed. {exc}")
+
+
+def _never_left(exc: BaseException) -> bool:
+    """Whether the request provably never reached Gmail.
+
+    A connection that was never opened, a proxy that refused, a name that did
+    not resolve: the bytes went nowhere, so this is an ordinary failure and
+    saying so costs nothing. Anything after the socket is open -- a read that
+    expires, a write that dies mid-body, a server that hangs up -- may have
+    been acted on, and only that half is ambiguous.
+
+    Imported here rather than at module scope to match `apollo.LiveHttp`, which
+    keeps `httpx` out of import time.
+    """
+    try:
+        import httpx
+    except ImportError:  # pragma: no cover - httpx is a hard dependency
+        return False
+    return isinstance(
+        exc,
+        (
+            httpx.ConnectError,
+            httpx.ConnectTimeout,
+            httpx.ProxyError,
+            httpx.PoolTimeout,
+            httpx.UnsupportedProtocol,
+            httpx.InvalidURL,
+        ),
+    )
+
+
 def _from_http_error(exc: BaseException) -> GmailError:
     """Turn httpx/Google HTTP failures into a GmailError with Google's message."""
     if isinstance(exc, HttpError):
@@ -110,9 +146,12 @@ def _from_http_error(exc: BaseException) -> GmailError:
         status = getattr(response, "status_code", None)
         if status:
             return GmailError(f"Gmail API returned HTTP {status}.")
-    # No status anywhere on the chain. Gmail never answered, so whether the
-    # request was acted on is not something this process can know.
+    # No status anywhere on the chain, so Gmail never answered. Whether the
+    # request was acted on depends on how far it got, and `_never_left` is the
+    # only part of that this process can actually decide.
     text = str(exc).strip()
+    if _never_left(exc):
+        return GmailError(text or "Gmail could not be reached, so nothing was sent.")
     return GmailOutcomeUnknown(
         text or "Gmail did not answer, so the outcome is unknown."
     )
@@ -406,10 +445,15 @@ class GmailApi:
                 client_secret=self.client_secret,
                 refresh_token=refresh,
             )
-        except GmailError:
-            raise
+        except GmailError as exc:
+            # A refresh sends no mail, so it never produces an unknown outcome.
+            # Whatever went wrong on the token endpoint, the caller has no
+            # usable credential and therefore made no request with one. Letting
+            # a `GmailOutcomeUnknown` through from here would quarantine a send
+            # that was never built.
+            raise _definite(exc)
         except Exception as exc:
-            raise _from_http_error(exc) from exc
+            raise _definite(_from_http_error(exc)) from exc
         access = str(tokens.get("access_token") or "")
         if not access:
             raise GmailError("Gmail token refresh failed.")
@@ -431,11 +475,32 @@ class GmailApi:
                 profile = load_google(self.secrets)
                 profile["access_token"] = ""
                 save_google(self.secrets, profile)
-                token = self._refresh(profile, str(profile.get("refresh_token") or ""))
+                try:
+                    token = self._refresh(
+                        profile, str(profile.get("refresh_token") or "")
+                    )
+                except GmailError:
+                    raise
+                except Exception as refresh_exc:
+                    # Gmail answered 401, so the first attempt sent nothing,
+                    # and the retry was never built. Both halves are known.
+                    raise GmailError(
+                        "Gmail rejected the access token and refreshing it "
+                        f"failed, so nothing was sent. {refresh_exc}"
+                    ) from refresh_exc
                 headers["Authorization"] = f"Bearer {token}"
-                if method == "get":
-                    return self.http.get(url, headers=headers, **kwargs)
-                return self.http.post(url, headers=headers, **kwargs)
+                # The retry runs inside this `except`, so the sibling clauses
+                # below never see what it raises. Without its own handler a
+                # transport error escaped raw, missed every classifier, and was
+                # swallowed as an ordinary failure by the tool layer.
+                try:
+                    if method == "get":
+                        return self.http.get(url, headers=headers, **kwargs)
+                    return self.http.post(url, headers=headers, **kwargs)
+                except GmailError:
+                    raise
+                except Exception as retry_exc:
+                    raise _from_http_error(retry_exc) from retry_exc
             raise _from_http_error(exc) from exc
         except GmailError:
             raise

--- a/desktop/coworker/server.py
+++ b/desktop/coworker/server.py
@@ -95,6 +95,7 @@ from coworker.effective_tools import (
 from coworker.events import build_event, new_turn_identity, TurnIdentity
 from coworker.gmail import (
     GmailError,
+    GmailOutcomeUnknown,
     MissingGmail,
     SendAuthority,
     SendAuthorityError,
@@ -656,6 +657,11 @@ def create_app(
             sent = send_reviewed_draft(app.state.gmail, authority)
         except SendAuthorityError as exc:
             return False, {"error": str(exc), "code": exc.code, "sent": False}
+        except GmailOutcomeUnknown:
+            # Gmail never answered. Reporting `sent: False` here would be a
+            # claim this process cannot make, so the exception carries on to
+            # `guarded_call`, which quarantines the effect for a person.
+            raise
         except GmailError as exc:
             return False, {"error": str(exc), "code": "gmail_failed", "sent": False}
         except Exception as exc:
@@ -3236,6 +3242,19 @@ def create_app(
                             queue_item_id,
                             state="interrupted",
                             error="Run cancelled before completion.",
+                        )
+                    elif status == "held":
+                        # Same word problem, third surface. A queue row that
+                        # says "failed" invites the retry the fence exists to
+                        # stop, so the item is interrupted and says why.
+                        store.finish_queue_item(
+                            run_sid,
+                            queue_item_id,
+                            state="interrupted",
+                            error=(
+                                "The outcome of the last action is unknown. "
+                                "It is held for review."
+                            ),
                         )
                     else:
                         store.finish_queue_item(

--- a/desktop/coworker/server.py
+++ b/desktop/coworker/server.py
@@ -28,7 +28,20 @@ from coworker.automation.scheduler import (
     next_monday_0900,
     now_iso,
 )
+from coworker.agent_run_dispatch import (
+    AgentRunContext,
+    AgentRunEffectQuarantined,
+    AgentRunUnavailable,
+    guarded_call,
+)
+from coworker.agent_run_approval import AgentRunEffectFenced
+from coworker.agent_run_reconcile import (
+    OPERATOR_DECISIONS,
+    contested_approvals,
+    review_queue,
+)
 from coworker.agent_run_repository import AgentRunRepository
+from coworker.agent_run_resume import restart as agent_run_restart
 from coworker.apollo import (
     ENRICH_CREDIT_COST,
     MISSING_KEY as APOLLO_MISSING_KEY,
@@ -438,9 +451,19 @@ def create_app(
             people=app.state.people,
         )
     )
-    # Read side only. Registering an owner and reclaiming leases belongs to
-    # whatever starts the sidecar process, not to opening the store.
     app.state.agent_runs = AgentRunRepository(root)
+    # This process becomes an Agent Run owner here, and it is the process that
+    # starts the sidecar, so this is where the marker belongs. The marker holds
+    # an exclusive `flock` for the life of the process, which is what lets a
+    # later start prove this one is gone rather than assume it.
+    app.state.run_owner = app.state.agent_runs.registry.register()
+    # One reconciliation pass, once, at start. Its only write is a quarantine,
+    # because an effect that was dispatched and never reported back has to stop
+    # being mistakable for work in progress before anything else reads the run.
+    # Resuming and delivering are deliberately not done here.
+    app.state.run_restart = agent_run_restart(
+        app.state.agent_runs, app.state.run_owner
+    )
     app.state.run_ledger = RunLedger(app.state.agent_runs, approvals=app.state.store)
     app.include_router(run_ledger_router(ledger=app.state.run_ledger))
     app.state.calendar = calendar_from_secrets(app.state.secrets, http=http)
@@ -522,6 +545,9 @@ def create_app(
                 wait_permission=None,
                 system_prompt_fn=system_prompt,
                 telemetry=app.state.telemetry_recorder,
+                agent_runs=app.state.agent_runs,
+                run_owner=app.state.run_owner,
+                run_trigger="scheduled",
             )
         )
 
@@ -709,10 +735,58 @@ def create_app(
             "apollo_id": result.get("apolloId"),
         }
 
+    def _approval_run_context(item: dict[str, Any]) -> AgentRunContext | None:
+        """A run of this executor's own, to fence one approved effect.
+
+        Deliberately not the turn's run. A turn parked on this approval may be
+        alive and about to come back through `resume_from_approval`, and two
+        processes racing for one lease would leave whichever lost unable to
+        checkpoint. A child run avoids the race entirely, and the effect is
+        still joined to the turn by `approval_id`, which is the key the review
+        queue reads anyway.
+
+        Returning None is the fail-closed direction: `guarded_call` then
+        refuses the call outright rather than making it unrecorded.
+        """
+        approval_id = str(item.get("id") or "")
+        parked_run = str(item.get("run_id") or "")
+        resource = item.get("resource") if isinstance(item.get("resource"), dict) else {}
+        try:
+            return AgentRunContext.start(
+                app.state.agent_runs,
+                app.state.run_owner,
+                session_id=(
+                    str(item.get("session_id") or "")
+                    or store.open_session_id()
+                    or "main"
+                ),
+                trigger="chat",
+                goal=f"approved:{item.get('name')}:{approval_id}",
+                person_id=str(resource.get("person_id") or "") or None,
+                parent_run_id=(
+                    parked_run
+                    if parked_run
+                    and app.state.agent_runs.get_run(parked_run) is not None
+                    else None
+                ),
+            )
+        except Exception as exc:
+            return AgentRunContext.disarmed(
+                app.state.agent_runs,
+                app.state.run_owner,
+                reason=f"{type(exc).__name__}: {exc}",
+            )
+
     async def _execute_claimed_approval(
         item: dict[str, Any], *, claimant: str
     ) -> dict[str, Any] | None:
-        """Run an allow-claimed approval server-side and persist its receipt."""
+        """Run an allow-claimed approval server-side and persist its receipt.
+
+        The claim that got here already made this the only executor. What this
+        adds is the other half: the run store records the dispatch before the
+        call and the outcome after it, so a process that dies in between leaves
+        an effect a person settles rather than a machine retries.
+        """
         approval_span = None
         approval_tool_span = None
         try:
@@ -737,42 +811,76 @@ def create_app(
         except ValueError:
             pass
         bound = _bound_resource(item)
-        try:
+        approval_id = str(item.get("id") or "")
+        run_context = _approval_run_context(item)
+
+        async def _invoke() -> tuple[bool, dict[str, Any]]:
             if bound is not None:
                 runner = (
                     _execute_bound_send
                     if bound["kind"] == "gmail_send_authority"
                     else _execute_bound_enrichment
                 )
-                ok, result = await asyncio.to_thread(runner, item)
-            else:
-                ok, result = await asyncio.to_thread(
-                    execute,
-                    item["name"],
-                    _claimed_arguments(item),
-                    store=app.state.store,
-                    gmail=app.state.gmail,
-                    drive=app.state.drive,
-                    calendar=app.state.calendar,
-                    http=app.state.http,
-                    apollo_key=app.state.apollo_key,
-                    tavily_key=app.state.tavily_key,
-                    skills=app.state.skills,
-                    mcp=app.state.mcp,
-                    people=app.state.people,
-                    workspace_runtime=app.state.workspace_runtime,
-                    approval_granted=True,
-                    approval_scope=str(item.get("scope") or "once"),
-                    approval_fingerprint=(
-                        str((item.get("resource") or {}).get("fingerprint"))
-                        if isinstance(item.get("resource"), dict)
-                        and (item.get("resource") or {}).get("fingerprint")
-                        else None
-                    ),
-                    session_id=str(item.get("session_id") or ""),
-                    actor=str(item.get("actor") or "assistant"),
-                    run_id=str(item.get("run_id") or "") or None,
-                )
+                return await asyncio.to_thread(runner, item)
+            return await asyncio.to_thread(
+                execute,
+                item["name"],
+                _claimed_arguments(item),
+                store=app.state.store,
+                gmail=app.state.gmail,
+                drive=app.state.drive,
+                calendar=app.state.calendar,
+                http=app.state.http,
+                apollo_key=app.state.apollo_key,
+                tavily_key=app.state.tavily_key,
+                skills=app.state.skills,
+                mcp=app.state.mcp,
+                people=app.state.people,
+                workspace_runtime=app.state.workspace_runtime,
+                approval_granted=True,
+                approval_scope=str(item.get("scope") or "once"),
+                approval_fingerprint=(
+                    str((item.get("resource") or {}).get("fingerprint"))
+                    if isinstance(item.get("resource"), dict)
+                    and (item.get("resource") or {}).get("fingerprint")
+                    else None
+                ),
+                session_id=str(item.get("session_id") or ""),
+                actor=str(item.get("actor") or "assistant"),
+                run_id=str(item.get("run_id") or "") or None,
+            )
+
+        try:
+            # Dispatch commits before the call, outcome after. Calling the
+            # runner directly here is the trap `docs/agent-runs.md` names.
+            ok, result = await guarded_call(
+                run_context,
+                tool_name=str(item.get("name") or ""),
+                arguments=_claimed_arguments(item),
+                call=_invoke,
+                tool_call_id=approval_id,
+                approval_id=approval_id,
+            )
+        except AgentRunEffectQuarantined as exc:
+            # The inbox is about to record a terminal status for this claim.
+            # It is not the fence of record: the run store holds `ambiguous`,
+            # and `agent_run_reconcile` is what makes a surface say so.
+            ok, result = False, {
+                "error": (
+                    "The outcome of this action is unknown. It is held for "
+                    "review; do not retry it until it is settled."
+                ),
+                "code": "outcome_unknown",
+                "effect_id": exc.effect_id,
+            }
+        except AgentRunUnavailable as exc:
+            ok, result = False, {
+                "error": (
+                    "Sourcecado could not record this action durably, so it "
+                    f"was not attempted. {exc}"
+                ),
+                "code": "agent_run_unavailable",
+            }
         except asyncio.CancelledError:
             if approval_tool_span is not None:
                 approval_tool_span.cancel()
@@ -788,6 +896,11 @@ def create_app(
             else:
                 approval_tool_span.partial(ErrorKind.TOOL)
                 approval_span.partial(ErrorKind.TOOL)
+        if run_context is not None:
+            # A quarantine already parked this run as `interrupted` and closed
+            # the context, so this is a no-op there and the run keeps saying
+            # the outcome is unknown.
+            run_context.finish("complete" if ok else "partial", status=str(ok))
         receipt = app.state.inbox.complete_execution(
             str(item["id"]),
             claimant=claimant,
@@ -1397,6 +1510,64 @@ def create_app(
         if not claim.decision_recorded:
             response["idempotent"] = True
         return response
+
+    # Not under /v1/agent-runs: `run_ledger_api` already owns
+    # /v1/agent-runs/{run_id} and is registered first, so a literal segment
+    # there would be swallowed by the id route. The resource here is an
+    # external effect anyway, not a run.
+    @app.get("/v1/agent-run-effects/quarantine")
+    async def quarantine_list():
+        """The review queue: every external effect nobody knows the outcome of.
+
+        Joined to the approval that authorized it, so an operator sees what
+        they allowed, not just an effect id. The run store is the fence of
+        record here: a row whose inbox claim disagrees says so on the row.
+        """
+        await _reap_and_publish_expired()
+        rows = review_queue(app.state.agent_runs, app.state.store)
+        return {
+            "effects": rows,
+            "decisions": list(OPERATOR_DECISIONS),
+            # Resolved rows too: an interrupted claim is a resolved approval
+            # whose execution never reported, which is exactly the disagreement
+            # this list exists to name.
+            "contested": contested_approvals(
+                app.state.agent_runs,
+                app.state.store.list_inbox(pending_only=False),
+            ),
+        }
+
+    @app.post("/v1/agent-run-effects/quarantine/{effect_id}")
+    async def quarantine_resolve(effect_id: str, request: Request):
+        """A person settles what the machine could not.
+
+        The three decisions are the operator half of the vocabulary and the
+        store refuses anything else. Settling does not restart the run: what to
+        do with a turn whose send may already have gone out is the operator's
+        next decision, and no code makes it for them.
+        """
+        payload = await request.json()
+        decision = str(payload.get("decision") or "").strip()
+        operator = str(payload.get("operator") or "").strip()
+        note = payload.get("note")
+        try:
+            resolved = await asyncio.to_thread(
+                app.state.agent_runs.resolve_quarantined_effect,
+                effect_id,
+                decision=decision,
+                operator=operator,
+                note=str(note) if note is not None else None,
+            )
+        except ValueError as exc:
+            return JSONResponse(
+                {"error": str(exc), "decisions": list(OPERATOR_DECISIONS)},
+                status_code=400,
+            )
+        except AgentRunEffectFenced as exc:
+            return JSONResponse({"error": str(exc)}, status_code=409)
+        except KeyError:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        return {"effect": resolved}
 
     @app.post("/v1/schedule/tick")
     def schedule_tick():
@@ -3047,6 +3218,11 @@ def create_app(
                     identity=control.identity,
                     control=control,
                     telemetry=app.state.telemetry_recorder,
+                    agent_runs=app.state.agent_runs,
+                    run_owner=app.state.run_owner,
+                    run_trigger=(
+                        "chat" if queue_item_id is None else "queued_chat"
+                    ),
                 )
                 status = str(result.get("status") or "error")
                 if queue_item_id is not None:

--- a/desktop/coworker/tools.py
+++ b/desktop/coworker/tools.py
@@ -25,7 +25,12 @@ from coworker.evidence_envelope import (
 )
 from coworker.mcp import mcp_evidence
 from coworker.web import MISSING_KEY as TAVILY_MISSING, search_web, web_evidence
-from coworker.gmail import GmailError, MissingGmail, gmail_evidence
+from coworker.gmail import (
+    GmailError,
+    GmailOutcomeUnknown,
+    MissingGmail,
+    gmail_evidence,
+)
 from coworker.board_tools import BOARD_TOOL_NAMES, BOARD_TOOL_SCHEMAS, execute_board_tool
 from coworker.drive_ingestion import DRIVE_INDEX_QUERY_SCHEMA, DriveIngestionStore
 from coworker.people import PersonStore
@@ -767,6 +772,10 @@ def execute(
         client = gmail if gmail is not None else MissingGmail()
         try:
             result = client.send(draft_id=draft_id)
+        except GmailOutcomeUnknown:
+            # `ok=False` says nothing happened. Gmail never answered, so that
+            # is not something this layer knows. `guarded_call` quarantines it.
+            raise
         except GmailError as exc:
             return False, {"error": str(exc)}
         except Exception as exc:

--- a/desktop/coworker/turn.py
+++ b/desktop/coworker/turn.py
@@ -17,6 +17,7 @@ from coworker.agent_run_dispatch import (
     guarded_call,
     needs_fence,
 )
+from coworker.agent_runs import TERMINAL_AGENT_RUN_STATES
 from coworker.compaction import (
     CompactionContext,
     SessionCompactor,
@@ -817,6 +818,11 @@ async def run_turn(
         how it ended and how long it was, never what it said.
         """
         if run_context is None:
+            return
+        # The chat protocol carries states the run store does not know. `held`
+        # is one: a quarantined effect already parked the run and released its
+        # lease, and there is no run state that means "a person owns this now".
+        if state not in TERMINAL_AGENT_RUN_STATES:
             return
         run_context.finish(state, status=state, text=text_so_far)
 
@@ -1679,6 +1685,26 @@ async def run_turn(
     except asyncio.CancelledError:
         turn_span.cancel()
         raise
+    except AgentRunEffectQuarantined as exc:
+        # A consequential call was dispatched and never reported back. Saying
+        # "failed" here would be a claim nobody can make, and an operator told
+        # a send failed is an operator who sends it again. The effect is on the
+        # review queue; the terminal points at it and stops.
+        turn_span.partial(ErrorKind.TOOL)
+        _persist_closed(store, sid, history, workspace_runtime)
+        await _terminal(
+            {
+                "type": "error",
+                "state": "held",
+                "code": "outcome_unknown",
+                "effect_id": exc.effect_id,
+                "message": (
+                    "The outcome of this action is unknown. It is held for "
+                    "review; do not retry it until it is settled."
+                ),
+            }
+        )
+        return {"status": "held", "text": last_text}
     except Exception as exc:
         turn_span.fail(turn_error_kind)
         _persist_closed(store, sid, history, workspace_runtime)

--- a/desktop/coworker/turn.py
+++ b/desktop/coworker/turn.py
@@ -10,6 +10,13 @@ import uuid
 from datetime import UTC, datetime
 from typing import Any, Awaitable, Callable
 
+from coworker.agent_run_dispatch import (
+    AgentRunContext,
+    AgentRunEffectQuarantined,
+    AgentRunUnavailable,
+    guarded_call,
+    needs_fence,
+)
 from coworker.compaction import (
     CompactionContext,
     SessionCompactor,
@@ -631,6 +638,17 @@ def _record_person_file(
     record_tool_on_person(people, sid, call.name, call.arguments, result, ok=ok)
 
 
+def _bound_person_id(execute_kwargs: dict, sid: str) -> str | None:
+    """The person this session works, so a run receipt names them."""
+    people = execute_kwargs.get("people")
+    if people is None:
+        return None
+    try:
+        return people.person_for_session(sid)
+    except Exception:
+        return None
+
+
 def _persist_closed(
     store: ConversationStore,
     sid: str,
@@ -672,6 +690,9 @@ async def run_turn(
     run_budget_policy: RunBudgetPolicy | None = None,
     context_projection: Any = None,
     projection_identity: Any = None,
+    agent_runs: Any = None,
+    run_owner: Any = None,
+    run_trigger: str = "chat",
 ) -> dict[str, Any]:
     workspace_runtime = execute_kwargs.get("workspace_runtime")
     events = TurnEventStream(
@@ -709,6 +730,31 @@ async def run_turn(
     turn_span = recorder.start_span(
         AgentTurnSpan(operation="agent.turn"), trace_context
     )
+    # The durable Agent Run, sharing the turn's own run id so a receipt, a
+    # person event, and a checkpoint all point at one identity.
+    #
+    # A run store that will not open a run does not stop the turn, and it does
+    # not quietly let it through either: `guarded_call` refuses every
+    # consequential tool while `run_context` is None, exactly as it does for a
+    # context that lost its lease. Reading work still runs; sending does not.
+    try:
+        run_context = AgentRunContext.start(
+            agent_runs,
+            run_owner,
+            session_id=sid,
+            trigger=run_trigger,
+            goal=text,
+            run_id=events.identity.run_id,
+            person_id=_bound_person_id(execute_kwargs, sid),
+            provider_model_id=str(getattr(provider, "model_id", "") or "") or None,
+        )
+    except Exception as exc:
+        # A caller that supplied a run store and got no run is fenced shut, not
+        # unfenced. Reading work still runs; every consequential tool refuses.
+        run_context = AgentRunContext.disarmed(
+            agent_runs, run_owner, reason=f"{type(exc).__name__}: {exc}"
+        )
+    model_step = 0
 
     async def _emit(event: dict[str, Any]) -> None:
         await events.send(event)
@@ -764,7 +810,20 @@ async def run_turn(
         )
         _record_person_file(sid, call, ok, result, execute_kwargs)
 
+    def _end_run(state: str, text_so_far: str) -> None:
+        """Close the durable run in the same shape the operator was told.
+
+        Shape only. The answer itself is in the transcript; the run row carries
+        how it ended and how long it was, never what it said.
+        """
+        if run_context is None:
+            return
+        run_context.finish(state, status=state, text=text_so_far)
+
     async def _terminal(event: dict[str, Any]) -> None:
+        _end_run(
+            str(event.get("state") or "failed"), str(event.get("text") or "")
+        )
         if control is None:
             await _emit(event)
         else:
@@ -814,6 +873,7 @@ async def run_turn(
     ) -> dict[str, Any]:
         turn_span.cancel()
         _persist_closed(store, sid, history, workspace_runtime)
+        _end_run("stopped", text_so_far)
         if control is not None:
             await control.finish_stopped(text_so_far)
         else:
@@ -936,6 +996,20 @@ async def run_turn(
             if budget_stop is not None:
                 break
             budget.start_model_turn()
+            model_step += 1
+            if run_context is not None:
+                run_context.note(
+                    "model_pending",
+                    state="running",
+                    payload={
+                        "step": model_step,
+                        "attempt_id": f"model-{events.identity.run_id}-{model_step}",
+                        "provider": _telemetry_provider_name(selected_provider),
+                        "model_id": str(
+                            getattr(selected_provider, "model_id", "") or ""
+                        ),
+                    },
+                )
             _persist_closed(store, sid, history, workspace_runtime)
             # The canonical view. Compaction reads it and never writes it; the
             # transcript on disk stays the record of what actually happened.
@@ -1159,6 +1233,39 @@ async def run_turn(
                 # The same typed values the provider span just recorded, so
                 # the budget is measured from telemetry rather than re-derived.
                 budget.record_request(provider_usage, provider_cost)
+                if run_context is not None:
+                    run_context.note(
+                        "model_completed",
+                        state="running",
+                        payload={
+                            "step": model_step,
+                            "attempt_id": (
+                                f"model-{events.identity.run_id}-{model_step}"
+                            ),
+                            "provider": _telemetry_provider_name(attempt_provider),
+                            "model_id": str(
+                                getattr(attempt_provider, "model_id", "") or ""
+                            ),
+                            "status": str(
+                                _telemetry_stop_reason(
+                                    provider_finish_reason, used_tools=bool(calls)
+                                ).value
+                            ),
+                        },
+                        usage=(
+                            {}
+                            if provider_usage is None
+                            else {
+                                "input_tokens": provider_usage.input_tokens,
+                                "output_tokens": provider_usage.output_tokens,
+                                "total_tokens": provider_usage.total_tokens,
+                            }
+                        ),
+                        provider_model_id=str(
+                            getattr(attempt_provider, "model_id", "") or ""
+                        )
+                        or None,
+                    )
                 if provider_usage is not None:
                     # The provider's own count of the prompt it just read.
                     # Preferred over the estimate when sizing the next step.
@@ -1292,9 +1399,24 @@ async def run_turn(
                             **({"resource": resource} if resource else {}),
                         }
                     )
+                    # Park the durable run on the person too. The lease is
+                    # released with this write, so a crash while the operator
+                    # is deciding leaves a run nobody owns and nothing resumes.
+                    if run_context is not None:
+                        run_context.park(
+                            call.id, tool_name=call.name, step=model_step
+                        )
                     if wait_permission is None:
                         return {"status": "waiting", "text": last_text}
                     choice = await wait_permission(call.id)
+                    # Back through the approval door, which is the only way in
+                    # to a parked run. A cancel did not authorize the call, and
+                    # the door takes allow or deny only; the inbox and the
+                    # transcript keep the word "cancelled".
+                    if run_context is not None:
+                        run_context.resume(
+                            call.id, "allow" if choice == "allow" else "deny"
+                        )
                     if choice == "cancel":
                         cancelled = inbox.cancel(call.id)
                         if cancelled is not None:
@@ -1404,6 +1526,21 @@ async def run_turn(
                     }
                 )
                 tool_span = turn_span.child(_telemetry_tool_span(call.name))
+                # A fenced tool gets its `tool_pending` from the dispatch, in
+                # the same transaction as the effect row. A retry-safe one has
+                # no effect record, so the checkpoint is written here or the
+                # receipt shows no reading work at all.
+                fenced = needs_fence(call.name)
+                if run_context is not None and not fenced:
+                    run_context.note(
+                        "tool_pending",
+                        state="running",
+                        payload={
+                            "step": model_step,
+                            "tool_name": call.name,
+                            "tool_call_id": call.id,
+                        },
+                    )
                 try:
                     kw = {
                         k: v for k, v in execute_kwargs.items() if not k.startswith("_")
@@ -1415,9 +1552,42 @@ async def run_turn(
                     kw["approval_fingerprint"] = approval_fingerprint
                     if approval_claimant is not None:
                         kw["actor"] = str(claim.item.get("actor") or "operator")
-                    ok, result = await asyncio.to_thread(
-                        execute, call.name, call.arguments, **kw
+
+                    async def _invoke() -> tuple[bool, dict[str, Any]]:
+                        return await asyncio.to_thread(
+                            execute, call.name, call.arguments, **kw
+                        )
+
+                    # The one door to a tool in this loop. `guarded_call`
+                    # commits the dispatch before the call and the outcome
+                    # after it for everything outside `permissions.RETRY_SAFE`;
+                    # calling `execute` directly here would be the trap
+                    # `docs/agent-runs.md` names.
+                    ok, result = await guarded_call(
+                        run_context,
+                        tool_name=call.name,
+                        arguments=call.arguments,
+                        call=_invoke,
+                        tool_call_id=call.id,
+                        approval_id=(
+                            call.id if approval_claimant is not None else None
+                        ),
+                        step=model_step,
                     )
+                except AgentRunEffectQuarantined:
+                    # The call may have reached a real person. The turn ends
+                    # rather than continuing as if it had merely failed.
+                    tool_span.partial(ErrorKind.TOOL)
+                    raise
+                except AgentRunUnavailable as exc:
+                    tool_span.partial(ErrorKind.TOOL)
+                    ok, result = False, {
+                        "error": (
+                            "Sourcecado could not record this action durably, "
+                            f"so it was not attempted. {exc}"
+                        ),
+                        "code": "agent_run_unavailable",
+                    }
                 except asyncio.CancelledError:
                     tool_span.cancel()
                     raise
@@ -1427,6 +1597,20 @@ async def run_turn(
                     tool_span.finish()
                 else:
                     tool_span.partial(ErrorKind.TOOL)
+                if run_context is not None and not fenced:
+                    run_context.note(
+                        "tool_completed",
+                        state="running",
+                        payload={
+                            "step": model_step,
+                            "tool_name": call.name,
+                            "tool_call_id": call.id,
+                            "status": "succeeded" if ok else "failed",
+                            "error_class": (
+                                None if ok else str(result.get("code") or "tool_error")
+                            ),
+                        },
+                    )
                 if (
                     call.name in {"remember", "memory_update", "memory_forget"}
                     and system_prompt_fn

--- a/desktop/docs/agent-runs.md
+++ b/desktop/docs/agent-runs.md
@@ -1,9 +1,11 @@
 # Durable Agent Runs: identity, leases, and checkpoints
 
 Status: active-stack engineering reference. Covers the run store, its ownership
-rules, the external-effect fence, and restart classification. The chat, queue,
-schedule, server, and UI wiring are separate later work and are not implemented
-here: nothing in this document is called by the running application yet.
+rules, the external-effect fence, restart classification, and -- since slice 5
+-- the production paths that enter them. Chat, queued chat, scheduled routines,
+approvals, and the operator review queue all run through the store now;
+`coworker/agent_run_dispatch.py` is the seam and
+`coworker/agent_run_reconcile.py` is the rule for reading two stores at once.
 
 ## What an Agent Run is
 
@@ -213,7 +215,7 @@ decision that cannot wait, because an effect nobody knows the outcome of must
 stop being mistakable for work in progress before anything else looks at the
 run. Resuming and delivering are left to the caller.
 
-## A trap for whoever wires this up
+## The trap, and where the wiring avoids it
 
 A consequential tool **must** open an effect record before it is called.
 `dispatch_effect` commits before the call and `record_effect_outcome` commits
@@ -232,35 +234,82 @@ one code path nobody exercises by hand.
 `permissions.RETRY_SAFE`, and everything outside that list is consequential,
 including a tool the permission module has never heard of.
 
+Slice 5 answers the trap with one function rather than discipline.
+`agent_run_dispatch.guarded_call` is the only way either production path
+reaches a tool, and the ordering is control flow inside it: `dispatch` returns
+only after its transaction committed, and the call cannot run before `dispatch`
+returns. `turn.py` and `server.py` each call it once. Neither calls `execute`
+around it.
+
+Three consequences follow, and each is a test.
+
+- Every tool outside `RETRY_SAFE` is fenced, not a list of the ones anyone
+  thought of. `agent_run_dispatch.needs_fence` is `replay_class` and nothing
+  else.
+- A call that *raises* is quarantined rather than reported. A cancelled turn
+  is the reachable case: an operator pressed stop while a send was in flight,
+  and nothing observed the outcome. `record_effect_outcome` has no value for
+  that, so the guard does not invent one.
+- A caller that supplied a run store and could not open a run refuses to make
+  the call. A caller that supplied no run store was never fenced, which is the
+  legacy and test path. The two are different values, not the same `None`.
+
 ## Extension points
 
 The following are named seams, not implementations.
 
 - **Heartbeat.** `renew_lease` is the seam a long provider call renews through.
   Losing renewal must abandon the work, not continue it.
-- **Wiring.** Nothing constructs an `AgentRunRepository` for run execution in
-  the running application yet. The process that starts the sidecar registers one
-  owner with `OwnerRegistry.register()` and calls `agent_run_resume.restart()`
-  once, at startup. The repository deliberately does not reconcile in its
-  constructor, because opening a store is not the same event as starting a
-  process.
+- **Wiring.** `create_app` registers one owner with `OwnerRegistry.register()`
+  and calls `agent_run_resume.restart()` once, because that is the function
+  that starts the sidecar process. The repository still does not reconcile in
+  its constructor, because opening a store is not the same event as starting a
+  process, and `create_app` opens it a line earlier than it becomes an owner.
 - **The two halves of at-most-once.** `store.decide_and_claim_inbox_execution`
-  makes an approved send dispatch at most once. This store makes the outcome of
-  that dispatch un-guessable after a crash. Joining them -- so that a quarantined
-  effect and an `interrupted` inbox row are one thing an operator sees -- is
-  wiring, and the run store is the fence of record when they disagree.
-- **The review queue.** `list_quarantined_effects` is what a surface renders.
-  Nothing renders it yet.
+  makes an approved send dispatch at most once: only a `pending` row is
+  claimable, so a claim closed as `interrupted` is never re-executed. This
+  store makes the outcome of that dispatch un-guessable after a crash. Neither
+  re-implements the other -- nothing in `agent_run_reconcile` grants
+  permission to run -- and `agent_run_reconcile.reconciled_status` joins them:
+  **the run store is the fence of record when they disagree**, because its
+  writes bracket the external call and the inbox's do not. The inbox knows a
+  claimant vanished. Only the run store knows a call was dispatched.
+- **The review queue.** `list_quarantined_effects` is what a surface renders,
+  and `GET /v1/agent-run-effects/quarantine` renders it, joined to the approval
+  that authorized each effect. `POST` to the same path with one of the three
+  operator decisions settles one. The route deliberately does not live under
+  `/v1/agent-runs`, where `run_ledger_api` owns `{run_id}` and would swallow a
+  literal segment; and `run_ledger_api` stays read-only, as its docstring says.
 - **Receipts.** `agent_run_approval.external_effect_evidence` maps an unsettled
-  effect onto the `Evidence` vocabulary `run_receipt` already reads. Wiring it
-  into a receipt section is later work.
+  effect onto the `Evidence` vocabulary, and the review queue reads it, so a
+  queue row and a receipt use the same word for the same fact. A run receipt
+  reaches the same conclusion from checkpoints alone: `quarantine_effect`
+  writes `tool_outcome_unknown`, which `run_receipt._tools` already reports as
+  `Evidence.AMBIGUOUS`. `record_effect_outcome` now carries `tool_call_id` on
+  its checkpoint for the same reason `quarantine_effect` always did -- without
+  it a fenced call read as one call that never finished plus one outcome
+  belonging to nothing.
 
 ## Known gaps
 
 - The run store is a separate database from `club.db`, so a run checkpoint and a
-  conversation or approval write are not one transaction. Slice 3 must make the
-  run store the fence of record for external effects rather than relying on
-  cross-store atomicity.
+  conversation or approval write are not one transaction. The run store is the
+  fence of record for external effects instead of relying on cross-store
+  atomicity; `agent_run_reconcile` is where that preference is expressed.
+- An approval decided from the operator surface is executed under a run of the
+  server's own, not the turn's. That avoids a race for one lease between a
+  live turn and the HTTP executor, at the cost of a second run row per such
+  send. The effect still names the approval, which is the key the review queue
+  joins on.
+- A turn cancelled while an approval is outstanding resumes its run with
+  `deny`, because `resume_from_approval` takes allow or deny and a cancel is
+  neither. The word "cancelled" survives in the inbox and the transcript; the
+  run store records the nearest true thing, which is that the call was not
+  authorized.
+- A quarantined effect is joined to its approval by scanning `approval_id`,
+  which carries no index. Adding one is a schema change and therefore a
+  migration. The table holds one row per consequential call and is read when a
+  person opens the queue, so the scan is not on any hot path.
 - Owner marker files are removed when their owner is proven dead and its work
   reclaimed, and when a process releases its own owner. A process killed with
   no runs to reclaim leaves a marker behind.

--- a/desktop/docs/agent-runs.md
+++ b/desktop/docs/agent-runs.md
@@ -246,10 +246,19 @@ Three consequences follow, and each is a test.
 - Every tool outside `RETRY_SAFE` is fenced, not a list of the ones anyone
   thought of. `agent_run_dispatch.needs_fence` is `replay_class` and nothing
   else.
-- A call that *raises* is quarantined rather than reported. A cancelled turn
-  is the reachable case: an operator pressed stop while a send was in flight,
-  and nothing observed the outcome. `record_effect_outcome` has no value for
-  that, so the guard does not invent one.
+- A call that *raises* is quarantined rather than reported. `record_effect_outcome`
+  has no value for "nothing at all", so the guard does not invent one.
+- **A layer below the fence can make that unreachable, and one did.** The guard
+  only ever sees what the tool lets past. `_execute_bound_send` and
+  `tools.execute` caught every Gmail exception and returned `ok=False`, so a
+  send that timed out after the request left the machine was recorded as
+  `failed` and the operator was offered a clean second send. The connector is
+  the only layer that can tell the two apart, so `gmail.GmailOutcomeUnknown` is
+  raised there when no HTTP status was ever observed, and both call sites
+  re-raise it. A status means Gmail answered, and an answer is a fact; no
+  status means the request left and nothing came back. `verify_send_authority`
+  reads before the send, so an unknown from that step stays a plain
+  `SendAuthorityError` and never reaches the queue.
 - A caller that supplied a run store and could not open a run refuses to make
   the call. A caller that supplied no run store was never fenced, which is the
   legacy and test path. The two are different values, not the same `None`.
@@ -323,3 +332,10 @@ The following are named seams, not implementations.
   run eligible to resume, but nothing decides whether resuming a turn whose send
   may already have gone out is what the operator wants. That is a person's next
   decision and no code makes it.
+- **`restart` classifies and only quarantines.** `plan_restart` returns `RESUME`
+  and `DELIVER` verdicts, and `create_app` stores the outcome on
+  `app.state.run_restart` without acting on either. So a safe incomplete run is
+  not continued at startup, a final answer that was generated and recorded but
+  never delivered is not delivered, and a missing person projection is not
+  repaired. Those are three of issue #63's acceptance criteria and they are
+  tracked separately; this file describes what runs, not what is planned.

--- a/desktop/surfaces/gui/src/api.ts
+++ b/desktop/surfaces/gui/src/api.ts
@@ -2123,3 +2123,92 @@ export async function exportDiagnosticBundle(
     (payload) => payload.bundle as DiagnosticBundleResult,
   );
 }
+
+// --- the external-effect review queue --------------------------------------
+//
+// An effect Sourcecado dispatched and never got an answer about. Neither
+// "sent" nor "not sent": a person decides which, and until they do nothing
+// retries it. `inboxClaim` is what the approval record says about the same
+// action, kept separate on purpose -- when the two disagree the run store is
+// the fence of record and `supersedesInbox` says so.
+
+export type QuarantineDecision =
+  | "resolved_succeeded"
+  | "resolved_failed"
+  | "abandoned";
+
+export type QuarantinedEffect = {
+  effectId: string;
+  runId: string;
+  toolName: string;
+  approvalId: string | null;
+  dispatchedAt: string | null;
+  reason: string | null;
+  status: string;
+  inboxClaim: string | null;
+  supersedesInbox: boolean;
+  needsAPerson: boolean;
+  sessionId: string | null;
+  personId: string | null;
+  approval: {
+    id: string;
+    name: string;
+    requestedAt: string | null;
+    resource: Record<string, unknown> | null;
+  } | null;
+};
+
+function readQuarantinedEffect(raw: any): QuarantinedEffect {
+  const approval = raw?.approval;
+  return {
+    effectId: String(raw?.effect_id || ""),
+    runId: String(raw?.run_id || ""),
+    toolName: String(raw?.tool_name || ""),
+    approvalId: raw?.approval_id ?? null,
+    dispatchedAt: raw?.dispatched_at ?? null,
+    reason: raw?.reason ?? null,
+    status: String(raw?.status || ""),
+    inboxClaim: raw?.inbox_claim ?? null,
+    supersedesInbox: Boolean(raw?.supersedes_inbox),
+    needsAPerson: Boolean(raw?.needs_a_person),
+    sessionId: raw?.session_id ?? null,
+    personId: raw?.person_id ?? null,
+    approval: approval
+      ? {
+          id: String(approval.id || ""),
+          name: String(approval.name || ""),
+          requestedAt: approval.requested_at ?? null,
+          resource:
+            approval.resource && typeof approval.resource === "object"
+              ? (approval.resource as Record<string, unknown>)
+              : null,
+        }
+      : null,
+  };
+}
+
+export async function getQuarantinedEffects(): Promise<QuarantinedEffect[]> {
+  const res = await get("/v1/agent-run-effects/quarantine");
+  if (!res.ok) throw new Error(`quarantine ${res.status}`);
+  const payload = await res.json();
+  const rows = Array.isArray(payload?.effects) ? payload.effects : [];
+  return rows.map(readQuarantinedEffect);
+}
+
+export async function settleQuarantinedEffect(
+  effectId: string,
+  decision: QuarantineDecision,
+  operator: string,
+  note?: string,
+): Promise<void> {
+  const res = await fetch(
+    `${httpBase()}/v1/agent-run-effects/quarantine/${encodeURIComponent(effectId)}`,
+    {
+      method: "POST",
+      headers: { "X-Club-Token": apiToken(), "Content-Type": "application/json" },
+      body: JSON.stringify({ decision, operator, note }),
+    },
+  );
+  const payload = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(payload?.error || `settle ${res.status}`);
+}

--- a/desktop/surfaces/gui/src/app/AppShell.tsx
+++ b/desktop/surfaces/gui/src/app/AppShell.tsx
@@ -4,6 +4,7 @@ import {
   createSession,
   getInbox,
   getMemoryBacklog,
+  getQuarantinedEffects,
   getSessions,
   pinSession,
   renameSession,
@@ -15,6 +16,7 @@ import { PersonFileView } from "../PersonFile";
 import { ChatPage } from "../routes/ChatPage";
 import { ConnectionsPage } from "../routes/ConnectionsPage";
 import { MemoryPage } from "../routes/MemoryPage";
+import { QuarantinePage } from "../routes/QuarantinePage";
 import { ScheduledPage } from "../routes/ScheduledPage";
 import { SettingsPage } from "../routes/SettingsPage";
 import { SkillsPage } from "../routes/SkillsPage";
@@ -38,6 +40,7 @@ export function AppShell() {
   const [railOpen, setRailOpen] = useState(false);
   const [scheduledApprovalCount, setScheduledApprovalCount] = useState(0);
   const [memoryReviewCount, setMemoryReviewCount] = useState(0);
+  const [heldEffectCount, setHeldEffectCount] = useState(0);
   const railTriggerRef = useRef<HTMLButtonElement>(null);
   const railFocusTimerRef = useRef<number | null>(null);
   const railWasOpenedRef = useRef(false);
@@ -112,12 +115,27 @@ export function AppShell() {
         () => {},
       );
     };
+    // Held external effects, on the same cadence. A held action is not an
+    // approval waiting for a decision, so it gets its own count: one asks
+    // "may I?" and the other asks "did it happen?".
+    const refreshHeld = () => {
+      getQuarantinedEffects().then(
+        (effects) => {
+          if (!active) return;
+          setHeldEffectCount(effects.length);
+        },
+        () => {},
+      );
+    };
     refreshInbox();
+    refreshHeld();
     window.addEventListener("focus", refreshInbox);
+    window.addEventListener("focus", refreshHeld);
     window.addEventListener("sourcecado:inbox-changed", refreshInbox);
     return () => {
       active = false;
       window.removeEventListener("focus", refreshInbox);
+      window.removeEventListener("focus", refreshHeld);
       window.removeEventListener("sourcecado:inbox-changed", refreshInbox);
     };
   }, []);
@@ -267,6 +285,8 @@ export function AppShell() {
     outlet = <MemoryPage />;
   } else if (route.kind === "scheduled") {
     outlet = <ScheduledPage />;
+  } else if (route.kind === "quarantine") {
+    outlet = <QuarantinePage />;
   } else if (route.kind === "connections") {
     outlet = <ConnectionsPage connectorId={route.connectorId} />;
   } else if (route.kind === "settings") {
@@ -308,6 +328,7 @@ export function AppShell() {
         sessions={sessions}
         scheduledApprovalCount={scheduledApprovalCount}
         memoryReviewCount={memoryReviewCount}
+        heldEffectCount={heldEffectCount}
         onNewChat={() => void handleNewChat()}
         onOpenSession={handleOpenSession}
         onPin={(session) => void handlePin(session)}

--- a/desktop/surfaces/gui/src/app/GlobalRail.tsx
+++ b/desktop/surfaces/gui/src/app/GlobalRail.tsx
@@ -50,6 +50,7 @@ type Props = {
   sessions: SessionRow[] | null;
   scheduledApprovalCount: number;
   memoryReviewCount: number;
+  heldEffectCount: number;
   onNewChat: () => void;
   onOpenSession: (session: SessionRow) => void;
   onPin: (session: SessionRow) => void;
@@ -58,7 +59,7 @@ type Props = {
   onClose: () => void;
 };
 
-export function GlobalRail({ open, route, sessions, scheduledApprovalCount, memoryReviewCount, onNewChat, onOpenSession, onPin, onRename, onSearch, onClose }: Props) {
+export function GlobalRail({ open, route, sessions, scheduledApprovalCount, memoryReviewCount, heldEffectCount, onNewChat, onOpenSession, onPin, onRename, onSearch, onClose }: Props) {
   const pinned = sessions?.filter((session) => session.pinned) || [];
   const recent = sessions?.filter((session) => !session.pinned) || [];
   const railRef = useRef<HTMLElement>(null);
@@ -140,6 +141,14 @@ export function GlobalRail({ open, route, sessions, scheduledApprovalCount, memo
             badgeLabel={`Saved memory: ${memoryReviewCount} waiting for review`}
           >
             Memory
+          </RailLink>
+          <RailLink
+            href="#/quarantine"
+            current={route.kind === "quarantine"}
+            badge={heldEffectCount}
+            badgeLabel={`Held actions: ${heldEffectCount} waiting for your answer`}
+          >
+            Needs your answer
           </RailLink>
         </div>
         <div className="thread-groups">

--- a/desktop/surfaces/gui/src/app/route.ts
+++ b/desktop/surfaces/gui/src/app/route.ts
@@ -6,6 +6,7 @@ export type AppRoute =
   | { kind: "settings" }
   | { kind: "skills" }
   | { kind: "memory" }
+  | { kind: "quarantine" }
   | { kind: "chat"; sessionId?: string; personId?: string };
 
 export function parseHash(hash: string): AppRoute {
@@ -35,6 +36,7 @@ export function parseHash(hash: string): AppRoute {
   if (hash === "#/settings") return { kind: "settings" };
   if (hash === "#/skills") return { kind: "skills" };
   if (hash === "#/memory") return { kind: "memory" };
+  if (hash === "#/quarantine") return { kind: "quarantine" };
   if (hash.startsWith("#/chat/") && hash.includes("/person/")) {
     const [sessionId, personId] = hash.slice("#/chat/".length).split("/person/", 2);
     if (sessionId && personId) {

--- a/desktop/surfaces/gui/src/chat/messageAdapter.ts
+++ b/desktop/surfaces/gui/src/chat/messageAdapter.ts
@@ -27,6 +27,7 @@ export type SourcecadoTextPart = {
     | "complete"
     | "cancelled"
     | "failed"
+    | "held"
     | "stopped"
     | "interrupted";
 };
@@ -106,6 +107,7 @@ export type SourcecadoStructuredMessage = {
     | "partial"
     | "cancelled"
     | "failed"
+    | "held"
     | "stopped"
     | "interrupted";
   readonly parts: readonly SourcecadoPart[];
@@ -195,6 +197,8 @@ function textPartStatus(state: SourcecadoTextPart["state"]) {
       return { type: "incomplete" as const, reason: "cancelled" as const };
     case "failed":
       return { type: "incomplete" as const, reason: "error" as const };
+    case "held":
+      return { type: "incomplete" as const, reason: "other" as const };
     case "stopped":
       return { type: "incomplete" as const, reason: "cancelled" as const };
     case "interrupted":
@@ -216,6 +220,8 @@ function messageStatus(state: SourcecadoStructuredMessage["state"]) {
       return { type: "incomplete" as const, reason: "cancelled" as const };
     case "failed":
       return { type: "incomplete" as const, reason: "error" as const };
+    case "held":
+      return { type: "incomplete" as const, reason: "other" as const };
     case "stopped":
       return { type: "incomplete" as const, reason: "cancelled" as const };
     case "interrupted":

--- a/desktop/surfaces/gui/src/chat/protocol.ts
+++ b/desktop/surfaces/gui/src/chat/protocol.ts
@@ -165,6 +165,20 @@ export type ProtocolChatEvent = ChatEventEnvelope &
         readonly message: string;
         readonly state: "failed";
       }
+    /**
+     * A consequential call was dispatched and never reported back.
+     *
+     * Not a softer `failed`. Nobody knows whether the mail went out, so the
+     * effect is on the operator's review queue and `effect_id` is the row to
+     * open. Telling a director a send failed is how a second one gets sent.
+     */
+    | {
+        readonly type: "error";
+        readonly message: string;
+        readonly state: "held";
+        readonly code: "outcome_unknown";
+        readonly effect_id: string;
+      }
   );
 
 /**
@@ -681,6 +695,12 @@ export function parseChatEvent(value: unknown): ChatEvent {
         )) ||
       (value.type === "error" &&
         value.state === "failed" &&
+        typeof value.message === "string") ||
+      (value.type === "error" &&
+        value.state === "held" &&
+        value.code === "outcome_unknown" &&
+        typeof value.effect_id === "string" &&
+        value.effect_id.length > 0 &&
         typeof value.message === "string") ||
       (value.type === "permission_required" &&
         typeof value.id === "string" &&

--- a/desktop/surfaces/gui/src/chat/store.ts
+++ b/desktop/surfaces/gui/src/chat/store.ts
@@ -805,6 +805,9 @@ export class SourcecadoChatStore {
       const terminalTextState =
         event.state === "cancelled" ||
         event.state === "failed" ||
+        // A held turn is over. Leaving the text part `running` shows a
+        // director a spinner for a send nobody knows the outcome of.
+        event.state === "held" ||
         event.state === "stopped" ||
         event.state === "interrupted"
           ? event.state

--- a/desktop/surfaces/gui/src/chat/store.ts
+++ b/desktop/surfaces/gui/src/chat/store.ts
@@ -163,6 +163,7 @@ export type SourcecadoEvent =
         | "partial"
         | "cancelled"
         | "failed"
+        | "held"
         | "stopped"
         | "interrupted";
     }
@@ -520,7 +521,9 @@ export class SourcecadoChatStore {
         type: "message_state_changed",
         threadId: event.session_id,
         messageId: event.message_id,
-        state: "failed",
+        // `held` carries through unchanged. Collapsing it into `failed` here
+        // would undo the whole point of the sidecar sending it.
+        state: event.state === "held" ? "held" : "failed",
       });
     }
   }

--- a/desktop/surfaces/gui/src/routes/ChatPage.tsx
+++ b/desktop/surfaces/gui/src/routes/ChatPage.tsx
@@ -296,7 +296,13 @@ export function ChatPage({
           runningThreadsRef.current.delete(threadId);
           activeRunsRef.current.delete(threadId);
           if (threadId === activeThreadRef.current) {
-            setAnnouncement("Run failed.");
+            setAnnouncement(
+              // "Run failed." would send someone reading by ear straight to a
+              // retry for a send that may already have gone out.
+              applied.state === "held"
+                ? "Run held for review."
+                : "Run failed.",
+            );
           }
         }
       }

--- a/desktop/surfaces/gui/src/routes/QuarantinePage.tsx
+++ b/desktop/surfaces/gui/src/routes/QuarantinePage.tsx
@@ -1,0 +1,261 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  getQuarantinedEffects,
+  settleQuarantinedEffect,
+  type QuarantineDecision,
+  type QuarantinedEffect,
+} from "../api";
+
+// Three decisions, in the order an operator actually works: check whether it
+// happened, say which, and only then give up on knowing. The wording avoids
+// "succeeded" and "failed" because those are what the machine says about
+// something it watched. These are what a person says about something nobody
+// watched.
+const DECISIONS: {
+  value: QuarantineDecision;
+  label: string;
+  help: string;
+}[] = [
+  {
+    value: "resolved_succeeded",
+    label: "It happened",
+    help: "You checked and the action went through. Do not run it again.",
+  },
+  {
+    value: "resolved_failed",
+    label: "It did not happen",
+    help: "You checked and nothing went out. Safe to ask for it again.",
+  },
+  {
+    value: "abandoned",
+    label: "Stop tracking it",
+    help: "You cannot tell, and you are choosing to leave it unresolved.",
+  },
+];
+
+const TOOL_LABELS: Record<string, string> = {
+  gmail_send: "Send email",
+  gmail_draft: "Create draft",
+  apollo_enrich_contact: "Enrich contact",
+  calendar_create: "Create calendar event",
+  calendar_update: "Update calendar event",
+};
+
+type PageState =
+  | { status: "loading" }
+  | { status: "loaded"; effects: QuarantinedEffect[] }
+  | { status: "failed" };
+
+function formatTimestamp(stamp: string | null): string {
+  if (!stamp) return "Unknown time";
+  const date = new Date(stamp);
+  if (Number.isNaN(date.getTime())) return stamp;
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function describeTool(name: string): string {
+  return TOOL_LABELS[name] || name;
+}
+
+/** The binding the director approved: recipient, subject, account. Never a body. */
+function approvalFacts(
+  resource: Record<string, unknown> | null,
+): { label: string; value: string }[] {
+  if (!resource) return [];
+  const fields: [string, string][] = [
+    ["to", "To"],
+    ["subject", "Subject"],
+    ["account", "Account"],
+    ["person_id", "Person"],
+  ];
+  return fields
+    .filter(([key]) => typeof resource[key] === "string" && resource[key])
+    .map(([key, label]) => ({ label, value: String(resource[key]) }));
+}
+
+function EffectCard({
+  effect,
+  onSettle,
+}: {
+  effect: QuarantinedEffect;
+  onSettle: (
+    effectId: string,
+    decision: QuarantineDecision,
+    note: string,
+  ) => Promise<void>;
+}) {
+  const [note, setNote] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const facts = approvalFacts(effect.approval?.resource ?? null);
+
+  async function decide(decision: QuarantineDecision) {
+    setBusy(true);
+    setError(null);
+    try {
+      await onSettle(effect.effectId, decision, note.trim());
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Could not save that.");
+      setBusy(false);
+    }
+  }
+
+  return (
+    <li className="quarantine-card">
+      <header>
+        <h2>{describeTool(effect.toolName)}</h2>
+        <time dateTime={effect.dispatchedAt || undefined}>
+          {formatTimestamp(effect.dispatchedAt)}
+        </time>
+      </header>
+      <p className="quarantine-lede">
+        Sourcecado started this action and never found out whether it finished.
+        It may have reached the other side, and it may not have. Nothing will
+        retry it.
+      </p>
+      {facts.length > 0 && (
+        <dl className="quarantine-facts">
+          {facts.map((fact) => (
+            <div key={fact.label}>
+              <dt>{fact.label}</dt>
+              <dd>{fact.value}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+      {effect.reason && <p className="quarantine-reason">{effect.reason}</p>}
+      {effect.supersedesInbox && effect.inboxClaim && (
+        // The reconciliation rule, said out loud. The approval record is not
+        // wrong about its own claim; it simply cannot know whether the call
+        // was made, and reading it alone would invite a second attempt.
+        <p className="quarantine-contested">
+          The approval record calls this “{effect.inboxClaim}”. That describes
+          the request, not the action. Only the answer below settles it.
+        </p>
+      )}
+      <label className="quarantine-note">
+        <span>What did you find? (optional)</span>
+        <input
+          type="text"
+          value={note}
+          onChange={(event) => setNote(event.target.value)}
+          placeholder="Checked the Sent folder"
+          disabled={busy}
+        />
+      </label>
+      <div className="quarantine-actions">
+        {DECISIONS.map((decision) => (
+          <button
+            key={decision.value}
+            type="button"
+            onClick={() => void decide(decision.value)}
+            disabled={busy}
+            title={decision.help}
+          >
+            {decision.label}
+          </button>
+        ))}
+      </div>
+      {error && (
+        <p className="quarantine-error" role="alert">
+          {error}
+        </p>
+      )}
+    </li>
+  );
+}
+
+export function QuarantinePage() {
+  const [state, setState] = useState<PageState>({ status: "loading" });
+  const [operator, setOperator] = useState("");
+
+  const load = useCallback(() => {
+    getQuarantinedEffects().then(
+      (effects) => setState({ status: "loaded", effects }),
+      () => setState({ status: "failed" }),
+    );
+  }, []);
+
+  useEffect(() => {
+    load();
+    window.addEventListener("focus", load);
+    return () => window.removeEventListener("focus", load);
+  }, [load]);
+
+  const settle = useCallback(
+    async (effectId: string, decision: QuarantineDecision, note: string) => {
+      // The store refuses an operator decision that names nobody, so the name
+      // is asked for here rather than discovered as a server error.
+      const who = operator.trim();
+      if (!who) throw new Error("Enter your name before settling an action.");
+      await settleQuarantinedEffect(effectId, decision, who, note || undefined);
+      load();
+    },
+    [operator, load],
+  );
+
+  if (state.status === "loading") {
+    return (
+      <main className="route-page" aria-busy="true">
+        <h1>Needs your answer</h1>
+        <div className="route-skeleton" aria-label="Loading held actions" />
+      </main>
+    );
+  }
+
+  if (state.status === "failed") {
+    return (
+      <main className="route-page">
+        <h1>Needs your answer</h1>
+        <p>Could not load held actions.</p>
+        <button type="button" onClick={load}>
+          Try again
+        </button>
+      </main>
+    );
+  }
+
+  return (
+    <main className="route-page quarantine-page">
+      <h1>Needs your answer</h1>
+      <p className="route-lede">
+        Actions that reach the outside world are recorded before Sourcecado
+        attempts them. If it stops before recording what happened, the action
+        lands here instead of being guessed at or run a second time.
+      </p>
+      {state.effects.length === 0 ? (
+        <p className="quarantine-empty">
+          Nothing is waiting. Every action Sourcecado started has a recorded
+          outcome.
+        </p>
+      ) : (
+        <>
+          <label className="quarantine-operator">
+            <span>Your name</span>
+            <input
+              type="text"
+              value={operator}
+              onChange={(event) => setOperator(event.target.value)}
+              placeholder="Who is deciding"
+            />
+          </label>
+          <ul className="quarantine-list">
+            {state.effects.map((effect) => (
+              <EffectCard
+                key={effect.effectId}
+                effect={effect}
+                onSettle={settle}
+              />
+            ))}
+          </ul>
+        </>
+      )}
+    </main>
+  );
+}

--- a/desktop/surfaces/gui/src/styles/route.css
+++ b/desktop/surfaces/gui/src/styles/route.css
@@ -1757,7 +1757,6 @@
   font-size: 12px;
   line-height: 1.45;
 }
-}
 
 /* The external-effect review queue. A held action is not an alarm and not a
    failure: it is an open question, so it reads in the warn register rather
@@ -1802,6 +1801,7 @@
   margin: 20px 0 0;
   padding: 0;
   list-style: none;
+}
 
 .quarantine-card {
   display: grid;

--- a/desktop/surfaces/gui/src/styles/route.css
+++ b/desktop/surfaces/gui/src/styles/route.css
@@ -1757,3 +1757,164 @@
   font-size: 12px;
   line-height: 1.45;
 }
+}
+
+/* The external-effect review queue. A held action is not an alarm and not a
+   failure: it is an open question, so it reads in the warn register rather
+   than the error one, and the three answers carry equal visual weight so the
+   surface never nudges an operator toward the convenient one. */
+.quarantine-page {
+  width: 100%;
+  max-width: 1040px;
+  margin: 0 auto;
+}
+
+.quarantine-empty {
+  margin-top: 24px;
+  color: var(--muted);
+}
+
+.quarantine-operator {
+  display: grid;
+  gap: 6px;
+  margin: 24px 0 0;
+  max-width: 320px;
+}
+
+.quarantine-operator span {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.quarantine-operator input,
+.quarantine-note input {
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+}
+
+.quarantine-list {
+  display: grid;
+  gap: 16px;
+  margin: 20px 0 0;
+  padding: 0;
+  list-style: none;
+
+.quarantine-card {
+  display: grid;
+  gap: 10px;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--warn);
+  border-radius: 8px;
+  background: var(--surface);
+}
+
+.quarantine-card header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.quarantine-card h2 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.quarantine-card time {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.quarantine-lede {
+  margin: 0;
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.quarantine-facts {
+  display: grid;
+  gap: 4px;
+  margin: 0;
+  padding: 12px;
+  border-radius: 6px;
+  background: var(--raised);
+}
+
+.quarantine-facts > div {
+  display: flex;
+  gap: 8px;
+}
+
+.quarantine-facts dt {
+  min-width: 80px;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.quarantine-facts dd {
+  margin: 0;
+  font-size: 13px;
+}
+
+.quarantine-reason,
+.quarantine-contested {
+  margin: 0;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.quarantine-contested {
+  padding: 10px 12px;
+  border-radius: 6px;
+  background: var(--warn-bg);
+  color: var(--warn);
+}
+
+.quarantine-note {
+  display: grid;
+  gap: 6px;
+}
+
+.quarantine-note span {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.quarantine-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.quarantine-actions button {
+  padding: 8px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--raised);
+  color: var(--text);
+  font: inherit;
+  cursor: pointer;
+}
+
+.quarantine-actions button:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+
+.quarantine-actions button:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.quarantine-error {
+  margin: 0;
+  padding: 10px 12px;
+  border-radius: 6px;
+  background: var(--error-bg);
+  color: var(--error);
+  font-size: 13px;
+}

--- a/desktop/surfaces/gui/tests/chatPage.test.tsx
+++ b/desktop/surfaces/gui/tests/chatPage.test.tsx
@@ -921,6 +921,27 @@ describe("ChatPage Warm Operator thread", () => {
       },
       "Run cancelled.",
     ],
+    [
+      // Nobody knows whether the send went out. "Run failed." would send a
+      // screen-reader user straight to a retry.
+      "an unknown outcome",
+      {
+        version: 2,
+        type: "error",
+        session_id: "thread-alpha",
+        run_id: "run-1",
+        event_id: "terminal-held",
+        message_id: "assistant-1",
+        part_id: "assistant-part-1",
+        state: "held",
+        code: "outcome_unknown",
+        effect_id: "effect-9f2c",
+        message:
+          "The outcome of this action is unknown. It is held for review; do " +
+          "not retry it until it is settled.",
+      },
+      "Run held for review.",
+    ],
   ] as const)("announces run %s outside the transcript", async (_label, terminal, expected) => {
     api.getSession.mockResolvedValue({
       id: "thread-alpha",

--- a/desktop/surfaces/gui/tests/heldOutcome.test.ts
+++ b/desktop/surfaces/gui/tests/heldOutcome.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { parseChatEvent } from "../src/api";
+import { convertStructuredMessage } from "../src/chat/messageAdapter";
+import { SourcecadoChatStore } from "../src/chat/store";
+
+/**
+ * A consequential call was dispatched and never reported back.
+ *
+ * "Failed" is a claim nobody can make about it, and a director told a send
+ * failed is a director who sends it again. The sidecar now ends that turn with
+ * `state: "held"`, and the thread has to carry the word through rather than
+ * flatten it back into an error.
+ */
+
+const envelope = {
+  version: 2,
+  session_id: "thread-alpha",
+  run_id: "run-1",
+  event_id: "event-terminal",
+  message_id: "message-answer-1",
+  part_id: "part-answer-1",
+} as const;
+
+const heldEvent = {
+  ...envelope,
+  type: "error",
+  state: "held",
+  code: "outcome_unknown",
+  effect_id: "effect-9f2c",
+  message:
+    "The outcome of this action is unknown. It is held for review; do not " +
+    "retry it until it is settled.",
+} as const;
+
+const runningEvents = [
+  { ...envelope, event_id: "event-1", type: "turn_start", state: "running" },
+  {
+    ...envelope,
+    event_id: "event-2",
+    type: "assistant_delta",
+    delta: "Sending the note.",
+  },
+];
+
+describe("a turn whose outcome is unknown", () => {
+  it("survives the parser instead of arriving as a malformed event", () => {
+    expect(parseChatEvent(heldEvent)).toEqual(heldEvent);
+  });
+
+  it("still rejects a held terminal that names no effect to settle", () => {
+    const { effect_id: _dropped, ...withoutEffect } = heldEvent;
+    expect(parseChatEvent(withoutEffect)).toMatchObject({
+      notice: { code: "malformed_event", recoverable: true },
+    });
+  });
+
+  it("marks the message held, not failed", () => {
+    const store = new SourcecadoChatStore(
+      [{ id: "thread-alpha", messages: [] }],
+      "thread-alpha",
+    );
+    store.replayChatEvents([...runningEvents, heldEvent]);
+    expect(store.messagesFor("thread-alpha")[0]?.state).toBe("held");
+  });
+
+  it("does not render as an error, because nothing is known to have failed", () => {
+    const store = new SourcecadoChatStore(
+      [{ id: "thread-alpha", messages: [] }],
+      "thread-alpha",
+    );
+    store.replayChatEvents([...runningEvents, heldEvent]);
+    const [message] = store
+      .messagesFor("thread-alpha")
+      .map(convertStructuredMessage);
+    expect(message?.status).not.toMatchObject({ reason: "error" });
+    expect(message?.status).toMatchObject({ type: "incomplete" });
+  });
+});

--- a/desktop/surfaces/gui/tests/heldOutcome.test.ts
+++ b/desktop/surfaces/gui/tests/heldOutcome.test.ts
@@ -64,6 +64,32 @@ describe("a turn whose outcome is unknown", () => {
     expect(store.messagesFor("thread-alpha")[0]?.state).toBe("held");
   });
 
+  it("stops the answer streaming, because the turn is over", () => {
+    // A held terminal ends the turn. If the text part stays `running` the
+    // director watches a spinner forever, which is the opposite of the signal
+    // this state exists to send.
+    const store = new SourcecadoChatStore(
+      [{ id: "thread-alpha", messages: [] }],
+      "thread-alpha",
+    );
+    store.replayChatEvents([...runningEvents, heldEvent]);
+    const part = store.messagesFor("thread-alpha")[0]?.parts[0];
+    expect(part).toMatchObject({ type: "text", state: "held" });
+  });
+
+  it("does not render the answer as still running once it is held", () => {
+    const store = new SourcecadoChatStore(
+      [{ id: "thread-alpha", messages: [] }],
+      "thread-alpha",
+    );
+    store.replayChatEvents([...runningEvents, heldEvent]);
+    const [message] = store
+      .messagesFor("thread-alpha")
+      .map(convertStructuredMessage);
+    const [content] = message?.content ?? [];
+    expect(content).not.toMatchObject({ status: { type: "running" } });
+  });
+
   it("does not render as an error, because nothing is known to have failed", () => {
     const store = new SourcecadoChatStore(
       [{ id: "thread-alpha", messages: [] }],

--- a/desktop/surfaces/gui/tests/quarantinePage.test.tsx
+++ b/desktop/surfaces/gui/tests/quarantinePage.test.tsx
@@ -1,0 +1,193 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { QuarantinePage } from "../src/routes/QuarantinePage";
+import { parseHash } from "../src/app/route";
+
+const api = vi.hoisted(() => ({
+  getQuarantinedEffects: vi.fn(),
+  settleQuarantinedEffect: vi.fn(),
+}));
+
+vi.mock("../src/api", () => ({
+  getQuarantinedEffects: api.getQuarantinedEffects,
+  settleQuarantinedEffect: api.settleQuarantinedEffect,
+}));
+
+const HELD_SEND = {
+  effectId: "effect-1",
+  runId: "run-1",
+  toolName: "gmail_send",
+  approvalId: "send_1",
+  dispatchedAt: "2026-08-27T09:12:00+00:00",
+  reason: "the owner process died mid-send",
+  status: "ambiguous",
+  inboxClaim: "interrupted",
+  supersedesInbox: true,
+  needsAPerson: true,
+  sessionId: "sess-1",
+  personId: "person-1",
+  approval: {
+    id: "send_1",
+    name: "gmail_send",
+    requestedAt: "2026-08-27T09:11:00+00:00",
+    resource: {
+      kind: "gmail_send_authority",
+      to: "ada@analytic.example",
+      subject: "Thursday?",
+      account: "director@sourcecado.test",
+    },
+  },
+};
+
+describe("the external-effect review queue", () => {
+  beforeEach(() => {
+    api.getQuarantinedEffects.mockReset();
+    api.settleQuarantinedEffect.mockReset();
+  });
+
+  it("says the outcome is unknown rather than calling it a failure", async () => {
+    api.getQuarantinedEffects.mockResolvedValue([HELD_SEND]);
+
+    render(<QuarantinePage />);
+
+    await screen.findByText(/Send email/);
+    const page = screen.getByRole("main");
+    expect(page.textContent).toMatch(/never found out whether it finished/);
+    // Never "failed": that is a claim about the world nobody is entitled to.
+    expect(page.textContent).not.toMatch(/\bfailed\b/i);
+    // And no control offers to run it again. Saying "nothing will retry it"
+    // is the promise; a retry button would break it.
+    for (const button of screen.getAllByRole("button")) {
+      expect(button.textContent).not.toMatch(/retry|send again|try again/i);
+    }
+  });
+
+  it("shows what was authorized and never the message body", async () => {
+    api.getQuarantinedEffects.mockResolvedValue([
+      {
+        ...HELD_SEND,
+        approval: {
+          ...HELD_SEND.approval,
+          resource: {
+            ...HELD_SEND.approval.resource,
+            body: "Hi Ada, would Thursday work?",
+          },
+        },
+      },
+    ]);
+
+    render(<QuarantinePage />);
+
+    await screen.findByText("ada@analytic.example");
+    expect(screen.getByText("Thursday?")).toBeTruthy();
+    expect(screen.getByText("director@sourcecado.test")).toBeTruthy();
+    // The binding the director read is enough to settle it. The body is not
+    // needed and never leaves the transcript.
+    expect(screen.getByRole("main").textContent).not.toMatch(/would Thursday work/);
+  });
+
+  it("names the three answers a person may give and no machine outcome", async () => {
+    api.getQuarantinedEffects.mockResolvedValue([HELD_SEND]);
+
+    render(<QuarantinePage />);
+
+    await screen.findByRole("button", { name: "It happened" });
+    expect(screen.getByRole("button", { name: "It did not happen" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Stop tracking it" })).toBeTruthy();
+    // "succeeded" and "failed" belong to the process that watched the call.
+    expect(screen.queryByRole("button", { name: /succeeded/i })).toBeNull();
+  });
+
+  it("tells the operator that the approval record does not settle this", async () => {
+    api.getQuarantinedEffects.mockResolvedValue([HELD_SEND]);
+
+    render(<QuarantinePage />);
+
+    const contested = await screen.findByText(/describes the request, not the action/);
+    expect(contested.textContent).toMatch(/interrupted/);
+  });
+
+  it("does not show that line when the two records agree", async () => {
+    api.getQuarantinedEffects.mockResolvedValue([
+      { ...HELD_SEND, supersedesInbox: false, inboxClaim: null },
+    ]);
+
+    render(<QuarantinePage />);
+
+    await screen.findByText(/Send email/);
+    expect(screen.queryByText(/describes the request, not the action/)).toBeNull();
+  });
+
+  it("settles one effect with a named person and reloads the queue", async () => {
+    api.getQuarantinedEffects
+      .mockResolvedValueOnce([HELD_SEND])
+      .mockResolvedValueOnce([]);
+    api.settleQuarantinedEffect.mockResolvedValue(undefined);
+
+    render(<QuarantinePage />);
+
+    await screen.findByRole("button", { name: "It happened" });
+    fireEvent.change(screen.getByLabelText("Your name"), {
+      target: { value: "Fisher" },
+    });
+    fireEvent.change(screen.getByLabelText("What did you find? (optional)"), {
+      target: { value: "Checked the Sent folder" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "It happened" }));
+
+    await waitFor(() =>
+      expect(api.settleQuarantinedEffect).toHaveBeenCalledWith(
+        "effect-1",
+        "resolved_succeeded",
+        "Fisher",
+        "Checked the Sent folder",
+      ),
+    );
+    await screen.findByText(/Nothing is waiting/);
+  });
+
+  it("refuses to settle an effect without saying who decided", async () => {
+    api.getQuarantinedEffects.mockResolvedValue([HELD_SEND]);
+
+    render(<QuarantinePage />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "It happened" }));
+
+    // The store refuses an unnamed operator decision. The surface says so
+    // before the request rather than surfacing a raw server error.
+    await screen.findByRole("alert");
+    expect(screen.getByRole("alert").textContent).toMatch(/Enter your name/);
+    expect(api.settleQuarantinedEffect).not.toHaveBeenCalled();
+  });
+
+  it("keeps the row when settling fails, so nothing looks resolved", async () => {
+    api.getQuarantinedEffects.mockResolvedValue([HELD_SEND]);
+    api.settleQuarantinedEffect.mockRejectedValue(new Error("effect is settled"));
+
+    render(<QuarantinePage />);
+
+    await screen.findByRole("button", { name: "It happened" });
+    fireEvent.change(screen.getByLabelText("Your name"), {
+      target: { value: "Fisher" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "It happened" }));
+
+    await screen.findByRole("alert");
+    expect(screen.getByRole("alert").textContent).toMatch(/effect is settled/);
+    expect(screen.getByText(/Send email/)).toBeTruthy();
+  });
+
+  it("says the queue is empty without implying anything is wrong", async () => {
+    api.getQuarantinedEffects.mockResolvedValue([]);
+
+    render(<QuarantinePage />);
+
+    await screen.findByText(/Every action Sourcecado started has a recorded outcome/);
+    expect(screen.queryByLabelText("Your name")).toBeNull();
+  });
+
+  it("is reachable at its own route", () => {
+    expect(parseHash("#/quarantine")).toEqual({ kind: "quarantine" });
+  });
+});

--- a/desktop/surfaces/gui/tests/shell.test.tsx
+++ b/desktop/surfaces/gui/tests/shell.test.tsx
@@ -24,6 +24,7 @@ const api = vi.hoisted(() => ({
   getHealth: vi.fn(),
   getInbox: vi.fn(),
   getMemoryBacklog: vi.fn(),
+  getQuarantinedEffects: vi.fn(),
   getPersona: vi.fn(),
   getPerson: vi.fn(),
   getSchedule: vi.fn(),
@@ -55,6 +56,7 @@ vi.mock("../src/api", () => ({
   getHealth: api.getHealth,
   getInbox: api.getInbox,
   getMemoryBacklog: api.getMemoryBacklog,
+  getQuarantinedEffects: api.getQuarantinedEffects,
   getPersona: api.getPersona,
   getPerson: api.getPerson,
   getSchedule: api.getSchedule,
@@ -90,6 +92,7 @@ describe("App shell routing", () => {
     api.getHealth.mockResolvedValue({ status: "ok", piece: "test", slice: 1, model: "test" });
     api.getInbox.mockResolvedValue({ items: [] });
     api.getMemoryBacklog.mockResolvedValue({ needs_review: 0, classified: 0, items: [] });
+    api.getQuarantinedEffects.mockResolvedValue([]);
     api.getPersona.mockResolvedValue({ id: "sourcing", name: "Sourcing Director", tools: [] });
     api.getPerson.mockResolvedValue({
       person: { person_id: "person-1", sequence_state: "open" },

--- a/desktop/tests/test_agent_run_fence_mutations.py
+++ b/desktop/tests/test_agent_run_fence_mutations.py
@@ -124,6 +124,62 @@ def test_a_dispatch_committed_after_the_call_leaves_the_window_unrecorded(
     ]
 
 
+def test_the_same_reversal_in_the_turn_loop_is_caught_the_same_way(
+    tmp_path, monkeypatch
+):
+    """Both dispatch sites, one guard, one mutation each.
+
+    `turn.py` and `server.py` reach a tool through the same function, so this
+    is not a second guard -- it is the second call site, held to the contract
+    by the same observation.
+    """
+    import sqlite3
+
+    repository, owner = _runs(tmp_path / "honest")
+
+    def _watcher(store):
+        def _execute(name, arguments, **kwargs):
+            connection = sqlite3.connect(store.path)
+            try:
+                store.seen = connection.execute(
+                    "SELECT tool_name, status FROM agent_run_effects"
+                ).fetchall()
+            finally:
+                connection.close()
+            return True, {"ok": True}
+
+        return _execute
+
+    monkeypatch.setattr(turn_module, "execute", _watcher(repository))
+    _turn(
+        tmp_path / "honest",
+        provider=OneToolProvider("gmail_send"),
+        repository=repository,
+        owner=owner,
+        wait="allow",
+    )
+    assert [tuple(map(str, row)) for row in repository.seen] == [
+        ("gmail_send", str(EffectStatus.DISPATCHED))
+    ]
+
+    monkeypatch.setattr(turn_module, "guarded_call", _dispatch_after_the_call)
+
+    broken, broken_owner = _runs(tmp_path / "broken")
+    monkeypatch.setattr(turn_module, "execute", _watcher(broken))
+    _turn(
+        tmp_path / "broken",
+        provider=OneToolProvider("gmail_send"),
+        repository=broken,
+        owner=broken_owner,
+        wait="allow",
+    )
+
+    assert broken.seen == []
+    assert [effect["status"] for effect in _effects(broken)] == [
+        str(EffectStatus.SUCCEEDED)
+    ]
+
+
 # --- mutation: a consequential tool wired without the fence ----------------
 
 

--- a/desktop/tests/test_agent_run_fence_mutations.py
+++ b/desktop/tests/test_agent_run_fence_mutations.py
@@ -1,0 +1,338 @@
+"""Each guard is broken on purpose, and the property it protects must collapse.
+
+A green fence test proves nothing if it would also pass with the fence removed.
+Every test here runs the honest path first, asserts the property, then breaks
+exactly one guard and asserts the same property fails. If one of these starts
+failing, the guard it names has stopped doing work and the test that covers it
+has gone vacuous.
+
+The four failure modes this slice is most exposed to, one test each:
+
+- the dispatch committed *after* the call instead of before it;
+- a consequential tool wired without the fence, because someone wrote a list;
+- a resume that treats a quarantined effect as work to continue;
+- the inbox overriding the run store when the two disagree.
+
+The first is the one that matters most. A system with the ordering reversed
+still writes effect records, still shows a review queue, and still passes any
+test that only asks "was an effect recorded?". It is protected against nothing,
+and only an observation taken from inside the call can tell the difference.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+from coworker import agent_run_dispatch as dispatch_module
+from coworker import agent_run_reconcile as reconcile_module
+from coworker import agent_run_resume as resume_module
+from coworker import server as server_module
+from coworker import turn as turn_module
+from coworker.agent_run_approval import EffectStatus
+from coworker.agent_run_repository import AgentRunRepository
+from coworker.agent_run_resume import ResumeAction, classify_resume, restart
+from coworker.agent_run_reconcile import review_queue, supersedes_inbox
+from coworker.store import ConversationStore
+
+from tests.test_agent_run_integration import (
+    ACCOUNT,
+    HEADERS,
+    OneToolProvider,
+    SID,
+    WatchingGmail,
+    _app,
+    _bound_person,
+    _effects,
+    _park_send,
+    _runs,
+    _turn,
+)
+
+
+# --- mutation: the dispatch commits after the call -------------------------
+
+
+def _watched_send(tmp_path) -> tuple[Any, WatchingGmail]:
+    """One approved send, with a Gmail that reads the run store mid-call."""
+    app = _app(tmp_path)
+    gmail = WatchingGmail(app.state.agent_runs.path)
+    gmail.account_email = ACCOUNT
+    app.state.gmail = gmail
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    item_id = _park_send(client, person_id, session_id)
+    res = client.post(
+        f"/v1/inbox/{item_id}",
+        headers=HEADERS,
+        json={"decision": "allow", "actor": "Fisher", "scope": "once"},
+    )
+    assert res.status_code == 200, res.text
+    assert len(gmail.sends) == 1, "the send never happened"
+    return app, gmail
+
+
+async def _dispatch_after_the_call(
+    context,
+    *,
+    tool_name,
+    arguments,
+    call,
+    tool_call_id=None,
+    approval_id=None,
+    step=None,
+):
+    """The mutation: same writes, same records, wrong order."""
+    if not dispatch_module.needs_fence(tool_name) or context is None:
+        return await call()
+    ok, result = await call()
+    effect_id = context.dispatch(
+        tool_name=tool_name,
+        arguments=arguments,
+        tool_call_id=tool_call_id,
+        approval_id=approval_id,
+        step=step,
+    )
+    context.record(effect_id, ok=ok)
+    return ok, result
+
+
+def test_a_dispatch_committed_after_the_call_leaves_the_window_unrecorded(
+    tmp_path, monkeypatch
+):
+    """The ordering, and only the ordering.
+
+    Both runs below end with one `succeeded` effect row. The difference is what
+    was on disk while Gmail was mid-send, which is exactly what a process that
+    died there would have left for a restart to find.
+    """
+    _honest_app, honest = _watched_send(tmp_path / "honest")
+    assert honest.seen == [("gmail_send", str(EffectStatus.DISPATCHED))]
+
+    monkeypatch.setattr(server_module, "guarded_call", _dispatch_after_the_call)
+
+    broken_app, broken = _watched_send(tmp_path / "broken")
+
+    # Nothing was on disk during the call: a crash there is unrecoverable.
+    assert broken.seen == []
+    # And the giveaway, which is why this test reads from inside the call:
+    # the finished record is identical, so every after-the-fact assertion
+    # about it still passes.
+    assert [effect["status"] for effect in _effects(broken_app.state.agent_runs)] == [
+        str(EffectStatus.SUCCEEDED)
+    ]
+
+
+# --- mutation: a consequential tool wired without the fence ----------------
+
+
+def _fenced_tool_run(tmp_path, tool_name, monkeypatch):
+    executed: list[str] = []
+
+    def _execute(name, arguments, **kwargs):
+        executed.append(name)
+        return True, {"ok": True}
+
+    monkeypatch.setattr(turn_module, "execute", _execute)
+    repository, owner = _runs(tmp_path)
+    _turn(
+        tmp_path,
+        provider=OneToolProvider(tool_name),
+        repository=repository,
+        owner=owner,
+        wait="allow",
+    )
+    assert executed == [tool_name], f"{tool_name} never ran"
+    return repository
+
+
+def test_a_hand_written_fence_list_lets_every_other_consequential_tool_through(
+    tmp_path, monkeypatch
+):
+    """`RETRY_SAFE` decides which tools are fenced. A list does not.
+
+    The mutation is the mistake a person would actually make: fence the one
+    tool everybody thinks of, and let the rest of the consequential set past.
+    """
+    honest = _fenced_tool_run(tmp_path / "honest", "apollo_enrich_contact", monkeypatch)
+    assert [effect["tool_name"] for effect in _effects(honest)] == [
+        "apollo_enrich_contact"
+    ]
+
+    monkeypatch.setattr(
+        dispatch_module, "needs_fence", lambda name: name == "gmail_send"
+    )
+
+    broken = _fenced_tool_run(tmp_path / "broken", "apollo_enrich_contact", monkeypatch)
+
+    # An Apollo enrichment spends real credits and left no record that it was
+    # attempted. A crash mid-call is a charge nobody can account for.
+    assert _effects(broken) == []
+    # `gmail_send` still works, which is why the gap would go unnoticed.
+    still_fenced = _fenced_tool_run(tmp_path / "still", "gmail_send", monkeypatch)
+    assert [effect["tool_name"] for effect in _effects(still_fenced)] == ["gmail_send"]
+
+
+# --- mutation: a resume that retries an ambiguous effect -------------------
+
+
+def _quarantined_run(tmp_path):
+    repository = AgentRunRepository(tmp_path)
+    owner = repository.registry.register()
+    started = repository.create_run(
+        session_id=SID, trigger="chat", goal="send it", owner=owner
+    )
+    commit = repository.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments={"draft_id": "d1"}
+    )
+    repository.quarantine_effect(
+        commit.lease, commit.effect["effect_id"], reason="the owner died"
+    )
+    run = repository.get_run(started.run["run_id"])
+    return repository, run
+
+
+def test_a_resume_that_ignores_effects_would_send_the_same_mail_twice(
+    tmp_path, monkeypatch
+):
+    """Effects outrank the run's own state, and that precedence is the guard.
+
+    Without it the run looks like ordinary interrupted work with a tool step
+    left to finish, and finishing it means calling `gmail_send` again.
+    """
+    repository, run = _quarantined_run(tmp_path / "honest")
+    checkpoints = repository.list_checkpoints(run["run_id"])
+    effects = repository.list_effects(run["run_id"])
+    # Non-vacuity: the run really is quarantined and really does look resumable.
+    assert effects[0]["status"] == str(EffectStatus.AMBIGUOUS)
+    assert run["current_state"] == "interrupted"
+
+    assert classify_resume(run, checkpoints, effects).action is ResumeAction.REVIEW
+    # A restart offers it to nobody: `resumable` is what a caller would pick up.
+    owner = repository.registry.register("owner-honest-restart")
+    assert restart(repository, owner).resumable == ()
+
+    # The mutation: stop letting a quarantined effect outrank the run state.
+    monkeypatch.setattr(resume_module, "quarantined", lambda items: [])
+
+    broken = classify_resume(run, checkpoints, effects)
+
+    assert broken.action is ResumeAction.RESUME
+    # The operational consequence: the run whose send may already have reached
+    # a real person is now on the list a caller resumes.
+    offered = restart(repository, owner).resumable
+    assert [verdict.run_id for verdict in offered] == [run["run_id"]]
+
+
+# --- mutation: the inbox overriding the run store --------------------------
+
+
+def _disagreeing_stores(tmp_path):
+    """One approved send: the inbox says interrupted, the run store ambiguous."""
+    conversations = ConversationStore(tmp_path / "conv")
+    repository = AgentRunRepository(tmp_path / "runs")
+    owner = repository.registry.register()
+    parked = conversations.park_inbox(
+        "send_1", "gmail_send", {"draft_id": "d1"}, session_id=SID
+    )
+    conversations.decide_and_claim_inbox_execution(
+        parked["id"], "allow", actor="Fisher", scope="once", claimant="http:1"
+    )
+    started = repository.create_run(
+        session_id=SID, trigger="chat", goal="send", owner=owner
+    )
+    commit = repository.dispatch_effect(
+        started.lease,
+        tool_name="gmail_send",
+        arguments={"draft_id": "d1"},
+        approval_id=parked["id"],
+    )
+    repository.quarantine_effect(
+        commit.lease, commit.effect["effect_id"], reason="owner died"
+    )
+    reopened = ConversationStore(tmp_path / "conv")
+    item = reopened.get_inbox(parked["id"])
+    assert item["execution_status"] == "interrupted", "the stores never disagreed"
+    return repository, reopened
+
+
+def test_letting_the_inbox_win_turns_an_unknown_outcome_into_a_failure(
+    tmp_path, monkeypatch
+):
+    """The run store is the fence of record when the two stores disagree.
+
+    Break that and the queue tells an operator the send was interrupted, which
+    reads as "it did not go out" and invites exactly one more send.
+    """
+    repository, approvals = _disagreeing_stores(tmp_path / "honest")
+    honest = review_queue(repository, approvals)
+    assert honest[0]["status"] == str(EffectStatus.AMBIGUOUS)
+    assert honest[0]["needs_a_person"] is True
+    assert honest[0]["supersedes_inbox"] is True
+
+    # The mutation: prefer whatever the inbox concluded about its claimant.
+    monkeypatch.setattr(
+        reconcile_module,
+        "reconciled_status",
+        lambda effect, approval: (
+            str(approval.get("execution_status"))
+            if approval is not None
+            else str(effect.get("status"))
+        ),
+    )
+
+    broken = review_queue(repository, approvals)
+
+    assert broken[0]["status"] == "interrupted"
+    # The row no longer says the two stores disagree, so no surface can know.
+    assert broken[0]["supersedes_inbox"] is False
+    assert supersedes_inbox(
+        {"status": str(EffectStatus.AMBIGUOUS)},
+        {"execution_status": "interrupted"},
+    ) is False
+
+
+# --- mutation: the fence disarmed at the call site -------------------------
+
+
+def test_a_turn_that_forgets_to_pass_its_run_store_is_fenced_by_nothing(
+    tmp_path, monkeypatch
+):
+    """Why `test_agent_run_integration` checks all three triggers behaviourally.
+
+    `run_turn` without a run store is the legacy path, and it is unfenced by
+    design. That is safe only for as long as every production caller passes
+    one, which is a property of the call sites and not of this module.
+    """
+    executed: list[str] = []
+
+    def _execute(name, arguments, **kwargs):
+        executed.append(name)
+        return True, {"ok": True}
+
+    monkeypatch.setattr(turn_module, "execute", _execute)
+
+    repository, owner = _runs(tmp_path / "wired")
+    _turn(
+        tmp_path / "wired",
+        provider=OneToolProvider("gmail_send"),
+        repository=repository,
+        owner=owner,
+        wait="allow",
+    )
+    assert len(_effects(repository)) == 1
+
+    # The mutation: the caller drops the run store, as `create_app` did before
+    # this slice. Nothing raises and nothing is recorded.
+    unwired, _owner = _runs(tmp_path / "unwired")
+    _turn(
+        tmp_path / "unwired",
+        provider=OneToolProvider("gmail_send"),
+        repository=None,
+        owner=None,
+        wait="allow",
+    )
+
+    assert executed == ["gmail_send", "gmail_send"], "one of the sends never ran"
+    assert _effects(unwired) == []

--- a/desktop/tests/test_agent_run_integration.py
+++ b/desktop/tests/test_agent_run_integration.py
@@ -275,6 +275,54 @@ def test_the_dispatch_is_committed_before_the_send_and_the_outcome_after(tmp_pat
     assert settled[0]["replay_class"] == str(ReplayClass.CONSEQUENTIAL)
 
 
+def test_the_turn_loop_also_commits_its_dispatch_before_the_call(tmp_path, monkeypatch):
+    """The same contract at the other dispatch site.
+
+    There are two places in the product that make a consequential call: the
+    turn loop and the server's approved-execution path. The test above covers
+    the second. This covers the first the same way -- by reading the run store
+    from a separate connection from inside the tool.
+    """
+    import coworker.turn as turn_module
+
+    repository, owner = _runs(tmp_path)
+    seen: list[list[tuple[str, str]]] = []
+
+    def _execute(name, arguments, **kwargs):
+        connection = sqlite3.connect(repository.path)
+        try:
+            seen.append(
+                [
+                    (str(row[0]), str(row[1]))
+                    for row in connection.execute(
+                        "SELECT tool_name, status FROM agent_run_effects"
+                    ).fetchall()
+                ]
+            )
+        finally:
+            connection.close()
+        return True, {"ok": True}
+
+    monkeypatch.setattr(turn_module, "execute", _execute)
+
+    _turn(
+        tmp_path,
+        provider=OneToolProvider("gmail_send"),
+        repository=repository,
+        owner=owner,
+        wait="allow",
+    )
+
+    # Non-vacuity: the tool really ran, once.
+    assert len(seen) == 1, "the turn never reached the tool"
+    # What was committed while the call was in flight.
+    assert seen[0] == [("gmail_send", str(EffectStatus.DISPATCHED))]
+    # And after.
+    assert [effect["status"] for effect in _effects(repository)] == [
+        str(EffectStatus.SUCCEEDED)
+    ]
+
+
 def test_a_send_that_fails_is_failed_and_not_ambiguous(tmp_path):
     """A tool that returns said what happened. Only silence is ambiguous."""
 

--- a/desktop/tests/test_agent_run_integration.py
+++ b/desktop/tests/test_agent_run_integration.py
@@ -1,0 +1,1074 @@
+"""Slice 5: the Agent Run store wired into the paths that actually run.
+
+Slices 1-4 built a fence and nothing entered it. Everything here is about
+whether a production path now does, so almost every test drives a real turn,
+a real HTTP approval, or a real scheduled job rather than calling the store.
+
+Two habits, on purpose.
+
+**Non-vacuity first.** A test that asserts "no second send happened" would pass
+if the run never started. Each one first proves the path got where it claims to
+have got -- a send attempt counted, an effect row present, an approval that
+reached the gate -- and only then asserts the property.
+
+**The ordering contract is observed, not narrated.** The strongest test in this
+file reads `agent_run_effects` from a second database connection *while the
+send is in flight*. A dispatch written after the call, or inside the same
+transaction, is invisible from there and the test fails. Asserting that
+`dispatch_effect` was called first would keep passing after the ordering was
+reversed, so nothing below does that.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import pathlib
+import sqlite3
+import subprocess
+import sys
+import time
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from coworker.agent_run_approval import EffectStatus, replay_class, ReplayClass
+from coworker.agent_run_dispatch import (
+    AgentRunContext,
+    AgentRunEffectQuarantined,
+    AgentRunUnavailable,
+    guarded_call,
+    needs_fence,
+)
+from coworker.agent_run_owner import OwnerRegistry
+from coworker.agent_run_reconcile import (
+    contested_approvals,
+    reconciled_status,
+    review_queue,
+    supersedes_inbox,
+)
+from coworker.agent_run_repository import AgentRunRepository
+from coworker.agent_run_resume import ResumeAction, classify_resume, restart
+from coworker.gmail import FakeGmail
+from coworker.inbox import Inbox
+from coworker.people import PersonStore
+from coworker.permissions import ASK, AUTO, RETRY_SAFE
+from coworker.provider import FakeProvider, StreamChunk, ToolCall
+from coworker.server import TOKEN_HEADER, create_app
+from coworker.store import ConversationStore
+from coworker.tools import OPENAI_TOOLS
+from coworker.turn import run_turn
+
+TOKEN = "test-token-agent-run-integration"
+HEADERS = {TOKEN_HEADER: TOKEN}
+SID = "sess-agent-run"
+
+BODY = "Hi Ada,\n\nWould Thursday work for a short call?\n\nFisher"
+SUBJECT = "Thursday?"
+ADA_EMAIL = "ada@analytic.example"
+ACCOUNT = "director@sourcecado.test"
+
+
+# --- harness ---------------------------------------------------------------
+
+
+class OneToolProvider:
+    """Asks for one named tool, then stops."""
+
+    provider_id = "fake"
+    model_id = "fake"
+
+    def __init__(self, tool_name: str, arguments: Any = None) -> None:
+        self.tool_name = tool_name
+        self.arguments = arguments if arguments is not None else {}
+        self.requests = 0
+        self.calls: list[list[dict[str, Any]]] = []
+
+    async def astream(self, *, messages, tools=None, context_id=None):
+        self.calls.append(list(messages))
+        index = self.requests
+        self.requests += 1
+        yield StreamChunk.started(provider=self.provider_id, model=self.model_id)
+        if index > 0:
+            yield StreamChunk(text_delta="Done.")
+            yield StreamChunk(finish_reason="stop")
+            return
+        yield StreamChunk(text_delta="Working. ")
+        yield StreamChunk(finish_reason="tool_calls")
+        yield StreamChunk(
+            tool_calls=[
+                ToolCall(id="call_one", name=self.tool_name, arguments=self.arguments)
+            ]
+        )
+
+
+def _runs(tmp_path) -> tuple[AgentRunRepository, Any]:
+    repository = AgentRunRepository(tmp_path / "runs")
+    return repository, repository.registry.register()
+
+
+def _turn(
+    tmp_path,
+    *,
+    provider,
+    repository=None,
+    owner=None,
+    text="Do the thing.",
+    sid=SID,
+    store=None,
+    people=None,
+    wait=None,
+    **kwargs,
+):
+    conv = store if store is not None else ConversationStore(tmp_path / "conv")
+    person_store = people if people is not None else PersonStore(tmp_path / "people")
+
+    async def _wait(_call_id: str) -> str:
+        return wait or "allow"
+
+    result = asyncio.run(
+        run_turn(
+            text=text,
+            sid=sid,
+            store=conv,
+            provider=provider,
+            persona=None,
+            skills=None,
+            inbox=Inbox(conv),
+            openai_tools=OPENAI_TOOLS,
+            execute_kwargs={"people": person_store},
+            wait_permission=_wait if wait is not None else None,
+            agent_runs=repository,
+            run_owner=owner,
+            **kwargs,
+        )
+    )
+    return result, conv
+
+
+def _effects(repository: AgentRunRepository) -> list[dict[str, Any]]:
+    return [
+        effect
+        for run in repository.list_runs(limit=100)
+        for effect in repository.list_effects(run["run_id"])
+    ]
+
+
+def _app(tmp_path, gmail=None, **kwargs):
+    return create_app(
+        token=TOKEN, provider=None, state=tmp_path, gmail=gmail, **kwargs
+    )
+
+
+def _gmail(cls=FakeGmail, **kwargs) -> FakeGmail:
+    gmail = cls(**kwargs)
+    gmail.account_email = ACCOUNT
+    return gmail
+
+
+def _bound_person(app, *, email: str = ADA_EMAIL):
+    people = app.state.people
+    person = people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L.",
+        title="Head of Data",
+        company="Analytic",
+    )
+    people.apply_enrichment(person["person_id"], name="Ada Lovelace", email=email)
+    person = people.get(person["person_id"])
+    session_id = app.state.store.create_session()["session_id"]
+    people.bind_session(
+        session_id, person["person_id"], expected_person_version=int(person["version"])
+    )
+    return person["person_id"], session_id
+
+
+def _park_send(client, person_id, session_id):
+    draft = client.post(
+        f"/v1/people/{person_id}/outreach/draft",
+        headers=HEADERS,
+        json={"session_id": session_id, "subject": SUBJECT, "body": BODY},
+    )
+    assert draft.status_code == 201, draft.text
+    drafted = draft.json()["draft"]
+    parked = client.post(
+        f"/v1/people/{person_id}/outreach/send-approval",
+        headers=HEADERS,
+        json={
+            "session_id": session_id,
+            "draft_id": drafted["id"],
+            "reviewed_body_digest": drafted["body_digest"],
+        },
+    )
+    assert parked.status_code == 201, parked.text
+    return parked.json()["item"]["id"]
+
+
+# ==========================================================================
+# 1 -- the ordering contract, observed from inside the call
+# ==========================================================================
+
+
+class WatchingGmail(FakeGmail):
+    """Gmail that reads the run store from a second connection mid-send.
+
+    This is the whole ordering contract in one fixture. `send` runs between
+    `dispatch_effect` and `record_effect_outcome`, so whatever it can see
+    committed is what a process dying right here would have left behind.
+    """
+
+    def __init__(self, db_path) -> None:
+        super().__init__()
+        self.db_path = db_path
+        self.seen: list[tuple[str, str]] = []
+
+    def send(self, *, draft_id: str):
+        connection = sqlite3.connect(self.db_path)
+        try:
+            self.seen = [
+                (str(row[0]), str(row[1]))
+                for row in connection.execute(
+                    "SELECT tool_name, status FROM agent_run_effects"
+                ).fetchall()
+            ]
+        finally:
+            connection.close()
+        return super().send(draft_id=draft_id)
+
+
+def test_the_dispatch_is_committed_before_the_send_and_the_outcome_after(tmp_path):
+    """Dispatch commits before the call. Outcome commits after it.
+
+    Read from a separate connection while Gmail is mid-send, so a dispatch
+    written after the call -- or in the same transaction as it -- is not
+    visible and this fails. It is the one property the whole slice rests on.
+    """
+    app = _app(tmp_path)
+    gmail = WatchingGmail(app.state.agent_runs.path)
+    gmail.account_email = ACCOUNT
+    app.state.gmail = gmail
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    item_id = _park_send(client, person_id, session_id)
+
+    res = client.post(
+        f"/v1/inbox/{item_id}",
+        headers=HEADERS,
+        json={"decision": "allow", "actor": "Fisher", "scope": "once"},
+    )
+
+    # Non-vacuity: the send really happened, so the window really was entered.
+    assert res.status_code == 200, res.text
+    assert res.json()["ok"] is True
+    assert len(gmail.sends) == 1
+
+    # What a process dying inside the window would have left on disk.
+    assert gmail.seen == [("gmail_send", str(EffectStatus.DISPATCHED))]
+
+    # And after: the same effect, settled by the process that dispatched it.
+    settled = _effects(app.state.agent_runs)
+    assert [effect["status"] for effect in settled] == [
+        str(EffectStatus.SUCCEEDED)
+    ]
+    assert settled[0]["approval_id"] == item_id
+    assert settled[0]["replay_class"] == str(ReplayClass.CONSEQUENTIAL)
+
+
+def test_a_send_that_fails_is_failed_and_not_ambiguous(tmp_path):
+    """A tool that returns said what happened. Only silence is ambiguous."""
+
+    class RefusingGmail(FakeGmail):
+        def send(self, *, draft_id: str):
+            self.send_attempts.append(draft_id)
+            raise RuntimeError("Gmail refused the submission.")
+
+    app = _app(tmp_path, _gmail(RefusingGmail))
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    item_id = _park_send(client, person_id, session_id)
+
+    res = client.post(
+        f"/v1/inbox/{item_id}",
+        headers=HEADERS,
+        json={"decision": "allow", "actor": "Fisher", "scope": "once"},
+    )
+
+    assert res.status_code == 200, res.text
+    # Non-vacuity: Gmail was really reached and really refused.
+    assert len(app.state.gmail.send_attempts) == 1
+    assert app.state.gmail.sends == []
+    assert [effect["status"] for effect in _effects(app.state.agent_runs)] == [
+        str(EffectStatus.FAILED)
+    ]
+    assert app.state.agent_runs.list_quarantined_effects() == []
+
+
+# ==========================================================================
+# 2 -- which tools are fenced, derived and not listed
+# ==========================================================================
+
+
+def test_the_fenced_set_is_read_from_retry_safe_and_not_written_down():
+    """No hand-written list. `RETRY_SAFE` decides, and the rest is fenced."""
+    names = {
+        str((schema.get("function") or {}).get("name") or "")
+        for schema in OPENAI_TOOLS
+    }
+    names.discard("")
+    assert len(names) > 10, "the tool registry did not load"
+
+    for name in sorted(names):
+        assert needs_fence(name) is (name not in RETRY_SAFE), name
+
+    # Every approval-gated tool is fenced, because none is retry safe.
+    assert ASK, "the ASK set is empty"
+    for name in sorted(ASK):
+        assert needs_fence(name), name
+    # A tool the permission module has never heard of fails closed.
+    assert needs_fence("a_tool_nobody_declared")
+    # And a read stays cheap.
+    assert not needs_fence("gmail_search")
+    assert replay_class("gmail_search") is ReplayClass.SAFE
+
+
+@pytest.mark.parametrize(
+    "tool_name", sorted((AUTO | ASK) - RETRY_SAFE)
+)
+def test_every_consequential_tool_in_a_turn_opens_an_effect_record(
+    tmp_path, tool_name, monkeypatch
+):
+    """Not just `gmail_send`. The trap in `docs/agent-runs.md` is this one.
+
+    Driven over the real turn loop with the real permission gate, one test per
+    tool that `RETRY_SAFE` does not cover, so a tool moving between the sets
+    cannot quietly slip past the fence.
+    """
+    import coworker.turn as turn_module
+
+    seen: list[str] = []
+
+    def _execute(name, arguments, **kwargs):
+        seen.append(name)
+        return True, {"ok": True}
+
+    monkeypatch.setattr(turn_module, "execute", _execute)
+    repository, owner = _runs(tmp_path)
+
+    _turn(
+        tmp_path,
+        provider=OneToolProvider(tool_name),
+        repository=repository,
+        owner=owner,
+        wait="allow",
+    )
+
+    # Non-vacuity: the tool really ran. A zero-effect count on a tool that was
+    # never reached would prove nothing.
+    assert seen == [tool_name], f"{tool_name} never executed"
+    effects = _effects(repository)
+    assert [effect["tool_name"] for effect in effects] == [tool_name]
+    assert effects[0]["status"] == str(EffectStatus.SUCCEEDED)
+    assert effects[0]["replay_class"] == str(ReplayClass.CONSEQUENTIAL)
+
+
+@pytest.mark.parametrize("tool_name", sorted(RETRY_SAFE))
+def test_a_retry_safe_tool_costs_no_effect_record(tmp_path, tool_name, monkeypatch):
+    """The fence is not a tax on reading. A safe tool opens no effect row."""
+    import coworker.turn as turn_module
+
+    seen: list[str] = []
+
+    def _execute(name, arguments, **kwargs):
+        seen.append(name)
+        return True, {"ok": True}
+
+    monkeypatch.setattr(turn_module, "execute", _execute)
+    repository, owner = _runs(tmp_path)
+
+    _turn(
+        tmp_path,
+        provider=OneToolProvider(tool_name),
+        repository=repository,
+        owner=owner,
+    )
+
+    assert seen == [tool_name], f"{tool_name} never executed"
+    assert _effects(repository) == []
+    # It is still on the record as work: the receipt sees reading too.
+    run = repository.list_runs(limit=10)[0]
+    kinds = [item["kind"] for item in repository.list_checkpoints(run["run_id"])]
+    assert "tool_pending" in kinds and "tool_completed" in kinds
+
+
+# ==========================================================================
+# 3 -- the three triggers, each from its own production path
+# ==========================================================================
+
+
+def test_a_chat_turn_over_the_socket_creates_a_durable_run(tmp_path):
+    app = _app(tmp_path)
+    app.state.provider = FakeProvider(deltas=("Hello ", "world"))
+    client = TestClient(app)
+    sid = app.state.store.open_session_id()
+
+    with client.websocket_connect("/ws/chat", subprotocols=["club", TOKEN]) as ws:
+        ws.send_json({"type": "chat", "text": "hi", "session_id": sid})
+        while ws.receive_json()["type"] not in ("turn_end", "error"):
+            pass
+
+    runs = app.state.agent_runs.list_runs(session_id=sid, limit=10)
+    assert [run["trigger"] for run in runs] == ["chat"]
+    assert runs[0]["current_state"] == "complete"
+    # The run id is the turn's own, so a receipt and an event point at one thing.
+    assert runs[0]["run_id"].startswith("run_")
+
+
+def test_a_scheduled_routine_creates_a_run_with_the_scheduled_trigger(tmp_path):
+    app = _app(tmp_path)
+    app.state.provider = FakeProvider(deltas=("Reviewed.",))
+    job = app.state.store.add_job("0 9 * * 1", "Review the shortlist.")
+
+    recorded = app.state.scheduler.run_job(int(job["id"]))
+
+    # Non-vacuity: the routine really ran to a receipt.
+    assert recorded["status"] == "success"
+    runs = app.state.agent_runs.list_runs(trigger="scheduled", limit=10)
+    assert len(runs) == 1
+    assert runs[0]["session_id"] == f"sched-{job['id']}"
+    assert runs[0]["current_state"] == "complete"
+
+
+def _wait_until(predicate, timeout: float = 5.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.02)
+    return predicate()
+
+
+def test_a_queued_message_creates_a_run_with_the_queued_trigger(tmp_path):
+    """The third trigger, from the queue drain the socket actually uses."""
+    app = _app(tmp_path)
+    app.state.provider = FakeProvider(deltas=("Queued answer.",))
+    client = TestClient(app)
+    sid = app.state.store.open_session_id()
+
+    with client.websocket_connect("/ws/chat", subprotocols=["club", TOKEN]) as ws:
+        ws.send_json(
+            {
+                "type": "queue_add",
+                "session_id": sid,
+                "command_id": "queued-1",
+                "item_id": "queued-item-1",
+                "text": "answer this later",
+            }
+        )
+        assert ws.receive_json()["type"] == "queue_snapshot"
+        # `queue_add` only enqueues. Resume is what drains it.
+        ws.send_json(
+            {
+                "type": "queue_resume",
+                "session_id": sid,
+                "command_id": "queued-resume",
+            }
+        )
+        while ws.receive_json()["type"] not in ("turn_end", "error"):
+            pass
+
+    assert _wait_until(
+        lambda: any(
+            run["trigger"] == "queued_chat"
+            for run in app.state.agent_runs.list_runs(session_id=sid, limit=10)
+        )
+    ), [run["trigger"] for run in app.state.agent_runs.list_runs(session_id=sid, limit=10)]
+
+
+# ==========================================================================
+# 4 -- restart: an unreported effect is quarantined, never replayed
+# ==========================================================================
+
+
+def test_startup_registers_an_owner_and_runs_one_reconciliation_pass(tmp_path):
+    app = _app(tmp_path)
+
+    assert app.state.run_owner is not None
+    # The marker is held for the life of the process, which is what proof of
+    # death later reads.
+    assert (
+        app.state.agent_runs.registry.liveness_of(
+            app.state.run_owner.owner_id, app.state.run_owner.host
+        ).value
+        == "alive"
+    )
+    assert app.state.run_restart is not None
+    assert app.state.run_restart.quarantined == ()
+
+
+# The other half of a process that dies mid-send: a real process, really
+# exiting. Proof of death is a kernel fact -- the `flock` an owner holds is
+# released when the process exits and never before -- so simulating it by
+# unlinking the marker would test something else entirely. A missing marker is
+# `unknown`, and unknown never authorises a reclaim.
+_DYING_OWNER = """
+import sys
+from coworker.agent_run_owner import OwnerRegistry
+from coworker.agent_run_repository import AgentRunRepository
+
+base = sys.argv[1]
+repository = AgentRunRepository(base)
+owner = OwnerRegistry(base).register("owner-that-dies")
+started = repository.create_run(
+    session_id="sess-agent-run", trigger="chat", goal="send it", owner=owner
+)
+commit = repository.dispatch_effect(
+    started.lease, tool_name="gmail_send", arguments={"draft_id": "d1"}
+)
+print(started.run["run_id"])
+print(commit.effect["effect_id"])
+# Exit here. The outcome is never recorded and the kernel drops the lock.
+"""
+
+
+def test_a_process_that_died_mid_send_leaves_an_effect_a_person_must_settle(
+    tmp_path,
+):
+    """The window, opened by a real process that then really exits.
+
+    Restart quarantines it. It never resumes it and never retries the send.
+    """
+    base = tmp_path / "runs"
+    dead = subprocess.run(
+        [sys.executable, "-c", _DYING_OWNER, str(base)],
+        capture_output=True,
+        text=True,
+        cwd=str(pathlib.Path(__file__).resolve().parents[1]),
+    )
+    assert dead.returncode == 0, dead.stderr
+    run_id, effect_id = dead.stdout.split()
+
+    repository = AgentRunRepository(base)
+    survivor = repository.registry.register("owner-that-restarts")
+    # Non-vacuity: before the restart the row still reads as owned, and the
+    # effect is open. A test that skipped this could not tell a working
+    # quarantine from a store that was empty all along.
+    assert repository.get_run(run_id)["lease_owner"] == "owner-that-dies"
+    assert repository.list_effects(run_id)[0]["status"] == str(
+        EffectStatus.DISPATCHED
+    )
+
+    outcome = restart(repository, survivor)
+
+    verdicts = {verdict.run_id: verdict.action for verdict in outcome.verdicts}
+    assert verdicts[run_id] is ResumeAction.QUARANTINE
+    assert [effect["effect_id"] for effect in outcome.quarantined] == [effect_id]
+    held = repository.list_quarantined_effects()
+    assert [effect["status"] for effect in held] == [str(EffectStatus.AMBIGUOUS)]
+    # The run comes to rest interrupted, holding no lease.
+    settled_run = repository.get_run(run_id)
+    assert settled_run["current_state"] == "interrupted"
+    assert settled_run["lease_owner"] is None
+
+
+def test_a_restart_never_takes_a_lease_from_an_owner_that_is_still_alive(tmp_path):
+    """The reason restart cannot just assume every previous owner is dead."""
+    base = tmp_path / "runs"
+    repository = AgentRunRepository(base)
+    living = repository.registry.register("owner-still-working")
+    started = repository.create_run(
+        session_id=SID, trigger="chat", goal="send it", owner=living
+    )
+    repository.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments={"draft_id": "d1"}
+    )
+
+    second = AgentRunRepository(base)
+    second.registry = repository.registry
+    outcome = restart(second, second.registry.register("owner-second-sidecar"))
+
+    verdicts = {verdict.run_id: verdict.action for verdict in outcome.verdicts}
+    assert verdicts[started.run["run_id"]] is ResumeAction.NOTHING
+    assert outcome.quarantined == ()
+    assert second.list_quarantined_effects() == []
+
+
+def test_a_quarantined_effect_is_never_resumed_and_never_retried(tmp_path):
+    """`REVIEW`, not `RESUME`. Effects outrank the run's own state."""
+    repository = AgentRunRepository(tmp_path / "runs")
+    registry = OwnerRegistry(tmp_path / "runs")
+    owner = registry.register("owner-quarantine")
+    started = repository.create_run(
+        session_id=SID, trigger="chat", goal="send it", owner=owner
+    )
+    commit = repository.dispatch_effect(
+        started.lease, tool_name="gmail_send", arguments={"draft_id": "d1"}
+    )
+    repository.quarantine_effect(
+        commit.lease, commit.effect["effect_id"], reason="the process died"
+    )
+
+    run = repository.get_run(started.run["run_id"])
+    verdict = classify_resume(
+        run,
+        repository.list_checkpoints(run["run_id"]),
+        repository.list_effects(run["run_id"]),
+    )
+
+    assert verdict.action is ResumeAction.REVIEW
+    assert verdict.effect_id == commit.effect["effect_id"]
+    # A second restart does not quarantine it again or move it on.
+    again = restart(repository, owner)
+    assert again.quarantined == ()
+    assert [item.action for item in again.verdicts] == [ResumeAction.REVIEW]
+
+
+def test_a_cancelled_call_quarantines_rather_than_calling_it_failed(tmp_path):
+    """Stop pressed mid-send. Nothing observed the outcome, so nothing claims one."""
+    repository, owner = _runs(tmp_path)
+    context = AgentRunContext.start(
+        repository, owner, session_id=SID, trigger="chat", goal="send"
+    )
+
+    async def _cancelled() -> tuple[bool, dict[str, Any]]:
+        raise asyncio.CancelledError()
+
+    async def _drive() -> None:
+        with pytest.raises(asyncio.CancelledError):
+            await guarded_call(
+                context,
+                tool_name="gmail_send",
+                arguments={"draft_id": "d1"},
+                call=_cancelled,
+            )
+
+    asyncio.run(_drive())
+
+    held = repository.list_quarantined_effects()
+    assert [effect["tool_name"] for effect in held] == ["gmail_send"]
+    assert held[0]["status"] == str(EffectStatus.AMBIGUOUS)
+
+
+def test_a_raised_call_quarantines_and_the_turn_does_not_carry_on(tmp_path):
+    repository, owner = _runs(tmp_path)
+    context = AgentRunContext.start(
+        repository, owner, session_id=SID, trigger="chat", goal="send"
+    )
+
+    async def _explodes() -> tuple[bool, dict[str, Any]]:
+        raise RuntimeError("the socket died mid-request")
+
+    async def _drive() -> None:
+        with pytest.raises(AgentRunEffectQuarantined):
+            await guarded_call(
+                context,
+                tool_name="gmail_send",
+                arguments={"draft_id": "d1"},
+                call=_explodes,
+            )
+
+    asyncio.run(_drive())
+    assert len(repository.list_quarantined_effects()) == 1
+    assert context.closed
+
+
+# ==========================================================================
+# 5 -- reconciliation: the run store is the fence of record
+# ==========================================================================
+
+
+def test_the_run_store_overrides_an_inbox_that_calls_an_unknown_outcome_interrupted():
+    """The documented rule, as a rule.
+
+    The inbox knows a claimant vanished. Only the run store knows a call was
+    dispatched, because only its write ordering brackets that call.
+    """
+    effect = {
+        "effect_id": "effect-1",
+        "run_id": "run-1",
+        "tool_name": "gmail_send",
+        "approval_id": "send_1",
+        "status": str(EffectStatus.AMBIGUOUS),
+    }
+    approval = {"id": "send_1", "execution_status": "interrupted"}
+
+    assert reconciled_status(effect, approval) == str(EffectStatus.AMBIGUOUS)
+    assert supersedes_inbox(effect, approval) is True
+    # And the other direction: a send the run store saw succeed is not an
+    # interruption, whatever the inbox concluded about its claimant.
+    succeeded = {**effect, "status": str(EffectStatus.SUCCEEDED)}
+    assert reconciled_status(succeeded, approval) == str(EffectStatus.SUCCEEDED)
+    assert supersedes_inbox(succeeded, approval) is True
+    # With no effect record there is nothing to override.
+    assert reconciled_status(None, approval) == "interrupted"
+    assert supersedes_inbox(None, approval) is False
+
+
+def test_an_interrupted_approval_with_a_quarantined_effect_is_reported_as_ambiguous(
+    tmp_path,
+):
+    """End to end over both real stores, not two dicts."""
+    conversations = ConversationStore(tmp_path / "conv")
+    repository = AgentRunRepository(tmp_path / "runs")
+    owner = repository.registry.register()
+    parked = conversations.park_inbox(
+        "send_1", "gmail_send", {"draft_id": "d1"}, session_id=SID
+    )
+    conversations.decide_and_claim_inbox_execution(
+        parked["id"], "allow", actor="Fisher", scope="once", claimant="http:1"
+    )
+    started = repository.create_run(
+        session_id=SID, trigger="chat", goal="send", owner=owner
+    )
+    commit = repository.dispatch_effect(
+        started.lease,
+        tool_name="gmail_send",
+        arguments={"draft_id": "d1"},
+        approval_id=parked["id"],
+    )
+    # The process dies. Each store reconciles independently, and they disagree.
+    ConversationStore(tmp_path / "conv")
+    repository.quarantine_effect(
+        commit.lease, commit.effect["effect_id"], reason="owner died"
+    )
+
+    reopened = ConversationStore(tmp_path / "conv")
+    item = reopened.get_inbox(parked["id"])
+    assert item["execution_status"] == "interrupted", "the inbox never disagreed"
+
+    rows = review_queue(repository, reopened)
+    assert len(rows) == 1
+    assert rows[0]["status"] == str(EffectStatus.AMBIGUOUS)
+    assert rows[0]["inbox_claim"] == "interrupted"
+    assert rows[0]["supersedes_inbox"] is True
+    assert rows[0]["fence_of_record"] == "agent_run_store"
+    assert rows[0]["needs_a_person"] is True
+    assert rows[0]["evidence"] == "ambiguous"
+    assert rows[0]["approval"]["id"] == parked["id"]
+
+    contested = contested_approvals(repository, reopened.list_inbox(pending_only=False))
+    assert [row["effect_id"] for row in contested] == [commit.effect["effect_id"]]
+
+
+# ==========================================================================
+# 6 -- the review queue an operator actually uses
+# ==========================================================================
+
+
+def _quarantined_send(app, client):
+    """One approved send whose executor died inside the window."""
+    person_id, session_id = _bound_person(app)
+    item_id = _park_send(client, person_id, session_id)
+    claim = app.state.store.decide_and_claim_inbox_execution(
+        item_id, "allow", actor="Fisher", scope="once", claimant="http:dead"
+    )
+    assert claim["owned"] is True, "the claim never landed"
+    started = app.state.agent_runs.create_run(
+        session_id=session_id,
+        trigger="chat",
+        goal="send",
+        owner=app.state.run_owner,
+    )
+    commit = app.state.agent_runs.dispatch_effect(
+        started.lease,
+        tool_name="gmail_send",
+        arguments={"draft_id": "d1"},
+        approval_id=item_id,
+    )
+    app.state.agent_runs.quarantine_effect(
+        commit.lease, commit.effect["effect_id"], reason="owner died mid-send"
+    )
+    return item_id, commit.effect["effect_id"]
+
+
+def test_the_review_queue_shows_what_was_authorized_and_what_can_be_decided(
+    tmp_path,
+):
+    app = _app(tmp_path, _gmail())
+    client = TestClient(app)
+    item_id, effect_id = _quarantined_send(app, client)
+
+    res = client.get("/v1/agent-run-effects/quarantine", headers=HEADERS)
+
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert [row["effect_id"] for row in body["effects"]] == [effect_id]
+    row = body["effects"][0]
+    assert row["tool_name"] == "gmail_send"
+    assert row["approval_id"] == item_id
+    assert row["needs_a_person"] is True
+    # The operator sees the binding they approved: recipient, subject, account.
+    resource = row["approval"]["resource"]
+    assert resource["to"] == ADA_EMAIL
+    assert resource["subject"] == SUBJECT
+    # And never the body.
+    assert "body" not in resource
+    assert body["decisions"] == [
+        "abandoned",
+        "resolved_failed",
+        "resolved_succeeded",
+    ]
+
+
+def test_an_operator_settles_a_quarantined_effect_and_it_leaves_the_queue(tmp_path):
+    app = _app(tmp_path, _gmail())
+    client = TestClient(app)
+    _item_id, effect_id = _quarantined_send(app, client)
+
+    res = client.post(
+        f"/v1/agent-run-effects/quarantine/{effect_id}",
+        headers=HEADERS,
+        json={
+            "decision": "resolved_succeeded",
+            "operator": "Fisher",
+            "note": "Checked the Sent folder; it went out.",
+        },
+    )
+
+    assert res.status_code == 200, res.text
+    settled = res.json()["effect"]
+    assert settled["status"] == "resolved_succeeded"
+    assert settled["resolved_by"] == "Fisher"
+    assert client.get("/v1/agent-run-effects/quarantine", headers=HEADERS).json()[
+        "effects"
+    ] == []
+    # Settled is final: a second decision is refused, not silently applied.
+    again = client.post(
+        f"/v1/agent-run-effects/quarantine/{effect_id}",
+        headers=HEADERS,
+        json={"decision": "abandoned", "operator": "Fisher"},
+    )
+    assert again.status_code == 409, again.text
+
+
+def test_a_machine_outcome_is_not_a_decision_a_person_may_make(tmp_path):
+    app = _app(tmp_path, _gmail())
+    client = TestClient(app)
+    _item_id, effect_id = _quarantined_send(app, client)
+
+    res = client.post(
+        f"/v1/agent-run-effects/quarantine/{effect_id}",
+        headers=HEADERS,
+        json={"decision": "succeeded", "operator": "Fisher"},
+    )
+
+    assert res.status_code == 400, res.text
+    assert "machine outcome" in res.json()["error"]
+    # It is still quarantined, so nothing was half-applied.
+    assert len(app.state.agent_runs.list_quarantined_effects()) == 1
+
+
+def test_settling_an_effect_needs_a_named_person(tmp_path):
+    app = _app(tmp_path, _gmail())
+    client = TestClient(app)
+    _item_id, effect_id = _quarantined_send(app, client)
+
+    res = client.post(
+        f"/v1/agent-run-effects/quarantine/{effect_id}",
+        headers=HEADERS,
+        json={"decision": "abandoned", "operator": ""},
+    )
+
+    assert res.status_code == 400, res.text
+    assert len(app.state.agent_runs.list_quarantined_effects()) == 1
+
+
+# ==========================================================================
+# 7 -- the two halves of at-most-once, composed and not duplicated
+# ==========================================================================
+
+
+def test_the_claim_stops_a_second_attempt_and_the_fence_records_the_first(tmp_path):
+    """One claim, one send, one effect record. Neither half repeats the other.
+
+    The inbox claim is what makes this the only executor. The run store never
+    decides whether the call may happen; it records that it did.
+    """
+    app = _app(tmp_path, _gmail())
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    item_id = _park_send(client, person_id, session_id)
+
+    first = client.post(
+        f"/v1/inbox/{item_id}",
+        headers=HEADERS,
+        json={"decision": "allow", "actor": "Fisher", "scope": "once"},
+    )
+    second = client.post(
+        f"/v1/inbox/{item_id}",
+        headers=HEADERS,
+        json={"decision": "allow", "actor": "Fisher", "scope": "once"},
+    )
+
+    assert first.status_code == 200 and first.json()["ok"] is True
+    assert second.status_code == 200
+    # One send, whatever the second request thought it was doing.
+    assert len(app.state.gmail.sends) == 1
+    assert len(app.state.gmail.send_attempts) == 1
+    # And exactly one effect record: the fence did not open a second window.
+    effects = _effects(app.state.agent_runs)
+    assert len(effects) == 1
+    assert effects[0]["status"] == str(EffectStatus.SUCCEEDED)
+
+
+def test_an_interrupted_claim_is_never_re_executed(tmp_path):
+    """The claim's half, stated. Only `pending` is claimable."""
+    app = _app(tmp_path, _gmail())
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    item_id = _park_send(client, person_id, session_id)
+    claim = app.state.store.decide_and_claim_inbox_execution(
+        item_id, "allow", actor="Fisher", scope="once", claimant="http:dead"
+    )
+    assert claim["owned"] is True
+
+    # The claimant dies; a restart closes the claim without replaying it.
+    ConversationStore(tmp_path)
+    reopened = app.state.store.get_inbox(item_id)
+    assert reopened["execution_status"] == "interrupted"
+
+    again = app.state.store.decide_and_claim_inbox_execution(
+        item_id, "allow", actor="Fisher", scope="once", claimant="http:new"
+    )
+    assert again["claimed"] is False
+    assert again["owned"] is False
+    assert app.state.gmail.sends == []
+
+
+# ==========================================================================
+# 8 -- approvals move the run through the door, not around it
+# ==========================================================================
+
+
+def test_an_approved_turn_parks_its_run_and_comes_back_through_the_door(
+    tmp_path, monkeypatch
+):
+    import coworker.turn as turn_module
+
+    monkeypatch.setattr(
+        turn_module, "execute", lambda name, arguments, **kwargs: (True, {"ok": True})
+    )
+    repository, owner = _runs(tmp_path)
+
+    _turn(
+        tmp_path,
+        provider=OneToolProvider("gmail_send"),
+        repository=repository,
+        owner=owner,
+        wait="allow",
+    )
+
+    run = repository.list_runs(limit=10)[0]
+    kinds = [item["kind"] for item in repository.list_checkpoints(run["run_id"])]
+    assert "waiting_approval" in kinds, "the run never parked on the person"
+    assert "approval_resolved" in kinds, "the run never came back through the door"
+    # The approval is on the run row, which is what the door checks against.
+    assert run["approval_ids"] == ["call_one"]
+    assert run["current_state"] == "complete"
+
+
+def test_a_denied_approval_still_returns_the_run_to_its_owner(
+    tmp_path, monkeypatch
+):
+    import coworker.turn as turn_module
+
+    monkeypatch.setattr(
+        turn_module, "execute", lambda name, arguments, **kwargs: (True, {"ok": True})
+    )
+    repository, owner = _runs(tmp_path)
+
+    _turn(
+        tmp_path,
+        provider=OneToolProvider("gmail_send"),
+        repository=repository,
+        owner=owner,
+        wait="deny",
+    )
+
+    run = repository.list_runs(limit=10)[0]
+    # A denial is not a parked run left behind: it reaches a terminal state.
+    assert run["current_state"] in {"complete", "partial"}
+    assert _effects(repository) == [], "a denied call must open no effect record"
+
+
+# ==========================================================================
+# 9 -- failing closed
+# ==========================================================================
+
+
+def test_a_caller_that_supplied_a_run_store_and_got_no_run_refuses_to_send(tmp_path):
+    """The distinction the fence turns on.
+
+    A caller that never armed the fence is not fenced. A caller that armed it
+    and got nothing must not send, and this is that case.
+    """
+    repository, owner = _runs(tmp_path)
+    disarmed = AgentRunContext.disarmed(repository, owner, reason="disk is full")
+    calls: list[str] = []
+
+    def _call(name: str):
+        async def _run() -> tuple[bool, dict[str, Any]]:
+            calls.append(name)
+            return True, {"ok": True}
+
+        return _run
+
+    async def _drive() -> None:
+        with pytest.raises(AgentRunUnavailable):
+            await guarded_call(
+                disarmed,
+                tool_name="gmail_send",
+                arguments={},
+                call=_call("gmail_send"),
+            )
+        # A read still runs: the fence stops sends, not the product.
+        ok, _result = await guarded_call(
+            disarmed,
+            tool_name="gmail_search",
+            arguments={},
+            call=_call("gmail_search"),
+        )
+        assert ok is True
+
+    asyncio.run(_drive())
+    assert calls == ["gmail_search"]
+    assert _effects(repository) == []
+
+
+def test_a_turn_whose_run_store_will_not_open_a_run_refuses_consequential_work(
+    tmp_path, monkeypatch
+):
+    import coworker.turn as turn_module
+
+    executed: list[str] = []
+
+    def _execute(name, arguments, **kwargs):
+        executed.append(name)
+        return True, {"ok": True}
+
+    monkeypatch.setattr(turn_module, "execute", _execute)
+    repository, owner = _runs(tmp_path)
+    monkeypatch.setattr(
+        repository,
+        "create_run",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("disk is full")),
+    )
+
+    result, conv = _turn(
+        tmp_path,
+        provider=OneToolProvider("gmail_send"),
+        repository=repository,
+        owner=owner,
+        wait="allow",
+    )
+
+    assert executed == [], "the send was attempted with no way to record it"
+    # It is reported, not silently dropped.
+    tool_results = [
+        message
+        for message in conv.load(SID)
+        if message.get("role") == "tool"
+    ]
+    assert tool_results, "the turn never reached the tool step"
+    assert "could not record this action durably" in tool_results[-1]["content"]
+    assert result["status"] in {"partial", "ok"}

--- a/desktop/tests/test_ambiguous_send_outcome.py
+++ b/desktop/tests/test_ambiguous_send_outcome.py
@@ -19,7 +19,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from coworker.agent_run_approval import EffectStatus
-from coworker.apollo import FakeHttp
+from coworker.apollo import FakeHttp, HttpError
 from coworker.gmail import (
     DRAFTS_URL,
     GmailApi,
@@ -43,14 +43,48 @@ SEND_URL = f"{DRAFTS_URL}/send"
 def _api(tmp_path, routes) -> GmailApi:
     secrets = SecretStore(tmp_path / "secrets.json")
     secrets.put("gmail", {"refresh_token": "rt", "access_token": "at"})
-    return GmailApi(
-        secrets, http=FakeHttp(routes), client_id="cid", client_secret="sec"
-    )
+    http = routes if hasattr(routes, "post") else FakeHttp(routes)
+    return GmailApi(secrets, http=http, client_id="cid", client_secret="sec")
 
 
 def _timeout() -> httpx.ReadTimeout:
     """What httpx raises when the request went out and the read expired."""
     return httpx.ReadTimeout("timed out", request=httpx.Request("POST", SEND_URL))
+
+
+def _refused() -> httpx.ConnectError:
+    """What httpx raises when the socket never opened."""
+    return httpx.ConnectError(
+        "[Errno 61] Connection refused", request=httpx.Request("POST", SEND_URL)
+    )
+
+
+TOKEN_URL = "https://oauth2.googleapis.com/token"
+
+
+def _four_o_one_then(retry_error, *, refresh_fails: bool = False):
+    """Gmail rejects the cached token, then the retry hits `retry_error`."""
+
+    class Scripted:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def get(self, url, **kwargs):  # pragma: no cover - send is a POST
+            raise AssertionError(url)
+
+        def post(self, url, **kwargs):
+            self.calls.append(url)
+            if url == SEND_URL and self.calls.count(SEND_URL) == 1:
+                raise HttpError(401, url)
+            if url == TOKEN_URL:
+                if refresh_fails:
+                    raise retry_error
+                return {"access_token": "fresh"}
+            if url == SEND_URL:
+                raise retry_error
+            raise AssertionError(url)
+
+    return Scripted()
 
 
 def _rejected(status: int, message: str) -> httpx.HTTPStatusError:
@@ -72,6 +106,45 @@ def test_a_send_gmail_rejected_is_a_plain_failure_and_not_an_unknown(tmp_path):
         api.send(draft_id="draft_1")
     assert not isinstance(raised.value, GmailOutcomeUnknown)
     assert "insufficient scopes" in str(raised.value)
+
+
+def test_a_send_that_never_reached_gmail_is_a_plain_failure(tmp_path):
+    """A refused connection is not an unknown outcome. Nothing was attempted.
+
+    "No HTTP status" is too coarse on its own. A read that expires means the
+    request left and nothing came back; a connection that was never opened
+    means the bytes never went anywhere. On a laptop that is regularly offline,
+    calling the second one ambiguous puts a row in the operator's review queue
+    for every send they tried on a train.
+    """
+    api = _api(tmp_path, {SEND_URL: _refused()})
+    with pytest.raises(GmailError) as raised:
+        api.send(draft_id="draft_1")
+    assert not isinstance(raised.value, GmailOutcomeUnknown)
+
+
+def test_a_retry_after_a_refreshed_token_can_still_end_unknown(tmp_path):
+    """The 401 retry is the routine path, and it was skipping the classifier.
+
+    `_access_token` caches with no expiry check, so the first send after the
+    token ages out always runs POST, 401, refresh, POST. That retry sits inside
+    an `except` block, and an exception raised there is not caught by the
+    sibling clauses of the same `try`. It escaped as a raw transport error.
+    """
+    api = _api(tmp_path, _four_o_one_then(_timeout()))
+    with pytest.raises(GmailOutcomeUnknown):
+        api.send(draft_id="draft_1")
+    assert api.http.calls.count(SEND_URL) == 2
+
+
+def test_a_token_refresh_that_fails_means_nothing_was_sent(tmp_path):
+    """Gmail answered 401, so the first attempt sent nothing, and the retry
+    was never built. Both halves are known, so this is a plain failure."""
+    api = _api(tmp_path, _four_o_one_then(_timeout(), refresh_fails=True))
+    with pytest.raises(GmailError) as raised:
+        api.send(draft_id="draft_1")
+    assert not isinstance(raised.value, GmailOutcomeUnknown)
+    assert api.http.calls.count(SEND_URL) == 1
 
 
 def test_a_timeout_while_checking_the_draft_is_not_an_unknown_send(tmp_path):

--- a/desktop/tests/test_ambiguous_send_outcome.py
+++ b/desktop/tests/test_ambiguous_send_outcome.py
@@ -1,0 +1,312 @@
+"""A send whose response never came back is not a send that failed.
+
+`agent_run_dispatch` exists to keep two facts apart: "it failed" and "we do not
+know". PR #124 wired the fence around the send paths, but both of them catch
+every exception the Gmail client raises and return `ok=False`, so the second
+fact was destroyed one layer below the fence and never reached it.
+
+The distinction is only decidable where the HTTP call happens. A status code
+means Gmail answered, and an answer is a fact. No status at all means the
+request left this machine and nothing came back, which is the whole ambiguous
+window the run store was built for.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from fastapi.testclient import TestClient
+
+from coworker.agent_run_approval import EffectStatus
+from coworker.apollo import FakeHttp
+from coworker.gmail import (
+    DRAFTS_URL,
+    GmailApi,
+    GmailError,
+    GmailOutcomeUnknown,
+)
+from coworker.gmail import FakeGmail
+from coworker.secrets import SecretStore
+from coworker.server import TOKEN_HEADER, create_app
+
+TOKEN = "test-token-ambiguous-send"
+HEADERS = {TOKEN_HEADER: TOKEN}
+ACCOUNT = "director@sourcecado.test"
+ADA_EMAIL = "ada@analytic.example"
+SUBJECT = "Thursday?"
+BODY = "Hi Ada,\n\nWould Thursday work for a short call?\n\nFisher"
+
+SEND_URL = f"{DRAFTS_URL}/send"
+
+
+def _api(tmp_path, routes) -> GmailApi:
+    secrets = SecretStore(tmp_path / "secrets.json")
+    secrets.put("gmail", {"refresh_token": "rt", "access_token": "at"})
+    return GmailApi(
+        secrets, http=FakeHttp(routes), client_id="cid", client_secret="sec"
+    )
+
+
+def _timeout() -> httpx.ReadTimeout:
+    """What httpx raises when the request went out and the read expired."""
+    return httpx.ReadTimeout("timed out", request=httpx.Request("POST", SEND_URL))
+
+
+def _rejected(status: int, message: str) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", SEND_URL)
+    response = httpx.Response(status, json={"error": {"message": message}}, request=request)
+    return httpx.HTTPStatusError(f"HTTP {status}", request=request, response=response)
+
+
+def test_a_send_whose_response_never_arrived_says_the_outcome_is_unknown(tmp_path):
+    api = _api(tmp_path, {SEND_URL: _timeout()})
+    with pytest.raises(GmailOutcomeUnknown):
+        api.send(draft_id="draft_1")
+
+
+def test_a_send_gmail_rejected_is_a_plain_failure_and_not_an_unknown(tmp_path):
+    """Gmail answered with a status. Nothing was sent and the code may say so."""
+    api = _api(tmp_path, {SEND_URL: _rejected(403, "Request had insufficient scopes.")})
+    with pytest.raises(GmailError) as raised:
+        api.send(draft_id="draft_1")
+    assert not isinstance(raised.value, GmailOutcomeUnknown)
+    assert "insufficient scopes" in str(raised.value)
+
+
+def test_a_timeout_while_checking_the_draft_is_not_an_unknown_send(tmp_path):
+    """The binding check reads. It runs before the send, so nothing is in doubt.
+
+    `draft_snapshot` already converts anything `get_draft` raises into
+    `SendAuthorityError`. This pins that, because the new unknown must not
+    escape through a read and put a send that never happened into review.
+    """
+    from coworker.gmail import SendAuthority, SendAuthorityError, send_reviewed_draft
+
+    class UnreachableOnRead:
+        drafts: list = []
+        sends: list = []
+
+        def get_draft(self, *, draft_id: str):
+            raise GmailOutcomeUnknown("Gmail did not answer, so the outcome is unknown.")
+
+        def send(self, *, draft_id: str):  # pragma: no cover - must never run
+            raise AssertionError("the send must not be attempted")
+
+    authority = SendAuthority(
+        approval_id="a1",
+        person_id="p1",
+        draft_id="draft_1",
+        account="director@sourcecado.test",
+        to="ada@analytic.example",
+        subject="Thursday?",
+        body_digest="deadbeef",
+    )
+    with pytest.raises(SendAuthorityError) as raised:
+        send_reviewed_draft(UnreachableOnRead(), authority)
+    assert not isinstance(raised.value, GmailOutcomeUnknown)
+    assert raised.value.code == "draft_unavailable"
+
+
+# ==========================================================================
+# The approval path: the fence must see the unknown
+# ==========================================================================
+
+
+class TimingOutGmail(FakeGmail):
+    """The send request left the machine. The read expired.
+
+    `send_attempts` still records the attempt, because the attempt is the fact
+    that makes the outcome ambiguous.
+    """
+
+    def send(self, *, draft_id: str):
+        self.send_attempts.append(draft_id)
+        raise GmailOutcomeUnknown("Gmail did not answer, so the outcome is unknown.")
+
+
+def _approved_send_that_times_out(tmp_path):
+    """Park one reviewed send, allow it, and let the send time out."""
+    gmail = TimingOutGmail()
+    gmail.account_email = ACCOUNT
+    app = create_app(token=TOKEN, provider=None, state=tmp_path, gmail=gmail)
+    client = TestClient(app)
+    people = app.state.people
+    person = people.keep_from_apollo(
+        apollo_id="ada",
+        first_name="Ada",
+        last_name_obfuscated="L.",
+        title="Head of Data",
+        company="Analytic",
+    )
+    people.apply_enrichment(person["person_id"], name="Ada Lovelace", email=ADA_EMAIL)
+    person = people.get(person["person_id"])
+    person_id = person["person_id"]
+    session_id = app.state.store.create_session()["session_id"]
+    people.bind_session(
+        session_id, person_id, expected_person_version=int(person["version"])
+    )
+    drafted = client.post(
+        f"/v1/people/{person_id}/outreach/draft",
+        headers=HEADERS,
+        json={"session_id": session_id, "subject": SUBJECT, "body": BODY},
+    ).json()["draft"]
+    item_id = client.post(
+        f"/v1/people/{person_id}/outreach/send-approval",
+        headers=HEADERS,
+        json={
+            "session_id": session_id,
+            "draft_id": drafted["id"],
+            "reviewed_body_digest": drafted["body_digest"],
+        },
+    ).json()["item"]["id"]
+    client.post(
+        f"/v1/inbox/{item_id}",
+        headers=HEADERS,
+        json={"decision": "allow", "actor": "Fisher", "scope": "once"},
+    )
+    return app, client, item_id
+
+
+def test_an_approved_send_that_times_out_is_held_for_review_not_called_failed(tmp_path):
+    app, client, item_id = _approved_send_that_times_out(tmp_path)
+
+    # Non-vacuity: the request really did leave the machine.
+    assert app.state.gmail.send_attempts == ["draft_1"]
+
+    queue = client.get("/v1/agent-run-effects/quarantine", headers=HEADERS).json()
+    held = [(row["tool_name"], row["status"]) for row in queue["effects"]]
+    assert held == [("gmail_send", str(EffectStatus.AMBIGUOUS))]
+    assert queue["effects"][0]["needs_a_person"] is True
+
+
+def test_the_operator_is_told_the_outcome_is_unknown_not_that_it_failed(tmp_path):
+    app, client, item_id = _approved_send_that_times_out(tmp_path)
+    receipt = app.state.store.get_inbox(item_id)
+    assert "unknown" in str(receipt.get("execution_error") or "").lower()
+    assert "held for review" in str(receipt.get("execution_error") or "").lower()
+
+
+# ==========================================================================
+# The turn loop: same fact, same treatment
+# ==========================================================================
+
+
+def test_the_gmail_send_tool_does_not_turn_an_unknown_into_ok_false():
+    """`execute` is the other side of the fence and swallowed this too.
+
+    A tool result of `ok=False` is a statement that nothing happened. The tool
+    layer cannot make that statement about a request Gmail never answered, so
+    the exception carries on to `guarded_call`.
+    """
+    from coworker.tools import execute
+
+    gmail = TimingOutGmail()
+    gmail.account_email = ACCOUNT
+    with pytest.raises(GmailOutcomeUnknown):
+        execute("gmail_send", {"draft_id": "draft_1"}, gmail=gmail)
+    assert gmail.send_attempts == ["draft_1"]
+
+
+def test_a_send_gmail_rejected_is_still_an_ordinary_tool_failure():
+    """The inverse guard. A rejection is a fact and stays a plain failure."""
+    from coworker.tools import execute
+
+    class RejectingGmail(FakeGmail):
+        def send(self, *, draft_id: str):
+            raise GmailError("Request had insufficient scopes.")
+
+    ok, result = execute("gmail_send", {"draft_id": "draft_1"}, gmail=RejectingGmail())
+    assert ok is False
+    assert "insufficient scopes" in result["error"]
+
+
+def test_a_turn_whose_send_outcome_is_unknown_does_not_tell_the_operator_it_failed(
+    tmp_path,
+):
+    """The whole point, at the surface the director actually reads.
+
+    The approval path already maps this to `outcome_unknown`. The turn loop let
+    the exception reach the generic handler, which wrote `state: "failed"` and
+    printed the internal sentence, effect id and all.
+    """
+    import asyncio
+
+    from coworker.agent_run_repository import AgentRunRepository
+    from coworker.inbox import Inbox
+    from coworker.people import PersonStore
+    from coworker.provider import StreamChunk, ToolCall
+    from coworker.store import ConversationStore
+    from coworker.tools import OPENAI_TOOLS
+    from coworker.turn import run_turn
+
+    class AsksToSend:
+        provider_id = "fake"
+        model_id = "fake"
+
+        async def astream(self, *, messages, tools=None, context_id=None):
+            yield StreamChunk.started(provider=self.provider_id, model=self.model_id)
+            yield StreamChunk(text_delta="Sending. ")
+            yield StreamChunk(finish_reason="tool_calls")
+            yield StreamChunk(
+                tool_calls=[
+                    ToolCall(
+                        id="call_send",
+                        name="gmail_send",
+                        arguments={"draft_id": "draft_1"},
+                    )
+                ]
+            )
+
+    gmail = TimingOutGmail()
+    gmail.account_email = ACCOUNT
+    repository = AgentRunRepository(tmp_path / "runs")
+    owner = repository.registry.register()
+    conversations = ConversationStore(tmp_path / "conv")
+    seen: list[dict] = []
+
+    async def _emit(event):
+        seen.append(event)
+
+    async def _allow(_call_id):
+        return "allow"
+
+    asyncio.run(
+        run_turn(
+            text="Send the note.",
+            sid="sess-unknown-outcome",
+            store=conversations,
+            provider=AsksToSend(),
+            persona=None,
+            skills=None,
+            inbox=Inbox(conversations),
+            openai_tools=OPENAI_TOOLS,
+            execute_kwargs={
+                "people": PersonStore(tmp_path / "people"),
+                "gmail": gmail,
+            },
+            emit=_emit,
+            wait_permission=_allow,
+            agent_runs=repository,
+            run_owner=owner,
+        )
+    )
+
+    # Non-vacuity: the send really was attempted and really was fenced.
+    assert gmail.send_attempts == ["draft_1"]
+    held = repository.list_quarantined_effects()
+    assert [row["tool_name"] for row in held] == ["gmail_send"]
+
+    terminal = [
+        event
+        for event in seen
+        if event.get("type") in {"error", "turn_end", "turn_stopped"}
+    ]
+    assert len(terminal) == 1
+    event = terminal[0]
+    assert event["state"] == "held"
+    assert event["code"] == "outcome_unknown"
+    assert event["effect_id"] == held[0]["effect_id"]
+    assert "held for review" in event["message"]
+    # The internal sentence, and the bare effect id inside it, stay internal.
+    assert "never reported an outcome" not in event["message"]

--- a/desktop/tests/test_events.py
+++ b/desktop/tests/test_events.py
@@ -91,7 +91,22 @@ def test_contract_rejects_a_text_delta_without_string_content():
         ),
         (
             {"type": "error", "state": "complete", "message": "failed"},
-            "error.state must be failed",
+            "error.state must be failed or held",
+        ),
+        (
+            # `held` is the one terminal that points at something an operator
+            # has to open. Without the effect id it points at nothing.
+            {"type": "error", "state": "held", "message": "unknown"},
+            "error.code must be outcome_unknown when state is held",
+        ),
+        (
+            {
+                "type": "error",
+                "state": "held",
+                "code": "outcome_unknown",
+                "message": "unknown",
+            },
+            "error.effect_id must be a non-empty string when state is held",
         ),
         (
             {


### PR DESCRIPTION
Slices 5 and 6 of #63. **This does not close #63** — see the last section.

Correction to the first version of this description: it said "Completes #63". That was wrong, and the review caught it. The restart pass computes `RESUME` and `DELIVER` verdicts and throws them away, so three of #63's criteria are still unmet. That work is now #128.

> **This changes the live Gmail send path.** It is entirely reasonable to hold this PR until #84 is certified on a main that does not include it. Read the last section before merging.

## Why this exists

Slices 1–4 shipped a durable Agent Run, `flock`-backed owner liveness, versioned leases, an ambiguous-external-effect fence, and restart classification.

**None of it ran.** Measured on main before this branch, `dispatch_effect` was called **zero** times in `turn.py` and zero in `server.py`. Every guarantee those PRs described was true only of tests. This makes the fence real.

## The ordering contract

**Dispatch commits before the call. Outcome commits after.**

Dead before the dispatch commit means no call was made. Dead after means it may or may not have been. Get this backwards and the fence proves nothing while looking correct.

Both dispatch sites are tested for it:

- `test_the_dispatch_is_committed_before_the_send_and_the_outcome_after`
- `test_the_turn_loop_also_commits_its_dispatch_before_the_call`

And both are mutation-checked:

- `test_a_dispatch_committed_after_the_call_leaves_the_window_unrecorded`
- `test_the_same_reversal_in_the_turn_loop_is_caught_the_same_way`

## The fenced set is derived, not written down

A hand-maintained list of consequential tools is a list that goes stale the first time someone adds one.

`test_the_fenced_set_is_read_from_retry_safe_and_not_written_down` asserts the set comes from `permissions.RETRY_SAFE`. `test_every_consequential_tool_in_a_turn_opens_an_effect_record` proves coverage, and `test_a_retry_safe_tool_costs_no_effect_record` proves the inverse — a read-only tool pays no price.

The mutation that matters: `test_a_hand_written_fence_list_lets_every_other_consequential_tool_through`.

## Reconciliation: the run store is the fence of record

When the inbox says `interrupted` and the run store says `ambiguous`, they disagree about something important. The inbox knows an execution did not report back; the run store knows an effect may have reached the world.

`test_the_run_store_overrides_an_inbox_that_calls_an_unknown_outcome_interrupted` and `test_an_interrupted_approval_with_a_quarantined_effect_is_reported_as_ambiguous`.

Mutation: `test_letting_the_inbox_win_turns_an_unknown_outcome_into_a_failure` — which is how a real send gets recorded as a failure and then retried by a person.

`test_a_cancelled_call_quarantines_rather_than_calling_it_failed` covers the same shape from the cancel path.

## Composing with #66's at-most-once, not duplicating it

`store.decide_and_claim_inbox_execution` already guarantees at-most-once execution of an approved action through a single claiming UPDATE. The fence covers a different window — ambiguity *after* dispatch. They compose. No second locking mechanism was added.

Mutation: `test_a_resume_that_ignores_effects_would_send_the_same_mail_twice`.

## The operator review queue exists now

`list_quarantined_effects` had no UI. `QuarantinePage` renders it: what was held, why, and the three answers — succeeded, failed, abandoned — carrying equal visual weight, so the surface never nudges toward the convenient one.

The subtlest mutation is `test_a_turn_that_forgets_to_pass_its_run_store_is_fenced_by_nothing` — a turn constructed without its run store is silently unprotected, and that now fails loudly.

## Measurements

```
1878 passed, 3 skipped, 1 warning
 Test Files  57 passed (57)
      Tests  508 passed (508)
tsc --noEmit && vite build   clean
coworker.evals --suite sourcing   15/15 passed
```

Skip count held at 3. The eval suite is the one that matters here — this changes the agent loop, and #57's behavioural scenes exist to catch exactly that.

## Rebase note, and a correction worth recording

This branch was stacked on #123, which was squash-merged, so rebasing tried to replay commits main already had. Rebuilt by resetting to `origin/main` and cherry-picking the two slice commits.

That produced one conflict, in `route.css`, and it was the shared-trailing-line hazard: both `.channel-pill-preview` (from #122) and `.quarantine-contested` (this branch) end with the same `background: var(--warn-bg); color: var(--warn); }`, so git hoisted that tail outside the markers and **left both rules open**.

The delimiter arithmetic other lanes used — merged must equal base + (mine − base) + (theirs − base) — gave 282, and the first reconstruction hit 282 exactly and was still wrong. `postcss` rejected it with `Unexpected }` at line 1760. **The counts balanced; the placement did not.**

Rebuilt by appending each side's genuine additions to the base file rather than by diff extraction, which `diff` had been misattributing at the seam. The arithmetic is a necessary check, not a sufficient one — the build is what settles it.

## Review round two: the fence could not see the case it was built for

The first head wired `guarded_call` around both send paths and proved the ordering contract. The review then reproduced this:

```
gmail send attempts (request left the machine): 1
run store effect: [('gmail_send', 'failed')]
inbox execution_status: failed
operator review queue: []
person sequence_state: None
second draft allowed: 201
second send-approval allowed: 201
```

A Gmail send that timed out was recorded as `failed`. `_execute_bound_send` and `tools.execute` each caught every exception the Gmail client raised and returned `ok=False` before the guard could see one. So the ambiguous window the run store exists for was closed one layer below the fence, and the director was offered a clean second send to the same person.

### What changed

Only the connector knows which of the two facts it has. `gmail.GmailOutcomeUnknown` is raised where no HTTP status was ever observed. A status means Gmail answered, and an answer is a fact. No status means the request left and nothing came back.

Both call sites re-raise it, so `guarded_call` quarantines the effect and the existing `outcome_unknown` handling takes over.

`verify_send_authority` reads the live draft *before* the send. An unknown from that step stays a plain `SendAuthorityError`, because nothing left the machine and a read must not fill the operator's review queue. `test_a_timeout_while_checking_the_draft_is_not_an_unknown_send` pins that.

### The same word, three more surfaces

The turn loop let `AgentRunEffectQuarantined` reach the generic handler, which emitted `state: "failed"` and the internal exception sentence including a raw effect id. It now emits:

```json
{"type": "error", "state": "held", "code": "outcome_unknown",
 "effect_id": "effect-...",
 "message": "The outcome of this action is unknown. It is held for review; do not retry it until it is settled."}
```

`held` is a real state, not a relabelled `failed`. It is carried by the event contract in `events.py`, `chat/protocol.ts` and its runtime guard, the thread store, the message adapter, and the screen-reader announcement, which now says "Run held for review." rather than "Run failed." A queued item whose turn ends held is `interrupted`, not `failed`.

The event contract refuses a `held` terminal that names no effect id, because the operator's next move is to open that row.

### Measurements on this head

```
1888 passed, 3 skipped          (was 1878; +10)
 Test Files  58 passed (58)     (was 57)
      Tests  513 passed (513)   (was 508)
tsc --noEmit && vite build      clean
coworker.evals --suite sourcing 15/15 passed
```

### What is not covered by a test

The queued-chat branch that maps a held turn to an `interrupted` queue item is inline in the websocket run closure with no seam to call. It is a wording change on a third surface, verified by reading the flow, not by a test. Say the word and I will build the socket harness for it.

### Not in this PR

- **Apollo enrichment has the same swallow.** `_execute_bound_enrichment` catches every exception and returns `ok=False`, and enrichment spends a credit. Same class of bug, different connector, left out to keep this reviewable.
- **The settlement endpoint returns 500 for a non-object JSON body.** Real, but `payload = await request.json()` with no shape guard appears at ten handlers in `server.py`. Guarding one of them is worse than guarding none.
- **Read-only tools land in the send review queue.** `RETRY_SAFE` holds 12 names, so `web_search`, `fs_read`, `fs_stat` and `shell_poll` are all fenced. Failing closed is right; the queue a person reads for sends is the wrong place for a `web_search` row to appear.


## Read before merging

This wires the fence around actions that spend money and reach real people. It is well covered, and the evals pass, but it changes the live send path.

If you would rather certify #84 on a main without it, that is a reasonable sequencing choice and this PR can wait. Nothing else depends on it landing first.

## What still needs work — #63 stays open

`agent_run_resume.plan_restart` returns `RESUME`, `DELIVER`, `QUARANTINE`, `REVIEW` and `NOTHING`. `create_app` acts on `QUARANTINE` and assigns the rest to `app.state.run_restart`, which nothing reads. So a safe incomplete run is not continued at startup, a recorded-but-undelivered final answer is not delivered, and a missing person projection is not repaired. Those are #63's criteria and they are tracked in **#128**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjAD6SVox1gvF4sV3jTnJy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable tracking for agent runs across chat, queued, scheduled, and approval-driven actions.
  * Added safeguards that record consequential actions before execution and capture their outcomes afterward.
  * Added quarantine handling for interrupted or uncertain external actions.
  * Added an operator review queue to inspect and resolve held actions.
  * Added clear handling for approvals, pauses, resumes, failures, and unavailable actions.

* **Bug Fixes**
  * Improved reconciliation when approval records and run activity disagree.
  * Preserved action details in completion receipts for more reliable tracking.

* **Documentation**
  * Updated agent run documentation to reflect the production workflow and review process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
