### PR TITLE
fix(desktop): refuse a masked surname and enrich by stored Apollo ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ __pycache__/
 
 # isolated worktrees
 .claude/worktrees/
+.worktrees/
 
 # local agent configuration and vendored personal skills
 .claude/settings.local.json

--- a/desktop/coworker/apollo.py
+++ b/desktop/coworker/apollo.py
@@ -24,6 +24,9 @@ MISSING_KEY = "APOLLO_API_KEY is not configured."
 # cost before the director allows it; nothing here decides to spend on its own.
 ENRICH_CREDIT_COST = 1
 
+# How the approval card says a match key was chosen.
+MATCH_LABELS = {"email": "email", "apollo_id": "Apollo ID", "name": "name"}
+
 
 class HttpError(RuntimeError):
     def __init__(self, status: int, url: str = "", body: object | None = None) -> None:
@@ -238,6 +241,16 @@ def search_people(
     return {"people": people}
 
 
+def masked_name(value: str | None) -> bool:
+    """True when Apollo obfuscated this name, for example ``Zh***g``.
+
+    The shortlist hides surnames on purpose. Sending one to people/match
+    spends a credit on a lookup that cannot succeed, so a masked name is
+    never a usable match key.
+    """
+    return "*" in str(value or "")
+
+
 def enrich_contact(
     *,
     http: Any,
@@ -246,13 +259,20 @@ def enrich_contact(
     first_name: str | None = None,
     last_name: str | None = None,
     organization_name: str | None = None,
+    apollo_id: str | None = None,
 ) -> dict[str, Any]:
-    if not email and not (first_name and last_name):
-        raise ValueError("Provide email, or firstName and lastName.")
+    if masked_name(last_name):
+        raise ValueError(
+            "That surname is still obfuscated by Apollo, so it cannot match. "
+            "Enrich by Apollo ID or by email instead."
+        )
+    if not apollo_id and not email and not (first_name and last_name):
+        raise ValueError("Provide apolloId, email, or firstName and lastName.")
     data = http.post(
         MATCH_URL,
         headers={"content-type": "application/json", "x-api-key": api_key},
         json={
+            "id": apollo_id,
             "email": email,
             "first_name": first_name,
             "last_name": last_name,
@@ -284,14 +304,19 @@ def enrichment_match(person: dict[str, Any]) -> dict[str, Any] | None:
     first = str(person.get("first_name") or "").strip()
     last = str(person.get("last_name") or "").strip()
     company = str(person.get("company") or "").strip()
+    apollo_id = str(person.get("apollo_id") or "").strip()
     if email:
         return {"email": email, "organization_name": company or None}
-    if first and last:
+    if first and last and not masked_name(last):
         return {
             "first_name": first,
             "last_name": last,
             "organization_name": company or None,
         }
+    # A kept shortlist candidate has a masked surname and no email. The Apollo
+    # ID keep already stored identifies the exact record, so it is what is left.
+    if apollo_id:
+        return {"apollo_id": apollo_id}
     return None
 
 
@@ -308,7 +333,12 @@ def enrichment_resource(
         for part in (person.get("first_name"), person.get("last_name"))
         if part
     ).strip()
-    matched_on = "email" if match.get("email") else "name"
+    if match.get("email"):
+        matched_on = "email"
+    elif match.get("apollo_id"):
+        matched_on = "apollo_id"
+    else:
+        matched_on = "name"
     return {
         "kind": "apollo_enrichment",
         "person_id": str(person.get("person_id") or ""),
@@ -319,7 +349,7 @@ def enrichment_resource(
         "credits": ENRICH_CREDIT_COST,
         "reason": (
             f"Spends {ENRICH_CREDIT_COST} Apollo credit to look up "
-            f"{display or 'this person'} by {matched_on} and write the result "
+            f"{display or 'this person'} by {MATCH_LABELS[matched_on]} and write the result "
             "to this person file only."
         ),
     }

--- a/desktop/coworker/tools.py
+++ b/desktop/coworker/tools.py
@@ -11,6 +11,8 @@ from coworker.apollo import (
     MISSING_KEY,
     apollo_evidence,
     enrich_contact,
+    enrichment_match,
+    masked_name,
     search_people,
 )
 from coworker.apollo_curation import curate_apollo_candidates
@@ -821,15 +823,29 @@ def execute(
                 person_id = people.person_for_session(session_id)
             if not person_id:
                 return False, {"error": "Bind a person before enriching."}
-            if people is not None and people.get(person_id) is None:
+            person = people.get(person_id) if people is not None else None
+            if people is not None and person is None:
                 return False, {"error": "unknown person"}
+            match = {
+                "email": str(args.get("email") or "") or None,
+                "first_name": str(args.get("firstName") or "") or None,
+                "last_name": str(args.get("lastName") or "") or None,
+                "organization_name": str(args.get("organizationName") or "") or None,
+            }
+            usable = bool(match["email"]) or bool(
+                match["first_name"]
+                and match["last_name"]
+                and not masked_name(match["last_name"])
+            )
+            if not usable and person is not None:
+                # The shortlist hands the model an obfuscated surname. The
+                # person file knows its own Apollo ID, so take the match key
+                # from the file rather than letting the model guess a name.
+                match = enrichment_match(person) or match
             result = enrich_contact(
                 http=client,
                 api_key=apollo_key,
-                email=str(args.get("email") or "") or None,
-                first_name=str(args.get("firstName") or "") or None,
-                last_name=str(args.get("lastName") or "") or None,
-                organization_name=str(args.get("organizationName") or "") or None,
+                **match,
             )
             if people is not None:
                 people.apply_enrichment(

--- a/desktop/tests/test_apollo.py
+++ b/desktop/tests/test_apollo.py
@@ -101,3 +101,77 @@ def test_live_apollo_search_returns_no_emails():
     assert "people" in out
     for person in out["people"]:
         assert "email" not in person or person.get("email") in (None, "")
+
+
+def test_a_masked_surname_falls_back_to_the_person_files_apollo_id(tmp_path):
+    """Issue #126: the shortlist hands the model an obfuscated surname.
+
+    The model must not spend a credit guessing at it, and must not be
+    stranded either. The person file already stores the exact Apollo ID.
+    """
+    http = FakeHttp(
+        {
+            MATCH_URL: {
+                "person": {
+                    "id": "679c7e37",
+                    "name": "Fisher Zhang",
+                    "title": "Building GTM AI",
+                    "organization": {"name": "The Hog"},
+                    "email": "fisher@thehog.example",
+                    "phone_numbers": [],
+                }
+            }
+        }
+    )
+    people = PersonStore(tmp_path)
+    person = people.keep_from_apollo(
+        apollo_id="679c7e37",
+        first_name="Fisher",
+        last_name_obfuscated="Zh***g",
+        title="Building GTM AI",
+        company="The Hog",
+    )
+    people.bind_session("sess-hog", person["person_id"])
+
+    ok, result = execute(
+        "apollo_enrich_contact",
+        # Exactly what the shortlist gives the model.
+        {"firstName": "Fisher", "lastName": "Zh***g", "organizationName": "The Hog"},
+        http=http,
+        apollo_key="test-key",
+        people=people,
+        session_id="sess-hog",
+    )
+
+    assert ok is True, result
+    body = [c for c in http.calls if c["url"] == MATCH_URL][0]["json"]
+    assert body["id"] == "679c7e37"
+    # The mask must never travel to Apollo.
+    assert body["last_name"] is None
+    assert people.get(person["person_id"])["email"] == "fisher@thehog.example"
+
+
+def test_a_masked_surname_with_no_apollo_id_refuses_rather_than_spending(tmp_path):
+    http = FakeHttp({MATCH_URL: {"person": {"id": "x", "name": "Nobody"}}})
+    people = PersonStore(tmp_path)
+    person = people.keep_from_apollo(
+        apollo_id=None,
+        first_name="Fisher",
+        last_name_obfuscated="Zh***g",
+        title=None,
+        company=None,
+    )
+    people.bind_session("sess-none", person["person_id"])
+
+    ok, result = execute(
+        "apollo_enrich_contact",
+        {"firstName": "Fisher", "lastName": "Zh***g"},
+        http=http,
+        apollo_key="test-key",
+        people=people,
+        session_id="sess-none",
+    )
+
+    assert ok is False
+    assert "obfuscated" in result["error"]
+    assert [c for c in http.calls if c["url"] == MATCH_URL] == []

--- a/desktop/tests/test_approved_enrichment.py
+++ b/desktop/tests/test_approved_enrichment.py
@@ -126,7 +126,8 @@ def test_a_person_apollo_cannot_be_matched_on_is_refused_before_the_spend(tmp_pa
     http = FakeHttp({MATCH_URL: APOLLO_PERSON})
     app = _app(tmp_path, http)
     client = TestClient(app)
-    person_id, session_id = _person(app, apollo_id="ada", first="Ada", last=None)
+    # No email, no surname, and no Apollo ID: nothing identifies anybody.
+    person_id, session_id = _person(app, apollo_id=None, first="Ada", last=None)
 
     res = _park(client, person_id, session_id)
 
@@ -249,3 +250,74 @@ def test_an_expired_enrichment_approval_spends_no_credit(tmp_path):
     assert expired["decision"] is None
     assert _match_calls(http) == []
     assert app.state.people.get(person_id)["email"] is None
+
+
+# --------------------------------------------------------------------------
+# Issue #126 — a masked surname must never reach Apollo, and a kept candidate
+# must still be enrichable through the Apollo ID the shortlist already stored.
+# --------------------------------------------------------------------------
+
+
+def test_a_masked_surname_parks_no_approval_and_spends_nothing(tmp_path):
+    """The shortlist obfuscates surnames. `Zh***g` cannot match anybody.
+
+    Before this guard the match key was built from first plus last, both
+    non-empty, so an approval was parked and Allow spent one real credit on a
+    lookup that could not succeed.
+    """
+    http = FakeHttp({MATCH_URL: APOLLO_PERSON})
+    app = _app(tmp_path, http)
+    client = TestClient(app)
+    person_id, session_id = _person(app, apollo_id=None, first="Fisher", last="Zh***g")
+
+    res = _park(client, person_id, session_id)
+
+    assert res.status_code == 409
+    assert res.json()["code"] == "no_match_key"
+    assert app.state.inbox.pending() == []
+    assert _match_calls(http) == []
+
+
+def test_a_kept_candidate_enriches_through_its_stored_apollo_id(tmp_path):
+    """Keep stores the Apollo ID. A masked surname must not strand it."""
+    http = FakeHttp({MATCH_URL: APOLLO_PERSON})
+    app = _app(tmp_path, http)
+    client = TestClient(app)
+    person_id, session_id = _person(
+        app, apollo_id="679c7e37", first="Fisher", last="Zh***g"
+    )
+
+    parked = _park(client, person_id, session_id)
+
+    assert parked.status_code == 201, parked.text
+    resource = parked.json()["item"]["resource"]
+    assert resource["matched_on"] == "apollo_id"
+    assert "1 Apollo credit" in resource["reason"]
+    # Parking still spends nothing.
+    assert _match_calls(http) == []
+
+    decided = _decide(client, parked.json()["item"]["id"])
+
+    assert decided.status_code == 200, decided.text
+    calls = _match_calls(http)
+    assert len(calls) == 1
+    # The masked surname must not travel to Apollo at all.
+    body = calls[0]["json"]
+    assert body.get("id") == "679c7e37"
+    assert body.get("last_name") is None
+    assert app.state.people.get(person_id)["email"] == "ada@analytic.example"
+
+
+def test_a_real_surname_still_matches_on_name(tmp_path):
+    """Control. The mask guard must not swallow ordinary surnames."""
+    http = FakeHttp({MATCH_URL: APOLLO_PERSON})
+    app = _app(tmp_path, http)
+    client = TestClient(app)
+    person_id, session_id = _person(
+        app, apollo_id="ada", first="Ada", last="Lovelace"
+    )
+
+    parked = _park(client, person_id, session_id)
+
+    assert parked.status_code == 201, parked.text
+    assert parked.json()["item"]["resource"]["matched_on"] == "name"


### PR DESCRIPTION
Closes #126. Found during the #84 functional acceptance run, which is rejected at criterion 5 for this reason.

## Domain words

- **Shortlist** — the free Apollo search result. It hides surnames behind asterisks, for example `Zh***g`.
- **Keep** — filing a shortlist row as a person file. Spends nothing.
- **Enrich** — one call to Apollo's `people/match`. Spends one credit. This is the money.
- **Match key** — the field Apollo is asked to look somebody up by.

## Problem

Allow spent a real credit on a lookup that could not succeed.

`keep_from_apollo` stores the obfuscated surname verbatim, so a kept person file carries a last name like `Zh***g`. `enrichment_match()` built the lookup from first plus last name whenever both were non-empty. A masked surname passed that check.

Measured on 2026-08-28 against `origin/main` at d8867d3. An approval was parked for a real kept candidate, which spends nothing. The card read:

> Spends 1 Apollo credit to look up Fisher Zh\*\*\*g by name and write the result to this person file only.

The approval was denied, so no credit was spent.

The Apollo ID that identifies the exact record was already stored by `keep_from_apollo` and went unused. Neither `enrichment_match()` nor `enrich_contact()` accepted it. The result was that keep-to-enrich, the product's own curation path, could not complete without the director retyping the surname.

## Before and after

| Person file | Before | After |
|---|---|---|
| Masked surname, has Apollo ID | Parks an approval, Allow burns 1 credit, no match | Parks an approval matched on Apollo ID, Allow enriches |
| Masked surname, no Apollo ID | Parks an approval, Allow burns 1 credit, no match | `409 no_match_key`, nothing parked, nothing spent |
| Real surname | Matched on name | Unchanged, matched on name |
| Has email | Matched on email | Unchanged, matched on email |

## Changes

- `masked_name()` detects the obfuscation mask.
- `enrichment_match()` skips a masked surname, then falls back to the stored `apollo_id`. No approval can be parked for an unmatchable name.
- `enrich_contact()` accepts `apollo_id` and sends it as Apollo's `id` parameter. It also raises on a masked surname regardless of caller, so the model's tool path is covered too.
- The model's tool path takes its match key from the person file when the arguments it holds are not usable, instead of guessing a surname.

Preference order is unchanged where it already worked: email, then an unmasked name, then the Apollo ID. Putting the ID last keeps every existing `matched_on` value the same.

## Measurements

```
1827 passed, 3 skipped, 1 warning in 67.91s
 Test Files  56 passed (56)
      Tests  498 passed (498)
```

Baseline on `main` before this branch was 1822 passed. Net +5.

Mutation harness, breaking one guard at a time and requiring the owning test to go red:

```
  red: masked_name always says clean
  red: enrichment_match stops skipping masked surnames
  red: enrichment_match drops the Apollo ID fallback
  red: enrich_contact stops refusing a masked surname
  red: enrich_contact stops sending the Apollo ID
  red: model tool path drops the person-file fallback

6 red, 0 vacuous, 6 mutations
```

The harness clears `__pycache__` per run. Same-second writes with identical size deltas let CPython reuse the previous mutation's bytecode, which produced false GREENs in #109.

## One existing test changed

`test_a_person_apollo_cannot_be_matched_on_is_refused_before_the_spend` built its person with `apollo_id="ada"`. A stored Apollo ID is a usable match key after this change, so that person is now matchable and the test no longer tested what its name claimed. Its fixture now passes `apollo_id=None`. The assertions are untouched.

## Still wrong, and not in this PR

**Apollo returns a partially obfuscated name even after enrichment.** The live call below returned `name: 'Fisher Z'`, not the full surname. `apply_enrichment` splits that into `first_name='Fisher'` and `last_name='Z'`, so the person file still has no real surname after a successful enrichment. The email is what the send path needs, so this blocks nothing. Recording it because a reader would otherwise expect enrichment to fill in the surname.

**Initials are still treated as real surnames.** Existing fixtures carry last names like `L`, `Z`, and `R.`. Apollo cannot match on those either, so the same wasted-credit path exists for them. This PR only refuses the asterisk mask, which is what the live run produced. Widening the rule would change behaviour for several existing tests and deserves its own decision.

**Board visibility is untouched.** Kept candidates still do not appear on the Board. Filed as #127.

## Live verification

The `id` parameter path is confirmed against real Apollo. Fisher authorised one credit for this.

Called `enrich_contact(apollo_id="679c7e379ad76500015e7e64")` with no name and no email, through the branch code:

```
  apolloId         '679c7e379ad76500015e7e64'
  name             'Fisher Z'
  title            'Building GTM AI'
  organizationName 'The Hog (YC F25)'
  email            'fisher@thehog.ai'
```

Apollo honours `id`. The fallback resolves a kept candidate that the old code could not reach, and the address returned matches the one independently known to be correct. One credit spent, and it bought a real answer rather than the empty result the old path would have produced.

## Not tested

#84 criteria 6 through 12 remain unproven. They sit behind enrichment: the reviewed send, send receipts, reply filing, Drive and Calendar and Granola evidence, the living brief, and the handoff. #84 should be re-run once this lands.
