### PR TITLE
fix(desktop): keep a conversation usable after the reasoning cache is lost

### DIFF
--- a/desktop/coworker/provider.py
+++ b/desktop/coworker/provider.py
@@ -1276,11 +1276,14 @@ class DeepSeekProvider(OpenAICompatProvider):
                 if tools and "reasoning_content" not in message:
                     key = _continuity_key(prepared, message)
                     reasoning = cache.get(key) if cache is not None else None
-                    if reasoning is None:
-                        raise RuntimeError(
-                            "deepseek transient reasoning is unavailable for continuation"
-                        )
-                    message["reasoning_content"] = reasoning
+                    # The reasoning is deliberately never persisted, so a
+                    # restart empties this cache for every prior assistant
+                    # turn. DeepSeek accepts a continuation without it, and
+                    # refusing to send left the conversation permanently
+                    # unusable, so send what we have. Replay still happens
+                    # whenever the cache is warm.
+                    if reasoning is not None:
+                        message["reasoning_content"] = reasoning
             prepared.append(message)
         return prepared
 

--- a/desktop/tests/test_provider.py
+++ b/desktop/tests/test_provider.py
@@ -1182,9 +1182,16 @@ def test_turn_continues_after_workspace_shell_without_persisting_reasoning(
     assert "reasoning_content" not in durable
 
 
-def test_fresh_deepseek_provider_reports_unavailable_transient_continuation(
+def test_a_restarted_provider_continues_without_the_lost_reasoning(
     monkeypatch,
 ):
+    """Issue #130: a cold transient cache must not brick the conversation.
+
+    The reasoning is deliberately never persisted, so after a restart it is
+    gone for every prior assistant turn. Refusing to send left every
+    conversation with an assistant reply permanently unusable. DeepSeek
+    accepts the request without it, so send it.
+    """
     requests = []
 
     async def handler(request):
@@ -1192,7 +1199,8 @@ def test_fresh_deepseek_provider_reports_unavailable_transient_continuation(
         return httpx.Response(
             200,
             text=_sse(
-                {"choices": [{"delta": {}, "finish_reason": "stop"}]}
+                {"choices": [{"delta": {"content": "pong"}, "finish_reason": None}]},
+                {"choices": [{"delta": {}, "finish_reason": "stop"}]},
             ),
         )
 
@@ -1235,13 +1243,18 @@ def test_fresh_deepseek_provider_reports_unavailable_transient_continuation(
             )
         ]
 
-    with pytest.raises(
-        RuntimeError,
-        match="transient reasoning is unavailable for continuation",
-    ):
-        asyncio.run(consume())
+    chunks = asyncio.run(consume())
 
-    assert requests == []
+    # The request goes out rather than raising.
+    assert len(requests) == 1
+    sent = requests[0]["messages"]
+    assistant = next(m for m in sent if m["role"] == "assistant")
+    # Nothing was invented to fill the gap.
+    assert "reasoning_content" not in assistant
+    # The tool-call shape DeepSeek requires is still repaired.
+    assert assistant["content"] == ""
+    assert "".join(c.text_delta or "" for c in chunks) == "pong"
+    # The durable transcript is still never mutated.
     assert durable_messages == original
 
 
@@ -1284,11 +1297,14 @@ def test_deepseek_cancellation_propagates_closes_stream_and_discards_partial_cal
     stream = CancelStream()
     request_count = 0
 
+    continuation_bodies = []
+
     async def handler(request):
         nonlocal request_count
         request_count += 1
         if request_count == 1:
             return httpx.Response(200, stream=stream)
+        continuation_bodies.append(json.loads(request.content))
         return httpx.Response(
             200,
             text=_sse(
@@ -1352,17 +1368,25 @@ def test_deepseek_cancellation_propagates_closes_stream_and_discards_partial_cal
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task
-        with pytest.raises(
-            RuntimeError,
-            match="transient reasoning is unavailable for continuation",
-        ):
-            await consume_continuation()
+        await consume_continuation()
 
     asyncio.run(scenario())
 
     assert stream.closed is True
     assert not [chunk for chunk in emitted if chunk.tool_calls]
-    assert request_count == 1
+    # The cancelled round must not leave partial reasoning behind. It is no
+    # longer observable as a refusal (#130), so assert the property itself:
+    # the continuation carries no reasoning for the cancelled assistant turn.
+    assert continuation_bodies
+    first_continuation = continuation_bodies[0]
+    assert not [
+        message
+        for message in first_continuation["messages"]
+        if message["role"] == "assistant" and "reasoning_content" in message
+    ]
+    # Two requests now: the cancelled round, then the continuation that used
+    # to be refused before it ever reached the wire (#130).
+    assert request_count == 2
 
 
 def test_default_model_id_none(monkeypatch):


### PR DESCRIPTION
Fixes the P0 in #130. The interface half of that issue is filed separately and is not in this PR.

## Domain words

- **Transient reasoning** — private working-out DeepSeek returns alongside each reply, separate from the answer the operator reads.
- **Continuation** — any request that sends prior assistant turns back to the model, which is every turn after the first.
- **Durable transcript** — what Sourcecado writes to disk for a conversation.

## Problem

Any conversation with at least one assistant reply became permanently unusable after a sidecar restart. There was no recovery path in the product. The only escape was starting a new chat.

`_prepare_messages` required cached reasoning for every assistant message whenever tools were enabled, and tools are always enabled:

```python
if tools and "reasoning_content" not in message:
    reasoning = cache.get(key) if cache is not None else None
    if reasoning is None:
        raise RuntimeError("deepseek transient reasoning is unavailable for continuation")
```

The cache is `self._transient_reasoning`, an in-process `OrderedDict`. It is deliberately never persisted, and that decision is correct: `workspace_runtime.py:411` strips shell commands, stdin, file writes, and patch content before anything reaches the transcript, and model reasoning routinely restates the command it just ran or the file it just read. Three tests exist to keep reasoning off disk.

Nothing handled the cold-cache case. A restart empties the cache, every prior assistant turn fails the check, and the request is refused forever.

## Measured

2026-08-28, `origin/main` at 94c4939, reproduced over a raw websocket.

| Conversation | Shape | Before | After |
|---|---|---|---|
| Person bound, 8 messages, one tool call | has assistant turns | dead | works |
| Person bound, empty history | no assistant turns | works | works |
| Not bound, 1 user + 1 assistant, no tool call | one assistant turn | dead | works |

The third row is the point. Person binding is irrelevant and so is the tool call. The only thing that decided survival was whether an assistant had ever replied.

Before, on a restarted sidecar:

```
[01] turn_start   run_id=run_a7da283e67f74c0aba2f2fe7cca1c434
[02] error        "The model provider failed after bounded recovery attempts."
```

After, same conversation, same restart:

```
[01] turn_start
...  250+ assistant_delta
[257] turn_end
```

## The requirement was self-imposed

The exact durable history was posted to live DeepSeek with tools enabled and no `reasoning_content` on the assistant turn:

```
history: [('user', False), ('assistant', False), ('user', False)]
   HTTP 200
   content: 'pong'
```

DeepSeek serves it. The provider was refusing a request the API accepts.

## Change

One block. When the cache holds no reasoning, omit the field instead of raising. Replay is untouched when the cache is warm, and nothing is invented to fill the gap.

Reasoning is still never persisted. This PR does not weaken that.

## Tests

`test_fresh_deepseek_provider_reports_unavailable_transient_continuation` asserted the refusal, including `requests == []`. It is replaced by `test_a_restarted_provider_continues_without_the_lost_reasoning`, which asserts the request goes out, carries no `reasoning_content`, still repairs the tool-call shape, and still leaves `durable_messages == original`. The no-mutation guarantee is kept.

`test_deepseek_cancellation_propagates_closes_stream_and_discards_partial_call` used the refusal as a proxy for "the cancelled round left no partial reasoning behind". That property is now asserted directly: the first continuation request after a cancellation carries no `reasoning_content`. Its `request_count` expectation moves from 1 to 2, because the continuation now reaches the wire by design.

## Measurements

```
1827 passed, 3 skipped, 1 warning in 70.42s
```

Identical to the baseline count: one test removed, one added.

Mutation harness, breaking one behaviour at a time and requiring the owning test to go red:

```
  red: restore the old hard failure
  red: invent an empty reasoning instead of omitting
  red: stop replaying reasoning when the cache IS warm

3 red, 0 vacuous, 3 mutations
```

The third mutation is the important one. It proves warm-cache replay is still exercised, so this change did not quietly disable reasoning replay in live sessions.

## Rejected alternative

Persisting the reasoning so continuation survives a restart. It would preserve replay quality, and Fisher asked for it. It is not in this PR because it would defeat the redaction in `workspace_runtime.py:411` by writing, through free-form model text, the same file bodies and shell output that redaction keeps off disk. The live test above shows persistence is not needed to fix the outage. If replay quality after a restart turns out to matter, that is a separate change with its own privacy review.

## Still wrong, and not in this PR

**The interface drops the error.** The server emits `{"type": "error", "message": ...}` and persists it. `surfaces/gui/src/chat/store.ts:518` handles the event by setting the message state to `failed` and discarding `message`, so nothing renders. Separately, `isTransportError` requires `!("version" in event)`, but server error events carry `"version": 2`, so they never match that path either. That is why this bug looked like a silent freeze rather than an error, and it is why the first diagnosis of #130 was wrong. Filed separately.

**Other providers unverified.** Only DeepSeek was exercised. Whether the Kimi/Moonshot fallback has an equivalent continuation requirement was not checked.

**Answer quality after a cold cache is unmeasured.** The request now succeeds without the replayed reasoning. Whether multi-step tool answers are as good without it was not measured, only that they are produced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conversations using DeepSeek can now continue after a provider restart or cancellation, even when temporary reasoning data is unavailable.
  * Requests no longer fail or include fabricated reasoning when cached reasoning is missing.
  * Improved cancellation handling prevents incomplete tool calls and leaked reasoning from affecting subsequent messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->