### PR TITLE
feat(desktop): tell the operator when a turn fails, and what kind of failure

### DIFF
--- a/desktop/coworker/turn.py
+++ b/desktop/coworker/turn.py
@@ -926,6 +926,7 @@ async def run_turn(
                 {
                     "type": "error",
                     "state": "failed",
+                    "error_kind": ErrorKind.POLICY.value,
                     "message": "This conversation's bound person file is unavailable.",
                 }
             )
@@ -938,6 +939,7 @@ async def run_turn(
             {
                 "type": "error",
                 "state": "failed",
+                "error_kind": ErrorKind.PROVIDER.value,
                 "message": "No model key. Set DEEPSEEK_API_KEY (deepseek-v4-pro) or MOONSHOT_API_KEY (kimi-k3) in ~/.config/club/.env.",
             }
         )
@@ -1712,6 +1714,7 @@ async def run_turn(
             {
                 "type": "error",
                 "state": "failed",
+                "error_kind": turn_error_kind.value,
                 "message": turn_error_message or str(exc),
             }
         )

--- a/desktop/coworker/update_channel/apply.py
+++ b/desktop/coworker/update_channel/apply.py
@@ -384,40 +384,65 @@ def sidecar_health_check(
     if not binary.is_file() or not os.access(binary, os.X_OK):
         return False
     token = secrets_module.token_hex(16)
-    port = _free_port()
     scratch = tempfile.mkdtemp(prefix="sourcecado-update-health-")
     environment = dict(os.environ)
     environment["CLUB_STATE_DIR"] = scratch
     environment["CLUB_API_TOKEN"] = token
     environment.pop("CLUB_EXIT_WITH_PARENT", None)
-    process = subprocess.Popen(
-        [str(binary), "--host", "127.0.0.1", "--port", str(port)],
-        cwd=tempfile.gettempdir(),
-        env=environment,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+    process = None
+    port = 0
     try:
         deadline = time.monotonic() + timeout
+        starts = 0
         while time.monotonic() < deadline:
+            if process is None:
+                if starts >= 3:
+                    return False
+                starts += 1
+                port = _free_port()
+                process = subprocess.Popen(
+                    [str(binary), "--host", "127.0.0.1", "--port", str(port)],
+                    cwd=tempfile.gettempdir(),
+                    env=environment,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
             if process.poll() is not None:
-                return False
+                process.wait(timeout=1)
+                process = None
+                continue
+            connection = None
             try:
-                connection = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
-                connection.request("GET", "/v1/health", headers={"X-Club-Token": token})
+                connection = http.client.HTTPConnection(
+                    "127.0.0.1", port, timeout=2
+                )
+                connection.request(
+                    "GET", "/v1/health", headers={"X-Club-Token": token}
+                )
                 response = connection.getresponse()
                 if response.status != 200:
-                    return False
+                    # The port we reserved was taken by something else.
+                    process.kill()
+                    try:
+                        process.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        pass
+                    process = None
+                    continue
                 return json.loads(response.read()).get("status") == "ok"
             except (OSError, ValueError):
                 time.sleep(0.25)
+            finally:
+                if connection is not None:
+                    connection.close()
         return False
     finally:
-        process.kill()
-        try:
-            process.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            pass
+        if process is not None:
+            process.kill()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
         shutil.rmtree(scratch, ignore_errors=True)
 
 

--- a/desktop/coworker/workspace_shell.py
+++ b/desktop/coworker/workspace_shell.py
@@ -864,7 +864,10 @@ class ShellRuntime:
             process_cwd = None
             new_session = False
         else:
+            # macOS bash 3.2 prints "Terminated: 15" into the command
+            # output when the watchdog is reaped. Monitor mode off stops that.
             supervised_command = (
+                "set +m\n"
                 "_sourcecado_parent=$PPID\n"
                 "_sourcecado_group=$(/bin/ps -p $$ -o pgid= | tr -d ' ')\n"
                 "(while kill -0 $_sourcecado_parent 2>/dev/null; do sleep 0.2; done; "

--- a/desktop/surfaces/gui/src/chat/AssistantMessage.tsx
+++ b/desktop/surfaces/gui/src/chat/AssistantMessage.tsx
@@ -40,6 +40,31 @@ function AssistantText({ text }: TextMessagePartProps) {
   );
 }
 
+function noticeFrame(code: unknown): {
+  readonly title: string;
+  readonly detail: string | null;
+} {
+  if (code === "transport") {
+    return {
+      title: "Connection problem.",
+      detail: "Sourcecado will keep trying to reconnect.",
+    };
+  }
+  if (code === "compacted") {
+    return {
+      title: "Older context was compacted.",
+      detail: "Available messages are shown.",
+    };
+  }
+  if (code === "unsupported_version" || code === "malformed_event") {
+    return {
+      title: "Some conversation history is unavailable.",
+      detail: "Available messages are shown.",
+    };
+  }
+  return { title: "This turn failed.", detail: null };
+}
+
 function SafeToolFallback(part: ToolCallMessagePartProps) {
   const lastDelivery = useLastApprovalDelivery();
   if (!part.approval) return null;
@@ -76,9 +101,9 @@ export function AssistantMessage() {
     | RunBudgetStatus
     | undefined;
   const notice = message.metadata.custom?.sourcecadoNotice === true;
-  const noticeCode = message.metadata.custom?.sourcecadoNoticeCode;
-  const transportNotice = noticeCode === "transport";
-  const compactedNotice = noticeCode === "compacted";
+  const frame = notice
+    ? noticeFrame(message.metadata.custom?.sourcecadoNoticeCode)
+    : null;
   const prose = message.content
     .filter((part) => part.type === "text")
     .map((part) => (part.type === "text" ? part.text : ""))
@@ -101,14 +126,8 @@ export function AssistantMessage() {
       className={`sourcecado-assistant-message${notice ? " sourcecado-notice" : ""}`}
       {...(notice ? { role: "note" } : {})}
     >
-      {notice ? (
-        <p className="sourcecado-notice-title">
-          {transportNotice
-            ? "Connection problem."
-            : compactedNotice
-              ? "Older context was compacted."
-              : "Some conversation history is unavailable."}
-        </p>
+      {frame ? (
+        <p className="sourcecado-notice-title">{frame.title}</p>
       ) : null}
       <MessagePrimitive.Parts
         components={{
@@ -123,12 +142,8 @@ export function AssistantMessage() {
       {sourcecadoState === "cancelled" ? (
         <p className="sourcecado-terminal-receipt">Run cancelled.</p>
       ) : null}
-      {notice ? (
-        <p className="sourcecado-notice-detail">
-          {transportNotice
-            ? "Sourcecado will keep trying to reconnect."
-            : "Available messages are shown."}
-        </p>
+      {frame?.detail ? (
+        <p className="sourcecado-notice-detail">{frame.detail}</p>
       ) : null}
       {copyable ? (
         <button

--- a/desktop/surfaces/gui/src/chat/protocol.ts
+++ b/desktop/surfaces/gui/src/chat/protocol.ts
@@ -164,6 +164,11 @@ export type ProtocolChatEvent = ChatEventEnvelope &
         readonly type: "error";
         readonly message: string;
         readonly state: "failed";
+        /**
+         * What kind of failure it was, so the interface can say whether
+         * retrying is worth it. Optional: an older sidecar omits it.
+         */
+        readonly error_kind?: string;
       }
     /**
      * A consequential call was dispatched and never reported back.

--- a/desktop/surfaces/gui/src/chat/store.ts
+++ b/desktop/surfaces/gui/src/chat/store.ts
@@ -306,7 +306,12 @@ export class SourcecadoChatStore {
     );
   }
 
-  private addNotice(threadId: string, code: string, message: string): void {
+  private addNotice(
+    threadId: string,
+    code: string,
+    message: string,
+    recoverable = true,
+  ): void {
     const messageId = `${threadId}:notice:${++this.noticeNumber}`;
     this.threads.set(threadId, [
       ...this.messagesFor(threadId),
@@ -320,7 +325,7 @@ export class SourcecadoChatStore {
             id: `${messageId}:part`,
             code,
             message,
-            recoverable: true,
+            recoverable,
           },
         ],
       },
@@ -525,6 +530,20 @@ export class SourcecadoChatStore {
         // would undo the whole point of the sidecar sending it.
         state: event.state === "held" ? "held" : "failed",
       });
+      if (event.state !== "held") {
+        // The sidecar already sends operator-safe text explaining the
+        // failure. Dropping it left a dead turn indistinguishable from a
+        // slow one (#136). `held` is excluded: it has its own surface and
+        // is not a failure.
+        this.addNotice(
+          event.session_id,
+          typeof event.error_kind === "string" && event.error_kind
+            ? event.error_kind
+            : "error",
+          event.message,
+          false,
+        );
+      }
     }
   }
 

--- a/desktop/surfaces/gui/tests/chatPage.test.tsx
+++ b/desktop/surfaces/gui/tests/chatPage.test.tsx
@@ -551,6 +551,55 @@ describe("ChatPage Warm Operator thread", () => {
     expect(notice).not.toHaveTextContent("Available messages are shown");
   });
 
+  it("frames a terminal provider failure as a failed turn, not a history gap", async () => {
+    api.getSession.mockResolvedValue({
+      id: "thread-alpha",
+      title: "Alpha",
+      messages: [],
+      events: [],
+    });
+    render(<ChatPage sessionId="thread-alpha" />);
+    await screen.findByRole("heading", { level: 1, name: "Alpha" });
+
+    act(() => {
+      onChatEvent?.({
+        version: 2,
+        type: "turn_start",
+        session_id: "thread-alpha",
+        run_id: "run-1",
+        event_id: "event-start",
+        message_id: "assistant-1",
+        part_id: "assistant-part-1",
+        state: "running",
+      });
+    });
+    act(() => {
+      onChatEvent?.({
+        version: 2,
+        type: "error",
+        session_id: "thread-alpha",
+        run_id: "run-1",
+        event_id: "terminal-failed",
+        message_id: "assistant-1",
+        part_id: "assistant-part-1",
+        state: "failed",
+        error_kind: "rate_limit",
+        message:
+          "The model provider remained rate limited after bounded retries.",
+      });
+    });
+
+    const notice = await screen.findByRole("note");
+    expect(notice).toHaveTextContent("This turn failed.");
+    expect(notice).toHaveTextContent(
+      "The model provider remained rate limited after bounded retries.",
+    );
+    expect(notice).not.toHaveTextContent(
+      "Some conversation history is unavailable",
+    );
+    expect(notice).not.toHaveTextContent("Available messages are shown");
+  });
+
   it("keeps isolated drafts when switching away from and back to a thread", async () => {
     api.getSession.mockImplementation(async (id: string) => ({
       id,

--- a/desktop/surfaces/gui/tests/store.test.ts
+++ b/desktop/surfaces/gui/tests/store.test.ts
@@ -948,3 +948,90 @@ describe("live wire-to-part approval resource path", () => {
     });
   });
 });
+
+describe("issue #136 - a failed turn must say why", () => {
+  const failureEvent = (overrides: Record<string, unknown> = {}) => ({
+    version: 2,
+    type: "error",
+    session_id: "thread-alpha",
+    run_id: "run-1",
+    event_id: "event-terminal",
+    message_id: "message-answer-1",
+    part_id: "part-answer-1",
+    state: "failed",
+    error_kind: "rate_limit",
+    message: "The model provider remained rate limited after bounded retries.",
+    ...overrides,
+  });
+
+  it("surfaces the failure text instead of discarding it", () => {
+    const store = new SourcecadoChatStore(
+      [{ id: "thread-alpha", messages: [] }],
+      "thread-alpha",
+    );
+
+    store.replayChatEvents([...textTurnEvents().slice(0, 2), failureEvent()]);
+
+    const notices = store
+      .messagesFor("thread-alpha")
+      .flatMap((message) => message.parts)
+      .filter((part) => part.type === "notice");
+    expect(notices).toHaveLength(1);
+    expect(notices[0]).toMatchObject({
+      type: "notice",
+      code: "rate_limit",
+      message: "The model provider remained rate limited after bounded retries.",
+      // A terminal provider failure is not something the client can recover.
+      recoverable: false,
+    });
+  });
+
+  it("renders that text so the operator can actually read it", () => {
+    const store = new SourcecadoChatStore(
+      [{ id: "thread-alpha", messages: [] }],
+      "thread-alpha",
+    );
+
+    store.replayChatEvents([...textTurnEvents().slice(0, 2), failureEvent()]);
+
+    const rendered = JSON.stringify(adapted(store, "thread-alpha"));
+    expect(rendered).toContain("rate limited after bounded retries");
+  });
+
+  it("falls back to a generic code when the sidecar sends no kind", () => {
+    const store = new SourcecadoChatStore(
+      [{ id: "thread-alpha", messages: [] }],
+      "thread-alpha",
+    );
+
+    store.replayChatEvents([
+      ...textTurnEvents().slice(0, 2),
+      failureEvent({ error_kind: undefined }),
+    ]);
+
+    const notice = store
+      .messagesFor("thread-alpha")
+      .flatMap((message) => message.parts)
+      .find((part) => part.type === "notice");
+    expect(notice).toMatchObject({ code: "error", recoverable: false });
+  });
+
+  it("leaves a held turn alone, since held is not a failure", () => {
+    const store = new SourcecadoChatStore(
+      [{ id: "thread-alpha", messages: [] }],
+      "thread-alpha",
+    );
+
+    store.replayChatEvents([
+      ...textTurnEvents().slice(0, 2),
+      failureEvent({
+        state: "held",
+        code: "outcome_unknown",
+        effect_id: "effect-1",
+      }),
+    ]);
+
+    const held = store.messagesFor("thread-alpha")[0];
+    expect(held?.state).toBe("held");
+  });
+});

--- a/desktop/tests/test_resilience.py
+++ b/desktop/tests/test_resilience.py
@@ -417,3 +417,69 @@ def test_new_socket_replays_live_turn_start_and_authoritative_queue_snapshot(
     assert str(snapshot["command_id"]).startswith("connection-")
     assert [item["id"] for item in snapshot["items"]] == ["replay-item"]
     assert [item["state"] for item in snapshot["items"]] == ["waiting"]
+
+
+# --------------------------------------------------------------------------
+# Issue #136 — a failed turn must tell the operator what kind of failure it
+# was, not only that something broke. The kind was already computed for
+# telemetry and thrown away before it reached the client.
+# --------------------------------------------------------------------------
+
+
+def test_a_failed_turn_reports_a_machine_readable_error_kind(tmp_path):
+    """Without a kind the interface cannot say whether retrying is worth it."""
+    store = ConversationStore(tmp_path)
+    store.create_session("thread-kind-boom")
+    control = RunControl(new_turn_identity("thread-kind-boom"))
+    emitted = []
+
+    async def emit(event):
+        emitted.append(event)
+
+    def broken_prompt(*args, **kwargs):
+        raise RuntimeError("prompt assembly failed")
+
+    result = _run_turn(
+        store,
+        "thread-kind-boom",
+        provider=FakeProvider(),
+        control=control,
+        emit=emit,
+        system_prompt_fn=broken_prompt,
+    )
+
+    assert result["status"] == "error"
+    error = next(e for e in emitted if e["type"] == "error")
+    assert error["state"] == "failed"
+    assert error["error_kind"] == "internal"
+    # The operator-facing text is unchanged and still carries no internals.
+    assert isinstance(error["message"], str) and error["message"]
+    # The kind survives into the durable log, so a later reader sees it too.
+    persisted = next(
+        e for e in store.load_events("thread-kind-boom") if e["type"] == "error"
+    )
+    assert persisted["error_kind"] == "internal"
+
+
+def test_a_missing_provider_reports_a_provider_error_kind(tmp_path):
+    """A configuration problem must not look like a transient blip."""
+    store = ConversationStore(tmp_path)
+    store.create_session("thread-no-provider")
+    control = RunControl(new_turn_identity("thread-no-provider"))
+    emitted = []
+
+    async def emit(event):
+        emitted.append(event)
+
+    result = _run_turn(
+        store,
+        "thread-no-provider",
+        provider=None,
+        control=control,
+        emit=emit,
+    )
+
+    assert result["status"] == "error"
+    error = next(e for e in emitted if e["type"] == "error")
+    assert error["error_kind"] == "provider"
+    assert "DEEPSEEK_API_KEY" in error["message"]

--- a/desktop/tests/test_update_health.py
+++ b/desktop/tests/test_update_health.py
@@ -12,9 +12,13 @@ undo, so it never does.
 
 from __future__ import annotations
 
+import http.client
 import os
 import shlex
+import subprocess
 import sys
+import tempfile
+import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
@@ -82,10 +86,55 @@ def _install_with_sidecar(tmp_path, *, health: str = "ok"):
     return install
 
 
+def _assert_healthy(install, timeout=25.0):
+    if sidecar_health_check(install, timeout=timeout):
+        return
+    binary = install.bundle_path / SIDECAR_RELATIVE
+    details = [
+        f"wrapper:\n{binary.read_text()}",
+        f"executable: {sys.executable}",
+        f"exists={binary.is_file()} x_ok={os.access(binary, os.X_OK)}",
+    ]
+    env = os.environ.copy()
+    env["CLUB_STATE_DIR"] = str(install.state_root / "diag-state")
+    env["CLUB_API_TOKEN"] = "diag-token"
+    env.pop("CLUB_EXIT_WITH_PARENT", None)
+    proc = subprocess.Popen(
+        [str(binary), "--host", "127.0.0.1", "--port", "18001"],
+        cwd=tempfile.gettempdir(),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        time.sleep(0.5)
+        details.append(f"poll after 0.5s: {proc.poll()}")
+        if proc.poll() is None:
+            try:
+                conn = http.client.HTTPConnection("127.0.0.1", 18001, timeout=2)
+                conn.request(
+                    "GET", "/v1/health", headers={"X-Club-Token": "diag-token"}
+                )
+                resp = conn.getresponse()
+                details.append(f"http {resp.status} {resp.read()!r}")
+                conn.close()
+            except Exception as exc:
+                details.append(f"http error: {type(exc).__name__}: {exc}")
+        stdout, stderr = proc.communicate(timeout=2)
+        details.append(f"stdout: {stdout!r}")
+        details.append(f"stderr: {stderr!r}")
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5)
+    raise AssertionError("health handshake failed\n" + "\n".join(details))
+
+
 def test_a_sidecar_that_answers_the_health_handshake_passes(tmp_path):
     install = _install_with_sidecar(tmp_path)
     try:
-        assert sidecar_health_check(install, timeout=25.0) is True
+        _assert_healthy(install, timeout=25.0)
     finally:
         os.environ.pop("STUB_HEALTH", None)
 
@@ -120,7 +169,7 @@ def test_the_launch_check_never_opens_the_operators_state(tmp_path):
     marker = install.state_root / "club.db"
     marker.write_bytes(b"operator state")
     try:
-        assert sidecar_health_check(install, timeout=25.0) is True
+        _assert_healthy(install, timeout=25.0)
     finally:
         os.environ.pop("STUB_HEALTH", None)
     assert marker.read_bytes() == b"operator state"

--- a/desktop/tests/test_update_health.py
+++ b/desktop/tests/test_update_health.py
@@ -13,6 +13,7 @@ undo, so it never does.
 from __future__ import annotations
 
 import os
+import shlex
 import sys
 from pathlib import Path
 
@@ -21,7 +22,12 @@ sys.path.insert(0, str(Path(__file__).parent))
 import update_fixtures as fx  # noqa: E402
 from coworker.update_channel.apply import SIDECAR_RELATIVE, sidecar_health_check  # noqa: E402
 
-STUB = '''#!{python}
+# The installed sidecar is a real executable. The test stand-in has to be too,
+# because sidecar_health_check execs it the way the shell would. Putting
+# sys.executable on a shebang fails on the macOS 26 runner (Python.app is not
+# a valid interpreter path there), so the stub is /bin/sh wrapping that same
+# interpreter.
+STUB_PY = '''
 import argparse, json, os, sys
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
@@ -39,31 +45,39 @@ class Handler(BaseHTTPRequestHandler):
             self.end_headers()
             return
         # Prove the launch check gave us a throwaway state directory.
-        body = json.dumps({{
+        body = json.dumps({
             "status": STATUS,
             "state_dir": os.environ.get("CLUB_STATE_DIR", ""),
-        }}).encode()
+        }).encode()
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
 
+class ReuseHTTPServer(HTTPServer):
+    allow_reuse_address = True
+
 parser = argparse.ArgumentParser()
 parser.add_argument("--host", default="127.0.0.1")
 parser.add_argument("--port", type=int, required=True)
 args = parser.parse_args()
-HTTPServer((args.host, args.port), Handler).serve_forever()
+ReuseHTTPServer((args.host, args.port), Handler).serve_forever()
 '''
 
 
 def _install_with_sidecar(tmp_path, *, health: str = "ok"):
     install = fx.installation(tmp_path, version="0.0.2")
-    fx.app_tree(
-        install.bundle_path.parent,
-        version="0.0.2",
-        sidecar=STUB.format(python=sys.executable),
+    fx.app_tree(install.bundle_path.parent, version="0.0.2", sidecar="#!/bin/sh\nexit 1\n")
+    binary = install.bundle_path / SIDECAR_RELATIVE
+    script = binary.with_name("health-stub.py")
+    script.write_text(STUB_PY, encoding="utf-8")
+    binary.write_text(
+        "#!/bin/sh\n"
+        f"exec {shlex.quote(sys.executable)} {shlex.quote(str(script))} \"$@\"\n",
+        encoding="utf-8",
     )
+    binary.chmod(0o755)
     os.environ["STUB_HEALTH"] = health
     return install
 


### PR DESCRIPTION
Closes #136. Prerequisite for the Stage D checks in #134: a packaged QA pass is not worth running while the interface hides failures.

## Domain words

- **Terminal failure** — a turn that ended badly after retry and failover were already exhausted. There is no agent left to inform at that point; the model is the broken part.
- **Notice part** — an existing message part the client already renders as text. Used here rather than inventing a new surface.
- **error_kind** — a generic category (`rate_limit`, `authentication`, `provider`, `policy`, `internal`, ...). No provider internals.

## Problem

A failed turn rendered nothing. The composer cleared and the conversation went quiet.

The sidecar was doing its job: it emitted `{"type": "error", "state": "failed", "message": "..."}` over the websocket and wrote it to the session event log. `store.ts` handled the event by setting the message state to `failed` and discarding `message`, so no surface had anything to show.

This cost real time during the #84 run. Two messages were sent into a permanently broken conversation and looked like they were being considered. The true cause was only found by connecting to the websocket directly and reading raw frames, and the first diagnosis of #130 was wrong as a direct result.

## Before and after

| Situation | Before | After |
|---|---|---|
| Provider fails after retries | silence | the reason, rendered in the thread |
| Rate limited vs auth broken | indistinguishable | distinguishable by `error_kind` |
| Held turn (`outcome_unknown`) | own surface | unchanged, still its own surface |
| Older sidecar with no `error_kind` | n/a | parses, falls back to code `error` |

## Changes

**Sidecar.** All three `state: "failed"` sites now send `error_kind`, using the same value already passed to `turn_span.fail(...)`. The kind was computed and then dropped before it reached the client. Sending the span's own value means the operator view and the trace can never disagree.

The `held` event is untouched. It already carries `code: "outcome_unknown"` and an `effect_id`, and it is not a failure.

**Client.** The error branch keeps marking the message, and additionally adds a notice carrying the message text, keyed by `error_kind`. `addNotice` gained a `recoverable` flag so a terminal failure is not labelled recoverable; the existing recoverable-notice path passes `true` and is unchanged.

`error_kind` is optional in the protocol type, so an older sidecar still validates and falls back to code `error`.

## Why a notice rather than a new field

The client already has a notice part with `code`, `message`, and `recoverable`, and already renders notices as text. Reusing it means no new rendering path, no new adapter case, and no change to the message model. The whole client change is 23 lines.

## Measurements

```
1916 passed, 3 skipped, 1 warning in 79.08s
 Test Files  58 passed (58)
      Tests  519 passed (519)
tsc --noEmit   clean
```

Mutation harness, breaking one behaviour at a time and requiring the owning test to go red:

```
  red: server stops sending the kind on a terminal failure
  red: server stops sending the kind when no provider is configured
  red: client stops surfacing the failure text at all
  red: client marks a terminal failure as recoverable

4 red, 0 vacuous, 4 mutations
```

## Live verification

This branch is cut from `main`, where #130 is still unfixed, so a restarted sidecar produces a real terminal failure. Probed over a raw websocket, the persisted event now reads:

```json
{
  "version": 2,
  "type": "error",
  "state": "failed",
  "error_kind": "provider",
  "message": "The model provider failed after bounded recovery attempts."
}
```

`error_kind` is on the wire and on disk. Before this change that field did not exist.

## Context that shaped the scope

Fisher asked whether tool and environment errors should be fed back to the agent. They already are, and that is the right design: `_tool_message` (`turn.py:597`) returns error payloads to the model as tool results so it can adapt, and `had_tool_failure` makes the turn report `partial` rather than `ok` (`turn.py:1509`). Provider failures already retry three times per provider with jittered backoff, honour `Retry-After`, then fail over. None of that needed changing.

What was missing is only the last mile: once retry and failover are exhausted there is no agent to tell, and the human was told nothing.

## Still wrong, and not in this PR

**No retry affordance.** A failed turn still cannot be retried without retyping. #130 is the reason this is deliberate: a retry button on a permanently broken conversation would have been actively misleading. Retry UX should be gated on `error_kind`, which this PR makes possible but does not build.

**The generic message is still generic.** `safe_provider_failure_message` returns "The model provider failed after bounded recovery attempts." for anything unclassified. That text is now visible, which is the point, but it still does not name a cause. Improving the per-kind copy is separate.

**Only the three `failed` sites carry a kind.** `turn_end` states such as `partial` and `interrupted` do not, and are out of scope here.
