### PR TITLE
ci(desktop): gate Apple signing and update signing independently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,15 +159,28 @@ jobs:
           UPDATE_KEY: ${{ secrets.SOURCECADO_UPDATE_SIGNING_KEY }}
         run: |
           set -euo pipefail
-          if [ -n "$CERTIFICATE" ] && [ -n "$UPDATE_KEY" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
+          # Two independent credentials, deliberately not conflated. The Apple
+          # identity proves who built the artifact. The update key proves a
+          # manifest came from us and is generated offline with no Apple
+          # involvement. Requiring both meant that having no Apple certificate
+          # also blocked update-manifest generation, so the whole update,
+          # migration, and rollback path could not be exercised without paying
+          # Apple. They are now gated separately.
+          if [ -n "$CERTIFICATE" ]; then
+            echo "apple=true" >> "$GITHUB_OUTPUT"
           else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::No Apple signing identity or update signing key is configured. This build is UNSIGNED and UNNOTARIZED and has no update manifest. See desktop/docs/update-channel.md."
+            echo "apple=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No Apple signing identity is configured. This build is UNSIGNED and UNNOTARIZED, and Gatekeeper will require right-click then Open on first launch. See desktop/docs/update-channel.md."
+          fi
+          if [ -n "$UPDATE_KEY" ]; then
+            echo "update=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "update=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::No update signing key is configured. This build has no update manifest, so the update and rollback paths cannot be exercised. See desktop/docs/update-channel.md."
           fi
 
       - name: Import the Developer ID certificate
-        if: steps.signing.outputs.available == 'true'
+        if: steps.signing.outputs.apple == 'true'
         env:
           CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE_P12 }}
           CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
@@ -187,7 +200,7 @@ jobs:
           rm -f "$RUNNER_TEMP/certificate.p12"
 
       - name: Sign the application
-        if: steps.signing.outputs.available == 'true'
+        if: steps.signing.outputs.apple == 'true'
         env:
           IDENTITY: ${{ secrets.MACOS_SIGNING_IDENTITY }}
         working-directory: desktop/surfaces/gui/src-tauri/target/release/bundle/macos
@@ -204,7 +217,7 @@ jobs:
           codesign --verify --strict --verbose=2 Sourcecado.app
 
       - name: Notarize and staple
-        if: steps.signing.outputs.available == 'true'
+        if: steps.signing.outputs.apple == 'true'
         env:
           NOTARY_ISSUER: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
           NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
@@ -221,7 +234,7 @@ jobs:
           xcrun stapler staple Sourcecado.app
 
       - name: Verify the signed build independently
-        if: steps.signing.outputs.available == 'true'
+        if: steps.signing.outputs.apple == 'true'
         working-directory: desktop/surfaces/gui/src-tauri/target/release/bundle/macos
         run: |
           set -euo pipefail
@@ -245,6 +258,8 @@ jobs:
             echo "workflow_run: ${{ github.run_id }}"
             echo "built_at: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
             echo "runner: $(sw_vers -productVersion) $(uname -m)"
+            echo "signed: ${{ steps.signing.outputs.apple }}"
+            echo "update_manifest: ${{ steps.signing.outputs.update }}"
             rustc -vV
             python3 --version
             node --version
@@ -253,7 +268,7 @@ jobs:
           cat provenance.txt
 
       - name: Package the artifact and generate the signed update manifest
-        if: steps.signing.outputs.available == 'true'
+        if: steps.signing.outputs.update == 'true'
         env:
           SOURCECADO_UPDATE_SIGNING_KEY: ${{ secrets.SOURCECADO_UPDATE_SIGNING_KEY }}
         working-directory: desktop/surfaces/gui/src-tauri/target/release/bundle/macos
@@ -281,7 +296,7 @@ jobs:
             --home "$HOME"
 
       - name: Verify the update manifest independently
-        if: steps.signing.outputs.available == 'true'
+        if: steps.signing.outputs.update == 'true'
         working-directory: desktop/surfaces/gui/src-tauri/target/release/bundle/macos
         run: |
           set -euo pipefail
@@ -295,11 +310,11 @@ jobs:
             --installed-version "$SOURCECADO_MINIMUM_FROM" \
             --trust "${{ vars.SOURCECADO_UPDATE_KEY_ID }}=${{ vars.SOURCECADO_UPDATE_PUBLIC_KEY }}"
 
-      - name: Upload the signed preview artifact and its manifest
-        if: steps.signing.outputs.available == 'true'
+      - name: Upload the packaged preview artifact and its manifest
+        if: steps.signing.outputs.update == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: sourcecado-macos-preview-signed
+          name: sourcecado-macos-preview-packaged
           path: |
             desktop/surfaces/gui/src-tauri/target/release/bundle/macos/Sourcecado-*.zip
             desktop/surfaces/gui/src-tauri/target/release/bundle/macos/update-preview.json

--- a/desktop/docs/update-channel.md
+++ b/desktop/docs/update-channel.md
@@ -280,9 +280,41 @@ own environment, so pasting the signing key into a commit message is caught as
 ## Signing and notarization: what is authored and what is unrun
 
 The CI steps are written in `.github/workflows/ci.yml` in the `macos-preview`
-job. **None of them have run.** They are guarded on the signing secret being
-present and are skipped with an explicit notice when it is not, so a run without
+job. **None of them have run.** They are guarded on credentials being present
+and are skipped with an explicit notice when they are not, so a run without
 credentials cannot be mistaken for a signed one.
+
+The guard is **two independent gates**, not one:
+
+| Gate | Needs | Turns on |
+| --- | --- | --- |
+| `steps.signing.outputs.apple` | `MACOS_CERTIFICATE_P12` | signing, notarization, stapling, and the independent signature check |
+| `steps.signing.outputs.update` | `SOURCECADO_UPDATE_SIGNING_KEY` | artifact packaging, manifest generation, and the independent manifest check |
+
+They were one gate requiring both, which meant that having no Apple certificate
+also blocked update-manifest generation. Apple has nothing to do with the update
+key, so that conflation made the whole update, migration, and rollback path
+untestable without paying for a Developer Program membership.
+
+`provenance.txt` records `signed:` and `update_manifest:` for every build, so an
+unsigned artifact is self-describing and cannot be mistaken for a signed one
+later.
+
+## Exercising updates without an Apple identity
+
+The update signing key is generated offline and is not an Apple credential.
+Supply `SOURCECADO_UPDATE_SIGNING_KEY` alone and CI produces an unsigned
+`Sourcecado.app`, a packaged zip, and a fully signed and verified update
+manifest. That is enough to exercise clean install, the packaged journey,
+migration and backup, the authenticated update, every failure path, and
+rollback.
+
+What stays unavailable without the Apple identity: code signing, notarization,
+stapling, `spctl` acceptance, and a Gatekeeper-clean first launch. Gatekeeper
+requires right-click then Open until the app is signed and notarized.
+
+Locally none of this needs CI at all. `make update-manifest` and
+`make update-verify` read the key from the environment.
 
 To turn them on, supply these as protected repository secrets and variables:
 


### PR DESCRIPTION
Unblocks the QA in #134 without an Apple Developer membership.

## Problem

The `macos-preview` job had one credential gate requiring both credentials:

```bash
if [ -n "$CERTIFICATE" ] && [ -n "$UPDATE_KEY" ]; then
```

Seven steps hung off that single flag, including artifact packaging, update manifest generation, and the independent manifest verification. **Apple has no part in any of those.** The update signing key is an Ed25519 seed generated offline, documented in `update-channel.md` as "generate it offline, never in CI".

So having no Apple Developer membership also blocked the entire update, migration, and rollback path from ever being exercised, even though nothing in it touches Apple. That is a conflation, not a requirement.

Fisher does not want to buy a Developer Program membership for this project. Without this change that decision also costs the update and rollback QA, which is the larger half of #134 Stage E.

## Before and after

| Credentials supplied | Before | After |
|---|---|---|
| Neither | unsigned app, no manifest | unchanged |
| **Update key only** | **unsigned app, no manifest** | **unsigned app, signed and verified manifest** |
| Apple cert only | nothing signed, no manifest | signed and notarized app, no manifest |
| Both | everything | everything, unchanged |

The second row is the point of this PR.

## Changes

One gate becomes two:

| Gate | Needs | Turns on |
|---|---|---|
| `steps.signing.outputs.apple` | `MACOS_CERTIFICATE_P12` | signing, notarization, stapling, independent signature check |
| `steps.signing.outputs.update` | `SOURCECADO_UPDATE_SIGNING_KEY` | packaging, manifest generation, independent manifest check |

Each gate emits its own explicit warning when its credential is absent, so a skipped pass still cannot be mistaken for a completed one.

The uploaded artifact was named `sourcecado-macos-preview-signed` unconditionally. With only the update key that name would be a lie, so it is now `sourcecado-macos-preview-packaged`.

`provenance.txt` gains two lines:

```
signed: true|false
update_manifest: true|false
```

The artifact is now self-describing. #134 lists "the packaged journey behaves differently from the accepted #84 journey" and credential leakage as rejection conditions; an artifact that cannot say whether it was signed is one an operator can get wrong months later.

## Measurements

```
47 passed in 0.59s     # test_update_manifest, test_update_exercises, test_update_secrets
```

The workflow parses and the conditions resolve as intended:

```
Import the Developer ID certificate       if: steps.signing.outputs.apple == 'true'
Sign the application                      if: steps.signing.outputs.apple == 'true'
Notarize and staple                       if: steps.signing.outputs.apple == 'true'
Verify the signed build independently     if: steps.signing.outputs.apple == 'true'
Package the artifact and generate ...     if: steps.signing.outputs.update == 'true'
Verify the update manifest independently  if: steps.signing.outputs.update == 'true'
Upload the packaged preview artifact ...  if: steps.signing.outputs.update == 'true'
```

No file still references `outputs.available` or the old artifact name.

## Still wrong, and not in this PR

**Neither gate has ever run true.** No credentials exist in the repository yet, so both branches are unexercised. The YAML parses and the conditions read correctly by inspection, and that is the whole claim. First real proof comes when a key is supplied.

**`TRUSTED_KEYS` is still empty.** `coworker/update_channel/manifest.py` trusts no key for the `preview` channel, so a generated manifest still verifies nowhere except through the explicit `--trust` flag CI passes. Wiring a real public key is a separate change and needs the key to exist first.

**Signing is deferred, not removed.** #78's wording is certification "from the signed and packaged preview". An unsigned build cannot satisfy that, and cannot be handed to anyone else without Gatekeeper warnings. This PR buys the behavioural QA now and leaves the identity proof for when a certificate exists.
