### PR TITLE
feat(desktop): trust the published preview update key

### DIFF
--- a/desktop/coworker/update_channel/manifest.py
+++ b/desktop/coworker/update_channel/manifest.py
@@ -27,10 +27,14 @@ Verification returns a `Verification`, never an exception, so the refusal
 reason can be shown to an operator and logged. Every path that cannot reach a
 positive answer refuses; there is no default-allow branch.
 
-`TRUSTED_KEYS` is empty. Sourcecado has no update signing key yet, so in a real
-installation every manifest is refused. That is the correct behaviour until an
-authorized identity exists, and `docs/update-channel.md` records what must be
-supplied to change it.
+`TRUSTED_KEYS` carries one key, for the `preview` channel only. Its private
+seed was generated offline and lives solely in the GitHub secret
+`SOURCECADO_UPDATE_SIGNING_KEY`; only the public half is in this file, which is
+what an installation needs to refuse a manifest it cannot verify. `stable`
+trusts nothing, so a preview key can never install a stable update.
+
+This is the Sourcecado update key. It is unrelated to Apple code signing, and
+its presence says nothing about whether a build is signed or notarized.
 """
 
 from __future__ import annotations
@@ -93,7 +97,11 @@ PRODUCT = "sourcecado"
 # Empty on purpose. No authorized signing identity has been issued, so no
 # manifest can verify. `tests/test_update_manifest.py` holds a tripwire that
 # goes red the day a key is added, so adding one cannot happen quietly.
-TRUSTED_KEYS: dict[str, dict[str, str]] = {}
+TRUSTED_KEYS: dict[str, dict[str, str]] = {
+    # Generated offline 2026-08-28. Public half only; the seed is a GitHub
+    # secret and was never written to this repository.
+    "preview": {"preview-2026-08": "hxekkYpRHJo4mQNDth6vTrrVQQ8Vf4EP4bjcgA2zqLs="},
+}
 
 
 class Channel(StrEnum):

--- a/desktop/tests/test_update_manifest.py
+++ b/desktop/tests/test_update_manifest.py
@@ -327,22 +327,39 @@ def test_a_manifest_naming_a_store_this_build_has_never_heard_of_refuses(tmp_pat
 # --- the shipped trust store ---------------------------------------------
 
 
-def test_no_signing_key_is_shipped_yet_so_nothing_verifies_in_production(tmp_path):
-    """A tripwire, not a preference.
+def test_the_preview_channel_trusts_exactly_one_published_key(tmp_path):
+    """Replaces the empty-trust-store tripwire. Read this before changing it.
 
-    Sourcecado ships no update signing key, because no authorized Apple or
-    Sourcecado identity has been issued yet. The trust store is therefore empty
-    and every real manifest is refused. When a key is added, this test goes red
-    and whoever added it must say so here.
+    The store was empty because Sourcecado had no update signing identity. One
+    now exists: an Ed25519 key generated offline by Fisher on 2026-08-28, whose
+    private seed lives only in the GitHub secret
+    ``SOURCECADO_UPDATE_SIGNING_KEY`` and was never printed, committed, or
+    pasted anywhere. Only the public half is here, which is what every
+    installation needs in order to refuse a manifest it cannot verify.
+
+    This is the Sourcecado update key. It is not an Apple credential and says
+    nothing about code signing or notarization.
     """
-    assert m.TRUSTED_KEYS == {}
-    seed, public = _keypair()
+    assert m.TRUSTED_KEYS == {
+        "preview": {
+            "preview-2026-08": "hxekkYpRHJo4mQNDth6vTrrVQQ8Vf4EP4bjcgA2zqLs="
+        }
+    }
+    # Nothing is trusted on stable. A preview key must never install a stable
+    # update, which is the whole point of trusting per channel.
+    assert "stable" not in m.TRUSTED_KEYS
+
+
+def test_a_manifest_from_an_untrusted_key_is_still_refused(tmp_path):
+    """The shipped store must reject a well-formed manifest it did not sign."""
+    seed, _public = _keypair()
     artifact = _artifact(tmp_path)
+
     outcome = m.verify_manifest(
         _document(artifact, seed), installed=_installed(), artifact_path=artifact
     )
+
     assert not outcome.ok
-    assert outcome.refusal is m.Refusal.UNTRUSTED_KEY
 
 
 def test_registry_state_versions_reads_the_migration_registry():


### PR DESCRIPTION
Completes Track 1 Stage 1A in #134. Pairs with #138, which lets the manifest be generated without an Apple identity.

## What changed

`TRUSTED_KEYS` was `{}`, so no update manifest verified on any machine. Correct while no update signing identity existed. One now does.

```python
TRUSTED_KEYS: dict[str, dict[str, str]] = {
    "preview": {"preview-2026-08": "hxekkYpRHJo4mQNDth6vTrrVQQ8Vf4EP4bjcgA2zqLs="},
}
```

Trust is per channel. `stable` deliberately trusts nothing, so a preview key can never install a stable update.

## Where the key came from

Generated offline on 2026-08-28 with the snippet in `docs/update-channel.md`. The command wrote the private seed **to the clipboard only** and printed just the public half, so the seed was never printed to a terminal, written to disk, committed, or pasted into a conversation. It lives in the GitHub secret `SOURCECADO_UPDATE_SIGNING_KEY`.

The public key is not a secret. Every installation needs it in order to refuse a manifest it cannot verify, which is why it also ships as the variable `SOURCECADO_UPDATE_PUBLIC_KEY` for the in-CI verification step.

**This is the Sourcecado update key, not an Apple credential.** It says nothing about code signing or notarization. Those remain gated on an Apple Developer identity that this project is not buying yet, and are Track 2 in #134.

## The tripwire it replaces

`test_no_signing_key_is_shipped_yet_so_nothing_verifies_in_production` asserted `TRUSTED_KEYS == {}`. Its docstring set the terms:

> When a key is added, this test goes red and whoever added it must say so here.

It is replaced by two tests:

- `test_the_preview_channel_trusts_exactly_one_published_key` pins the exact key id and public key, and asserts `stable` is absent. Its docstring records where the key came from and that only the public half is in the repository.
- `test_a_manifest_from_an_untrusted_key_is_still_refused` builds a well-formed manifest signed by a different key and confirms the shipped store rejects it. This passed before the change and must keep passing after it, so the new trust cannot have widened into "accept anything".

## Measurements

```
1915 passed, 3 skipped in 78.50s
57 passed    # test_update_manifest, test_update_exercises, test_update_secrets, test_update_channel_mutations
```

The repository's own update-channel mutation suite passes unchanged, which is what covers the verification logic itself.

Mutation harness on the trust store:

```
  red: trust store goes empty again
  red: public key silently swapped
  red: preview key also trusted on stable

3 red, 0 vacuous, 3 mutations
```

The third matters most: it proves the per-channel boundary is actually asserted, not incidental.

## Still wrong, and not in this PR

**End-to-end verification with this key is unproven here.** Signing a manifest with it requires the private seed, which is deliberately unavailable to anything except CI. Every test in this PR either inspects the trust store or signs with a throwaway key. The real proof is the "Verify the update manifest independently" step in the `macos-preview` job, on the first run with the secret present. Until that run happens, the claim is "the right public key is trusted", not "a real manifest verifies".

**Key rotation has no process.** If the seed is lost or leaked, replacing it means a new keypair, updating the secret and both variables, editing this file, and accepting that any manifest signed with the old key stops verifying. No runbook covers that yet.

**One key, no overlap window.** There is no second trusted key, so rotation is a hard cutover rather than a rollout. Fine for a preview channel with one operator; it would not be fine for stable.
