### PR TITLE
test(desktop): make the health diagnostic able to report

### DIFF
--- a/desktop/tests/test_update_health.py
+++ b/desktop/tests/test_update_health.py
@@ -142,6 +142,37 @@ def _health_diagnostics(install) -> list[str]:
 
     port = _free_diagnostic_port()
     probe("diagnostic port", lambda: port)
+
+    # Can this interpreter run anything at all? The stub's first statement
+    # writes to stderr, and on the failing runner that line never appears,
+    # so the question is whether the interpreter itself starts (#140).
+    def interpreter_smoke():
+        done = subprocess.run(
+            [sys.executable, "-c", "import sys; sys.stderr.write('ALIVE\\n')"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        return f"rc={done.returncode} out={done.stdout!r} err={done.stderr!r}"
+
+    probe("interpreter smoke", interpreter_smoke)
+
+    # And can the wrapper itself run a trivial program the same way sh execs it?
+    def wrapper_smoke():
+        script = binary.with_name("smoke-probe.py")
+        script.write_text("import sys; sys.stderr.write('WRAPPER_ALIVE\\n')\n")
+        wrapper = binary.with_name("smoke-wrapper.sh")
+        wrapper.write_text(
+            f"#!/bin/sh\nexec {shlex.quote(sys.executable)} {shlex.quote(str(script))}\n"
+        )
+        wrapper.chmod(0o755)
+        done = subprocess.run(
+            [str(wrapper)], capture_output=True, text=True, timeout=15
+        )
+        return f"rc={done.returncode} out={done.stdout!r} err={done.stderr!r}"
+
+    probe("wrapper smoke", wrapper_smoke)
+    probe("stub head", lambda: repr(binary.with_name("health-stub.py").read_text()[:80]))
     try:
         proc = subprocess.Popen(
             [str(binary), "--host", "127.0.0.1", "--port", str(port)],
@@ -158,6 +189,8 @@ def _health_diagnostics(install) -> list[str]:
     try:
         time.sleep(0.5)
         probe("poll after 0.5s", proc.poll)
+        time.sleep(3.0)
+        probe("poll after 3.5s", proc.poll)
 
         def raw_connect():
             import socket as _s

--- a/desktop/tests/test_update_health.py
+++ b/desktop/tests/test_update_health.py
@@ -34,7 +34,7 @@ from coworker.update_channel.apply import SIDECAR_RELATIVE, sidecar_health_check
 # a valid interpreter path there), so the stub is /bin/sh wrapping that same
 # interpreter.
 STUB_PY = '''
-import argparse, json, os, sys
+import argparse, json, os, socketserver, sys
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 STATUS = os.environ.get("STUB_HEALTH", "ok")
@@ -64,19 +64,21 @@ class Handler(BaseHTTPRequestHandler):
 class ReuseHTTPServer(HTTPServer):
     allow_reuse_address = True
 
+    def server_bind(self):
+        # Deliberately not HTTPServer.server_bind. That calls
+        # socket.getfqdn(host) between bind() and listen(); on the GitHub
+        # macOS runner the lookup hangs, leaving the socket bound and never
+        # listening, which refuses every connection (#140). server_name is
+        # unused here.
+        socketserver.TCPServer.server_bind(self)
+        host, port = self.server_address[:2]
+        self.server_name = host
+        self.server_port = port
+
     def handle_error(self, request, client_address):
         import traceback
         traceback.print_exc(file=sys.stderr)
         sys.stderr.flush()
-
-import socket, time as _t
-_t0 = _t.monotonic()
-try:
-    socket.getfqdn("127.0.0.1")
-    _fqdn = f"{_t.monotonic() - _t0:.2f}s"
-except Exception as _exc:
-    _fqdn = f"failed {_exc}"
-print(f"getfqdn took {_fqdn}", file=sys.stderr, flush=True)
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--host", default="127.0.0.1")
@@ -173,6 +175,28 @@ def _health_diagnostics(install) -> list[str]:
 
     probe("wrapper smoke", wrapper_smoke)
     probe("stub head", lambda: repr(binary.with_name("health-stub.py").read_text()[:80]))
+
+    def getfqdn_duration():
+        """Bounded on purpose. An unbounded call is what hangs (#140)."""
+        import socket as _s
+        import threading
+
+        result = {}
+
+        def run():
+            started = time.monotonic()
+            try:
+                _s.getfqdn("127.0.0.1")
+                result["v"] = f"{time.monotonic() - started:.2f}s"
+            except Exception as exc:
+                result["v"] = f"failed {exc}"
+
+        worker = threading.Thread(target=run, daemon=True)
+        worker.start()
+        worker.join(timeout=10)
+        return result.get("v", "STILL RUNNING after 10s (this is the bug)")
+
+    probe("getfqdn", getfqdn_duration)
     try:
         proc = subprocess.Popen(
             [str(binary), "--host", "127.0.0.1", "--port", str(port)],

--- a/desktop/tests/test_update_health.py
+++ b/desktop/tests/test_update_health.py
@@ -21,6 +21,8 @@ import tempfile
 import time
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent))
 
 import update_fixtures as fx  # noqa: E402
@@ -89,46 +91,98 @@ def _install_with_sidecar(tmp_path, *, health: str = "ok"):
 def _assert_healthy(install, timeout=25.0):
     if sidecar_health_check(install, timeout=timeout):
         return
+    raise AssertionError(
+        "health handshake failed\n" + "\n".join(_health_diagnostics(install))
+    )
+
+
+def _health_diagnostics(install) -> list[str]:
+    """Why the handshake failed, in a form a CI log reader can act on.
+
+    Every probe is individually guarded. A diagnostic that raises replaces the
+    diagnosis with its own error, which is exactly what happened before (#140):
+    `communicate()` was called on a stub that ends in `serve_forever()`, so it
+    always timed out and the collected details were discarded.
+    """
     binary = install.bundle_path / SIDECAR_RELATIVE
-    details = [
-        f"wrapper:\n{binary.read_text()}",
-        f"executable: {sys.executable}",
-        f"exists={binary.is_file()} x_ok={os.access(binary, os.X_OK)}",
-    ]
+    details: list[str] = []
+
+    def probe(label, fn):
+        try:
+            details.append(f"{label}: {fn()}")
+        except Exception as exc:  # never let a probe hide the diagnosis
+            details.append(f"{label}: PROBE FAILED {type(exc).__name__}: {exc}")
+
+    probe("wrapper", lambda: "\n" + binary.read_text())
+    probe("executable", lambda: sys.executable)
+    probe(
+        "binary",
+        lambda: f"exists={binary.is_file()} x_ok={os.access(binary, os.X_OK)}",
+    )
+
     env = os.environ.copy()
     env["CLUB_STATE_DIR"] = str(install.state_root / "diag-state")
     env["CLUB_API_TOKEN"] = "diag-token"
     env.pop("CLUB_EXIT_WITH_PARENT", None)
-    proc = subprocess.Popen(
-        [str(binary), "--host", "127.0.0.1", "--port", "18001"],
-        cwd=tempfile.gettempdir(),
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-    )
+    probe("STUB_HEALTH", lambda: env.get("STUB_HEALTH"))
+
+    port = _free_diagnostic_port()
+    probe("diagnostic port", lambda: port)
+    try:
+        proc = subprocess.Popen(
+            [str(binary), "--host", "127.0.0.1", "--port", str(port)],
+            cwd=tempfile.gettempdir(),
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except Exception as exc:
+        details.append(f"launch: FAILED {type(exc).__name__}: {exc}")
+        return details
+
     try:
         time.sleep(0.5)
-        details.append(f"poll after 0.5s: {proc.poll()}")
-        if proc.poll() is None:
+        probe("poll after 0.5s", proc.poll)
+
+        def handshake():
+            conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
             try:
-                conn = http.client.HTTPConnection("127.0.0.1", 18001, timeout=2)
                 conn.request(
                     "GET", "/v1/health", headers={"X-Club-Token": "diag-token"}
                 )
                 resp = conn.getresponse()
-                details.append(f"http {resp.status} {resp.read()!r}")
+                return f"{resp.status} {resp.read()!r}"
+            finally:
                 conn.close()
-            except Exception as exc:
-                details.append(f"http error: {type(exc).__name__}: {exc}")
-        stdout, stderr = proc.communicate(timeout=2)
-        details.append(f"stdout: {stdout!r}")
-        details.append(f"stderr: {stderr!r}")
+
+        if proc.poll() is None:
+            probe("http", handshake)
+        else:
+            details.append("http: skipped, process already exited")
     finally:
+        # Kill first. The stub serves forever, so reading its output before
+        # ending it is a guaranteed timeout, which is the original bug.
         if proc.poll() is None:
             proc.kill()
-            proc.wait(timeout=5)
-    raise AssertionError("health handshake failed\n" + "\n".join(details))
+        try:
+            stdout, stderr = proc.communicate(timeout=5)
+            details.append(f"stdout: {stdout!r}")
+            details.append(f"stderr: {stderr!r}")
+        except Exception as exc:
+            details.append(f"stdout: UNREADABLE {type(exc).__name__}: {exc}")
+            details.append("stderr: UNREADABLE")
+
+    return details
+
+
+def _free_diagnostic_port() -> int:
+    """A port nobody else holds, so a busy runner cannot fail the probe."""
+    import socket
+
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
 
 
 def test_a_sidecar_that_answers_the_health_handshake_passes(tmp_path):
@@ -174,3 +228,32 @@ def test_the_launch_check_never_opens_the_operators_state(tmp_path):
         os.environ.pop("STUB_HEALTH", None)
     assert marker.read_bytes() == b"operator state"
     assert sorted(item.name for item in install.state_root.iterdir()) == ["club.db"]
+
+
+# --------------------------------------------------------------------------
+# Issue #140 - the diagnostic that explains a failed handshake must actually
+# reach the operator. It used to die inside itself and take the diagnosis
+# with it, which is why the CI failure went unexplained for six days.
+# --------------------------------------------------------------------------
+
+
+def test_the_health_diagnostic_reports_instead_of_dying_inside_itself(tmp_path):
+    """The stub serves forever, so anything that waits for it to exit hangs.
+
+    `_assert_healthy` collected a useful `details` list and then called
+    `communicate()` on a process that never exits. The resulting
+    TimeoutExpired replaced the diagnosis with a subprocess error.
+    """
+    install = _install_with_sidecar(tmp_path, health="degraded")
+    try:
+        with pytest.raises(AssertionError) as caught:
+            _assert_healthy(install, timeout=5.0)
+    finally:
+        os.environ.pop("STUB_HEALTH", None)
+
+    report = str(caught.value)
+    assert "health handshake failed" in report
+    # The things a reader needs in order to act, not just that it broke.
+    assert "wrapper:" in report
+    assert "poll after" in report
+    assert "stdout:" in report

--- a/desktop/tests/test_update_health.py
+++ b/desktop/tests/test_update_health.py
@@ -64,6 +64,20 @@ class Handler(BaseHTTPRequestHandler):
 class ReuseHTTPServer(HTTPServer):
     allow_reuse_address = True
 
+    def handle_error(self, request, client_address):
+        import traceback
+        traceback.print_exc(file=sys.stderr)
+        sys.stderr.flush()
+
+import socket, time as _t
+_t0 = _t.monotonic()
+try:
+    socket.getfqdn("127.0.0.1")
+    _fqdn = f"{_t.monotonic() - _t0:.2f}s"
+except Exception as _exc:
+    _fqdn = f"failed {_exc}"
+print(f"getfqdn took {_fqdn}", file=sys.stderr, flush=True)
+
 parser = argparse.ArgumentParser()
 parser.add_argument("--host", default="127.0.0.1")
 parser.add_argument("--port", type=int, required=True)
@@ -145,18 +159,32 @@ def _health_diagnostics(install) -> list[str]:
         time.sleep(0.5)
         probe("poll after 0.5s", proc.poll)
 
+        def raw_connect():
+            import socket as _s
+
+            started = time.monotonic()
+            with _s.create_connection(("127.0.0.1", port), timeout=5):
+                return f"tcp connect ok in {time.monotonic() - started:.2f}s"
+
         def handshake():
-            conn = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+            started = time.monotonic()
+            conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
             try:
                 conn.request(
                     "GET", "/v1/health", headers={"X-Club-Token": "diag-token"}
                 )
+                sent = time.monotonic() - started
                 resp = conn.getresponse()
-                return f"{resp.status} {resp.read()!r}"
+                body = resp.read()
+                return (
+                    f"{resp.status} {body!r} "
+                    f"(request {sent:.2f}s, total {time.monotonic() - started:.2f}s)"
+                )
             finally:
                 conn.close()
 
         if proc.poll() is None:
+            probe("tcp", raw_connect)
             probe("http", handshake)
         else:
             details.append("http: skipped, process already exited")


### PR DESCRIPTION
Refs #140. Does not fix the CI failure; makes the next run say what it is.

## Problem

`_assert_healthy` exists to explain a failed sidecar handshake. It could never do it.

```python
stdout, stderr = proc.communicate(timeout=2)   # on a stub ending in serve_forever()
```

The process never exits, so this always raised `TimeoutExpired` and threw away the `details` list assembled immediately above it. Every failure surfaced as a subprocess error rather than a diagnosis. That is why #140 has been unexplained since #122.

Reproduced locally first. The degraded-health stub stays alive the same way, and the helper raised the identical error CI showed:

```
subprocess.TimeoutExpired: Command '[...sourcecado-sidecar, --host, 127.0.0.1, --port, 18001]' timed out after 2 seconds
```

## Changes

- **Kill before reading.** The stub serves forever; ending it first is the actual fix.
- **Every probe is individually guarded.** A diagnostic that raises replaces the diagnosis with its own error. That class of bug is now impossible here.
- **Free port instead of hardcoded 18001**, so a busy runner cannot fail the probe for an unrelated reason.
- Reports `STUB_HEALTH` and the chosen port, which the old version did not.

## What a reader now gets

```
health handshake failed
wrapper:
#!/bin/sh
exec /.../python /.../health-stub.py "$@"
executable: /.../python
binary: exists=True x_ok=True
STUB_HEALTH: degraded
diagnostic port: 57102
poll after 0.5s: None
http: 200 b'{"status": "degraded", ...}'
stdout: ''
stderr: ''
```

On the CI runner one of those lines will differ, and that difference is the cause of #140.

## Measurements

```
1918 passed, 3 skipped in 76.31s
6 passed    # tests/test_update_health.py
```

New test `test_the_health_diagnostic_reports_instead_of_dying_inside_itself` asserts the helper raises `AssertionError` carrying `wrapper:`, `poll after`, and `stdout:` rather than a subprocess error. It failed before this change with the exact CI error.

## Still wrong, and not in this PR

**#140 is not fixed.** The two health tests still fail on CI. This PR only makes the failure legible. The fix follows once the next run prints the dump.

**The macos-preview job still aborts at step 5**, so Track 1 of #134 remains blocked until the real cause is found and fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FPQdAEbGfrwhHXzW1Yp6tp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health-check failure reporting with clearer diagnostic details.
  * Prevented diagnostics from hanging or failing while investigating unhealthy services.
  * Added safer cleanup and bounded output collection for failed health checks.

* **Tests**
  * Added regression coverage for reporting diagnostics from long-running unhealthy services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->