### PR TITLE
P0: Recover stale restored conversations

### DIFF
--- a/desktop/surfaces/gui/src/app/AppShell.tsx
+++ b/desktop/surfaces/gui/src/app/AppShell.tsx
@@ -14,6 +14,7 @@ import {
 import { BoardView } from "../Board";
 import { PersonFileView } from "../PersonFile";
 import { ChatPage } from "../routes/ChatPage";
+import { moveDraft, readDraft } from "../chat/draftStorage";
 import { ConnectionsPage } from "../routes/ConnectionsPage";
 import { MemoryPage } from "../routes/MemoryPage";
 import { QuarantinePage } from "../routes/QuarantinePage";
@@ -30,6 +31,9 @@ import { readShellCache, writeShellCache } from "./sessionCache";
 
 export function AppShell() {
   const [cachedListing] = useState(() => readShellCache());
+  const cachedChatRestoreHash = cachedListing && isRestorableChatHash(window.location.hash)
+    ? window.location.hash
+    : null;
   const [route, setRoute] = useState(() => parseHash(window.location.hash));
   const [sessions, setSessions] = useState<SessionRow[] | null>(cachedListing?.sessions || null);
   const [openSessionId, setOpenSessionId] = useState<string | null>(cachedListing?.open_id || null);
@@ -46,8 +50,10 @@ export function AppShell() {
   const railFocusTimerRef = useRef<number | null>(null);
   const railWasOpenedRef = useRef(false);
   const searchReturnFocusRef = useRef<HTMLElement | null>(null);
-  const deferDestinationPersistenceRef = useRef(isRootHash(window.location.hash));
-  const cachedRestoreHashRef = useRef<string | null>(null);
+  const deferDestinationPersistenceRef = useRef(
+    isRootHash(window.location.hash) || Boolean(cachedChatRestoreHash),
+  );
+  const bootRestoreHashRef = useRef<string | null>(cachedChatRestoreHash);
   function openSearch() {
     searchReturnFocusRef.current =
       document.activeElement instanceof HTMLElement ? document.activeElement : null;
@@ -93,8 +99,8 @@ export function AppShell() {
   useEffect(() => {
     if (deferDestinationPersistenceRef.current) return;
     if (isRootHash(window.location.hash)) return;
-    if (cachedRestoreHashRef.current === window.location.hash) return;
-    cachedRestoreHashRef.current = null;
+    if (bootRestoreHashRef.current === window.location.hash) return;
+    bootRestoreHashRef.current = null;
     if (route.kind === "chat" && route.sessionId?.startsWith("sched-")) return;
     setLastDestination(window.location.hash).catch(() => {});
   }, [route]);
@@ -217,24 +223,70 @@ export function AppShell() {
       const restored = cachedListing.last_destination ||
         (cachedListing.open_id ? `#/chat/${encodeURIComponent(cachedListing.open_id)}` : "");
       if (restored) {
-        cachedRestoreHashRef.current = restored;
+        bootRestoreHashRef.current = restored;
         window.location.hash = restored;
         setRoute(parseHash(restored));
       } else if (cachedListing.sessions.length > 0) {
-        cachedRestoreHashRef.current = "#/chat";
+        bootRestoreHashRef.current = "#/chat";
         window.location.hash = "#/chat";
         setRoute({ kind: "chat" });
       }
     }
     getSessions()
-      .then((listing) => {
+      .then(async (listing) => {
         if (!active) return;
+        const restoreRoute = bootRestoreHashRef.current
+          ? parseHash(bootRestoreHashRef.current)
+          : null;
+        const missingRestoreSessionId = restoreRoute?.kind === "chat" &&
+          restoreRoute.sessionId &&
+          !listing.sessions.some((session) => session.session_id === restoreRoute.sessionId)
+            ? restoreRoute.sessionId
+            : null;
+        const hasRecoverableDraft = Boolean(
+          missingRestoreSessionId && readDraft(missingRestoreSessionId),
+        );
+        if (
+          missingRestoreSessionId &&
+          (hasRecoverableDraft || listing.sessions.length === 0)
+        ) {
+          const created = await createSession();
+          if (!active) return;
+          if (hasRecoverableDraft) {
+            moveDraft(missingRestoreSessionId, created.id);
+          }
+          const now = new Date().toISOString();
+          const recoveredSession: SessionRow = {
+            session_id: created.id,
+            title: created.title,
+            n_msgs: created.n_msgs,
+            pinned: false,
+            opened_at: now,
+            updated_at: now,
+          };
+          const recoveredHash = `#/chat/${encodeURIComponent(created.id)}`;
+          const recoveredListing = {
+            sessions: [recoveredSession, ...listing.sessions],
+            open_id: created.id,
+            last_destination: recoveredHash,
+          };
+          setSessions(recoveredListing.sessions);
+          setOpenSessionId(created.id);
+          setStale(false);
+          writeShellCache(recoveredListing);
+          window.location.hash = recoveredHash;
+          setRoute(parseHash(recoveredHash));
+          bootRestoreHashRef.current = null;
+          deferDestinationPersistenceRef.current = false;
+          setBootPending(false);
+          return;
+        }
         setSessions(listing.sessions);
         setOpenSessionId(listing.open_id);
         setStale(false);
         writeShellCache(listing);
         const currentHash = window.location.hash;
-        const cacheStillOwnsHash = cachedRestoreHashRef.current === currentHash;
+        const cacheStillOwnsHash = bootRestoreHashRef.current === currentHash;
         if (isRootHash(currentHash) || cacheStillOwnsHash) {
           const restored = restoreHash(listing);
           if (restored) {
@@ -245,7 +297,7 @@ export function AppShell() {
             setRoute({ kind: "chat" });
           }
         }
-        cachedRestoreHashRef.current = null;
+        bootRestoreHashRef.current = null;
         deferDestinationPersistenceRef.current = false;
         setBootPending(false);
       })
@@ -279,7 +331,7 @@ export function AppShell() {
   } else if (
     bootPending &&
     route.kind === "chat" &&
-    cachedRestoreHashRef.current === window.location.hash
+    bootRestoreHashRef.current === window.location.hash
   ) {
     outlet = (
       <main className="route-page boot-page" aria-busy="true">
@@ -385,6 +437,13 @@ export function AppShell() {
 
 function isRootHash(hash: string) {
   return hash === "" || hash === "#" || hash === "#/";
+}
+
+function isRestorableChatHash(hash: string): boolean {
+  const route = parseHash(hash);
+  return route.kind === "chat" &&
+    Boolean(route.sessionId) &&
+    !route.sessionId?.startsWith("sched-");
 }
 
 function restoreHash(listing: {

--- a/desktop/surfaces/gui/src/app/AppShell.tsx
+++ b/desktop/surfaces/gui/src/app/AppShell.tsx
@@ -36,6 +36,7 @@ export function AppShell() {
   const [searchOpen, setSearchOpen] = useState(false);
   const [bootError, setBootError] = useState<string | null>(null);
   const [bootAttempt, setBootAttempt] = useState(0);
+  const [bootPending, setBootPending] = useState(true);
   const [stale, setStale] = useState(Boolean(cachedListing));
   const [railOpen, setRailOpen] = useState(false);
   const [scheduledApprovalCount, setScheduledApprovalCount] = useState(0);
@@ -211,6 +212,7 @@ export function AppShell() {
   useEffect(() => {
     let active = true;
     setBootError(null);
+    setBootPending(true);
     if (cachedListing && isRootHash(window.location.hash)) {
       const restored = cachedListing.last_destination ||
         (cachedListing.open_id ? `#/chat/${encodeURIComponent(cachedListing.open_id)}` : "");
@@ -234,24 +236,23 @@ export function AppShell() {
         const currentHash = window.location.hash;
         const cacheStillOwnsHash = cachedRestoreHashRef.current === currentHash;
         if (isRootHash(currentHash) || cacheStillOwnsHash) {
-          const restored = listing.last_destination ||
-            (listing.open_id ? `#/chat/${encodeURIComponent(listing.open_id)}` : "");
+          const restored = restoreHash(listing);
           if (restored) {
             window.location.hash = restored;
             setRoute(parseHash(restored));
-          } else if (listing.sessions.length > 0) {
-            // Sessions exist but neither open_id nor last_destination named one:
-            // escape the root "Restoring workspace" skeleton instead of hanging on it.
-            window.location.hash = "#/chat";
+          } else if (cacheStillOwnsHash) {
+            window.location.hash = "#/";
             setRoute({ kind: "chat" });
           }
         }
         cachedRestoreHashRef.current = null;
         deferDestinationPersistenceRef.current = false;
+        setBootPending(false);
       })
       .catch((error: unknown) => {
         if (!active) return;
         deferDestinationPersistenceRef.current = false;
+        setBootPending(false);
         setBootError(error instanceof Error ? error.message : String(error));
       });
     return () => {
@@ -269,6 +270,17 @@ export function AppShell() {
   } else if (isRootHash(window.location.hash) && sessions?.length === 0) {
     outlet = <WelcomePage onStartChat={() => void handleNewChat()} />;
   } else if (isRootHash(window.location.hash)) {
+    outlet = (
+      <main className="route-page boot-page" aria-busy="true">
+        <h1>Sourcecado</h1>
+        <div className="route-skeleton" aria-label="Restoring workspace" />
+      </main>
+    );
+  } else if (
+    bootPending &&
+    route.kind === "chat" &&
+    cachedRestoreHashRef.current === window.location.hash
+  ) {
     outlet = (
       <main className="route-page boot-page" aria-busy="true">
         <h1>Sourcecado</h1>
@@ -373,4 +385,27 @@ export function AppShell() {
 
 function isRootHash(hash: string) {
   return hash === "" || hash === "#" || hash === "#/";
+}
+
+function restoreHash(listing: {
+  sessions: SessionRow[];
+  open_id: string | null;
+  last_destination?: string | null;
+}): string {
+  const sessionIds = new Set(listing.sessions.map((session) => session.session_id));
+  const lastDestination = listing.last_destination || "";
+  if (lastDestination) {
+    const lastRoute = parseHash(lastDestination);
+    if (lastRoute.kind !== "chat") return lastDestination;
+    if (lastRoute.sessionId && sessionIds.has(lastRoute.sessionId)) {
+      return lastDestination;
+    }
+  }
+  if (listing.open_id && sessionIds.has(listing.open_id)) {
+    return `#/chat/${encodeURIComponent(listing.open_id)}`;
+  }
+  const firstSession = listing.sessions[0];
+  return firstSession
+    ? `#/chat/${encodeURIComponent(firstSession.session_id)}`
+    : "";
 }

--- a/desktop/surfaces/gui/src/chat/ThreadView.tsx
+++ b/desktop/surfaces/gui/src/chat/ThreadView.tsx
@@ -115,7 +115,7 @@ export function ThreadView({
         ) : loadError ? (
           <div className="sourcecado-load-error" role="alert">
             <p>We couldn’t load this conversation.</p>
-            <p>Your draft is still here. Retry when the sidecar is available.</p>
+            <p>Your draft is still here. Retry, or choose another conversation.</p>
             <button type="button" onClick={onRetry}>
               Retry loading conversation
             </button>

--- a/desktop/surfaces/gui/src/chat/draftStorage.ts
+++ b/desktop/surfaces/gui/src/chat/draftStorage.ts
@@ -1,0 +1,34 @@
+function draftKey(threadId: string): string {
+  return `sourcecado.chat.draft.v1:${encodeURIComponent(threadId)}`;
+}
+
+export function readDraft(threadId: string): string {
+  if (!threadId) return "";
+  try {
+    return window.localStorage.getItem(draftKey(threadId)) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+export function writeDraft(threadId: string, draft: string): void {
+  if (!threadId) return;
+  try {
+    if (draft) window.localStorage.setItem(draftKey(threadId), draft);
+    else window.localStorage.removeItem(draftKey(threadId));
+  } catch {
+    // Draft persistence is best-effort; the live composer remains usable.
+  }
+}
+
+export function moveDraft(fromThreadId: string, toThreadId: string): boolean {
+  const draft = readDraft(fromThreadId);
+  if (!draft || !toThreadId) return false;
+  try {
+    window.localStorage.setItem(draftKey(toThreadId), draft);
+    window.localStorage.removeItem(draftKey(fromThreadId));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/desktop/surfaces/gui/src/routes/ChatPage.tsx
+++ b/desktop/surfaces/gui/src/routes/ChatPage.tsx
@@ -27,6 +27,7 @@ import {
 } from "../chat/persistedQueue";
 import { SourcecadoChatStore } from "../chat/store";
 import { ThreadView } from "../chat/ThreadView";
+import { readDraft, writeDraft } from "../chat/draftStorage";
 import {
   RecoveryProvider,
   type RecoveryAction,
@@ -40,29 +41,6 @@ function appendText(message: AppendMessage): string {
     .map((part) => (part.type === "text" ? part.text : ""))
     .join("")
     .trim();
-}
-
-function draftKey(threadId: string): string {
-  return `sourcecado.chat.draft.v1:${encodeURIComponent(threadId)}`;
-}
-
-function readDraft(threadId: string): string {
-  if (!threadId) return "";
-  try {
-    return window.localStorage.getItem(draftKey(threadId)) ?? "";
-  } catch {
-    return "";
-  }
-}
-
-function writeDraft(threadId: string, draft: string): void {
-  if (!threadId) return;
-  try {
-    if (draft) window.localStorage.setItem(draftKey(threadId), draft);
-    else window.localStorage.removeItem(draftKey(threadId));
-  } catch {
-    // Draft persistence is best-effort; the live composer remains usable.
-  }
 }
 
 export function ChatPage({

--- a/desktop/surfaces/gui/tests/shell.test.tsx
+++ b/desktop/surfaces/gui/tests/shell.test.tsx
@@ -454,6 +454,148 @@ describe("App shell routing", () => {
     expect(screen.queryByText("We couldn’t load this conversation.")).not.toBeInTheDocument();
   });
 
+  it("reconciles a webview-restored person chat hash before loading it", async () => {
+    window.location.hash = "#/chat/missing/person/person-old";
+    window.localStorage.setItem("sourcecado.shell.sessions.v1", JSON.stringify({
+      sessions: [
+        {
+          session_id: "missing",
+          title: "Stale person chat",
+          n_msgs: 2,
+          pinned: false,
+          opened_at: "1",
+          updated_at: "1",
+        },
+      ],
+      open_id: "missing",
+      last_destination: "#/chat/missing/person/person-old",
+    }));
+    const listing = deferred<{
+      sessions: Array<{
+        session_id: string;
+        title: string;
+        n_msgs: number;
+        pinned: boolean;
+        opened_at: string;
+        updated_at: string;
+      }>;
+      open_id: string;
+      last_destination: string;
+    }>();
+    api.getSessions.mockReturnValue(listing.promise);
+    api.getSession.mockImplementation(async (id: string) => {
+      if (id === "missing") throw new Error("session 404");
+      return { id, title: "Alpha", messages: [], events: [] };
+    });
+
+    render(<App />);
+
+    await waitFor(() => expect(api.getSessions).toHaveBeenCalledTimes(1));
+    expect(api.getSession).not.toHaveBeenCalled();
+
+    listing.resolve({
+      sessions: [
+        {
+          session_id: "alpha",
+          title: "Alpha",
+          n_msgs: 1,
+          pinned: false,
+          opened_at: "2",
+          updated_at: "2",
+        },
+      ],
+      open_id: "alpha",
+      last_destination: "#/chat/missing/person/person-old",
+    });
+
+    await waitFor(() => expect(window.location.hash).toBe("#/chat/alpha"));
+    await waitFor(() => expect(api.getSession).toHaveBeenCalledWith("alpha"));
+    expect(api.getSession).not.toHaveBeenCalledWith("missing", "person-old");
+  });
+
+  it("recovers a stale person-chat draft in a new unbound conversation", async () => {
+    window.location.hash = "";
+    window.localStorage.setItem("sourcecado.shell.sessions.v1", JSON.stringify({
+      sessions: [
+        {
+          session_id: "missing",
+          title: "Stale person chat",
+          n_msgs: 2,
+          pinned: false,
+          opened_at: "1",
+          updated_at: "1",
+        },
+      ],
+      open_id: "missing",
+      last_destination: "#/chat/missing/person/person-old",
+    }));
+    window.localStorage.setItem("sourcecado.chat.draft.v1:missing", "Unsent note");
+    api.getSessions.mockResolvedValue({
+      sessions: [
+        {
+          session_id: "alpha",
+          title: "Another person",
+          n_msgs: 1,
+          pinned: false,
+          opened_at: "2",
+          updated_at: "2",
+        },
+      ],
+      open_id: "alpha",
+      last_destination: "#/chat/missing/person/person-old",
+    });
+    api.createSession.mockResolvedValue({ id: "recovered-draft", title: null, n_msgs: 0 });
+    api.getSession.mockImplementation(async (id: string) => ({
+      id,
+      title: null,
+      messages: [],
+      events: [],
+    }));
+
+    render(<App />);
+
+    await waitFor(() => expect(api.createSession).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(window.location.hash).toBe("#/chat/recovered-draft"));
+    expect(await screen.findByLabelText("Message Sourcecado")).toHaveValue("Unsent note");
+    expect(api.getSession).not.toHaveBeenCalledWith("alpha");
+  });
+
+  it("creates a usable empty conversation when no restored session survives", async () => {
+    window.location.hash = "";
+    window.localStorage.setItem("sourcecado.shell.sessions.v1", JSON.stringify({
+      sessions: [
+        {
+          session_id: "missing",
+          title: "Stale chat",
+          n_msgs: 2,
+          pinned: false,
+          opened_at: "1",
+          updated_at: "1",
+        },
+      ],
+      open_id: "missing",
+      last_destination: "#/chat/missing",
+    }));
+    api.getSessions.mockResolvedValue({
+      sessions: [],
+      open_id: null,
+      last_destination: "#/chat/missing",
+    });
+    api.createSession.mockResolvedValue({ id: "new-chat", title: null, n_msgs: 0 });
+    api.getSession.mockResolvedValue({
+      id: "new-chat",
+      title: null,
+      messages: [],
+      events: [],
+    });
+
+    render(<App />);
+
+    await waitFor(() => expect(api.createSession).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(window.location.hash).toBe("#/chat/new-chat"));
+    expect(await screen.findByLabelText("Message Sourcecado")).toBeEnabled();
+  });
+
   it("does not persist a cached destination before fresh session state resolves", async () => {
     window.location.hash = "";
     window.localStorage.setItem("sourcecado.shell.sessions.v1", JSON.stringify({

--- a/desktop/surfaces/gui/tests/shell.test.tsx
+++ b/desktop/surfaces/gui/tests/shell.test.tsx
@@ -394,6 +394,66 @@ describe("App shell routing", () => {
     );
   });
 
+  it("reconciles a cached person chat against fresh sessions before loading it", async () => {
+    window.location.hash = "";
+    window.localStorage.setItem("sourcecado.shell.sessions.v1", JSON.stringify({
+      sessions: [
+        {
+          session_id: "missing",
+          title: "Stale person chat",
+          n_msgs: 2,
+          pinned: false,
+          opened_at: "1",
+          updated_at: "1",
+        },
+      ],
+      open_id: "missing",
+      last_destination: "#/chat/missing/person/person-old",
+    }));
+    const listing = deferred<{
+      sessions: Array<{
+        session_id: string;
+        title: string;
+        n_msgs: number;
+        pinned: boolean;
+        opened_at: string;
+        updated_at: string;
+      }>;
+      open_id: string;
+      last_destination: string;
+    }>();
+    api.getSessions.mockReturnValue(listing.promise);
+    api.getSession.mockImplementation(async (id: string) => {
+      if (id === "missing") throw new Error("session 404");
+      return { id, title: "Alpha", messages: [], events: [] };
+    });
+
+    render(<App />);
+
+    await waitFor(() => expect(api.getSessions).toHaveBeenCalledTimes(1));
+    expect(api.getSession).not.toHaveBeenCalled();
+
+    listing.resolve({
+      sessions: [
+        {
+          session_id: "alpha",
+          title: "Alpha",
+          n_msgs: 1,
+          pinned: false,
+          opened_at: "2",
+          updated_at: "2",
+        },
+      ],
+      open_id: "alpha",
+      last_destination: "#/chat/missing/person/person-old",
+    });
+
+    await waitFor(() => expect(window.location.hash).toBe("#/chat/alpha"));
+    await waitFor(() => expect(api.getSession).toHaveBeenCalledWith("alpha"));
+    expect(api.getSession).not.toHaveBeenCalledWith("missing", "person-old");
+    expect(screen.queryByText("We couldn’t load this conversation.")).not.toBeInTheDocument();
+  });
+
   it("does not persist a cached destination before fresh session state resolves", async () => {
     window.location.hash = "";
     window.localStorage.setItem("sourcecado.shell.sessions.v1", JSON.stringify({
@@ -630,6 +690,24 @@ describe("App shell routing", () => {
 
     expect(await screen.findByText("This conversation is unavailable.")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open most recent conversation" })).toHaveAttribute("href", "#/chat/alpha");
+  });
+
+  it("does not blame the sidecar when a person-bound conversation is missing", async () => {
+    window.location.hash = "#/chat/missing/person/person-old";
+    api.getSessions.mockResolvedValue({
+      sessions: [
+        { session_id: "alpha", title: "Alpha", n_msgs: 2, pinned: false, opened_at: "1", updated_at: "1" },
+      ],
+      open_id: "alpha",
+      last_destination: "#/chat/alpha",
+    });
+    api.getSession.mockRejectedValue(new Error("session 404"));
+
+    render(<App />);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Your draft is still here. Retry, or choose another conversation.");
+    expect(alert).not.toHaveTextContent("sidecar");
   });
 
   it("moves an opened thread to the front of recent navigation", async () => {


### PR DESCRIPTION
## Summary

- hold cached and WKWebView-retained chat destinations behind the authoritative first session refresh
- validate saved chat routes against fresh session IDs and fall back to a valid open or recent conversation
- recover a stranded draft in a fresh unbound conversation instead of copying person-specific text into another person's chat
- create a usable empty conversation automatically when no saved session survives
- stop telling the operator that a missing conversation means the sidecar is unavailable
- cover cold launch, ordinary reopen, draft survival, empty recovery, and missing-conversation copy with regressions

## Verification

- `npm test` — 58 files and 526 tests passed
- `npm run build` — TypeScript and Vite production build passed
- `git diff --check` — passed

## Follow-up acceptance

The packaged-preview cold-launch and quit/reopen smoke check remains under #134 once CI produces the updated artifact.

Addresses #147