### PR TITLE
P1: Show kept people in the Board backlog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ The active runtime is `desktop/`. The previous hosted Next.js/Postgres applicati
 - Build the local Sourcecado desktop product: Python/FastAPI sidecar plus React/Vite/Tauri UI.
 - Optimize for one sourcing director now while keeping person files intelligible to a later officer.
 - A sequence is a person being worked through Open, In conversation, and Done. A company is context, not a deal.
+- A kept person appears in the Board's Backlog before outreach. Backlog is a Board lane, not a sequence state.
 - Apollo search may return candidates without an email. Enrichment is manual and credit-aware.
 - Sending is allowed only after explicit review and approval in Sourcecado. Never add auto-send.
 - Keep Gmail, Drive, Calendar, Granola, Apollo, and web work attached to the relevant person and run ledger.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -63,7 +63,7 @@ The accumulated person files, outcomes, source-backed notes, and handoffs that p
 The home surface where the director gives targets, asks questions, reviews work, and tells the assistant what to do next.
 
 **Board**
-The assistant's operating picture of sequences in Open, In conversation, and Done. It reports the work; it is not a CRM the director must constantly maintain.
+The assistant's operating picture of kept people and active sequences. A kept person appears in Backlog before outreach; active sequences remain Open, In conversation, and Done. Backlog is not a fourth sequence state. The Board reports the work; it is not a CRM the director must constantly maintain.
 
 **Person View**
 The full person file and handoff record. A compact version of the living brief may appear beside work in other surfaces.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The current product is the Python sidecar and React/Tauri desktop app in `deskto
 - Chat is home: the sourcing director gives Sourcecado a target and works with the assistant in a thread.
 - Apollo supplies candidate people; enrichment is deliberate because it spends credits.
 - Gmail, Drive, Calendar, Granola, and web research add context to a person file.
-- The board tracks people through Open, In conversation, and Done.
+- The board shows kept people in Backlog, then tracks active sequences through Open, In conversation, and Done.
 - Sending requires a human approval in Sourcecado. There is no auto-send or background bulk enrichment.
 - State and credentials remain local for the current one-operator build.
 

--- a/desktop/coworker/people.py
+++ b/desktop/coworker/people.py
@@ -18,6 +18,7 @@ _SID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 SCHEMA_VERSION = 1
 
 SEQUENCE_STATES = ("open", "in_conversation", "done")
+BOARD_LANES = ("backlog", *SEQUENCE_STATES)
 ACTORS = ("director", "assistant")
 ATTACHMENT_TYPES = frozenset({"artifact", "knowledge_gap", "source_ref"})
 PERSON_PATCH_FIELDS = frozenset(
@@ -1002,14 +1003,12 @@ class PersonStore:
         return person
 
     def list_board(self) -> dict[str, list[dict[str, Any]]]:
-        board: dict[str, list[dict[str, Any]]] = {
-            state: [] for state in SEQUENCE_STATES
-        }
+        board: dict[str, list[dict[str, Any]]] = {lane: [] for lane in BOARD_LANES}
         with self._lock:
             rows = self._conn.execute(
                 """
                 SELECT * FROM people
-                WHERE sequence_state IS NOT NULL AND deleted_at IS NULL
+                WHERE deleted_at IS NULL
                 ORDER BY updated_at DESC, person_id
                 """
             ).fetchall()
@@ -1017,7 +1016,13 @@ class PersonStore:
             person = self._person_dict(row)
             assert person is not None
             person.update(self.mail_state(person["person_id"]))
-            board[person["sequence_state"]].append(person)
+            lane = (
+                person["sequence_state"]
+                if person["sequence_state"] in SEQUENCE_STATES
+                else "backlog"
+            )
+            person["board_lane"] = lane
+            board[lane].append(person)
         return board
 
     def list_people(self) -> list[dict[str, Any]]:
@@ -1305,7 +1310,7 @@ class PersonStore:
         people = (
             board[sequence]
             if sequence is not None
-            else [person for state in SEQUENCE_STATES for person in board[state]]
+            else [person for lane in BOARD_LANES for person in board[lane]]
         )
         matched = []
         for person in people:

--- a/desktop/coworker/people.py
+++ b/desktop/coworker/people.py
@@ -578,9 +578,9 @@ class PersonStore:
         """File the durable receipt for one approved send, then open the person.
 
         Keyed on the Gmail message id, so re-filing the same message can never
-        produce a second receipt. Advancing to Open only happens when the person
-        is not already on the board; an in-conversation or done person is left
-        where the director put them.
+        produce a second receipt. Advancing to Open happens when the person is
+        not already in one of the three valid sequence states; an open,
+        in-conversation, or done person is left where the director put them.
         """
         if not message_id.strip():
             raise ValueError("message_id is required")
@@ -632,7 +632,7 @@ class PersonStore:
                     (person_id, external_key),
                 ).fetchone()
             )
-            needs_open = not str(row["sequence_state"] or "").strip()
+            needs_open = row["sequence_state"] not in SEQUENCE_STATES
         person = (
             self.set_sequence(
                 person_id,

--- a/desktop/coworker/reply_filing.py
+++ b/desktop/coworker/reply_filing.py
@@ -262,6 +262,13 @@ def classify(message: dict[str, Any], index: OutboundIndex) -> Verdict:
     for address in _addresses_in(
         message.get("to"), message.get("cc"), message.get("delivered_to")
     ):
+        # The connected sending account is expected on an inbound reply. If a
+        # person file happens to use that same address (for example an
+        # operator-controlled test recipient), it is still not another person
+        # on this reply. Treating it as one would copy another person's
+        # reply-attention gap onto the operator's file.
+        if address in index.accounts:
+            continue
         others |= set(index.people_by_address.get(address, frozenset()))
     others.discard(person_id)
     if others:

--- a/desktop/surfaces/gui/src/Board.tsx
+++ b/desktop/surfaces/gui/src/Board.tsx
@@ -147,8 +147,10 @@ export function BoardView() {
     }
   }
 
+  const backlog = board?.backlog ?? [];
   const empty =
     board !== null &&
+    backlog.length === 0 &&
     board.open.length === 0 &&
     board.in_conversation.length === 0 &&
     board.done.length === 0;
@@ -158,7 +160,7 @@ export function BoardView() {
       <header className="board-page-header">
         <p className="eyebrow">Sourcing workspace</p>
         <h1>Board</h1>
-        <p>Keep active people moving from open research to completed follow-up.</p>
+        <p>Keep sourced people visible from backlog through completed follow-up.</p>
         <div className="board-page-actions">
           <button type="button" disabled={checking} onClick={() => void checkReplies()}>
             {checking ? "Checking for replies…" : "Check for replies"}
@@ -183,6 +185,7 @@ export function BoardView() {
       ) : null}
       {board && !empty ? (
         <div className="board-grid">
+          <Bucket id="backlog" title="Backlog" people={backlog} />
           <Bucket id="open" title="Open" people={board.open} />
           <Bucket
             id="conversation"

--- a/desktop/surfaces/gui/src/api.ts
+++ b/desktop/surfaces/gui/src/api.ts
@@ -362,6 +362,7 @@ export type BoardPerson = {
   title: string | null;
   company: string | null;
   sequence_state: string | null;
+  board_lane?: "backlog" | "open" | "in_conversation" | "done";
   last_contact_at?: string | null;
   last_contact_direction?: "outbound" | "inbound" | null;
   replied?: boolean;
@@ -370,6 +371,7 @@ export type BoardPerson = {
 };
 
 export type Board = {
+  backlog: BoardPerson[];
   open: BoardPerson[];
   in_conversation: BoardPerson[];
   done: BoardPerson[];

--- a/desktop/surfaces/gui/src/styles.css
+++ b/desktop/surfaces/gui/src/styles.css
@@ -27,7 +27,7 @@
 
 .board-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 14px;
   margin-top: 24px;
 }

--- a/desktop/surfaces/gui/tests/boardPerson.test.tsx
+++ b/desktop/surfaces/gui/tests/boardPerson.test.tsx
@@ -185,6 +185,34 @@ describe("Board and person-file routes", () => {
     expect(screen.getByRole("region", { name: "In conversation" })).toHaveTextContent("None");
   });
 
+  it("renders kept people in Backlog without starting their sequence", async () => {
+    api.getBoard.mockResolvedValue({
+      backlog: [
+        {
+          person_id: "person-kept",
+          first_name: "Hudson",
+          last_name: "Liao",
+          title: "CEO",
+          company: "The Hog",
+          sequence_state: null,
+          board_lane: "backlog",
+        },
+      ],
+      open: [],
+      in_conversation: [],
+      done: [],
+    });
+
+    render(<BoardView />);
+
+    const backlog = await screen.findByRole("region", { name: "Backlog" });
+    expect(within(backlog).getByRole("link", { name: /Hudson Liao/ })).toHaveAttribute(
+      "href",
+      "#/people/person-kept",
+    );
+    expect(screen.getByRole("region", { name: "Open" })).toHaveTextContent("None");
+  });
+
   it("updates a person sequence through labeled pressed-state controls", async () => {
     const { container } = render(<PersonFileView personId="person one" />);
 

--- a/desktop/surfaces/gui/tests/boardPersonStyles.test.ts
+++ b/desktop/surfaces/gui/tests/boardPersonStyles.test.ts
@@ -6,7 +6,7 @@ const styles = readFileSync("src/styles.css", "utf8");
 describe("Board and person-file styles", () => {
   it("uses scoped responsive grids and touch-sized sequence controls", () => {
     expect(styles).toMatch(
-      /\.board-grid\s*\{[^}]*grid-template-columns:\s*repeat\(3, minmax\(0, 1fr\)\);/,
+      /\.board-grid\s*\{[^}]*grid-template-columns:\s*repeat\(4, minmax\(0, 1fr\)\);/,
     );
     expect(styles).toMatch(
       /\.person-sequence-action\s*\{[^}]*min-height:\s*44px;/,

--- a/desktop/tests/test_apollo_curation.py
+++ b/desktop/tests/test_apollo_curation.py
@@ -257,6 +257,13 @@ def test_single_candidate_api_binds_original_chat_to_that_person(tmp_path):
     }
     assert kept["sourcing_chat"] == {"session_id": session_id}
     assert app.state.people.person_for_session(session_id) == kept["person_id"]
+    board = TestClient(app).get(
+        "/v1/board",
+        headers={TOKEN_HEADER: TOKEN},
+    ).json()
+    assert [row["person_id"] for row in board["backlog"]] == [kept["person_id"]]
+    assert board["backlog"][0]["sequence_state"] is None
+    assert board["backlog"][0]["board_lane"] == "backlog"
 
 
 def test_retrying_only_failed_multi_rows_never_rebinds_or_updates_successes(tmp_path):

--- a/desktop/tests/test_approved_send.py
+++ b/desktop/tests/test_approved_send.py
@@ -391,6 +391,30 @@ def test_a_send_leaves_an_already_placed_person_where_the_director_put_them(tmp_
     assert app.state.people.get(person_id)["sequence_state"] == "in_conversation"
 
 
+def test_a_send_moves_an_unknown_legacy_state_out_of_backlog(tmp_path):
+    gmail = _gmail()
+    app = _app(tmp_path, gmail)
+    client = TestClient(app)
+    person_id, session_id = _bound_person(app)
+    app.state.people._conn.execute(
+        "UPDATE people SET sequence_state = 'kept' WHERE person_id = ?",
+        (person_id,),
+    )
+    app.state.people._conn.commit()
+    draft = _draft(client, person_id, session_id)
+    item_id = _park(client, person_id, session_id, draft)
+
+    res = _decide(client, item_id)
+
+    assert res.json()["ok"] is True
+    assert res.json()["result"]["advanced_to_open"] is True
+    assert app.state.people.get(person_id)["sequence_state"] == "open"
+    assert [row["person_id"] for row in app.state.people.list_board()["open"]] == [
+        person_id
+    ]
+    assert app.state.people.list_board()["backlog"] == []
+
+
 # --------------------------------------------------------------------------
 # Criterion 6 — deny, cancel, expiry, stale draft, failed submission
 # --------------------------------------------------------------------------

--- a/desktop/tests/test_board_tools.py
+++ b/desktop/tests/test_board_tools.py
@@ -52,7 +52,12 @@ def test_board_upsert_does_not_create_a_person_or_fill_open(tmp_path):
         people=store,
     )
     assert ok is False
-    assert store.list_board() == {"open": [], "in_conversation": [], "done": []}
+    assert store.list_board() == {
+        "backlog": [],
+        "open": [],
+        "in_conversation": [],
+        "done": [],
+    }
 
 
 def test_keeping_then_patching_puts_ada_on_the_person_board(tmp_path):
@@ -430,7 +435,12 @@ def test_delete_hides_the_person_from_the_board_and_keeps_a_receipt(tmp_path):
     )
     assert deleted["deleted"] is True
     assert store.get(ada["person_id"]) is None
-    assert store.list_board() == {"open": [], "in_conversation": [], "done": []}
+    assert store.list_board() == {
+        "backlog": [],
+        "open": [],
+        "in_conversation": [],
+        "done": [],
+    }
     assert store.timeline(ada["person_id"])[-1]["kind"] == "delete"
 
 

--- a/desktop/tests/test_bound_turn.py
+++ b/desktop/tests/test_bound_turn.py
@@ -568,7 +568,12 @@ def test_unbound_enrich_fails_closed(tmp_path):
     assert ok is False
     assert "bind" in result["error"].lower() or "person" in result["error"].lower()
     assert people.get_by_apollo_id("ada") is None
-    assert people.list_board() == {"open": [], "in_conversation": [], "done": []}
+    assert people.list_board() == {
+        "backlog": [],
+        "open": [],
+        "in_conversation": [],
+        "done": [],
+    }
     assert http.calls == []
 
 

--- a/desktop/tests/test_people.py
+++ b/desktop/tests/test_people.py
@@ -112,10 +112,37 @@ def _ada(store: PersonStore) -> dict:
     )
 
 
-def test_person_with_no_sequence_is_not_on_the_board(tmp_path):
+def test_person_with_no_sequence_is_on_the_board_backlog(tmp_path):
     store = PersonStore(tmp_path)
-    _ada(store)
-    assert store.list_board() == {"open": [], "in_conversation": [], "done": []}
+    person = _ada(store)
+
+    board = store.list_board()
+
+    assert person["sequence_state"] is None
+    assert [row["person_id"] for row in board["backlog"]] == [person["person_id"]]
+    assert board["backlog"][0]["board_lane"] == "backlog"
+    assert board["open"] == []
+    assert board["in_conversation"] == []
+    assert board["done"] == []
+
+
+def test_unknown_legacy_sequence_appears_in_backlog_without_outreach(tmp_path):
+    store = PersonStore(tmp_path)
+    person = _ada(store)
+    store._conn.execute(
+        "UPDATE people SET sequence_state = 'kept' WHERE person_id = ?",
+        (person["person_id"],),
+    )
+    store._conn.commit()
+
+    row = store.list_board()["backlog"][0]
+
+    assert row["person_id"] == person["person_id"]
+    assert row["sequence_state"] == "kept"
+    assert row["board_lane"] == "backlog"
+    assert row["last_contact_at"] is None
+    assert row["replied"] is False
+    assert row["follow_up"] == {"needed": False, "reason": None}
 
 
 def test_moving_person_to_open_puts_them_on_the_board(tmp_path):
@@ -142,7 +169,9 @@ def test_unknown_sequence_actor_or_person_is_rejected(tmp_path):
         store.set_sequence(person["person_id"], "open", actor="crm")
     with pytest.raises(ValueError, match="unknown person"):
         store.set_sequence("per_" + "0" * 32, "open", actor="assistant")
-    assert store.list_board() == {"open": [], "in_conversation": [], "done": []}
+    assert [row["person_id"] for row in store.list_board()["backlog"]] == [
+        person["person_id"]
+    ]
     assert store.get(person["person_id"])["sequence_state"] is None
 
 

--- a/desktop/tests/test_people_api.py
+++ b/desktop/tests/test_people_api.py
@@ -502,9 +502,9 @@ def test_get_person_does_not_leak_access_token(tmp_path):
     assert res.json()["timeline"][0]["payload"]["id"] == "d1"
 
 
-def test_empty_board_is_three_empty_lists(tmp_path):
+def test_empty_board_is_four_empty_lists(tmp_path):
     body = TestClient(_app(tmp_path)).get("/v1/board", headers={TOKEN_HEADER: TOKEN}).json()
-    assert body == {"open": [], "in_conversation": [], "done": []}
+    assert body == {"backlog": [], "open": [], "in_conversation": [], "done": []}
     blob = str(body)
     assert "amount" not in blob
     assert "pipeline" not in blob

--- a/desktop/tests/test_reply_filing.py
+++ b/desktop/tests/test_reply_filing.py
@@ -216,6 +216,52 @@ def test_a_reply_on_the_sent_thread_files_on_that_person_and_opens_the_conversat
     assert _gaps(people, person["person_id"]) == []
 
 
+def test_operator_person_file_never_receives_another_persons_reply_attention(tmp_path):
+    people = PersonStore(tmp_path)
+    gmail = _gmail()
+    operator = _person(
+        people,
+        first="Fisher",
+        last="Zhang",
+        email=ACCOUNT,
+        apollo_id="apollo-operator",
+    )
+    bob = _person(
+        people,
+        first="Bob",
+        last="Builder",
+        email="bob@analytic.example",
+        apollo_id="apollo-bob",
+    )
+    sent = _sent(people, gmail, bob)
+    _baseline(people, gmail)
+
+    gmail.deliver(
+        thread_id=sent["threadId"],
+        message_id="in_bob_operator_person_1",
+        sender="bob@analytic.example",
+        to=ACCOUNT,
+        subject="Re: Thursday?",
+        snippet="Thursday works.",
+    )
+    result = refresh_replies(people, _reader(gmail))
+
+    assert result["scanned"] == 1
+    assert result["filed"] == 1
+    assert result["unassigned"] == 0
+    board = people.list_board()
+    operator_row = next(
+        row for row in board["backlog"] if row["person_id"] == operator["person_id"]
+    )
+    bob_row = next(
+        row for row in board["in_conversation"] if row["person_id"] == bob["person_id"]
+    )
+    assert operator_row["replied"] is False
+    assert operator_row["follow_up"] == {"needed": False, "reason": None}
+    assert bob_row["replied"] is True
+    assert bob_row["follow_up"] == {"needed": True, "reason": "reply_unanswered"}
+
+
 def test_a_reply_leaves_a_person_the_director_already_moved_where_they_are(tmp_path):
     people = PersonStore(tmp_path)
     gmail = _gmail()

--- a/docs/superpowers/specs/2026-08-25-sourcecado-sourcing-director-spring.md
+++ b/docs/superpowers/specs/2026-08-25-sourcecado-sourcing-director-spring.md
@@ -49,7 +49,7 @@ Getting a real email address spends Apollo credits. The director does that on pu
 
 ### 3. Keep work in motion
 
-Outreach is not one email and a prayer. Each person we are working is a sequence. The assistant keeps the picture of what is open, what is in conversation, and what is done, so the director is not reconstructing it from Gmail search.
+Outreach is not one email and a prayer. A person the director keeps appears in the Board's Backlog before outreach starts. Each person we are actively working is a sequence. The assistant keeps the picture of what is waiting in Backlog, what is open, what is in conversation, and what is done, so the director is not reconstructing it from Gmail search.
 
 Follow-ups, "what did we last say," and "is this still alive" are the assistant's job. The conversation itself stays human.
 
@@ -69,7 +69,7 @@ The director opens Sourcecado and is in the thread with the assistant.
 
 They can say the target and get people back. They can say "write this one" and get a draft. They can say "what do I need for this conversation" and the brief is already on the person.
 
-When they want the operating picture, they open the dashboard: who is queued to write, which sequences are in conversation, what is done. It is the EA putting the board on the table for the principal. It is not a CRM they have to live in.
+When they want the operating picture, they open the dashboard: who is in Backlog, who is queued to write, which sequences are in conversation, what is done. It is the EA putting the board on the table for the principal. It is not a CRM they have to live in.
 
 When they need the record, they open the person. A small panel of the same brief sits beside whatever they are doing, so they do not have to leave the work to remember who this is.
 
@@ -123,7 +123,8 @@ These are true. They are not the outline of the work. They exist so an implement
 
 - Chat is home. The operating board is a destination in the rail.
 - A sequence is a person we are working. A company is how we tag that person, not a separate kind of work item. Do not call it a deal.
-- Sequences move Open → In conversation → Done. Three buckets. The director or the assistant moves them.
+- Kept people appear in the Board's Backlog before they enter a sequence. Backlog is a Board lane, not a sequence state.
+- Sequences move Open → In conversation → Done. Exactly three sequence states. The director or the assistant moves them.
 - Intake is Apollo search from a target the director named.
 - A draft may be queued from Apollo fields and the target. Cited web research is welcome in the brief. It is not a gate on drafting.
 - Enrich is manual and director-driven.


### PR DESCRIPTION
## User problem

Kept Apollo people could have durable person files and bound sourcing chats while remaining invisible on the Board until outreach began. The Board therefore hid the director's actual working set.

## What changed

- Added Backlog as a Board lane for active people whose `sequence_state` is null or an unknown legacy value.
- Kept Open, In conversation, and Done as the only sequence states.
- Included Backlog people in unfiltered Board queries while preserving sequence filters.
- Added the Backlog lane to the React Board and expanded the desktop grid to four responsive columns.
- Kept reply and follow-up projection scoped to each durable `person_id`.
- Made approved sends normalize null or unknown legacy states from Backlog to Open.
- Excluded the authenticated sending account from inbound reply candidate matching so another person's reply cannot create attention on an operator-controlled person file.
- Updated the source-of-truth spec and living product docs.

## Boundaries

- Included: Apollo keep to Board visibility, legacy null/unknown projection, Board/API/UI contracts, person-ID continuity, responsive layout, and product wording.
- Explicitly not included: guessing that a person is the operator from their name or company. QA ISSUE-002 owns Apollo candidate eligibility and was not selected.
- Product invariants preserved: Backlog is not a sequence state; no enrichment or send occurs; person files remain the durable object.

## Verification

### Automated tests

- Tests added or updated: person-store Backlog projection, unknown legacy-state projection, Apollo curation/bound-chat/Board identity, Board API shape, Backlog UI, and four-column responsive styling.
- Commands run:
  - `PYTHONPATH=desktop .../pytest -q desktop/tests`
  - `npm test`
  - `npm run build`
  - `git diff --check`
- Results:
  - Python: 1,922 passed, 3 skipped.
  - GUI: 58 files, 527 tests passed.
  - TypeScript/Vite production build passed.
  - Diff check passed.

### Live behavior demonstration

- Starting state: isolated local state with Hudson kept and unsequenced, plus one person in each active sequence state.
- Action performed: launched the sidecar and Vite UI, opened `#/board` in headless Chrome at 1440×1000, and inspected the rendered DOM and screenshot.
- Expected result: Backlog, Open, In conversation, and Done render as four lanes; Hudson appears only in Backlog and links to his durable person file.
- Observed result and evidence: headings were `[Backlog, Open, In conversation, Done]`; Hudson rendered as `Hudson Liao · CEO · The Hog · No contact yet`; his href used the kept `person_id`; computed grid had four equal columns; browser console errors were empty.

## AI Accountability Note

### AI helped with

Tracing the current Board/person-file contracts, implementing the Backlog projection, drafting regression tests, updating product docs, and running verification.

### I verified

The issue and #127 product decision, the source-of-truth spec, the real backend and UI paths, complete Python/GUI suites, production build, responsive DOM shape, person-file link identity, and browser console output.

### I am still uncertain about

The packaged macOS visual pass has not run on this branch. The live Vite/sidecar path and CI artifact build are expected to cover the same Board code.

## Safety and integrations

- [x] No credential, OAuth grant, token, private user data, or raw authorization material was committed or pasted into the PR.
- [x] External effects remain behind the correct permission and approval policy.
- [x] Paid or credit-sensitive actions remain deliberate, approval-gated, and outside mandatory course work.
- [x] Source references and restricted data remain scoped correctly when applicable.

## Reviewer checklist

- [ ] The change matches the ticket and respects its non-goals.
- [ ] The normal and important failure paths are covered.
- [ ] Automated verification is appropriate and passes.
- [ ] The live behavior demonstration is credible when required.
- [ ] The diff is understandable and safe to merge.
- [ ] I am giving meaningful Peer Approval, not a rubber stamp.

Closes #148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a **Backlog** lane to the Board for kept people before outreach begins.
  - People without a valid sequence state now appear in Backlog without starting outreach.
  - Board layout now displays four workflow lanes: Backlog, Open, In conversation, and Done.

- **Bug Fixes**
  - Prevented inbound replies from being incorrectly attributed to the connected sending account.

- **Documentation**
  - Clarified that Backlog is a Board lane, not a sequence state.

- **Tests**
  - Added coverage for Backlog visibility, lane assignment, reply filing, and the four-column layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
