### PR TITLE
P1: Recover the conversation rail on first paint

### DIFF
--- a/desktop/surfaces/gui/src/app/AppShell.tsx
+++ b/desktop/surfaces/gui/src/app/AppShell.tsx
@@ -5,7 +5,6 @@ import {
   getInbox,
   getMemoryBacklog,
   getQuarantinedEffects,
-  getSessions,
   pinSession,
   renameSession,
   setLastDestination,
@@ -28,6 +27,7 @@ import { CommandSearch } from "./CommandSearch";
 import { GlobalRail } from "./GlobalRail";
 import { parseHash } from "./route";
 import { readShellCache, writeShellCache } from "./sessionCache";
+import { getSessionsForBoot } from "./sessionBootstrap";
 
 export function AppShell() {
   const [cachedListing] = useState(() => readShellCache());
@@ -232,7 +232,7 @@ export function AppShell() {
         setRoute({ kind: "chat" });
       }
     }
-    getSessions()
+    getSessionsForBoot(() => active)
       .then(async (listing) => {
         if (!active) return;
         const restoreRoute = bootRestoreHashRef.current
@@ -287,6 +287,9 @@ export function AppShell() {
         writeShellCache(listing);
         const currentHash = window.location.hash;
         const cacheStillOwnsHash = bootRestoreHashRef.current === currentHash;
+        const persistNavigationAfterBoot =
+          deferDestinationPersistenceRef.current &&
+          shouldPersistDestination(currentHash, cacheStillOwnsHash);
         if (isRootHash(currentHash) || cacheStillOwnsHash) {
           const restored = restoreHash(listing);
           if (restored) {
@@ -299,11 +302,23 @@ export function AppShell() {
         }
         bootRestoreHashRef.current = null;
         deferDestinationPersistenceRef.current = false;
+        if (persistNavigationAfterBoot) {
+          setLastDestination(currentHash).catch(() => {});
+        }
         setBootPending(false);
       })
       .catch((error: unknown) => {
         if (!active) return;
+        const currentHash = window.location.hash;
+        const cacheStillOwnsHash = bootRestoreHashRef.current === currentHash;
+        const persistNavigationAfterBoot =
+          deferDestinationPersistenceRef.current &&
+          shouldPersistDestination(currentHash, cacheStillOwnsHash);
+        bootRestoreHashRef.current = null;
         deferDestinationPersistenceRef.current = false;
+        if (persistNavigationAfterBoot) {
+          setLastDestination(currentHash).catch(() => {});
+        }
         setBootPending(false);
         setBootError(error instanceof Error ? error.message : String(error));
       });
@@ -415,7 +430,7 @@ export function AppShell() {
           <button type="button" onClick={() => setBootAttempt((attempt) => attempt + 1)}>Retry</button>
         </div>
       )}
-      {stale && (
+      {stale && !bootPending && (
         <div className="shell-stale" role="status">
           <span>Cached conversations may be stale.</span>
           <button type="button" onClick={() => setBootAttempt((attempt) => attempt + 1)}>Reconnect</button>
@@ -437,6 +452,12 @@ export function AppShell() {
 
 function isRootHash(hash: string) {
   return hash === "" || hash === "#" || hash === "#/";
+}
+
+function shouldPersistDestination(hash: string, bootRestoreOwnsHash: boolean): boolean {
+  if (bootRestoreOwnsHash || isRootHash(hash)) return false;
+  const destination = parseHash(hash);
+  return !(destination.kind === "chat" && destination.sessionId?.startsWith("sched-"));
 }
 
 function isRestorableChatHash(hash: string): boolean {

--- a/desktop/surfaces/gui/src/app/AppShell.tsx
+++ b/desktop/surfaces/gui/src/app/AppShell.tsx
@@ -314,7 +314,9 @@ export function AppShell() {
         const persistNavigationAfterBoot =
           deferDestinationPersistenceRef.current &&
           shouldPersistDestination(currentHash, cacheStillOwnsHash);
-        bootRestoreHashRef.current = null;
+        if (!cacheStillOwnsHash) {
+          bootRestoreHashRef.current = null;
+        }
         deferDestinationPersistenceRef.current = false;
         if (persistNavigationAfterBoot) {
           setLastDestination(currentHash).catch(() => {});

--- a/desktop/surfaces/gui/src/app/sessionBootstrap.ts
+++ b/desktop/surfaces/gui/src/app/sessionBootstrap.ts
@@ -1,0 +1,21 @@
+import { getSessions } from "../api";
+
+const SESSION_LIST_RETRY_DELAYS_MS = [100, 300, 900] as const;
+
+/** Absorb the short sidecar/token startup race without hiding a real outage. */
+export async function getSessionsForBoot(isActive: () => boolean) {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= SESSION_LIST_RETRY_DELAYS_MS.length; attempt += 1) {
+    if (!isActive()) throw lastError ?? new Error("session bootstrap cancelled");
+    try {
+      return await getSessions();
+    } catch (error: unknown) {
+      lastError = error;
+      if (!isActive()) throw error;
+      const delay = SESSION_LIST_RETRY_DELAYS_MS[attempt];
+      if (delay === undefined) throw error;
+      await new Promise<void>((resolve) => window.setTimeout(resolve, delay));
+    }
+  }
+  throw lastError;
+}

--- a/desktop/surfaces/gui/tests/sessionBootstrap.test.ts
+++ b/desktop/surfaces/gui/tests/sessionBootstrap.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getSessionsForBoot } from "../src/app/sessionBootstrap";
+
+describe("session-list bootstrap", () => {
+  afterEach(() => {
+    window.__CLUB_HTTP__ = undefined;
+    window.__CLUB_API_TOKEN__ = undefined;
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the current launch token when a bounded retry runs", async () => {
+    window.__CLUB_HTTP__ = "http://sidecar.test";
+    window.__CLUB_API_TOKEN__ = "old-launch-token";
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        window.__CLUB_API_TOKEN__ = "rotated-launch-token";
+        return { ok: false, status: 401 };
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          sessions: [],
+          open_id: null,
+          last_destination: "#/skills",
+        }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(getSessionsForBoot(() => true)).resolves.toEqual({
+      sessions: [],
+      open_id: null,
+      last_destination: "#/skills",
+    });
+
+    const firstHeaders = fetchMock.mock.calls[0][1].headers as Headers;
+    const secondHeaders = fetchMock.mock.calls[1][1].headers as Headers;
+    expect(firstHeaders.get("X-Club-Token")).toBe("old-launch-token");
+    expect(secondHeaders.get("X-Club-Token")).toBe("rotated-launch-token");
+  });
+});

--- a/desktop/surfaces/gui/tests/shell.test.tsx
+++ b/desktop/surfaces/gui/tests/shell.test.tsx
@@ -897,6 +897,72 @@ describe("App shell routing", () => {
     await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
   });
 
+  it("keeps stale person-chat recovery intact across exhausted retries", async () => {
+    window.location.hash = "";
+    window.localStorage.setItem("sourcecado.shell.sessions.v1", JSON.stringify({
+      sessions: [
+        {
+          session_id: "missing",
+          title: "Stale person chat",
+          n_msgs: 2,
+          pinned: false,
+          opened_at: "1",
+          updated_at: "1",
+        },
+      ],
+      open_id: "missing",
+      last_destination: "#/chat/missing/person/person-old",
+    }));
+    window.localStorage.setItem("sourcecado.chat.draft.v1:missing", "Unsent note");
+    api.getSessions.mockRejectedValue(new Error("sidecar offline"));
+    api.createSession.mockResolvedValue({
+      id: "recovered-draft",
+      title: null,
+      n_msgs: 0,
+    });
+    api.getSession.mockResolvedValue({
+      id: "recovered-draft",
+      title: null,
+      messages: [],
+      events: [],
+    });
+
+    render(<App />);
+
+    const alert = await screen.findByRole("alert", undefined, { timeout: 2_500 });
+    expect(api.getSessions).toHaveBeenCalledTimes(4);
+    api.getSessions.mockResolvedValueOnce({
+      sessions: [
+        {
+          session_id: "alpha",
+          title: "Alpha",
+          n_msgs: 1,
+          pinned: false,
+          opened_at: "2",
+          updated_at: "2",
+        },
+      ],
+      open_id: "alpha",
+      last_destination: "#/chat/missing/person/person-old",
+    });
+    await waitFor(() =>
+      expect(api.getSession).toHaveBeenCalledWith("missing", "person-old"),
+    );
+    const staleLoadsBeforeRetry = api.getSession.mock.calls.filter(
+      ([sessionId, personId]) => sessionId === "missing" && personId === "person-old",
+    ).length;
+    fireEvent.click(within(alert).getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => expect(api.createSession).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(window.location.hash).toBe("#/chat/recovered-draft"));
+    expect(await screen.findByLabelText("Message Sourcecado")).toHaveValue("Unsent note");
+    expect(
+      api.getSession.mock.calls.filter(
+        ([sessionId, personId]) => sessionId === "missing" && personId === "person-old",
+      ),
+    ).toHaveLength(staleLoadsBeforeRetry);
+  });
+
   it("renders cached thread navigation as stale when reconnect fails", async () => {
     window.localStorage.setItem("sourcecado.shell.sessions.v1", JSON.stringify({
       sessions: [

--- a/desktop/surfaces/gui/tests/shell.test.tsx
+++ b/desktop/surfaces/gui/tests/shell.test.tsx
@@ -634,7 +634,10 @@ describe("App shell routing", () => {
     expect(api.setLastDestination).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole("link", { name: "Skills" }));
-    await waitFor(() => expect(api.setLastDestination).toHaveBeenCalledWith("#/skills"));
+    await waitFor(
+      () => expect(api.setLastDestination).toHaveBeenCalledWith("#/skills"),
+      { timeout: 2_500 },
+    );
   });
 
   it("escapes the boot skeleton when sessions exist but no restore target is known", async () => {
@@ -785,19 +788,112 @@ describe("App shell routing", () => {
     expect(document.querySelector("img.app-mark")).toHaveAttribute("src", "/favicon.png");
   });
 
-  it("keeps navigation usable through boot failure and retry", async () => {
+  it("automatically retries a transient first-paint session-list failure", async () => {
+    window.location.hash = "#/skills";
     api.getSessions
-      .mockRejectedValueOnce(new Error("sidecar offline"))
-      .mockResolvedValueOnce({ sessions: [], open_id: null, last_destination: "#/skills" });
+      .mockRejectedValueOnce(new Error("Load failed"))
+      .mockResolvedValueOnce({
+        sessions: [
+          {
+            session_id: "thread-alpha",
+            title: "QA Full User Trail",
+            n_msgs: 4,
+            pinned: false,
+            opened_at: "1",
+            updated_at: "2",
+          },
+        ],
+        open_id: "thread-alpha",
+        last_destination: "#/skills",
+      });
 
     render(<App />);
 
-    const alert = await screen.findByRole("alert");
+    await waitFor(() => expect(api.getSessions).toHaveBeenCalledTimes(2), {
+      timeout: 2_000,
+    });
+    expect(await screen.findByRole("link", { name: "QA Full User Trail" })).toBeInTheDocument();
+    expect(screen.queryByText(/Couldn’t refresh conversations/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Cached conversations may be stale/i)).not.toBeInTheDocument();
+  });
+
+  it("does not call cached conversations stale while a bounded retry is pending", async () => {
+    window.location.hash = "#/skills";
+    window.localStorage.setItem("sourcecado.shell.sessions.v1", JSON.stringify({
+      sessions: [
+        {
+          session_id: "cached",
+          title: "Cached conversation",
+          n_msgs: 3,
+          pinned: false,
+          opened_at: "1",
+          updated_at: "1",
+        },
+      ],
+      open_id: "cached",
+      last_destination: "#/skills",
+    }));
+    const listing = deferred<{
+      sessions: Array<{
+        session_id: string;
+        title: string;
+        n_msgs: number;
+        pinned: boolean;
+        opened_at: string;
+        updated_at: string;
+      }>;
+      open_id: string;
+      last_destination: string;
+    }>();
+    api.getSessions
+      .mockRejectedValueOnce(new Error("Load failed"))
+      .mockReturnValueOnce(listing.promise);
+
+    render(<App />);
+
+    await waitFor(() => expect(api.getSessions).toHaveBeenCalledTimes(2), {
+      timeout: 2_000,
+    });
+    expect(screen.getByRole("link", { name: "Cached conversation" })).toBeInTheDocument();
+    expect(screen.queryByText(/Couldn’t refresh conversations/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Cached conversations may be stale/i)).not.toBeInTheDocument();
+
+    listing.resolve({
+      sessions: [
+        {
+          session_id: "fresh",
+          title: "Fresh conversation",
+          n_msgs: 4,
+          pinned: false,
+          opened_at: "2",
+          updated_at: "2",
+        },
+      ],
+      open_id: "fresh",
+      last_destination: "#/skills",
+    });
+
+    expect(await screen.findByRole("link", { name: "Fresh conversation" })).toBeInTheDocument();
+    expect(screen.queryByText(/Cached conversations may be stale/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps navigation usable after bounded boot retries are exhausted", async () => {
+    api.getSessions.mockRejectedValue(new Error("sidecar offline"));
+
+    render(<App />);
+
+    const alert = await screen.findByRole("alert", undefined, { timeout: 2_500 });
     expect(alert).toHaveTextContent("sidecar offline");
+    expect(api.getSessions).toHaveBeenCalledTimes(4);
     expect(screen.getByRole("navigation", { name: "Sourcecado" })).toBeInTheDocument();
+    api.getSessions.mockResolvedValueOnce({
+      sessions: [],
+      open_id: null,
+      last_destination: "#/skills",
+    });
     fireEvent.click(within(alert).getByRole("button", { name: "Retry" }));
 
-    await waitFor(() => expect(api.getSessions).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(api.getSessions).toHaveBeenCalledTimes(5));
     await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument());
   });
 
@@ -814,7 +910,13 @@ describe("App shell routing", () => {
     render(<App />);
 
     expect(await screen.findByRole("link", { name: "Cached search" })).toBeInTheDocument();
-    expect(screen.getByText(/Cached conversations may be stale/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(
+        /Cached conversations may be stale/i,
+        undefined,
+        { timeout: 2_500 },
+      ),
+    ).toBeInTheDocument();
   });
 
   it("renders a recoverable one-line state for a missing thread", async () => {


### PR DESCRIPTION
## User problem

A short packaged-app startup race could make the first conversation-list request fail once. Sourcecado then left cached rail entries stale until the operator pressed Reconnect, even after the sidecar was healthy.

## What changed

- Added a bounded session-list bootstrap: initial request plus retries after 100 ms, 300 ms, and 900 ms.
- Re-reads the current launch token on every request so token rotation can recover.
- Stops issuing requests after the shell unmounts.
- Keeps cached rail data visible without calling it stale while a retry is still active.
- Shows the existing Retry and Reconnect controls only after the bounded path genuinely fails.
- Persists navigation made while startup refresh is pending instead of losing it when bootstrap settles.
- Preserves #153's stale person-chat and draft recovery marker through retry exhaustion so manual Retry can still reconcile safely.

## Boundaries

- Included: first-paint session-list readiness, bounded retry, token rotation, cached-rail warning timing, cancellation, manual recovery, and startup navigation persistence.
- Explicitly not included: websocket reconnect/failover, provider retry, or session transcript recovery.
- Product invariants preserved: cached data is read-only until authoritative refresh, scheduled transcripts are not persisted as the main destination, and no external effect is executed.

## Verification

### Automated tests

- Tests added or updated: transient first-list recovery, cached warning suppression while pending, bounded exhaustion/manual Retry, stale-cache failure, navigation during bootstrap, cancellation isolation, and rotated-token request headers.
- Commands run:
  - `npm test`
  - `npm run build`
  - `git diff --check`
- Results:
  - GUI: 59 files, 530 tests passed.
  - TypeScript/Vite production build passed.
  - Diff check passed.

### Live behavior demonstration

- Starting state: isolated sidecar state containing “Sourcing · Hudson Liao” and “QA Full User Trail.”
- Action performed: launched the real Vite/FastAPI paths in headless Chrome and aborted the first GET to `/v1/sessions`.
- Expected result: a bounded retry loads the authoritative conversation rail without Reconnect and without leaving an error/stale banner.
- Observed result and evidence: exactly two session-list requests occurred; the rail rendered New conversation, Sourcing · Hudson Liao, and QA Full User Trail; loading ended; alert and stale-banner text were absent; page errors were empty.

## AI Accountability Note

### AI helped with

Reproducing the startup race, designing the bounded retry seam, writing regression coverage, and running browser failure injection.

### I verified

The Tauri token-injection path, dynamic token reads at the API boundary, session-list bootstrap lifecycle, complete GUI suite, production build, failure/exhaustion states, and live rail recovery.

### I am still uncertain about

The exact PyInstaller startup latency distribution on slower Macs. The retry window is 1.3 seconds because the QA run showed the sidecar already serving adjacent endpoints; the packaged artifact should confirm that bound.

## Safety and integrations

- [x] No credential, OAuth grant, token, private user data, or raw authorization material was committed or pasted into the PR.
- [x] External effects remain behind the correct permission and approval policy.
- [x] Paid or credit-sensitive actions remain deliberate, approval-gated, and outside mandatory course work.
- [x] Source references and restricted data remain scoped correctly when applicable.

## Reviewer checklist

- [ ] The change matches the ticket and respects its non-goals.
- [ ] The normal and important failure paths are covered.
- [ ] Automated verification is appropriate and passes.
- [ ] The live behavior demonstration is credible when required.
- [ ] The diff is understandable and safe to merge.
- [ ] I am giving meaningful Peer Approval, not a rubber stamp.

Closes #149


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initial session loading with automatic retries for temporary failures.
  * Preserved cached navigation while session data is still loading.
  * Improved recovery when cached navigation becomes unavailable.
  * Added manual recovery after retry attempts are exhausted.
  * Restored stale person-chat drafts more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->