### PR TITLE
P1: Treat Apollo surname masks as missing data

### DIFF
--- a/desktop/coworker/apollo.py
+++ b/desktop/coworker/apollo.py
@@ -14,7 +14,10 @@ from coworker.evidence_envelope import (
     external,
     opaque,
 )
-from coworker.person_identity import apollo_surname_is_masked
+from coworker.person_identity import (
+    apollo_surname_is_masked,
+    without_apollo_name_masks,
+)
 
 SEARCH_URL = "https://api.apollo.io/api/v1/mixed_people/api_search"
 MATCH_URL = "https://api.apollo.io/api/v1/people/match"
@@ -425,14 +428,22 @@ def apollo_evidence(tool_name: str, payload: dict[str, Any]) -> EvidenceParts:
             envelopes=combined.envelopes,
         )
     if tool_name == "apollo_enrich_contact":
+        raw_name = str(payload.get("name") or "").strip()
+        safe_name = without_apollo_name_masks(raw_name) or "Apollo contact"
         return external(
             "apollo",
             identity=("contact", payload.get("email"), payload.get("linkedinUrl")),
-            title=str(payload.get("name") or "Apollo contact"),
+            title=safe_name,
             body="\n".join(
-                f"{key}: {payload.get(key)}"
-                for key in ("name", "title", "organizationName", "email", "phone")
-                if payload.get(key)
+                f"{key}: {value}"
+                for key, value in (
+                    ("name", safe_name if raw_name else None),
+                    ("title", payload.get("title")),
+                    ("organizationName", payload.get("organizationName")),
+                    ("email", payload.get("email")),
+                    ("phone", payload.get("phone")),
+                )
+                if value
             ),
             url=payload.get("linkedinUrl"),
             sensitivity="sensitive",

--- a/desktop/coworker/apollo.py
+++ b/desktop/coworker/apollo.py
@@ -14,6 +14,7 @@ from coworker.evidence_envelope import (
     external,
     opaque,
 )
+from coworker.person_identity import apollo_surname_is_masked
 
 SEARCH_URL = "https://api.apollo.io/api/v1/mixed_people/api_search"
 MATCH_URL = "https://api.apollo.io/api/v1/people/match"
@@ -333,6 +334,9 @@ def enrichment_resource(
         for part in (person.get("first_name"), person.get("last_name"))
         if part
     ).strip()
+    approval_display = display or "Unnamed person"
+    if person.get("last_name_status") == "hidden_by_apollo":
+        approval_display = f"{approval_display} (surname hidden by Apollo)"
     if match.get("email"):
         matched_on = "email"
     elif match.get("apollo_id"):
@@ -342,14 +346,14 @@ def enrichment_resource(
     return {
         "kind": "apollo_enrichment",
         "person_id": str(person.get("person_id") or ""),
-        "person": display or "Unnamed person",
+        "person": approval_display,
         "title": person.get("title") or None,
         "company": person.get("company") or None,
         "matched_on": matched_on,
         "credits": ENRICH_CREDIT_COST,
         "reason": (
             f"Spends {ENRICH_CREDIT_COST} Apollo credit to look up "
-            f"{display or 'this person'} by {MATCH_LABELS[matched_on]} and write the result "
+            f"{approval_display} by {MATCH_LABELS[matched_on]} and write the result "
             "to this person file only."
         ),
     }
@@ -370,24 +374,35 @@ def apollo_evidence(tool_name: str, payload: dict[str, Any]) -> EvidenceParts:
         for row in rows:
             if not isinstance(row, dict):
                 continue
+            last_name = row.get("lastNameObfuscated")
+            surname_hidden = apollo_surname_is_masked(last_name)
+            safe_name = " ".join(
+                str(part or "")
+                for part in (
+                    row.get("firstName"),
+                    None if surname_hidden else last_name,
+                )
+            ).strip()
+            body_fields = [
+                ("firstName", row.get("firstName")),
+                (
+                    "lastNameStatus",
+                    "surname hidden by Apollo" if surname_hidden else last_name,
+                ),
+                ("title", row.get("title")),
+                ("organizationName", row.get("organizationName")),
+            ]
             parts.append(
                 external(
                     "apollo",
                     identity=("person", row.get("apolloId")),
-                    title=" ".join(
-                        str(row.get(key) or "")
-                        for key in ("firstName", "lastNameObfuscated")
-                    ).strip()
-                    or "Apollo candidate",
+                    title=(
+                        f"{safe_name} (surname hidden by Apollo)"
+                        if surname_hidden and safe_name
+                        else safe_name or "Apollo candidate"
+                    ),
                     body="\n".join(
-                        f"{key}: {row.get(key)}"
-                        for key in (
-                            "firstName",
-                            "lastNameObfuscated",
-                            "title",
-                            "organizationName",
-                        )
-                        if row.get(key)
+                        f"{key}: {value}" for key, value in body_fields if value
                     ),
                     sensitivity="sensitive",
                 )

--- a/desktop/coworker/apollo_curation.py
+++ b/desktop/coworker/apollo_curation.py
@@ -68,6 +68,7 @@ def curate_apollo_candidates(
                 "operation": "updated" if existing is not None else "created",
                 "first_name": person["first_name"],
                 "last_name": person["last_name"],
+                "last_name_status": person["last_name_status"],
                 "title": person["title"],
                 "company": person["company"],
                 "sourcing_chat": (

--- a/desktop/coworker/migrations.py
+++ b/desktop/coworker/migrations.py
@@ -40,6 +40,10 @@ from coworker.agent_run_approval import EFFECT_STATEMENTS
 from coworker.agent_run_repository import SCHEMA_VERSION as AGENT_RUNS_DB_VERSION
 from coworker.mcp import SCHEMA_VERSION as MCP_CONFIG_VERSION
 from coworker.people import SCHEMA_VERSION as PEOPLE_DB_VERSION
+from coworker.person_identity import (
+    apollo_surname_is_masked,
+    without_apollo_name_masks,
+)
 from coworker.secrets import SCHEMA_VERSION as SECRETS_VERSION
 from coworker.store import SCHEMA_VERSION as CONVERSATION_DB_VERSION
 from coworker.store import TRANSCRIPT_VERSION
@@ -458,6 +462,12 @@ _PEOPLE_ADDED_COLUMNS: tuple[tuple[str, str, str], ...] = (
     ("people", "deleted_at", "TEXT"),
 )
 
+_PEOPLE_APOLLO_SURNAME_COLUMN = (
+    "people",
+    "apollo_last_name_obfuscated",
+    "TEXT",
+)
+
 _PEOPLE_ADDED_TABLES = {
     "session_people": """
         CREATE TABLE IF NOT EXISTS session_people (
@@ -639,6 +649,107 @@ def _adopt_people_db(context: MigrationContext) -> int:
 
 def _count_people_db(context: MigrationContext) -> int:
     return _sqlite_adoption_count(context, _PEOPLE_ADDED_COLUMNS, _PEOPLE_ADDED_TABLES)
+
+
+def _count_masked_people_names(context: MigrationContext) -> int:
+    conn = context.connection
+    assert conn is not None
+    if "people" not in table_names(conn):
+        return 0
+    touched = int(
+        conn.execute(
+            "SELECT COUNT(*) FROM people WHERE last_name LIKE '%*%'"
+        ).fetchone()[0]
+    )
+    if "apollo_last_name_obfuscated" not in column_names(conn, "people"):
+        touched += 1
+    if "person_versions" in table_names(conn):
+        for row in conn.execute("SELECT person_json FROM person_versions").fetchall():
+            try:
+                person = json.loads(str(row[0]))
+            except json.JSONDecodeError:
+                continue
+            if isinstance(person, dict) and apollo_surname_is_masked(
+                person.get("last_name")
+            ):
+                touched += 1
+    return touched
+
+
+def _separate_masked_people_names(context: MigrationContext) -> int:
+    """Keep Apollo's masked hint without treating it as a person's surname."""
+    conn = context.connection
+    assert conn is not None
+    touched = _count_masked_people_names(context)
+    table, column, definition = _PEOPLE_APOLLO_SURNAME_COLUMN
+    if column not in column_names(conn, table):
+        conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {definition}")
+    conn.execute(
+        """
+        UPDATE people SET
+            apollo_last_name_obfuscated = last_name,
+            last_name = NULL
+        WHERE last_name LIKE '%*%'
+        """
+    )
+    handoff_fields = (
+        "handoff_who",
+        "handoff_wanted",
+        "handoff_happened",
+        "handoff_they_want",
+    )
+    available_people_columns = column_names(conn, "people")
+    present_handoff_fields = [
+        field for field in handoff_fields if field in available_people_columns
+    ]
+    if present_handoff_fields:
+        rows = conn.execute(
+            f"SELECT person_id, {', '.join(present_handoff_fields)} FROM people"
+        ).fetchall()
+        for row in rows:
+            updates = {
+                field: without_apollo_name_masks(row[index + 1])
+                for index, field in enumerate(present_handoff_fields)
+                if row[index + 1]
+                and without_apollo_name_masks(row[index + 1]) != row[index + 1]
+            }
+            if not updates:
+                continue
+            assignments = ", ".join(f"{field} = ?" for field in updates)
+            conn.execute(
+                f"UPDATE people SET {assignments} WHERE person_id = ?",
+                (*updates.values(), row[0]),
+            )
+    if "person_versions" in table_names(conn):
+        rows = conn.execute(
+            "SELECT rowid, person_json FROM person_versions"
+        ).fetchall()
+        for rowid, raw_person in rows:
+            try:
+                person = json.loads(str(raw_person))
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(person, dict):
+                continue
+            changed = False
+            if apollo_surname_is_masked(person.get("last_name")):
+                person["last_name"] = None
+                person["last_name_status"] = "hidden_by_apollo"
+                changed = True
+            for field in handoff_fields:
+                if not person.get(field):
+                    continue
+                safe = without_apollo_name_masks(person[field])
+                if safe != person[field]:
+                    person[field] = safe
+                    changed = True
+            if not changed:
+                continue
+            conn.execute(
+                "UPDATE person_versions SET person_json = ? WHERE rowid = ?",
+                (json.dumps(person, sort_keys=True), rowid),
+            )
+    return touched
 
 
 # DriveIngestionStore grew `work_revision` onto jobs after the first ship. The
@@ -860,6 +971,18 @@ REGISTRY: tuple[StoreSpec, ...] = (
             "Adopt the person schema shipped before the registry existed.",
             _count_people_db,
             _adopt_people_db,
+        )
+        + (
+            Migration(
+                from_version=1,
+                to_version=2,
+                description=(
+                    "Move Apollo-masked surnames out of canonical person names "
+                    "and make historical person snapshots safe to restore."
+                ),
+                count=_count_masked_people_names,
+                apply=_separate_masked_people_names,
+            ),
         ),
         json_columns=(
             ("events", "payload"),

--- a/desktop/coworker/people.py
+++ b/desktop/coworker/people.py
@@ -12,10 +12,15 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from coworker.person_identity import (
+    apollo_surname_is_masked,
+    without_apollo_name_masks,
+)
+
 _SID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
 
 # Declared schema version for people.db, read by coworker.migrations.
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 SEQUENCE_STATES = ("open", "in_conversation", "done")
 ACTORS = ("director", "assistant")
@@ -73,6 +78,7 @@ class PersonStore:
                 apollo_id TEXT UNIQUE,
                 first_name TEXT,
                 last_name TEXT,
+                apollo_last_name_obfuscated TEXT,
                 title TEXT,
                 company TEXT,
                 email TEXT,
@@ -150,6 +156,18 @@ class PersonStore:
             self._conn.execute("ALTER TABLE people ADD COLUMN outcome TEXT")
         if "deleted_at" not in columns:
             self._conn.execute("ALTER TABLE people ADD COLUMN deleted_at TEXT")
+        if "apollo_last_name_obfuscated" not in columns:
+            self._conn.execute(
+                "ALTER TABLE people ADD COLUMN apollo_last_name_obfuscated TEXT"
+            )
+        self._conn.execute(
+            """
+            UPDATE people SET
+                apollo_last_name_obfuscated = last_name,
+                last_name = NULL
+            WHERE last_name LIKE '%*%'
+            """
+        )
         event_columns = {
             str(row["name"])
             for row in self._conn.execute("PRAGMA table_info(events)").fetchall()
@@ -173,6 +191,22 @@ class PersonStore:
         if row is None:
             return None
         person = dict(row)
+        apollo_hidden = person.pop("apollo_last_name_obfuscated", None)
+        for field in (
+            "handoff_who",
+            "handoff_wanted",
+            "handoff_happened",
+            "handoff_they_want",
+        ):
+            if person.get(field):
+                person[field] = without_apollo_name_masks(person[field])
+        person["last_name_status"] = (
+            "known"
+            if _clean(person.get("last_name"))
+            else "hidden_by_apollo"
+            if _clean(apollo_hidden)
+            else "missing"
+        )
         person["version"] = int(person.get("version") or 1)
         person["restricted"] = False
         return person
@@ -320,6 +354,16 @@ class PersonStore:
         apollo = _clean(apollo_id)
         first_name = _clean(first_name)
         last_name_obfuscated = _clean(last_name_obfuscated)
+        incoming_last_name = (
+            None
+            if apollo_surname_is_masked(last_name_obfuscated)
+            else last_name_obfuscated
+        )
+        incoming_hidden_last_name = (
+            last_name_obfuscated
+            if apollo_surname_is_masked(last_name_obfuscated)
+            else None
+        )
         title = _clean(title)
         company = _clean(company)
         cleaned_target = _clean(target)
@@ -333,22 +377,34 @@ class PersonStore:
             if existing is not None:
                 restoring = bool(existing["deleted_at"])
                 now = self._now()
+                stored_last_name = _clean(existing["last_name"])
+                stored_hidden_last_name = _clean(
+                    existing["apollo_last_name_obfuscated"]
+                )
+                next_last_name = incoming_last_name or stored_last_name
+                next_hidden_last_name = (
+                    None
+                    if incoming_last_name
+                    else incoming_hidden_last_name or stored_hidden_last_name
+                )
                 changed = restoring or any(
                     incoming is not None and incoming != existing[field]
                     for incoming, field in (
                         (first_name, "first_name"),
-                        (last_name_obfuscated, "last_name"),
                         (title, "title"),
                         (company, "company"),
                         (cleaned_target, "target"),
                     )
+                ) or next_last_name != stored_last_name or (
+                    next_hidden_last_name != stored_hidden_last_name
                 )
                 next_version = int(existing["version"] or 1) + int(changed)
                 self._conn.execute(
                     """
                     UPDATE people SET
                         first_name = COALESCE(?, first_name),
-                        last_name = COALESCE(?, last_name),
+                        last_name = ?,
+                        apollo_last_name_obfuscated = ?,
                         title = COALESCE(?, title),
                         company = COALESCE(?, company),
                         target = COALESCE(?, target),
@@ -359,7 +415,8 @@ class PersonStore:
                     """,
                     (
                         first_name,
-                        last_name_obfuscated,
+                        next_last_name,
+                        next_hidden_last_name,
                         title,
                         company,
                         cleaned_target,
@@ -389,14 +446,16 @@ class PersonStore:
                 self._conn.execute(
                     """
                     INSERT INTO people (
-                        person_id, apollo_id, first_name, last_name, title, company, target
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                        person_id, apollo_id, first_name, last_name,
+                        apollo_last_name_obfuscated, title, company, target
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         pid,
                         apollo,
                         first_name,
-                        last_name_obfuscated,
+                        incoming_last_name,
+                        incoming_hidden_last_name,
                         title,
                         company,
                         cleaned_target,
@@ -440,6 +499,8 @@ class PersonStore:
             parts = str(name).split(None, 1)
             first_name = parts[0]
             last_name = parts[1] if len(parts) > 1 else None
+            if apollo_surname_is_masked(last_name):
+                last_name = None
         with self._lock:
             exists = self._conn.execute(
                 "SELECT 1 FROM people WHERE person_id = ?",
@@ -1332,6 +1393,17 @@ class PersonStore:
         unknown = set(fields) - PERSON_PATCH_FIELDS
         if unknown:
             raise ValueError(f"unsupported person fields {sorted(unknown)}")
+        if apollo_surname_is_masked(fields.get("last_name")):
+            raise ValueError("an obfuscated Apollo surname cannot be canonical")
+        fields = dict(fields)
+        for field in (
+            "handoff_who",
+            "handoff_wanted",
+            "handoff_happened",
+            "handoff_they_want",
+        ):
+            if fields.get(field):
+                fields[field] = without_apollo_name_masks(fields[field])
         self._require_audit(actor, rationale_summary)
         with self._lock:
             row = self._load_person_row(person_id)
@@ -1540,13 +1612,20 @@ class PersonStore:
             if snapshot is None:
                 raise ValueError(f"unknown record version {to_version}")
             target = json.loads(str(snapshot["person_json"]))
+            target_last_name = target.get("last_name")
+            target_hidden_last_name = None
+            if apollo_surname_is_masked(target_last_name):
+                target_hidden_last_name = target_last_name
+                target_last_name = None
             attachments = json.loads(str(snapshot["attachments_json"]))
             now = self._now()
             next_version = expected_version + 1
             cursor = self._conn.execute(
                 """
                 UPDATE people SET
-                    first_name = ?, last_name = ?, title = ?, company = ?, target = ?,
+                    first_name = ?, last_name = ?,
+                    apollo_last_name_obfuscated = COALESCE(?, apollo_last_name_obfuscated),
+                    title = ?, company = ?, target = ?,
                     sequence_state = ?, outcome = ?,
                     handoff_who = ?, handoff_wanted = ?, handoff_happened = ?,
                     handoff_they_want = ?, version = ?, updated_at = ?
@@ -1554,16 +1633,17 @@ class PersonStore:
                 """,
                 (
                     target.get("first_name"),
-                    target.get("last_name"),
+                    target_last_name,
+                    target_hidden_last_name,
                     target.get("title"),
                     target.get("company"),
                     target.get("target"),
                     target.get("sequence_state"),
                     target.get("outcome"),
-                    target.get("handoff_who"),
-                    target.get("handoff_wanted"),
-                    target.get("handoff_happened"),
-                    target.get("handoff_they_want"),
+                    without_apollo_name_masks(target.get("handoff_who")) or None,
+                    without_apollo_name_masks(target.get("handoff_wanted")) or None,
+                    without_apollo_name_masks(target.get("handoff_happened")) or None,
+                    without_apollo_name_masks(target.get("handoff_they_want")) or None,
                     next_version,
                     now,
                     person_id,

--- a/desktop/coworker/person_identity.py
+++ b/desktop/coworker/person_identity.py
@@ -6,16 +6,18 @@ import re
 from typing import Any
 
 _MASKED_TOKEN = re.compile(r"(?<!\S)\S*\*+\S*(?!\S)")
+_SURROUNDING_PUNCTUATION = "\"'“”‘’()[]{}.,!?;:"
 
 
 def _replace_masked_token(match: re.Match[str]) -> str:
     token = match.group(0)
+    core = token.strip(_SURROUNDING_PUNCTUATION)
     # Preserve ordinary Markdown emphasis and horizontal rules. Apollo name
     # masks contain at least one real Unicode letter or number outside the
     # asterisks, regardless of script.
-    if token.startswith("*") and token.endswith("*"):
+    if core.startswith("*") and core.endswith("*"):
         return token
-    if not any(character.isalnum() for character in token if character != "*"):
+    if not any(character.isalnum() for character in core if character != "*"):
         return token
     return "(surname hidden by Apollo)"
 

--- a/desktop/coworker/person_identity.py
+++ b/desktop/coworker/person_identity.py
@@ -5,7 +5,19 @@ from __future__ import annotations
 import re
 from typing import Any
 
-_MASKED_TOKEN = re.compile(r"(?<!\S)[^\s*]*[A-Za-z][^\s*]*\*+[^\s]*(?!\S)")
+_MASKED_TOKEN = re.compile(r"(?<!\S)\S*\*+\S*(?!\S)")
+
+
+def _replace_masked_token(match: re.Match[str]) -> str:
+    token = match.group(0)
+    # Preserve ordinary Markdown emphasis and horizontal rules. Apollo name
+    # masks contain at least one real Unicode letter or number outside the
+    # asterisks, regardless of script.
+    if token.startswith("*") and token.endswith("*"):
+        return token
+    if not any(character.isalnum() for character in token if character != "*"):
+        return token
+    return "(surname hidden by Apollo)"
 
 
 def apollo_surname_is_masked(value: object) -> bool:
@@ -16,7 +28,7 @@ def without_apollo_name_masks(value: object) -> str:
     text = str(value or "").strip()
     if not text:
         return ""
-    return _MASKED_TOKEN.sub("(surname hidden by Apollo)", text)
+    return _MASKED_TOKEN.sub(_replace_masked_token, text)
 
 
 def sanitize_apollo_name_masks(value: Any) -> Any:

--- a/desktop/coworker/person_identity.py
+++ b/desktop/coworker/person_identity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 
 _MASKED_TOKEN = re.compile(r"(?<!\S)[^\s*]*[A-Za-z][^\s*]*\*+[^\s]*(?!\S)")
 
@@ -16,3 +17,18 @@ def without_apollo_name_masks(value: object) -> str:
     if not text:
         return ""
     return _MASKED_TOKEN.sub("(surname hidden by Apollo)", text)
+
+
+def sanitize_apollo_name_masks(value: Any) -> Any:
+    """Recursively replace Apollo mask tokens without guessing their letters."""
+    if isinstance(value, str):
+        return without_apollo_name_masks(value)
+    if isinstance(value, list):
+        return [sanitize_apollo_name_masks(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(sanitize_apollo_name_masks(item) for item in value)
+    if isinstance(value, dict):
+        return {
+            key: sanitize_apollo_name_masks(item) for key, item in value.items()
+        }
+    return value

--- a/desktop/coworker/person_identity.py
+++ b/desktop/coworker/person_identity.py
@@ -1,0 +1,18 @@
+"""Safe person-name handling shared by storage, migration, and presentation."""
+
+from __future__ import annotations
+
+import re
+
+_MASKED_TOKEN = re.compile(r"(?<!\S)[^\s*]*[A-Za-z][^\s*]*\*+[^\s]*(?!\S)")
+
+
+def apollo_surname_is_masked(value: object) -> bool:
+    return "*" in str(value or "")
+
+
+def without_apollo_name_masks(value: object) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    return _MASKED_TOKEN.sub("(surname hidden by Apollo)", text)

--- a/desktop/coworker/server.py
+++ b/desktop/coworker/server.py
@@ -93,6 +93,7 @@ from coworker.effective_tools import (
     effective_tool_catalog,
 )
 from coworker.events import build_event, new_turn_identity, TurnIdentity
+from coworker.person_identity import without_apollo_name_masks
 from coworker.gmail import (
     GmailError,
     GmailOutcomeUnknown,
@@ -631,6 +632,35 @@ def create_app(
                 except Exception:
                     app.state.live_event_senders.discard(registration)
 
+    def _sync_person_sourcing_title(person_id: str) -> str | None:
+        """Keep Sourcecado-generated person-chat titles on the canonical name."""
+        try:
+            session_id = app.state.people.session_for_person(person_id)
+        except ValueError:
+            return None
+        if session_id is None:
+            return None
+        row = app.state.store.index(session_id)
+        person = app.state.people.get(person_id)
+        if row is None or person is None:
+            return None
+        current = str(row.get("title") or "")
+        if current.startswith("Sourcing ·") or not current:
+            brief = build_brief(person, app.state.people.timeline(person_id))
+            safe = f"Sourcing · {str(brief['who'] or 'Person')}"
+        else:
+            safe = without_apollo_name_masks(current)
+        if safe != current:
+            app.state.store.rename_session(session_id, safe)
+        return safe
+
+    # Older builds wrote Apollo's mask into bound chat titles. Repair those
+    # titles once while the sidecar is opening, before any surface can read
+    # them. Approved enrichment calls this helper again to promote the full
+    # verified name without making a read endpoint mutate durable state.
+    for existing_person in app.state.people.list_people():
+        _sync_person_sourcing_title(str(existing_person["person_id"]))
+
     def _bound_resource(item: dict[str, Any]) -> dict[str, Any] | None:
         """The person-bound authority this approval was parked with, if any."""
         resource = item.get("resource")
@@ -733,6 +763,7 @@ def create_app(
         )
         if filed is None:
             return False, {"error": "unknown person"}
+        _sync_person_sourcing_title(person_id)
         return True, {
             "person_id": person_id,
             "credits": ENRICH_CREDIT_COST,
@@ -2289,6 +2320,7 @@ def create_app(
                 status_code=409,
             )
         if existing_session_id is not None:
+            _sync_person_sourcing_title(person_id)
             existing = app.state.store.index(existing_session_id)
             if existing is None:
                 return JSONResponse(

--- a/desktop/coworker/turn.py
+++ b/desktop/coworker/turn.py
@@ -33,6 +33,7 @@ from coworker.evidence_envelope import (
 from coworker.inbox import Inbox
 from coworker.ledger import record_tool_on_person
 from coworker.permissions import RETRY_SAFE, decide
+from coworker.person_identity import sanitize_apollo_name_masks
 from coworker.provider import (
     ModelUsage,
     ProviderErrorKind,
@@ -70,10 +71,46 @@ from coworker.telemetry import (
 from coworker.tools import evidence_for, execute
 
 INTERRUPTED_TOOL = '{"error": "tool call interrupted"}'
+_APOLLO_TOOLS = frozenset({"apollo_search_people", "apollo_enrich_contact"})
 
 
 def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
+
+
+def _safe_apollo_json(value: object) -> str:
+    if not isinstance(value, str):
+        return json.dumps(sanitize_apollo_name_masks(value))
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError:
+        return str(sanitize_apollo_name_masks(value))
+    return json.dumps(sanitize_apollo_name_masks(decoded))
+
+
+def _model_safe_apollo_message(message: dict[str, Any]) -> dict[str, Any]:
+    """Project legacy Apollo transcript records without exposing name masks."""
+    safe = dict(message)
+    calls = message.get("tool_calls")
+    if isinstance(calls, list):
+        safe_calls: list[Any] = []
+        for call in calls:
+            if not isinstance(call, dict):
+                safe_calls.append(call)
+                continue
+            safe_call = dict(call)
+            function = call.get("function")
+            if isinstance(function, dict) and function.get("name") in _APOLLO_TOOLS:
+                safe_function = dict(function)
+                safe_function["arguments"] = _safe_apollo_json(
+                    function.get("arguments") or "{}"
+                )
+                safe_call["function"] = safe_function
+            safe_calls.append(safe_call)
+        safe["tool_calls"] = safe_calls
+    if message.get("role") == "tool" and message.get("name") in _APOLLO_TOOLS:
+        safe["content"] = _safe_apollo_json(message.get("content") or "{}")
+    return safe
 
 
 def _telemetry_provider_name(provider: Any) -> str:
@@ -588,7 +625,11 @@ def _assistant_tool_message(text: str, calls: list[ToolCall]) -> dict[str, Any]:
                 "type": "function",
                 "function": {
                     "name": call.name,
-                    "arguments": json.dumps(call.arguments),
+                    "arguments": json.dumps(
+                        sanitize_apollo_name_masks(call.arguments)
+                        if call.name in _APOLLO_TOOLS
+                        else call.arguments
+                    ),
                 },
             }
             for call in calls
@@ -1022,7 +1063,9 @@ async def run_turn(
             # The canonical view. Compaction reads it and never writes it; the
             # transcript on disk stays the record of what actually happened.
             canonical_messages = [
-                {k: v for k, v in message.items() if k != "message_id"}
+                _model_safe_apollo_message(
+                    {k: v for k, v in message.items() if k != "message_id"}
+                )
                 for message in history
             ]
             step_budget = context_budget(

--- a/desktop/surfaces/gui/src/Board.tsx
+++ b/desktop/surfaces/gui/src/Board.tsx
@@ -70,6 +70,9 @@ function Bucket({
               >
                 <strong>{copy.name}</strong>
                 {copy.detail ? <span>{copy.detail}</span> : null}
+                {person.last_name_status === "hidden_by_apollo" ? (
+                  <span>Surname hidden by Apollo</span>
+                ) : null}
                 <span className="board-row-contact">
                   {contactLine(person)}
                   <FollowUpChip person={person} />

--- a/desktop/surfaces/gui/src/PersonFile.tsx
+++ b/desktop/surfaces/gui/src/PersonFile.tsx
@@ -357,6 +357,9 @@ export function PersonFileView({ personId }: { personId: string }) {
         <a className="person-back-link" href="#/board">← Board</a>
         <p className="eyebrow">Person file</p>
         <h1>{file.brief.who || "Person"}</h1>
+        {file.person.last_name_status === "hidden_by_apollo" ? (
+          <p>Surname hidden by Apollo. Enrich to verify the full name.</p>
+        ) : null}
         {file.brief.why ? <p>{file.brief.why}</p> : null}
         <div className="person-chat-action">
           <button

--- a/desktop/surfaces/gui/src/api.ts
+++ b/desktop/surfaces/gui/src/api.ts
@@ -359,6 +359,7 @@ export type BoardPerson = {
   person_id: string;
   first_name: string | null;
   last_name: string | null;
+  last_name_status?: "known" | "hidden_by_apollo" | "missing";
   title: string | null;
   company: string | null;
   sequence_state: string | null;
@@ -551,6 +552,7 @@ export type ApolloCurationKept = {
   operation: "created" | "updated";
   first_name: string | null;
   last_name: string | null;
+  last_name_status: "known" | "hidden_by_apollo" | "missing";
   title: string | null;
   company: string | null;
   sourcing_chat: { session_id: string } | null;
@@ -772,6 +774,17 @@ export async function curateApolloCandidates(input: {
     ) {
       throw new Error("Apollo curation payload malformed");
     }
+    const rawLastName = nullableText(item.last_name);
+    const lastNameIsMasked = Boolean(rawLastName?.includes("*"));
+    const lastNameStatus = ["known", "hidden_by_apollo", "missing"].includes(
+      String(item.last_name_status),
+    )
+      ? String(item.last_name_status)
+      : lastNameIsMasked
+        ? "hidden_by_apollo"
+        : rawLastName
+          ? "known"
+          : "missing";
     return {
       row_index: item.row_index as number,
       apollo_id: item.apollo_id,
@@ -779,7 +792,8 @@ export async function curateApolloCandidates(input: {
       version: item.version as number,
       operation: item.operation as "created" | "updated",
       first_name: nullableText(item.first_name),
-      last_name: nullableText(item.last_name),
+      last_name: lastNameIsMasked ? null : rawLastName,
+      last_name_status: lastNameStatus as ApolloCurationKept["last_name_status"],
       title: nullableText(item.title),
       company: nullableText(item.company),
       sourcing_chat: chat ? { session_id: chat.session_id as string } : null,

--- a/desktop/surfaces/gui/src/chat/ActivityGroup.tsx
+++ b/desktop/surfaces/gui/src/chat/ActivityGroup.tsx
@@ -10,6 +10,7 @@ import type { ToolFailure } from "./protocol";
 import { useRecoveryActions } from "./recovery";
 import { useInspector } from "./Inspector";
 import { EvidenceSetResult } from "../generative/EvidenceSetResult";
+import { sanitizeApolloNameMasks } from "../personName";
 
 type ActivityState =
   | "Running"
@@ -248,6 +249,12 @@ function ActivityRow({ tool }: { readonly tool: ToolCallMessagePart }) {
   const { act } = useRecoveryActions();
   const { select } = useInspector();
   const [showDetails, setShowDetails] = useState(false);
+  const inspectorArgs = tool.toolName.startsWith("apollo_")
+    ? sanitizeApolloNameMasks(tool.args)
+    : tool.args;
+  const inspectorResult = tool.toolName.startsWith("apollo_")
+    ? sanitizeApolloNameMasks(tool.result)
+    : tool.result;
   return (
     <li
       data-tool-call-id={tool.toolCallId}
@@ -268,8 +275,8 @@ function ActivityRow({ tool }: { readonly tool: ToolCallMessagePart }) {
                 id: tool.toolCallId,
                 title: presentation.label,
                 status: "success",
-                args: tool.args,
-                result: tool.result,
+                args: inspectorArgs,
+                result: inspectorResult,
                 timing: tool.timing,
               },
               event.currentTarget,

--- a/desktop/surfaces/gui/src/chat/ApprovalCard.tsx
+++ b/desktop/surfaces/gui/src/chat/ApprovalCard.tsx
@@ -4,7 +4,7 @@ import { useEffect, useId, useRef, useState } from "react";
 import { toolPresentation } from "./toolRegistry";
 import { CalendarApprovalSummary } from "../generative/CalendarEventResult";
 import { GmailDraftBody } from "../generative/GmailDraftResult";
-import { withoutApolloNameMasks } from "../personName";
+import { sanitizeApolloNameMasks, withoutApolloNameMasks } from "../personName";
 
 type ApprovalState =
   | "pending"
@@ -185,12 +185,7 @@ function displayedArguments(
   args: Readonly<Record<string, unknown>>,
 ): Readonly<Record<string, unknown>> {
   if (toolName !== "apollo_enrich_contact") return args;
-  return Object.fromEntries(
-    Object.entries(args).map(([key, value]) => [
-      key,
-      typeof value === "string" ? withoutApolloNameMasks(value) : value,
-    ]),
-  );
+  return sanitizeApolloNameMasks(args) as Readonly<Record<string, unknown>>;
 }
 
 function resolvedLabel(state: ApprovalState): string {

--- a/desktop/surfaces/gui/src/chat/ApprovalCard.tsx
+++ b/desktop/surfaces/gui/src/chat/ApprovalCard.tsx
@@ -4,6 +4,7 @@ import { useEffect, useId, useRef, useState } from "react";
 import { toolPresentation } from "./toolRegistry";
 import { CalendarApprovalSummary } from "../generative/CalendarEventResult";
 import { GmailDraftBody } from "../generative/GmailDraftResult";
+import { withoutApolloNameMasks } from "../personName";
 
 type ApprovalState =
   | "pending"
@@ -179,6 +180,19 @@ function scopeStatement(toolName: string): string {
   return "Scope: allow once.";
 }
 
+function displayedArguments(
+  toolName: string,
+  args: Readonly<Record<string, unknown>>,
+): Readonly<Record<string, unknown>> {
+  if (toolName !== "apollo_enrich_contact") return args;
+  return Object.fromEntries(
+    Object.entries(args).map(([key, value]) => [
+      key,
+      typeof value === "string" ? withoutApolloNameMasks(value) : value,
+    ]),
+  );
+}
+
 function resolvedLabel(state: ApprovalState): string {
   switch (state) {
     case "allowed":
@@ -219,6 +233,7 @@ export function ApprovalCard({
   const pending = audit.approvalState === "pending";
   const presentation = toolPresentation(part.toolName);
   const args = part.args as Readonly<Record<string, unknown>>;
+  const safeArgs = displayedArguments(part.toolName, args);
   const fields = decisionFields(part.toolName, args);
   const gmailDraft =
     part.toolName === "gmail_draft" || part.toolName === "gmail_create_draft";
@@ -230,6 +245,11 @@ export function ApprovalCard({
     gmailDraft && typeof args.body === "string" ? args.body : null;
   const shellCommand =
     part.toolName === "shell_exec" ? shellCommandResourceOf(part) : null;
+  const approvalReason = part.approval?.reason
+    ? part.toolName === "apollo_enrich_contact"
+      ? withoutApolloNameMasks(part.approval.reason)
+      : part.approval.reason
+    : "This external action needs your approval.";
 
   useEffect(() => {
     if (pending) headingRef.current?.focus();
@@ -423,7 +443,7 @@ export function ApprovalCard({
           Apollo enrichment uses credits. No credit is spent until you choose Allow once.
         </p>
       ) : null}
-      <p>{part.approval?.reason ?? "This external action needs your approval."}</p>
+      <p>{approvalReason}</p>
       <button
         type="button"
         aria-expanded={showDetails}
@@ -439,7 +459,7 @@ export function ApprovalCard({
               Exact fingerprint: {shellCommand?.fingerprint?.slice(0, 16) ?? "unavailable"}
             </p>
           ) : (
-            <pre>{JSON.stringify(args, null, 2)}</pre>
+            <pre>{JSON.stringify(safeArgs, null, 2)}</pre>
           )}
           <p>{scopeStatement(part.toolName)}</p>
         </div>

--- a/desktop/surfaces/gui/src/generative/ApolloPeopleResult.tsx
+++ b/desktop/surfaces/gui/src/generative/ApolloPeopleResult.tsx
@@ -8,12 +8,14 @@ import {
 import { usePopulateComposer } from "../chat/ComposerDraftContext";
 import { useInspector } from "../chat/Inspector";
 import type { DomainRendererProps } from "../chat/toolRegistry";
+import { hasApolloNameMask } from "../personName";
 
 type ApolloCandidate = {
   readonly id: string;
   readonly name: string;
   readonly title: string | null;
   readonly company: string | null;
+  readonly surnameHidden: boolean;
   readonly hasEmail: boolean;
   readonly phoneStatus: string | null;
   readonly missing: readonly string[];
@@ -39,12 +41,14 @@ function candidateOf(value: unknown, index: number): ApolloCandidate | null {
   const raw = record(value);
   if (!raw) return null;
   const firstName = text(raw.firstName);
-  const lastName = text(raw.lastNameObfuscated);
+  const apolloLastName = text(raw.lastNameObfuscated);
+  const surnameHidden = hasApolloNameMask(apolloLastName);
+  const lastName = surnameHidden ? null : apolloLastName;
   const title = text(raw.title);
   const company = text(raw.organizationName);
   const missing = [
     !title ? "title" : null,
-    !firstName || !lastName ? "full name" : null,
+    !firstName || (!lastName && !surnameHidden) ? "full name" : null,
     !company ? "company" : null,
   ].filter((field): field is string => field !== null);
   return {
@@ -52,6 +56,7 @@ function candidateOf(value: unknown, index: number): ApolloCandidate | null {
     name: [firstName, lastName].filter(Boolean).join(" ") || "Unnamed candidate",
     title,
     company,
+    surnameHidden,
     hasEmail: raw.hasEmail === true,
     phoneStatus: text(raw.directPhoneStatus),
     missing,
@@ -275,7 +280,10 @@ export function ApolloPeopleResult({
   }
 
   function keptName(person: ApolloCurationResult["kept"][number]): string {
-    return [person.first_name, person.last_name].filter(Boolean).join(" ") || "Person";
+    const name = [person.first_name, person.last_name].filter(Boolean).join(" ") || "Person";
+    return person.last_name_status === "hidden_by_apollo"
+      ? `${name} (surname hidden by Apollo)`
+      : name;
   }
 
   async function openKeptChat(person: ApolloCurationResult["kept"][number]) {
@@ -397,6 +405,7 @@ export function ApolloPeopleResult({
               </span>
               {candidate.phoneStatus ? ` · Phone: ${candidate.phoneStatus}` : ""}
             </p>
+            {candidate.surnameHidden ? <p>Surname hidden by Apollo</p> : null}
             {missingLabel(candidate.missing) ? (
               <p>{missingLabel(candidate.missing)} from Apollo source.</p>
             ) : null}

--- a/desktop/surfaces/gui/src/generative/ApolloPeopleResult.tsx
+++ b/desktop/surfaces/gui/src/generative/ApolloPeopleResult.tsx
@@ -8,7 +8,7 @@ import {
 import { usePopulateComposer } from "../chat/ComposerDraftContext";
 import { useInspector } from "../chat/Inspector";
 import type { DomainRendererProps } from "../chat/toolRegistry";
-import { hasApolloNameMask } from "../personName";
+import { hasApolloNameMask, withoutApolloNameMasks } from "../personName";
 
 type ApolloCandidate = {
   readonly id: string;
@@ -121,7 +121,13 @@ export function ApolloPeopleResult({
   }
   const raw = record(result);
   if (toolName === "apollo_enrich_contact") {
-    const name = text(raw?.name);
+    const rawName = text(raw?.name);
+    const nameMasked = hasApolloNameMask(rawName);
+    const name = rawName
+      ? nameMasked
+        ? withoutApolloNameMasks(rawName)
+        : rawName
+      : null;
     const title = text(raw?.title);
     const company = text(raw?.organizationName);
     const email = text(raw?.email);
@@ -138,6 +144,7 @@ export function ApolloPeopleResult({
     const contactName = name ?? "Enriched contact";
     const missing = [
       !name ? "name" : null,
+      nameMasked ? "verified full name" : null,
       !title ? "title" : null,
       !company ? "company" : null,
       !email ? "email" : null,

--- a/desktop/surfaces/gui/src/personName.ts
+++ b/desktop/surfaces/gui/src/personName.ts
@@ -6,8 +6,9 @@ export function withoutApolloNameMasks(value: string): string {
   return value
     .split(/\s+/)
     .map((token) => {
-      const markdownEmphasis = token.startsWith("*") && token.endsWith("*");
-      const hasUnicodeLetterOrNumber = /[\p{L}\p{N}]/u.test(token.replaceAll("*", ""));
+      const core = token.replace(/^["'“”‘’()[\]{}.,!?;:]+|["'“”‘’()[\]{}.,!?;:]+$/gu, "");
+      const markdownEmphasis = core.startsWith("*") && core.endsWith("*");
+      const hasUnicodeLetterOrNumber = /[\p{L}\p{N}]/u.test(core.replaceAll("*", ""));
       return token.includes("*") && hasUnicodeLetterOrNumber && !markdownEmphasis
         ? "(surname hidden by Apollo)"
         : token;

--- a/desktop/surfaces/gui/src/personName.ts
+++ b/desktop/surfaces/gui/src/personName.ts
@@ -5,11 +5,13 @@ export function hasApolloNameMask(value: unknown): boolean {
 export function withoutApolloNameMasks(value: string): string {
   return value
     .split(/\s+/)
-    .map((token) =>
-      token.includes("*") && /[A-Za-z]/.test(token)
+    .map((token) => {
+      const markdownEmphasis = token.startsWith("*") && token.endsWith("*");
+      const hasUnicodeLetterOrNumber = /[\p{L}\p{N}]/u.test(token.replaceAll("*", ""));
+      return token.includes("*") && hasUnicodeLetterOrNumber && !markdownEmphasis
         ? "(surname hidden by Apollo)"
-        : token,
-    )
+        : token;
+    })
     .join(" ");
 }
 

--- a/desktop/surfaces/gui/src/personName.ts
+++ b/desktop/surfaces/gui/src/personName.ts
@@ -12,3 +12,14 @@ export function withoutApolloNameMasks(value: string): string {
     )
     .join(" ");
 }
+
+export function sanitizeApolloNameMasks(value: unknown): unknown {
+  if (typeof value === "string") return withoutApolloNameMasks(value);
+  if (Array.isArray(value)) return value.map(sanitizeApolloNameMasks);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, item]) => [key, sanitizeApolloNameMasks(item)]),
+    );
+  }
+  return value;
+}

--- a/desktop/surfaces/gui/src/personName.ts
+++ b/desktop/surfaces/gui/src/personName.ts
@@ -1,0 +1,14 @@
+export function hasApolloNameMask(value: unknown): boolean {
+  return typeof value === "string" && value.includes("*");
+}
+
+export function withoutApolloNameMasks(value: string): string {
+  return value
+    .split(/\s+/)
+    .map((token) =>
+      token.includes("*") && /[A-Za-z]/.test(token)
+        ? "(surname hidden by Apollo)"
+        : token,
+    )
+    .join(" ");
+}

--- a/desktop/surfaces/gui/tests/activityGroup.test.tsx
+++ b/desktop/surfaces/gui/tests/activityGroup.test.tsx
@@ -165,7 +165,8 @@ describe("ActivityGroup", () => {
       name: "Searched Apollo · Completed",
     });
     expect(disclosure).toHaveAttribute("aria-expanded", "false");
-    expect(screen.getByText("Tim Zh***g")).toBeInTheDocument();
+    expect(screen.getByText("Tim")).toBeInTheDocument();
+    expect(screen.getByText("Surname hidden by Apollo")).toBeInTheDocument();
   });
 
   it("does not duplicate the domain result when the activity trace is also expanded", () => {
@@ -195,7 +196,8 @@ describe("ActivityGroup", () => {
     fireEvent.click(
       screen.getByRole("button", { name: "Searched Apollo · Completed" }),
     );
-    expect(screen.getAllByText("Tim Zh***g")).toHaveLength(1);
+    expect(screen.getAllByText("Tim")).toHaveLength(1);
+    expect(screen.getAllByText("Surname hidden by Apollo")).toHaveLength(1);
   });
 
   it("auto-collapses the activity trace to a quiet receipt once a running turn completes", () => {

--- a/desktop/surfaces/gui/tests/apolloCurationApi.test.ts
+++ b/desktop/surfaces/gui/tests/apolloCurationApi.test.ts
@@ -73,11 +73,13 @@ describe("Apollo curation API boundary", () => {
       version: 2,
       operation: "created",
       first_name: "Tim",
-      last_name: "Zh***g",
+      last_name: null,
+      last_name_status: "hidden_by_apollo",
       title: "CEO",
       company: "Apollo.io",
       sourcing_chat: null,
     });
+    expect(JSON.stringify(result)).not.toContain("Zh***g");
     expect(JSON.stringify(result)).not.toContain("PRIVATE");
   });
 });

--- a/desktop/surfaces/gui/tests/apolloPeopleResult.test.tsx
+++ b/desktop/surfaces/gui/tests/apolloPeopleResult.test.tsx
@@ -106,13 +106,25 @@ describe("Apollo people result", () => {
     api.openPersonSourcingChat.mockReset();
   });
 
+  it("shows an honest incomplete name without rendering Apollo's mask", () => {
+    const { container } = renderApollo();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Searched Apollo · Completed" }),
+    );
+
+    expect(screen.getByText("Tim")).toBeInTheDocument();
+    expect(screen.getByText("Surname hidden by Apollo")).toBeInTheDocument();
+    expect(screen.getByRole("checkbox", { name: "Select Tim" })).toBeInTheDocument();
+    expect(container).not.toHaveTextContent("Zh***g");
+  });
+
   it("lets the director select several candidates and review before keeping", async () => {
     renderApollo();
     fireEvent.click(
       screen.getByRole("button", { name: "Searched Apollo · Completed" }),
     );
 
-    fireEvent.click(screen.getByRole("checkbox", { name: "Select Tim Zh***g" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Tim" }));
     fireEvent.click(screen.getByRole("checkbox", { name: "Select Maya" }));
     fireEvent.change(
       screen.getByRole("textbox", { name: "Target for selected people" }),
@@ -125,7 +137,8 @@ describe("Apollo people result", () => {
     const review = screen.getByRole("region", {
       name: "Review selected Apollo candidates",
     });
-    expect(review).toHaveTextContent("Tim Zh***g");
+    expect(review).toHaveTextContent("Tim");
+    expect(review).not.toHaveTextContent("Zh***g");
     expect(review).toHaveTextContent("Maya");
     expect(review).toHaveTextContent(
       "Invite senior operators to the director's dinner.",
@@ -159,7 +172,8 @@ describe("Apollo people result", () => {
           version: 1,
           operation: "created",
           first_name: "Tim",
-          last_name: "Zh***g",
+          last_name: null,
+          last_name_status: "hidden_by_apollo",
           title: "CEO",
           company: "Apollo.io",
           sourcing_chat: { session_id: "thread-apollo" },
@@ -175,7 +189,7 @@ describe("Apollo people result", () => {
     });
     renderApollo();
     fireEvent.click(screen.getByRole("button", { name: "Searched Apollo · Completed" }));
-    fireEvent.click(screen.getByRole("checkbox", { name: "Select Tim Zh***g" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Tim" }));
     fireEvent.change(screen.getByRole("textbox", { name: "Target for selected people" }), {
       target: { value: "Director-authored target" },
     });
@@ -188,7 +202,9 @@ describe("Apollo people result", () => {
       ),
     );
     expect(
-      await screen.findByRole("button", { name: "Open sourcing chat for Tim Zh***g" }),
+      await screen.findByRole("button", {
+        name: "Open sourcing chat for Tim (surname hidden by Apollo)",
+      }),
     ).toBeInTheDocument();
     expect(screen.queryByText(/original target conversation remains unbound/i)).not.toBeInTheDocument();
   });
@@ -209,7 +225,7 @@ describe("Apollo people result", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: "Searched Apollo · Completed" }));
 
-    expect(screen.getAllByRole("checkbox", { name: "Select Tim Zh***g" })).toHaveLength(1);
+    expect(screen.getAllByRole("checkbox", { name: "Select Tim" })).toHaveLength(1);
     expect(screen.getByText("1 candidate")).toBeInTheDocument();
     expect(screen.queryByText("Duplicate must not replace first")).not.toBeInTheDocument();
   });
@@ -227,7 +243,8 @@ describe("Apollo people result", () => {
           version: 1,
           operation: "created",
           first_name: "Tim",
-          last_name: "Zh***g",
+          last_name: null,
+          last_name_status: "hidden_by_apollo",
           title: "CEO",
           company: "Apollo.io",
           sourcing_chat: null,
@@ -240,6 +257,7 @@ describe("Apollo people result", () => {
           operation: "created",
           first_name: "Maya",
           last_name: null,
+          last_name_status: "missing",
           title: null,
           company: "Apollo.io",
           sourcing_chat: null,
@@ -256,11 +274,11 @@ describe("Apollo people result", () => {
     api.openPersonSourcingChat.mockResolvedValueOnce({
       created: true,
       session: { id: "thread-tim", title: "Sourcing · Tim", n_msgs: 0 },
-      active_person: { person_id: "person-tim-file", version: 1, label: "Tim Zh***g" },
+      active_person: { person_id: "person-tim-file", version: 1, label: "Tim" },
     });
     renderApollo();
     fireEvent.click(screen.getByRole("button", { name: "Searched Apollo · Completed" }));
-    fireEvent.click(screen.getByRole("checkbox", { name: "Select Tim Zh***g" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Tim" }));
     fireEvent.click(screen.getByRole("checkbox", { name: "Select Maya" }));
     fireEvent.change(screen.getByRole("textbox", { name: "Target for selected people" }), {
       target: { value: "Director-authored target" },
@@ -269,13 +287,17 @@ describe("Apollo people result", () => {
     fireEvent.click(screen.getByRole("button", { name: "Keep 2 people" }));
 
     expect(
-      await screen.findByRole("link", { name: "Open person file for Tim Zh***g" }),
+      await screen.findByRole("link", {
+        name: "Open person file for Tim (surname hidden by Apollo)",
+      }),
     ).toHaveAttribute("href", "#/people/person-tim-file");
     expect(
       screen.getByRole("link", { name: "Open person file for Maya" }),
     ).toHaveAttribute("href", "#/people/person-maya-file");
     fireEvent.click(
-      screen.getByRole("button", { name: "Create sourcing chat for Tim Zh***g" }),
+      screen.getByRole("button", {
+        name: "Create sourcing chat for Tim (surname hidden by Apollo)",
+      }),
     );
     await waitFor(() =>
       expect(api.openPersonSourcingChat).toHaveBeenCalledWith("person-tim-file", 1),
@@ -298,7 +320,8 @@ describe("Apollo people result", () => {
           version: 1,
           operation: "created",
           first_name: "Tim",
-          last_name: "Zh***g",
+          last_name: null,
+          last_name_status: "hidden_by_apollo",
           title: "CEO",
           company: "Apollo.io",
           sourcing_chat: null,
@@ -315,14 +338,16 @@ describe("Apollo people result", () => {
     api.openPersonSourcingChat.mockRejectedValueOnce(new Error("stale person version"));
     renderApollo();
     fireEvent.click(screen.getByRole("button", { name: "Searched Apollo · Completed" }));
-    fireEvent.click(screen.getByRole("checkbox", { name: "Select Tim Zh***g" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Tim" }));
     fireEvent.change(screen.getByRole("textbox", { name: "Target for selected people" }), {
       target: { value: "Director-authored target" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Review 1 selected candidate" }));
     fireEvent.click(screen.getByRole("button", { name: "Keep 1 person" }));
     fireEvent.click(
-      await screen.findByRole("button", { name: "Create sourcing chat for Tim Zh***g" }),
+      await screen.findByRole("button", {
+        name: "Create sourcing chat for Tim (surname hidden by Apollo)",
+      }),
     );
 
     expect(
@@ -344,7 +369,8 @@ describe("Apollo people result", () => {
             version: 1,
             operation: "created",
             first_name: "Tim",
-            last_name: "Zh***g",
+            last_name: null,
+            last_name_status: "hidden_by_apollo",
             title: "CEO",
             company: "Apollo.io",
             sourcing_chat: null,
@@ -373,6 +399,7 @@ describe("Apollo people result", () => {
             operation: "created",
             first_name: "Maya",
             last_name: null,
+            last_name_status: "missing",
             title: null,
             company: "Apollo.io",
             sourcing_chat: null,
@@ -388,7 +415,7 @@ describe("Apollo people result", () => {
       });
     renderApollo();
     fireEvent.click(screen.getByRole("button", { name: "Searched Apollo · Completed" }));
-    fireEvent.click(screen.getByRole("checkbox", { name: "Select Tim Zh***g" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Tim" }));
     fireEvent.click(screen.getByRole("checkbox", { name: "Select Maya" }));
     fireEvent.change(screen.getByRole("textbox", { name: "Target for selected people" }), {
       target: { value: "Director-authored target" },
@@ -399,7 +426,11 @@ describe("Apollo people result", () => {
     expect(
       await screen.findByText("Maya needs review (invalid candidate)."),
     ).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Open person file for Tim Zh***g" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: "Open person file for Tim (surname hidden by Apollo)",
+      }),
+    ).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Retry 1 failed candidate" }));
 
     await waitFor(() => expect(api.curateApolloCandidates).toHaveBeenCalledTimes(2));
@@ -408,7 +439,11 @@ describe("Apollo people result", () => {
       expect.objectContaining({ apolloId: "person-partial" }),
     ]);
     expect(retry.bindOriginal).toBe(false);
-    expect(screen.getByRole("link", { name: "Open person file for Tim Zh***g" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: "Open person file for Tim (surname hidden by Apollo)",
+      }),
+    ).toBeInTheDocument();
     expect(
       await screen.findByRole("link", { name: "Open person file for Maya" }),
     ).toBeInTheDocument();
@@ -531,11 +566,11 @@ describe("Apollo people result", () => {
       screen.getByText("Enrichment uses Apollo credits and requires approval."),
     ).toBeInTheDocument();
     fireEvent.click(
-      screen.getByRole("button", { name: "Inspect candidate Tim Zh***g" }),
+      screen.getByRole("button", { name: "Inspect candidate Tim" }),
     );
     const inspector = screen.getByRole("complementary", { name: "Inspector" });
     expect(within(inspector).getByRole("heading", { level: 2 })).toHaveTextContent(
-      "Tim Zh***g",
+      "Tim",
     );
     expect(within(inspector).getByText("Apollo")).toBeInTheDocument();
 
@@ -618,7 +653,8 @@ describe("Apollo people result", () => {
       screen.getByRole("heading", { name: "Apollo shortlist" }),
     ).toBeInTheDocument();
     expect(screen.getByText("2 candidates")).toBeInTheDocument();
-    expect(screen.getByText("Tim Zh***g")).toBeInTheDocument();
+    expect(screen.getByText("Tim")).toBeInTheDocument();
+    expect(screen.getByText("Surname hidden by Apollo")).toBeInTheDocument();
     expect(screen.getByText("CEO · Apollo.io")).toBeInTheDocument();
     expect(screen.getByText("Email available after enrichment")).toBeInTheDocument();
     expect(

--- a/desktop/surfaces/gui/tests/apolloPeopleResult.test.tsx
+++ b/desktop/surfaces/gui/tests/apolloPeopleResult.test.tsx
@@ -116,6 +116,12 @@ describe("Apollo people result", () => {
     expect(screen.getByText("Surname hidden by Apollo")).toBeInTheDocument();
     expect(screen.getByRole("checkbox", { name: "Select Tim" })).toBeInTheDocument();
     expect(container).not.toHaveTextContent("Zh***g");
+
+    fireEvent.click(screen.getByRole("button", { name: "Inspect Searched Apollo" }));
+    fireEvent.click(screen.getByText("Result"));
+    const inspector = screen.getByRole("complementary", { name: "Inspector" });
+    expect(inspector).toHaveTextContent("surname hidden by Apollo");
+    expect(inspector).not.toHaveTextContent("Zh***g");
   });
 
   it("lets the director select several candidates and review before keeping", async () => {
@@ -621,6 +627,42 @@ describe("Apollo people result", () => {
       "href",
       "https://www.linkedin.com/in/timzheng",
     );
+  });
+
+  it("renders a masked enrichment name as an honest incomplete identity", () => {
+    const { container } = renderApollo(
+      apolloEnrich({
+        result: {
+          name: "Ada L***e",
+          title: "Founder",
+          organizationName: "Analytic",
+          email: "ada@analytic.example",
+          phone: null,
+          linkedinUrl: "https://www.linkedin.com/in/ada",
+        },
+      }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Enriched contact with Apollo · Completed",
+      }),
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: "Inspect enriched contact Ada (surname hidden by Apollo)",
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Missing verified full name", { exact: false })).toBeInTheDocument();
+    expect(container).not.toHaveTextContent("L***e");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Inspect Enriched contact with Apollo" }),
+    );
+    fireEvent.click(screen.getByText("Result"));
+    const inspector = screen.getByRole("complementary", { name: "Inspector" });
+    expect(inspector).toHaveTextContent("Ada (surname hidden by Apollo)");
+    expect(inspector).not.toHaveTextContent("L***e");
   });
 
   it("does not present Apollo enrichment as running before approval", () => {

--- a/desktop/surfaces/gui/tests/apolloPeopleResult.test.tsx
+++ b/desktop/surfaces/gui/tests/apolloPeopleResult.test.tsx
@@ -629,41 +629,46 @@ describe("Apollo people result", () => {
     );
   });
 
-  it("renders a masked enrichment name as an honest incomplete identity", () => {
-    const { container } = renderApollo(
-      apolloEnrich({
-        result: {
-          name: "Ada L***e",
-          title: "Founder",
-          organizationName: "Analytic",
-          email: "ada@analytic.example",
-          phone: null,
-          linkedinUrl: "https://www.linkedin.com/in/ada",
-        },
-      }),
-    );
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "Enriched contact with Apollo · Completed",
-      }),
-    );
+  it.each(["Ada L***e", "Ada 张***李"])(
+    "renders a masked enrichment name as an honest incomplete identity: %s",
+    (maskedName) => {
+      const { container } = renderApollo(
+        apolloEnrich({
+          result: {
+            name: maskedName,
+            title: "Founder",
+            organizationName: "Analytic",
+            email: "ada@analytic.example",
+            phone: null,
+            linkedinUrl: "https://www.linkedin.com/in/ada",
+          },
+        }),
+      );
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: "Enriched contact with Apollo · Completed",
+        }),
+      );
 
-    expect(
-      screen.getByRole("button", {
-        name: "Inspect enriched contact Ada (surname hidden by Apollo)",
-      }),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Missing verified full name", { exact: false })).toBeInTheDocument();
-    expect(container).not.toHaveTextContent("L***e");
+      expect(
+        screen.getByRole("button", {
+          name: "Inspect enriched contact Ada (surname hidden by Apollo)",
+        }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Missing verified full name", { exact: false }),
+      ).toBeInTheDocument();
+      expect(container).not.toHaveTextContent(maskedName);
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Inspect Enriched contact with Apollo" }),
-    );
-    fireEvent.click(screen.getByText("Result"));
-    const inspector = screen.getByRole("complementary", { name: "Inspector" });
-    expect(inspector).toHaveTextContent("Ada (surname hidden by Apollo)");
-    expect(inspector).not.toHaveTextContent("L***e");
-  });
+      fireEvent.click(
+        screen.getByRole("button", { name: "Inspect Enriched contact with Apollo" }),
+      );
+      fireEvent.click(screen.getByText("Result"));
+      const inspector = screen.getByRole("complementary", { name: "Inspector" });
+      expect(inspector).toHaveTextContent("Ada (surname hidden by Apollo)");
+      expect(inspector).not.toHaveTextContent(maskedName);
+    },
+  );
 
   it("does not present Apollo enrichment as running before approval", () => {
     renderApollo(

--- a/desktop/surfaces/gui/tests/approvalCard.test.tsx
+++ b/desktop/surfaces/gui/tests/approvalCard.test.tsx
@@ -264,6 +264,34 @@ describe("ApprovalCard", () => {
     expect(onDecision).toHaveBeenCalledWith(true);
   });
 
+  it("sanitizes a restored Apollo approval that contains a masked surname", () => {
+    const { container } = render(
+      <ApprovalCard
+        part={{
+          ...approvalPart(),
+          toolName: "apollo_enrich_contact",
+          args: {
+            firstName: "Fisher",
+            lastName: "Zh***g",
+            organizationName: "The Hog",
+          },
+          approval: {
+            id: "approval-apollo-restored",
+            reason:
+              "Spends 1 Apollo credit to look up Fisher Zh***g by Apollo ID.",
+          },
+        } as ToolCallMessagePartProps}
+        onDecision={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Review full request and policy" }),
+    );
+    expect(container).toHaveTextContent("Fisher (surname hidden by Apollo)");
+    expect(container).not.toHaveTextContent("Zh***g");
+  });
+
   it("does not re-offer a queued decision and explains it is waiting for the connection", async () => {
     const onDecision = vi.fn().mockResolvedValue("queued");
     render(<ApprovalCard part={approvalPart()} onDecision={onDecision} />);

--- a/desktop/surfaces/gui/tests/boardPerson.test.tsx
+++ b/desktop/surfaces/gui/tests/boardPerson.test.tsx
@@ -185,6 +185,52 @@ describe("Board and person-file routes", () => {
     expect(screen.getByRole("region", { name: "In conversation" })).toHaveTextContent("None");
   });
 
+  it("labels an Apollo-hidden surname honestly on Board and person file", async () => {
+    api.getBoard.mockResolvedValue({
+      open: [
+        {
+          person_id: "person one",
+          first_name: "Hudson",
+          last_name: null,
+          last_name_status: "hidden_by_apollo",
+          title: "CEO",
+          company: "The Hog",
+          sequence_state: "open",
+        },
+      ],
+      in_conversation: [],
+      done: [],
+    });
+    api.getPerson.mockResolvedValue({
+      ...(await api.getPerson()),
+      person: {
+        person_id: "person one",
+        first_name: "Hudson",
+        last_name: null,
+        last_name_status: "hidden_by_apollo",
+        sequence_state: "open",
+        version: 2,
+        sources: [],
+      },
+      brief: livingBrief({
+        who: "Hudson, CEO at The Hog",
+        why: "YC F25 target",
+        learned: [],
+        missing: [],
+        sources: [],
+      }),
+    });
+
+    const board = render(<BoardView />);
+    expect(await screen.findByText("Surname hidden by Apollo")).toBeInTheDocument();
+    expect(board.container).not.toHaveTextContent("***");
+    board.unmount();
+
+    const person = render(<PersonFileView personId="person one" />);
+    expect(await screen.findByText(/Enrich to verify the full name/i)).toBeInTheDocument();
+    expect(person.container).not.toHaveTextContent("***");
+  });
+
   it("updates a person sequence through labeled pressed-state controls", async () => {
     const { container } = render(<PersonFileView personId="person one" />);
 

--- a/desktop/surfaces/gui/tests/chatPage.test.tsx
+++ b/desktop/surfaces/gui/tests/chatPage.test.tsx
@@ -2172,7 +2172,8 @@ describe("ChatPage Warm Operator thread", () => {
         name: "Searched Apollo · Completed",
       }),
     );
-    expect(screen.getByText("Restored Le***")).toBeInTheDocument();
+    expect(screen.getByText("Restored")).toBeInTheDocument();
+    expect(screen.getByText("Surname hidden by Apollo")).toBeInTheDocument();
     expect(screen.getByText("Director at Abridge")).toBeInTheDocument();
 
     const live = {
@@ -2233,7 +2234,8 @@ describe("ChatPage Warm Operator thread", () => {
       });
     });
 
-    expect(await screen.findByText("Live Ki***")).toBeInTheDocument();
+    expect(await screen.findByText("Live")).toBeInTheDocument();
+    expect(screen.getAllByText("Surname hidden by Apollo")).toHaveLength(2);
     expect(screen.getByText("VP Talent at Acme")).toBeInTheDocument();
     expect(
       screen.queryByRole("list", { name: "Loading Apollo candidates" }),

--- a/desktop/surfaces/gui/tests/personName.test.ts
+++ b/desktop/surfaces/gui/tests/personName.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { withoutApolloNameMasks } from "../src/personName";
+
+describe("Apollo name masks", () => {
+  it("handles non-Latin masked surnames without rewriting Markdown prose", () => {
+    expect(withoutApolloNameMasks("Ada 张***李")).toBe(
+      "Ada (surname hidden by Apollo)",
+    );
+    expect(
+      withoutApolloNameMasks("This is **important**. Use *carefully*, please."),
+    ).toBe("This is **important**. Use *carefully*, please.");
+  });
+});

--- a/desktop/tests/test_apollo.py
+++ b/desktop/tests/test_apollo.py
@@ -2,8 +2,18 @@ import os
 
 import pytest
 
-from coworker.apollo import MATCH_URL, SEARCH_URL, FakeHttp, LiveHttp, search_people
+from coworker.apollo import (
+    MATCH_URL,
+    SEARCH_URL,
+    FakeHttp,
+    LiveHttp,
+    enrichment_match,
+    enrichment_resource,
+    apollo_evidence,
+    search_people,
+)
 from coworker.people import PersonStore
+from coworker.evidence_envelope import model_payload
 from coworker.tools import execute
 
 
@@ -40,6 +50,29 @@ def test_apollo_search_does_not_invent_emails():
     assert "email" not in person
     assert "should-not-leak" not in str(result)
     assert http.calls[0]["headers"]["x-api-key"] == "test-key"
+
+
+def test_apollo_search_model_evidence_never_contains_the_masked_surname():
+    parts = apollo_evidence(
+        "apollo_search_people",
+        {
+            "people": [
+                {
+                    "apolloId": "person-fisher",
+                    "firstName": "Fisher",
+                    "lastNameObfuscated": "Zh***g",
+                    "title": "Building GTM AI",
+                    "organizationName": "The Hog",
+                }
+            ]
+        },
+    )
+
+    rendered = str(model_payload(parts))
+
+    assert "Fisher" in rendered
+    assert "surname hidden by Apollo" in rendered
+    assert "Zh***g" not in rendered
 
 
 def test_apollo_enrich_returns_contact(tmp_path):
@@ -149,6 +182,24 @@ def test_a_masked_surname_falls_back_to_the_person_files_apollo_id(tmp_path):
     # The mask must never travel to Apollo.
     assert body["last_name"] is None
     assert people.get(person["person_id"])["email"] == "fisher@thehog.example"
+
+
+def test_enrichment_approval_names_an_incomplete_person_without_the_mask(tmp_path):
+    people = PersonStore(tmp_path)
+    person = people.keep_from_apollo(
+        apollo_id="679c7e37",
+        first_name="Fisher",
+        last_name_obfuscated="Zh***g",
+        title="Building GTM AI",
+        company="The Hog",
+    )
+    match = enrichment_match(person)
+    assert match is not None
+
+    resource = enrichment_resource(person, match)
+
+    assert resource["person"] == "Fisher (surname hidden by Apollo)"
+    assert "Zh***g" not in str(resource)
 
 
 def test_a_masked_surname_with_no_apollo_id_refuses_rather_than_spending(tmp_path):

--- a/desktop/tests/test_apollo.py
+++ b/desktop/tests/test_apollo.py
@@ -75,11 +75,12 @@ def test_apollo_search_model_evidence_never_contains_the_masked_surname():
     assert "Zh***g" not in rendered
 
 
-def test_apollo_enrichment_model_evidence_never_contains_a_masked_name():
+@pytest.mark.parametrize("masked_name", ["Ada L***e", "Ada 张***李"])
+def test_apollo_enrichment_model_evidence_never_contains_a_masked_name(masked_name):
     parts = apollo_evidence(
         "apollo_enrich_contact",
         {
-            "name": "Ada L***e",
+            "name": masked_name,
             "title": "Founder",
             "organizationName": "Analytic",
             "email": "ada@analytic.example",
@@ -89,7 +90,7 @@ def test_apollo_enrichment_model_evidence_never_contains_a_masked_name():
     rendered = str(model_payload(parts))
 
     assert "Ada (surname hidden by Apollo)" in rendered
-    assert "L***e" not in rendered
+    assert masked_name not in rendered
 
 
 def test_apollo_enrich_returns_contact(tmp_path):

--- a/desktop/tests/test_apollo.py
+++ b/desktop/tests/test_apollo.py
@@ -75,6 +75,23 @@ def test_apollo_search_model_evidence_never_contains_the_masked_surname():
     assert "Zh***g" not in rendered
 
 
+def test_apollo_enrichment_model_evidence_never_contains_a_masked_name():
+    parts = apollo_evidence(
+        "apollo_enrich_contact",
+        {
+            "name": "Ada L***e",
+            "title": "Founder",
+            "organizationName": "Analytic",
+            "email": "ada@analytic.example",
+        },
+    )
+
+    rendered = str(model_payload(parts))
+
+    assert "Ada (surname hidden by Apollo)" in rendered
+    assert "L***e" not in rendered
+
+
 def test_apollo_enrich_returns_contact(tmp_path):
     http = FakeHttp(
         {

--- a/desktop/tests/test_approved_enrichment.py
+++ b/desktop/tests/test_approved_enrichment.py
@@ -195,6 +195,49 @@ def test_an_approved_enrichment_updates_only_that_person_and_files_the_receipt(
     assert enrich_events[0]["session_id"] == session_id
 
 
+def test_verified_enrichment_promotes_the_full_name_across_person_surfaces(tmp_path):
+    from coworker.server import system_prompt
+
+    http = FakeHttp({MATCH_URL: APOLLO_PERSON})
+    app = _app(tmp_path, http)
+    client = TestClient(app)
+    person_id, session_id = _person(
+        app,
+        apollo_id="apollo_person_77",
+        first="Ada",
+        last="L***e",
+    )
+    app.state.store.rename_session(session_id, "Sourcing · Ada L***e")
+    parked = _park(client, person_id, session_id)
+    assert "L***e" not in parked.text
+
+    decided = _decide(client, parked.json()["item"]["id"])
+
+    assert decided.status_code == 200, decided.text
+    person = app.state.people.get(person_id)
+    assert person is not None
+    assert person["person_id"] == person_id
+    assert person["last_name"] == "Lovelace"
+    assert person["last_name_status"] == "known"
+    assert "L***e" not in str(person)
+    person_view = client.get(f"/v1/people/{person_id}", headers=HEADERS)
+    assert person_view.status_code == 200
+    assert "Ada Lovelace" in person_view.text
+    assert "L***e" not in person_view.text
+    prompt = system_prompt(
+        app.state.store,
+        people=app.state.people,
+        session_id=session_id,
+    )
+    assert "Ada Lovelace" in prompt
+    assert "L***e" not in prompt
+    session = app.state.store.index(session_id)
+    assert session is not None
+    assert "Ada Lovelace" in str(session["title"])
+    assert "L***e" not in str(session["title"])
+    assert app.state.people.person_for_session(session_id) == person_id
+
+
 def test_a_denied_enrichment_spends_no_credit(tmp_path):
     http = FakeHttp({MATCH_URL: APOLLO_PERSON})
     app = _app(tmp_path, http)

--- a/desktop/tests/test_bound_turn.py
+++ b/desktop/tests/test_bound_turn.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 
 from coworker.apollo import MATCH_URL, FakeHttp
 from coworker.gmail import FakeGmail
@@ -46,6 +47,56 @@ def _run(*, tmp_path, sid, text, provider, people, gmail=None, drive=None, wait=
             wait_permission=_wait if wait is not None else None,
         )
     )
+
+
+def test_restored_apollo_mask_never_reaches_the_next_model_request(tmp_path):
+    store = ConversationStore(tmp_path)
+    store.append("sess-legacy-enrichment", {"role": "user", "content": "Enrich Ada"})
+    store.append(
+        "sess-legacy-enrichment",
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "legacy-enrich",
+                    "type": "function",
+                    "function": {
+                        "name": "apollo_enrich_contact",
+                        "arguments": json.dumps(
+                            {
+                                "firstName": "Ada",
+                                "lastName": "L***e",
+                                "organizationName": "Analytic",
+                            }
+                        ),
+                    },
+                }
+            ],
+        },
+    )
+    store.append(
+        "sess-legacy-enrichment",
+        {
+            "role": "tool",
+            "name": "apollo_enrich_contact",
+            "tool_call_id": "legacy-enrich",
+            "content": json.dumps({"error": "Director denied this enrichment."}),
+        },
+    )
+    provider = FakeProvider(deltas=("Understood.",))
+
+    _run(
+        tmp_path=tmp_path,
+        sid="sess-legacy-enrichment",
+        text="Leave the person incomplete",
+        provider=provider,
+        people=PersonStore(tmp_path),
+    )
+
+    model_request = json.dumps(provider.calls[0])
+    assert "surname hidden by Apollo" in model_request
+    assert "L***e" not in model_request
 
 
 def test_keep_one_person_binds_that_session_only(tmp_path):

--- a/desktop/tests/test_bound_turn.py
+++ b/desktop/tests/test_bound_turn.py
@@ -1,6 +1,8 @@
 import asyncio
 import json
 
+import pytest
+
 from coworker.apollo import MATCH_URL, FakeHttp
 from coworker.gmail import FakeGmail
 from coworker.inbox import Inbox
@@ -49,7 +51,10 @@ def _run(*, tmp_path, sid, text, provider, people, gmail=None, drive=None, wait=
     )
 
 
-def test_restored_apollo_mask_never_reaches_the_next_model_request(tmp_path):
+@pytest.mark.parametrize("masked_last_name", ["L***e", "张***李"])
+def test_restored_apollo_mask_never_reaches_the_next_model_request(
+    tmp_path, masked_last_name
+):
     store = ConversationStore(tmp_path)
     store.append("sess-legacy-enrichment", {"role": "user", "content": "Enrich Ada"})
     store.append(
@@ -66,7 +71,7 @@ def test_restored_apollo_mask_never_reaches_the_next_model_request(tmp_path):
                         "arguments": json.dumps(
                             {
                                 "firstName": "Ada",
-                                "lastName": "L***e",
+                                "lastName": masked_last_name,
                                 "organizationName": "Analytic",
                             }
                         ),
@@ -96,7 +101,7 @@ def test_restored_apollo_mask_never_reaches_the_next_model_request(tmp_path):
 
     model_request = json.dumps(provider.calls[0])
     assert "surname hidden by Apollo" in model_request
-    assert "L***e" not in model_request
+    assert masked_last_name not in model_request
 
 
 def test_keep_one_person_binds_that_session_only(tmp_path):

--- a/desktop/tests/test_bound_turn.py
+++ b/desktop/tests/test_bound_turn.py
@@ -99,9 +99,13 @@ def test_restored_apollo_mask_never_reaches_the_next_model_request(
         people=PersonStore(tmp_path),
     )
 
-    model_request = json.dumps(provider.calls[0])
-    assert "surname hidden by Apollo" in model_request
-    assert masked_last_name not in model_request
+    restored_call = next(
+        message
+        for message in provider.calls[0]
+        if message.get("role") == "assistant" and message.get("tool_calls")
+    )["tool_calls"][0]
+    restored_arguments = json.loads(restored_call["function"]["arguments"])
+    assert restored_arguments["lastName"] == "(surname hidden by Apollo)"
 
 
 def test_keep_one_person_binds_that_session_only(tmp_path):

--- a/desktop/tests/test_migrations.py
+++ b/desktop/tests/test_migrations.py
@@ -254,7 +254,7 @@ def test_legacy_people_db_upgrades_from_the_pre_registry_shape(tmp_path):
     assert store_plan.record_count > 0
 
     assert migrations.apply_migrations(root).error is None
-    assert _user_version(db) == 1
+    assert _user_version(db) == 2
 
     conn = sqlite3.connect(db)
     conn.row_factory = sqlite3.Row
@@ -275,6 +275,104 @@ def test_legacy_people_db_upgrades_from_the_pre_registry_shape(tmp_path):
         assert {"person_attachments", "person_versions"} <= tables
     finally:
         conn.close()
+
+
+def test_people_v2_moves_masked_surnames_out_of_canonical_history(tmp_path):
+    from coworker.people import PersonStore
+    from coworker.store import ConversationStore
+
+    root = tmp_path / "state"
+    conversations = ConversationStore(root)
+    conversations.create_session("sourcing-fisher")
+    conversations.rename_session("sourcing-fisher", "Sourcing · Fisher Zh***g")
+    store = PersonStore(root)
+    person = store.keep_from_apollo(
+        apollo_id="apollo-fisher",
+        first_name="Fisher",
+        last_name_obfuscated="Zhang",
+        title="Building GTM AI",
+        company="The Hog",
+    )
+    store.bind_session("sourcing-fisher", person["person_id"])
+    event = store.append_event(
+        person["person_id"],
+        source="apollo",
+        kind="search",
+        summary="Kept from the Apollo shortlist",
+        actor="assistant",
+    )
+    snapshot = json.loads(
+        store._conn.execute(
+            "SELECT person_json FROM person_versions WHERE person_id = ? AND version = 1",
+            (person["person_id"],),
+        ).fetchone()[0]
+    )
+    snapshot["last_name"] = "Zh***g"
+    snapshot["handoff_who"] = "Fisher Zh***g"
+    snapshot.pop("last_name_status", None)
+    store._conn.execute(
+        "UPDATE people SET last_name = 'Zh***g', "
+        "apollo_last_name_obfuscated = NULL, handoff_who = 'Fisher Zh***g' "
+        "WHERE person_id = ?",
+        (person["person_id"],),
+    )
+    store._conn.execute(
+        "UPDATE person_versions SET person_json = ? WHERE person_id = ? AND version = 1",
+        (json.dumps(snapshot), person["person_id"]),
+    )
+    store._conn.execute("PRAGMA user_version = 1")
+    store._conn.commit()
+
+    plan = _plan_for(migrations.plan_migrations(root), "people_db")
+    assert plan.status is StoreStatus.PENDING
+    assert plan.from_version == 1
+    assert plan.to_version == 2
+
+    outcome = migrations.apply_migrations(root)
+
+    assert outcome.error is None
+    assert _user_version(root / "people.db") == 2
+    loaded = PersonStore(root).get(person["person_id"])
+    assert loaded is not None
+    assert loaded["person_id"] == person["person_id"]
+    assert loaded["apollo_id"] == "apollo-fisher"
+    assert loaded["last_name"] is None
+    assert loaded["last_name_status"] == "hidden_by_apollo"
+    assert loaded["handoff_who"] == "Fisher (surname hidden by Apollo)"
+    assert "Zh***g" not in str(loaded)
+    assert PersonStore(root).person_for_session("sourcing-fisher") == person["person_id"]
+    assert PersonStore(root).timeline(person["person_id"])[0]["event_id"] == event["event_id"]
+    migrated_conn = sqlite3.connect(root / "people.db")
+    try:
+        migrated_snapshot = json.loads(
+            migrated_conn.execute(
+                "SELECT person_json FROM person_versions "
+                "WHERE person_id = ? AND version = 1",
+                (person["person_id"],),
+            ).fetchone()[0]
+        )
+    finally:
+        migrated_conn.close()
+    assert migrated_snapshot["last_name"] is None
+    assert migrated_snapshot["last_name_status"] == "hidden_by_apollo"
+    assert migrated_snapshot["handoff_who"] == "Fisher (surname hidden by Apollo)"
+    assert "Zh***g" not in str(migrated_snapshot)
+    from coworker.server import TOKEN_HEADER, create_app
+    from fastapi.testclient import TestClient
+
+    app = create_app(token="migration-test-token", provider=None, state=root)
+    migrated_title = app.state.store.index("sourcing-fisher")["title"]
+    assert "Fisher" in migrated_title
+    assert "Zh***g" not in migrated_title
+    sessions = TestClient(app).get(
+        "/v1/sessions",
+        headers={TOKEN_HEADER: "migration-test-token"},
+    ).json()["sessions"]
+    title = next(
+        row["title"] for row in sessions if row["session_id"] == "sourcing-fisher"
+    )
+    assert "Fisher" in title
+    assert "Zh***g" not in title
 
 
 def test_legacy_meeting_evidence_db_upgrades_from_the_pre_registry_shape(tmp_path):
@@ -384,7 +482,7 @@ def test_state_is_readable_by_the_real_stores_after_a_restart(tmp_path):
 
     # Constructing the stores must not knock the recorded version off current.
     assert _user_version(root / "club.db") == 2
-    assert _user_version(root / "people.db") == 1
+    assert _user_version(root / "people.db") == 2
 
 
 # --- failing closed ------------------------------------------------------
@@ -654,15 +752,16 @@ def test_a_partially_applied_migration_does_not_leave_other_stores_half_done(
     original = migrations.spec_for("people_db")
     broken = migrations.dataclasses.replace(
         original,
-        migrations=(
-            Migration(
+            migrations=(
+                Migration(
                 from_version=0,
                 to_version=1,
                 description="deliberately failing step",
                 count=lambda _context: 1,
-                apply=explode,
+                    apply=explode,
+                ),
+                *original.migrations[1:],
             ),
-        ),
     )
     monkeypatch.setattr(
         migrations,

--- a/desktop/tests/test_people.py
+++ b/desktop/tests/test_people.py
@@ -17,7 +17,9 @@ def test_keeping_apollo_row_files_person_without_email(tmp_path):
     assert loaded is not None
     assert loaded["apollo_id"] == "abc123"
     assert loaded["first_name"] == "Alyssa"
-    assert loaded["last_name"] == "W***n"
+    assert loaded["last_name"] is None
+    assert loaded["last_name_status"] == "hidden_by_apollo"
+    assert "W***n" not in str(loaded)
     assert loaded["title"] == "Partner"
     assert loaded["company"] == "Codeology"
     assert loaded["target"] == "club research dinner"
@@ -74,7 +76,8 @@ def test_keeping_a_thinner_apollo_row_does_not_blank_the_person_file(tmp_path):
         company=None,
     )
     assert again["person_id"] == kept["person_id"]
-    assert again["last_name"] == "W***n"
+    assert again["last_name"] is None
+    assert again["last_name_status"] == "hidden_by_apollo"
     assert again["title"] == "Partner"
     assert again["company"] == "Codeology"
     assert again["target"] == "club research dinner"
@@ -97,9 +100,35 @@ def test_blank_apollo_fields_count_as_missing_not_as_a_value(tmp_path):
         company="   ",
     )
     assert again["first_name"] == "Alyssa"
-    assert again["last_name"] == "W***n"
+    assert again["last_name"] is None
+    assert again["last_name_status"] == "hidden_by_apollo"
     assert again["title"] == "Partner"
     assert again["company"] == "Codeology"
+
+
+def test_person_patch_refuses_an_obfuscated_canonical_surname(tmp_path):
+    store = PersonStore(tmp_path)
+    person = store.keep_from_apollo(
+        apollo_id="abc123",
+        first_name="Alyssa",
+        last_name_obfuscated="W***n",
+        title="Partner",
+        company="Codeology",
+    )
+
+    with pytest.raises(ValueError, match="obfuscated"):
+        store.patch(
+            person["person_id"],
+            fields={"last_name": "W***n"},
+            expected_version=person["version"],
+            actor="director",
+            rationale_summary="Do not store Apollo's mask as a name.",
+        )
+
+    loaded = store.get(person["person_id"])
+    assert loaded is not None
+    assert loaded["last_name"] is None
+    assert loaded["last_name_status"] == "hidden_by_apollo"
 
 
 def _ada(store: PersonStore) -> dict:

--- a/desktop/tests/test_people.py
+++ b/desktop/tests/test_people.py
@@ -131,6 +131,29 @@ def test_person_patch_refuses_an_obfuscated_canonical_surname(tmp_path):
     assert loaded["last_name_status"] == "hidden_by_apollo"
 
 
+def test_person_handoff_preserves_ordinary_markdown_emphasis(tmp_path):
+    store = PersonStore(tmp_path)
+    person = store.keep_from_apollo(
+        apollo_id="abc123",
+        first_name="Alyssa",
+        last_name_obfuscated="W***n",
+        title="Partner",
+        company="Codeology",
+    )
+    prose = "This is **important**. Use *carefully*, please."
+
+    updated = store.patch(
+        person["person_id"],
+        fields={"handoff_happened": prose},
+        expected_version=person["version"],
+        actor="director",
+        rationale_summary="Preserve the director's formatting.",
+    )
+
+    assert updated["handoff_happened"] == prose
+    assert PersonStore(tmp_path).get(person["person_id"])["handoff_happened"] == prose
+
+
 def _ada(store: PersonStore) -> dict:
     return store.keep_from_apollo(
         apollo_id="ada",

--- a/desktop/tests/test_people_keep.py
+++ b/desktop/tests/test_people_keep.py
@@ -27,7 +27,8 @@ def test_keep_one_apollo_row_files_person_without_email(tmp_path):
     person = people.get(kept[0]["person_id"])
     assert person is not None
     assert person["first_name"] == "Alyssa"
-    assert person["last_name"] == "W***n"
+    assert person["last_name"] is None
+    assert person["last_name_status"] == "hidden_by_apollo"
     assert person["title"] == "Partner"
     assert person["company"] == "Codeology"
     assert person["target"] == "club research dinner"
@@ -67,7 +68,8 @@ def test_keep_row_with_blank_apollo_fields_keeps_what_the_file_has(tmp_path):
     assert again["kept"][0]["company"] == "Codeology"
 
     person = people.get(person_id)
-    assert person["last_name"] == "W***n"
+    assert person["last_name"] is None
+    assert person["last_name_status"] == "hidden_by_apollo"
     assert person["title"] == "Partner"
     assert person["company"] == "Codeology"
     assert person["target"] == "club research dinner"


### PR DESCRIPTION
## User problem

Apollo returns masked surnames such as `Zh***g` in search results. Sourcecado treated those vendor placeholders as real surnames, so the mask leaked into durable person files, Board cards, chat titles, prompts, approvals, and handoffs.

Closes #150.

## What changed

- Separate the private Apollo mask hint from canonical `last_name`, with an explicit `last_name_status` for honest incomplete identities.
- Add people schema v2 migration that preserves person/session/timeline identity while removing masks from canonical rows, snapshots, and handoff prose.
- Keep Apollo ID matching and credit approval intact; approved enrichment promotes a verified full name and refreshes generated sourcing-chat titles.
- Sanitize shortlist, Board, person-file, restored approval, chat, and model-evidence surfaces without guessing hidden characters.
- Reject masked canonical patches and connector name matches.

## Boundaries

- Included: Apollo keep and enrichment identity flow, durable people migration, generated bound-chat title repair, user-visible and model-visible name surfaces.
- Explicitly not included: guessing or reconstructing hidden surname characters; auto-enrichment; changing the Apollo raw source record returned by the provider.
- Product invariants preserved: Apollo ID remains durable, enrichment costs one explicitly approved credit, no send behavior changed, source and timeline identities remain stable.

## Verification

### Automated tests

- Tests added or updated: people keep/patch, migration/snapshot/handoff preservation, Apollo model evidence and approval labels, enrichment promotion, Board/person/chat UI, restored approvals, and curation API compatibility.
- Commands run: `PYTHONPATH=desktop /Users/fisher/Documents/GitHub2026/Sourcecado/desktop/.venv/bin/pytest -q desktop/tests`; `npm test`; `npm run build`; `python -m compileall -q desktop/coworker`.
- Results: 1,929 backend tests passed with 3 skipped; 532 GUI tests passed; TypeScript and Vite production build passed; Python compilation passed.

### Live behavior demonstration

- Starting state: isolated local state with an Apollo person named Fisher plus masked surname `Zh***g`, an Open Board record, and a restored bound chat titled with the old mask.
- Action performed: started the sidecar and Vite app, then navigated through Board, person file, and Open sourcing chat in a 1440x1000 Chromium session.
- Expected result: no surface renders `***`; the incomplete identity is labeled honestly; the restored chat title is repaired from canonical person data.
- Observed result and evidence: Board, person file, rail title, bound chat header, and route all rendered without `***`; Board showed `Surname hidden by Apollo`; person file showed `Surname hidden by Apollo. Enrich to verify the full name.`; restored title became `Sourcing · Fisher, Building GTM AI at The Hog`.

## AI Accountability Note

### AI helped with

Tracing every canonical, rendered, prompt, approval, migration, and connector boundary; writing test-first changes; running the regression suites and live browser repro.

### I verified

The diff, migration behavior, full backend and GUI suites, production build, compile pass, and isolated live UI flow described above.

### I am still uncertain about

Review the deliberate boundary where raw Apollo search evidence retains the provider field internally while every canonical, model, and rendered surface removes the mask. Also challenge the one-time startup repair for legacy bound-chat titles.

## Safety and integrations

- [x] No credential, OAuth grant, token, private user data, or raw authorization material was committed or pasted into the PR.
- [x] External effects remain behind the correct permission and approval policy.
- [x] Paid or credit-sensitive actions remain deliberate, approval-gated, and outside mandatory course work.
- [x] Source references and restricted data remain scoped correctly when applicable.

## Reviewer checklist

- [x] The change matches the ticket and respects its non-goals.
- [x] The normal and important failure paths are covered.
- [x] Automated verification is appropriate and passes.
- [x] The live behavior demonstration is credible when required.
- [x] The diff is understandable and safe to merge.
- [ ] I am giving meaningful Peer Approval, not a rubber stamp.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Apollo-masked surnames are now identified and stored separately from canonical names.
  * Records clearly indicate whether a surname is known, missing, or hidden by Apollo.
  * Board, person profiles, search results, and approval views display “Surname hidden by Apollo” instead of obfuscated text.
  * Verified enrichment updates records and related conversation titles with the confirmed full name.

* **Bug Fixes**
  * Prevented masked surnames from appearing in evidence, handoffs, stored history, or session titles.
  * Existing records are migrated automatically to the updated format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


