### PR TITLE
P1: replace Board with a compact Contacts table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 Sourcecado is a local-first desktop assistant for a Codeology sourcing director. The current spring proves the complete job for one operator on one machine: name a target, find people, prepare tailored outreach, deliberately enrich when needed, approve and send, keep conversations moving, and leave a person file another officer can pick up.
 
-Chat is home. The board is the assistant's operating picture. The person file is the durable domain object.
+Chat is home. Contacts is the assistant's operating picture for active sequences. The person file is the durable domain object.
 
 The active runtime is `desktop/`. The previous hosted Next.js/Postgres application is preserved in `archive/hosted-web/` and must not be treated as the current implementation.
 
@@ -13,7 +13,7 @@ The active runtime is `desktop/`. The previous hosted Next.js/Postgres applicati
 - Build the local Sourcecado desktop product: Python/FastAPI sidecar plus React/Vite/Tauri UI.
 - Optimize for one sourcing director now while keeping person files intelligible to a later officer.
 - A sequence is a person being worked through Open, In conversation, and Done. A company is context, not a deal.
-- A kept person appears in the Board's Backlog before outreach. Backlog is a Board lane, not a sequence state.
+- A kept person remains durable in the internal Board projection before outreach, but the Contacts surface shows only active sequences in Open, In conversation, and Done.
 - Apollo search may return candidates without an email. Enrichment is manual and credit-aware.
 - Sending is allowed only after explicit review and approval in Sourcecado. Never add auto-send.
 - Keep Gmail, Drive, Calendar, Granola, Apollo, and web work attached to the relevant person and run ledger.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -62,8 +62,8 @@ The accumulated person files, outcomes, source-backed notes, and handoffs that p
 **Chat**
 The home surface where the director gives targets, asks questions, reviews work, and tells the assistant what to do next.
 
-**Board**
-The assistant's operating picture of kept people and active sequences. A kept person appears in Backlog before outreach; active sequences remain Open, In conversation, and Done. Backlog is not a fourth sequence state. The Board reports the work; it is not a CRM the director must constantly maintain.
+**Contacts**
+The assistant's compact operating picture of active sequences. It presents Open, In conversation, and Done as table filters and keeps each row attached to its durable Person File. Kept people without a sequence remain stored in the internal Board projection but do not appear in Contacts yet. Contacts reports the work; it is not a CRM the director must constantly maintain.
 
 **Person View**
 The full person file and handoff record. A compact version of the living brief may appear beside work in other surfaces.
@@ -79,7 +79,7 @@ Supporting destinations in the rail. They configure connectors, skills, workspac
 
 ## Safety and scope invariants
 
-- Chat is home; the board and person view support it.
+- Chat is home; Contacts and the person view support it.
 - A human chooses the target, person, enrichment, and send.
 - No background bulk enrichment and no auto-send.
 - Connector output is untrusted input and must not override product policy.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -15,7 +15,7 @@
 - **Direction:** Industrial/Utilitarian × Organic — "Warm Operator."
 - **Decoration level:** Intentional. The dense table stays quiet and legible. Warmth and avocado character live in empty states, onboarding, the nav header, and run-ledger "win" moments. **Never decorate the table.**
 - **Mood:** Calm, dense, fast, trustworthy — but warm and human. Confidence through restraint, not chrome.
-- **Memorable thing:** "Warm, approachable, friendly, on-theme with avocado/Codeology." Every decision serves this. The painted owl with the avocado satchel is the mascot and dock icon. Masters live in `brand/`. The owl belongs in the dock, the rail mark, first-run welcome, and empty states — never on the board or other dense tables. The geometric avocado-pit motif remains a color/shape language, not the app icon.
+- **Memorable thing:** "Warm, approachable, friendly, on-theme with avocado/Codeology." Every decision serves this. The painted owl with the avocado satchel is the mascot and dock icon. Masters live in `brand/`. The owl belongs in the dock, the rail mark, first-run welcome, and empty states — never on Contacts or other dense tables. The geometric avocado-pit motif remains a color/shape language, not the app icon.
 - **Reference sites:** attio.com (density), linear.app (chrome restraint), clay.com (warmth concentrated in low-density zones).
 
 ## Typography
@@ -61,7 +61,7 @@
 ## Layout
 - **Approach:** Hybrid, grid-disciplined app shell.
 - **Shell:** Persistent global rail / center work surface / contextual inspector when evidence or a person brief needs detail. The inspector may collapse on narrow windows; it must never trap the operator away from the thread.
-- **Hero object:** The conversation is home. Dense board and person-file views are destinations in the rail; structured tool results appear inline when the assistant is doing sourcing work.
+- **Hero object:** The conversation is home. Dense Contacts and person-file views are destinations in the rail; structured tool results appear inline when the assistant is doing sourcing work.
 - **Grid:** Desktop-first shell with responsive collapse behavior. Content within panes uses a 4px rhythm and maintains usable composer and approval controls at narrow widths.
 - **Border radius:** 8px cards/inputs/panels · 6px buttons · 4px tiny inline tags · full (9999px) pills/avatars/toggles. Friendly-precise band — avoid ≥12px (toy) and ≤4px (clinical).
 - **Elevation:** Borders over shadows for dense surfaces (1px `#E7E3DA` hairlines). Reserve soft shadows for floating elements only — command palette, Gmail-draft popup, inspector.
@@ -82,6 +82,6 @@
 | Date | Decision | Rationale |
 |------|----------|-----------|
 | 2026-06-18 | Initial design system created ("Warm Operator") | Created by /design-consultation. Direction chosen: data-dense operator tool with warm/avocado character. Research-backed (Attio/Linear density + Clay warmth split). Approved after live HTML preview. |
-| 2026-08-25 | Chat became the home surface | The sourcing-director job begins with a target and a conversation; the board reports work and the person file preserves it. |
+| 2026-08-25 | Chat became the home surface | The sourcing-director job begins with a target and a conversation; Contacts reports active sequences and the person file preserves the full record. |
 | 2026-08-26 | Local desktop became the active product | The React/Vite/Tauri shell and Python sidecar replaced the hosted web app as the implementation target. |
 | 2026-08-28 | Owl mascot replaced the geometric avocado dock icon | New painted brand set: flight pose as the app icon, mapping pose on empty threads, meadow pose stored, landing-hero on first-run welcome, light social card on the README. |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The current product is the Python sidecar and React/Tauri desktop app in `deskto
 - Chat
 - People enrichment: Apollo supplies name, email, phone ; enrichment is deliberate because it spends credits.
 - Connectors: Gmail, Drive, Calendar, Granola, and web research add context
-- CRM board: Backlog, Open, In conversation, and Done.
+- Contacts: a compact table of active sequences in Open, In conversation, and Done. Kept people without a sequence remain durable Person Files but do not appear in Contacts yet.
 
 The current product specification is [Sourcecado as the sourcing director's assistant](docs/superpowers/specs/2026-08-25-sourcecado-sourcing-director-spring.md).
 

--- a/desktop/surfaces/gui/src/Board.tsx
+++ b/desktop/surfaces/gui/src/Board.tsx
@@ -8,10 +8,8 @@ import {
   type ReplyRefreshResult,
 } from "./api";
 
-function label(person: BoardPerson): { name: string; detail: string | null } {
-  const name = [person.first_name, person.last_name].filter(Boolean).join(" ") || "Unknown person";
-  const detail = [person.title, person.company].filter(Boolean).join(" · ");
-  return { name, detail: detail || null };
+function personName(person: BoardPerson): string {
+  return [person.first_name, person.last_name].filter(Boolean).join(" ") || "Unknown person";
 }
 
 function day(stamp: string | null | undefined): string | null {
@@ -40,50 +38,142 @@ function FollowUpChip({ person }: { person: BoardPerson }) {
   );
 }
 
-function Bucket({
-  id,
-  title,
-  people,
-}: {
-  id: string;
-  title: string;
-  people: BoardPerson[];
-}) {
-  const headingId = `board-${id}-heading`;
+function initials(person: BoardPerson): string {
+  const letters = [person.first_name, person.last_name]
+    .filter((value): value is string => typeof value === "string" && value.length > 0)
+    .map((value) => Array.from(value)[0])
+    .join("")
+    .slice(0, 2);
+  return letters.toLocaleUpperCase() || "?";
+}
+
+const SEQUENCE_LABEL: Record<string, string> = {
+  open: "Open",
+  in_conversation: "In conversation",
+  done: "Done",
+};
+
+type SequenceFilter = "all" | "open" | "in_conversation" | "done";
+
+const SEQUENCE_FILTERS: { value: SequenceFilter; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "open", label: "Open" },
+  { value: "in_conversation", label: "In conversation" },
+  { value: "done", label: "Done" },
+];
+
+function ContactRow({ person }: { person: BoardPerson }) {
+  const name = personName(person);
+  const sequence = SEQUENCE_LABEL[person.sequence_state ?? ""] ?? "Unknown";
   return (
-    <section className="board-bucket" aria-labelledby={headingId}>
-      <div className="board-bucket-heading">
-        <h2 id={headingId}>{title}</h2>
-        <span aria-label={`${people.length} people`}>{people.length}</span>
-      </div>
-      {people.length === 0 ? (
-        <p className="board-bucket-empty">None</p>
-      ) : (
-        <div className="board-rows">
-          {people.map((person) => {
-            const copy = label(person);
-            return (
-              <a
-                key={person.person_id}
-                className="board-row"
-                href={`#/people/${encodeURIComponent(person.person_id)}`}
-              >
-                <strong>{copy.name}</strong>
-                {copy.detail ? <span>{copy.detail}</span> : null}
-                {person.last_name_status === "hidden_by_apollo" ? (
-                  <span>Surname hidden by Apollo</span>
-                ) : null}
-                <span className="board-row-contact">
-                  {contactLine(person)}
-                  <FollowUpChip person={person} />
-                </span>
-              </a>
-            );
-          })}
+    <tr>
+      <td>
+        <div className="contacts-identity">
+          <span className="contacts-avatar" aria-hidden="true">
+            {initials(person)}
+          </span>
+          <span className="contacts-cell-copy">
+            <a href={`#/people/${encodeURIComponent(person.person_id)}`}>
+              <strong>{name}</strong>
+            </a>
+            {person.last_name_status === "hidden_by_apollo" ? (
+              <span>Surname hidden by Apollo</span>
+            ) : null}
+          </span>
         </div>
-      )}
-    </section>
+      </td>
+      <td>
+        <span className="contacts-primary">{person.title || "No title recorded"}</span>
+        <span className="contacts-secondary">{person.company || "No company recorded"}</span>
+      </td>
+      <td>
+        <span className={`contacts-sequence contacts-sequence-${person.sequence_state}`}>
+          {sequence}
+        </span>
+      </td>
+      <td>
+        <span className="contacts-last-contact">{contactLine(person)}</span>
+      </td>
+      <td>
+        {person.follow_up?.needed ? (
+          <FollowUpChip person={person} />
+        ) : (
+          <span className="contacts-attention-empty" aria-label="No attention needed">
+            —
+          </span>
+        )}
+      </td>
+    </tr>
   );
+}
+
+function ContactsTable({ people }: { people: BoardPerson[] }) {
+  return (
+    <div className="contacts-table-scroll">
+      <table className="contacts-table" aria-label="Active sourcing contacts">
+        <thead>
+          <tr>
+            <th scope="col">Contact</th>
+            <th scope="col">Role &amp; company</th>
+            <th scope="col">Sequence</th>
+            <th scope="col">Last contact</th>
+            <th scope="col">Attention</th>
+          </tr>
+        </thead>
+        <tbody>
+          {people.map((person) => (
+            <ContactRow key={person.person_id} person={person} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ContactsFilters({
+  active,
+  board,
+  onChange,
+}: {
+  active: SequenceFilter;
+  board: Board;
+  onChange: (filter: SequenceFilter) => void;
+}) {
+  const counts: Record<SequenceFilter, number> = {
+    all: board.open.length + board.in_conversation.length + board.done.length,
+    open: board.open.length,
+    in_conversation: board.in_conversation.length,
+    done: board.done.length,
+  };
+  return (
+    <div
+      className="contacts-filters"
+      role="group"
+      aria-label="Filter contacts by sequence status"
+    >
+      {SEQUENCE_FILTERS.map((filter) => (
+        <button
+          key={filter.value}
+          type="button"
+          aria-pressed={active === filter.value}
+          onClick={() => onChange(filter.value)}
+        >
+          <span>{filter.label}</span>
+          <span className="contacts-filter-count">{counts[filter.value]}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function matchesContact(person: BoardPerson, query: string): boolean {
+  const needle = query.trim().toLocaleLowerCase();
+  if (!needle) return true;
+  return [person.first_name, person.last_name, person.title, person.company]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ")
+    .toLocaleLowerCase()
+    .includes(needle);
 }
 
 /** What the refresh did, said plainly. Counts come from the server. */
@@ -112,6 +202,8 @@ export function BoardView() {
   const [attempt, setAttempt] = useState(0);
   const [checking, setChecking] = useState(false);
   const [replyStatusText, setReplyStatusText] = useState<string | null>(null);
+  const [sequenceFilter, setSequenceFilter] = useState<SequenceFilter>("all");
+  const [contactQuery, setContactQuery] = useState("");
 
   useEffect(() => {
     let active = true;
@@ -150,20 +242,24 @@ export function BoardView() {
     }
   }
 
-  const backlog = board?.backlog ?? [];
+  const contacts = board
+    ? [...board.open, ...board.in_conversation, ...board.done]
+    : [];
+  const visibleContacts =
+    (sequenceFilter === "all"
+      ? contacts
+      : contacts.filter((person) => person.sequence_state === sequenceFilter)
+    ).filter((person) => matchesContact(person, contactQuery));
   const empty =
     board !== null &&
-    backlog.length === 0 &&
-    board.open.length === 0 &&
-    board.in_conversation.length === 0 &&
-    board.done.length === 0;
+    contacts.length === 0;
 
   return (
     <main className="route-page board-page">
       <header className="board-page-header">
-        <p className="eyebrow">Sourcing workspace</p>
-        <h1>Board</h1>
-        <p>Keep sourced people visible from backlog through completed follow-up.</p>
+        <p className="eyebrow">Active sequences</p>
+        <h1>Contacts</h1>
+        <p>Keep active people moving from open outreach through completed follow-up.</p>
         <div className="board-page-actions">
           <button type="button" disabled={checking} onClick={() => void checkReplies()}>
             {checking ? "Checking for replies…" : "Check for replies"}
@@ -171,10 +267,10 @@ export function BoardView() {
           {replyStatusText ? <p role="status">{replyStatusText}</p> : null}
         </div>
       </header>
-      {board === null && !failed ? <p role="status">Loading board…</p> : null}
+      {board === null && !failed ? <p role="status">Loading contacts…</p> : null}
       {failed ? (
         <section className="route-error" role="alert">
-          <p>Couldn’t load the board.</p>
+          <p>Couldn’t load contacts.</p>
           <button type="button" onClick={() => setAttempt((value) => value + 1)}>
             Retry
           </button>
@@ -182,21 +278,39 @@ export function BoardView() {
       ) : null}
       {empty ? (
         <section className="route-empty" role="status">
-          <h2>No one in motion</h2>
-          <p>Keep a person from sourcing results to add them here.</p>
+          <h2>No active contacts</h2>
+          <p>Start a sequence from a Person File to add someone here.</p>
         </section>
       ) : null}
       {board && !empty ? (
-        <div className="board-grid">
-          <Bucket id="backlog" title="Backlog" people={backlog} />
-          <Bucket id="open" title="Open" people={board.open} />
-          <Bucket
-            id="conversation"
-            title="In conversation"
-            people={board.in_conversation}
-          />
-          <Bucket id="done" title="Done" people={board.done} />
-        </div>
+        <section className="contacts-list" aria-label="Sequence contacts">
+          <div className="contacts-controls">
+            <ContactsFilters
+              active={sequenceFilter}
+              board={board}
+              onChange={setSequenceFilter}
+            />
+            <label className="contacts-search">
+              <span className="contacts-visually-hidden">Search active contacts</span>
+              <input
+                type="search"
+                aria-label="Search active contacts"
+                placeholder="Search active contacts"
+                value={contactQuery}
+                onChange={(event) => setContactQuery(event.currentTarget.value)}
+              />
+            </label>
+          </div>
+          {visibleContacts.length > 0 ? (
+            <ContactsTable people={visibleContacts} />
+          ) : (
+            <p className="contacts-filter-empty" role="status">
+              {contactQuery.trim()
+                ? `No contacts match “${contactQuery.trim()}”.`
+                : `No contacts in ${SEQUENCE_LABEL[sequenceFilter] ?? "this status"}.`}
+            </p>
+          )}
+        </section>
       ) : null}
     </main>
   );

--- a/desktop/surfaces/gui/src/Board.tsx
+++ b/desktop/surfaces/gui/src/Board.tsx
@@ -65,15 +65,32 @@ const SEQUENCE_FILTERS: { value: SequenceFilter; label: string }[] = [
 function ContactRow({ person }: { person: BoardPerson }) {
   const name = personName(person);
   const sequence = SEQUENCE_LABEL[person.sequence_state ?? ""] ?? "Unknown";
+  const href = `#/people/${encodeURIComponent(person.person_id)}`;
+  const openPersonFile = () => {
+    window.location.hash = href;
+  };
   return (
-    <tr>
+    <tr
+      className="contacts-row"
+      tabIndex={0}
+      aria-label={`Open Person File for ${name}`}
+      onClick={(event) => {
+        if ((event.target as HTMLElement).closest("a")) return;
+        openPersonFile();
+      }}
+      onKeyDown={(event) => {
+        if (event.key !== "Enter") return;
+        event.preventDefault();
+        openPersonFile();
+      }}
+    >
       <td>
         <div className="contacts-identity">
           <span className="contacts-avatar" aria-hidden="true">
             {initials(person)}
           </span>
           <span className="contacts-cell-copy">
-            <a href={`#/people/${encodeURIComponent(person.person_id)}`}>
+            <a href={href} tabIndex={-1}>
               <strong>{name}</strong>
             </a>
             {person.last_name_status === "hidden_by_apollo" ? (

--- a/desktop/surfaces/gui/src/PersonFile.tsx
+++ b/desktop/surfaces/gui/src/PersonFile.tsx
@@ -341,7 +341,7 @@ export function PersonFileView({ personId }: { personId: string }) {
           <button type="button" onClick={() => setAttempt((value) => value + 1)}>
             Retry
           </button>
-          <a href="#/board">Back to Board</a>
+          <a href="#/board">Back to Contacts</a>
         </section>
       </main>
     );
@@ -365,7 +365,7 @@ export function PersonFileView({ personId }: { personId: string }) {
   return (
     <main className="route-page person-page">
       <header className="person-page-header">
-        <a className="person-back-link" href="#/board">← Board</a>
+        <a className="person-back-link" href="#/board">← Contacts</a>
         <p className="eyebrow">Person file</p>
         <h1>{file.brief.who || "Person"}</h1>
         {file.person.last_name_status === "hidden_by_apollo" ? (

--- a/desktop/surfaces/gui/src/app/CommandSearch.tsx
+++ b/desktop/surfaces/gui/src/app/CommandSearch.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import type { SessionRow } from "../api";
 
 const DESTINATIONS = [
-  { label: "Board", hash: "#/board" },
+  { label: "Contacts", hash: "#/board" },
   { label: "Scheduled", hash: "#/scheduled" },
   { label: "Connections", hash: "#/connections" },
   { label: "Skills", hash: "#/skills" },

--- a/desktop/surfaces/gui/src/app/GlobalRail.tsx
+++ b/desktop/surfaces/gui/src/app/GlobalRail.tsx
@@ -124,7 +124,7 @@ export function GlobalRail({ open, route, sessions, scheduledApprovalCount, memo
           <kbd>⌘K</kbd>
         </button>
         <div className="destination-links">
-          <RailLink href="#/board" current={route.kind === "board" || route.kind === "person"}>Board</RailLink>
+          <RailLink href="#/board" current={route.kind === "board" || route.kind === "person"}>Contacts</RailLink>
           <RailLink
             href="#/scheduled"
             current={route.kind === "scheduled"}

--- a/desktop/surfaces/gui/src/styles.css
+++ b/desktop/surfaces/gui/src/styles.css
@@ -4,7 +4,7 @@
 @import "./styles/route.css";
 @import "./styles/responsive.css";
 
-/* Board and person-file routes. This stays here (not in styles/route.css)
+/* Contacts and person-file routes. This stays here (not in styles/route.css)
    because tests/boardPersonStyles.test.ts reads src/styles.css directly
    via fs and is owned by the component agent working on Board.tsx /
    PersonFile.tsx in this review pass, not by this stylesheet split.
@@ -17,7 +17,7 @@
   margin: 0 auto;
 }
 
-.board-page-header > p:last-child,
+.board-page-header > p:not(.eyebrow),
 .person-page-header > p:last-child {
   max-width: 680px;
   margin: 8px 0 0;
@@ -25,14 +25,24 @@
   line-height: 1.55;
 }
 
-.board-grid {
+.board-page-header {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 14px;
-  margin-top: 24px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  column-gap: 24px;
 }
 
-.board-bucket,
+.board-page-header > :not(.board-page-actions) {
+  grid-column: 1;
+}
+
+.board-page-header .board-page-actions {
+  grid-column: 2;
+  grid-row: 1 / span 3;
+  align-self: end;
+  margin: 0;
+}
+
 .person-summary-card,
 .person-sequence,
 .person-section {
@@ -42,99 +52,255 @@
   background: var(--surface);
 }
 
-.board-bucket {
+.contacts-list {
+  margin-top: 24px;
   overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
 }
 
-.board-bucket-heading {
+.contacts-controls {
   display: flex;
-  min-height: 48px;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding: 0 16px;
+  gap: 16px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.contacts-filters {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.contacts-filters button {
+  display: inline-flex;
+  min-height: 34px;
+  align-items: center;
+  gap: 7px;
+  padding: 0 10px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  cursor: pointer;
+}
+
+.contacts-filters button:hover {
+  background: var(--raised);
+  color: var(--text);
+}
+
+.contacts-filters button[aria-pressed="true"] {
+  border-color: var(--border);
+  background: var(--raised);
+  color: var(--text);
+}
+
+.contacts-filter-count {
+  min-width: 18px;
+  padding: 1px 5px;
+  border-radius: 9999px;
+  background: var(--canvas);
+  color: var(--muted);
+  font-family: ui-monospace, "Geist Mono", monospace;
+  font-size: 10px;
+  text-align: center;
+}
+
+.contacts-search input {
+  width: 230px;
+  min-height: 34px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--canvas);
+  color: var(--text);
+  font: inherit;
+}
+
+.contacts-search input::placeholder {
+  color: var(--muted);
+}
+
+.contacts-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.contacts-table-scroll {
+  overflow-x: auto;
+}
+
+.contacts-table {
+  width: 100%;
+  min-width: 820px;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.contacts-table th {
+  height: 34px;
+  padding: 0 14px;
   border-bottom: 1px solid var(--border);
   background: var(--raised);
-}
-
-.board-bucket-heading h2,
-.person-page h2 {
-  margin: 0;
-  font-size: 14px;
-  font-weight: 650;
-}
-
-.board-bucket-heading span {
   color: var(--muted);
-  font-size: 12px;
+  font-family: ui-monospace, "Geist Mono", monospace;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: .07em;
+  text-align: left;
+  text-transform: uppercase;
 }
 
-.board-rows {
-  display: grid;
-}
-
-.board-row {
-  display: flex;
-  min-height: 64px;
-  flex-direction: column;
-  justify-content: center;
-  gap: 3px;
-  padding: 10px 16px;
+.contacts-table tbody tr {
+  height: 56px;
   border-bottom: 1px solid var(--border);
-  color: var(--text);
-  text-decoration: none;
 }
 
-.board-row:last-child {
+.contacts-table tbody tr:last-child {
   border-bottom: 0;
 }
 
-.board-row:hover {
+.contacts-table tbody tr:hover {
   background: var(--raised);
 }
 
-.board-row:focus-visible,
-.person-back-link:focus-visible,
-.person-sequence-action:focus-visible,
-.person-chat-action button:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
+.contacts-table td {
+  min-width: 0;
+  overflow: hidden;
+  padding: 9px 14px;
+  color: var(--muted);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.board-row strong {
+.contacts-table th:nth-child(1) { width: 25%; }
+.contacts-table th:nth-child(2) { width: 28%; }
+.contacts-table th:nth-child(3) { width: 17%; }
+.contacts-table th:nth-child(4) { width: 18%; }
+.contacts-table th:nth-child(5) { width: 12%; }
+
+.contacts-table td:first-child a {
+  color: var(--text);
+  font-weight: 550;
+  text-decoration: none;
+}
+
+.contacts-identity {
+  display: grid;
+  grid-template-columns: 30px minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+}
+
+.contacts-avatar {
+  display: grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: 9999px;
+  background: var(--accent-tint);
+  color: var(--accent-deep);
+  font-family: ui-monospace, "Geist Mono", monospace;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.contacts-cell-copy,
+.contacts-primary,
+.contacts-secondary {
+  display: block;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.board-row span,
-.board-bucket-empty,
-.person-empty,
-.person-timeline-meta {
-  color: var(--muted);
-  font-size: 12px;
-}
-
-.board-bucket-empty {
-  margin: 0;
-  padding: 18px 16px;
-}
-
-/* Follow-up state on the board row. The row stays a quiet table line; the one
-   piece of colour is the warm "needs attention" pill, and it only appears when
-   something is actually waiting. */
-.board-row-contact {
-  display: flex;
-  align-items: center;
-  gap: 8px;
+.contacts-cell-copy > span,
+.contacts-secondary {
+  display: block;
   margin-top: 2px;
   color: var(--muted);
-  font-size: 12px;
+  font-size: 11px;
+}
+
+.contacts-primary {
+  color: var(--text);
+  font-weight: 500;
+}
+
+.contacts-sequence {
+  display: inline-flex;
+  min-height: 22px;
+  align-items: center;
+  gap: 6px;
+  padding: 0 8px;
+  border-radius: 9999px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.contacts-sequence::before {
+  width: 6px;
+  height: 6px;
+  border-radius: 9999px;
+  background: currentColor;
+  content: "";
+  opacity: .72;
+}
+
+.contacts-sequence-open {
+  background: var(--accent-tint);
+  color: var(--accent-deep);
+}
+
+.contacts-sequence-in_conversation {
+  background: var(--raised);
+  color: var(--pit);
+}
+
+.contacts-sequence-done {
+  background: var(--raised);
+  color: var(--muted);
+}
+
+.contacts-last-contact {
+  color: var(--muted);
   font-variant-numeric: tabular-nums;
 }
 
+.contacts-attention-empty {
+  color: var(--muted);
+}
+
+.contacts-table a:focus-visible,
+.contacts-filters button:focus-visible,
+.contacts-search input:focus-visible,
+.person-back-link:focus-visible,
+.person-sequence-action:focus-visible,
+.person-chat-action button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* A dense contact row stays quiet; colour appears only when attention is real. */
 .board-row-flag {
-  padding: 1px 8px;
+  display: inline-flex;
+  min-height: 22px;
+  align-items: center;
+  padding: 0 8px;
   border-radius: 9999px;
   background: var(--warn-bg);
   color: var(--warn);
@@ -142,6 +308,25 @@
   font-weight: 600;
   letter-spacing: .04em;
   white-space: nowrap;
+}
+
+.contacts-filter-empty {
+  margin: 0;
+  padding: 48px 18px;
+  color: var(--muted);
+  text-align: center;
+}
+
+.person-page h2 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.person-empty,
+.person-timeline-meta {
+  color: var(--muted);
+  font-size: 12px;
 }
 
 .board-page-actions {
@@ -542,16 +727,37 @@
   opacity: .65;
 }
 
-@media (max-width: 1179px) {
-  .board-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
 @media (max-width: 767px) {
-  .board-grid,
   .person-summary-grid {
     grid-template-columns: 1fr;
+  }
+
+  .board-page-header {
+    grid-template-columns: 1fr;
+  }
+
+  .board-page-header .board-page-actions {
+    grid-column: 1;
+    grid-row: auto;
+    margin-top: 16px;
+  }
+
+  .contacts-controls {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .contacts-filters {
+    overflow-x: auto;
+  }
+
+  .contacts-filters button,
+  .contacts-search input {
+    min-height: 44px;
+  }
+
+  .contacts-search input {
+    width: 100%;
   }
 
   .board-page-actions button {

--- a/desktop/surfaces/gui/src/styles.css
+++ b/desktop/surfaces/gui/src/styles.css
@@ -167,6 +167,15 @@
   border-bottom: 1px solid var(--border);
 }
 
+.contacts-row {
+  cursor: pointer;
+}
+
+.contacts-row:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--accent);
+}
+
 .contacts-table tbody tr:last-child {
   border-bottom: 0;
 }

--- a/desktop/surfaces/gui/tests/boardPerson.test.tsx
+++ b/desktop/surfaces/gui/tests/boardPerson.test.tsx
@@ -173,6 +173,32 @@ describe("Contacts and person-file routes", () => {
     });
   });
 
+  it("announces that Contacts is loading", () => {
+    api.getBoard.mockReturnValue(new Promise(() => {}));
+
+    render(<BoardView />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Loading contacts");
+  });
+
+  it("recovers from a Contacts load failure without leaking details", async () => {
+    api.getBoard
+      .mockRejectedValueOnce(new Error("contacts 500 token=private /state/path"))
+      .mockResolvedValueOnce({ open: [], in_conversation: [], done: [] });
+
+    const { container } = render(<BoardView />);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Couldn’t load contacts");
+    expect(container).not.toHaveTextContent("token=private");
+    expect(container).not.toHaveTextContent("/state/path");
+
+    fireEvent.click(within(alert).getByRole("button", { name: "Retry" }));
+
+    expect(await screen.findByRole("heading", { name: "No active contacts" })).toBeInTheDocument();
+    expect(api.getBoard).toHaveBeenCalledTimes(2);
+  });
+
   it("renders active sequences in a Contacts table", async () => {
     render(<BoardView />);
 
@@ -190,6 +216,22 @@ describe("Contacts and person-file routes", () => {
       "#/people/person%20one",
     );
     expect(screen.queryByRole("region", { name: "Open" })).not.toBeInTheDocument();
+  });
+
+  it("opens the Person File from pointer or keyboard interaction anywhere in a row", async () => {
+    window.location.hash = "#/board";
+    render(<BoardView />);
+
+    const row = await screen.findByRole("row", { name: "Open Person File for Alyssa Lee" });
+    expect(row).toHaveAttribute("tabindex", "0");
+
+    fireEvent.click(within(row).getByText("Codeology"));
+    expect(window.location.hash).toBe("#/people/person%20one");
+
+    window.location.hash = "#/board";
+    row.focus();
+    fireEvent.keyDown(row, { key: "Enter" });
+    expect(window.location.hash).toBe("#/people/person%20one");
   });
 
   it("filters Contacts by the three sequence states", async () => {

--- a/desktop/surfaces/gui/tests/boardPerson.test.tsx
+++ b/desktop/surfaces/gui/tests/boardPerson.test.tsx
@@ -35,7 +35,7 @@ vi.mock("../src/api", () => ({
   setPersonSequence: api.setPersonSequence,
 }));
 
-describe("Board and person-file routes", () => {
+describe("Contacts and person-file routes", () => {
   beforeEach(() => {
     api.getBoard.mockResolvedValue({
       open: [
@@ -173,16 +173,126 @@ describe("Board and person-file routes", () => {
     });
   });
 
-  it("renders labeled Board buckets and safe person links", async () => {
+  it("renders active sequences in a Contacts table", async () => {
     render(<BoardView />);
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Board" })).toBeInTheDocument();
-    const open = screen.getByRole("region", { name: "Open" });
-    expect(within(open).getByRole("link", { name: /Alyssa Lee/ })).toHaveAttribute(
+    expect(
+      await screen.findByRole("heading", { level: 1, name: "Contacts" }),
+    ).toBeInTheDocument();
+    const table = screen.getByRole("table", { name: "Active sourcing contacts" });
+    expect(within(table).getByRole("columnheader", { name: "Contact" })).toBeInTheDocument();
+    expect(within(table).getByRole("columnheader", { name: "Role & company" })).toBeInTheDocument();
+    expect(within(table).getByRole("columnheader", { name: "Sequence" })).toBeInTheDocument();
+    expect(within(table).getByRole("columnheader", { name: "Last contact" })).toBeInTheDocument();
+    expect(within(table).getByRole("columnheader", { name: "Attention" })).toBeInTheDocument();
+    expect(within(table).getByRole("link", { name: /Alyssa Lee/ })).toHaveAttribute(
       "href",
       "#/people/person%20one",
     );
-    expect(screen.getByRole("region", { name: "In conversation" })).toHaveTextContent("None");
+    expect(screen.queryByRole("region", { name: "Open" })).not.toBeInTheDocument();
+  });
+
+  it("filters Contacts by the three sequence states", async () => {
+    api.getBoard.mockResolvedValue({
+      backlog: [
+        {
+          person_id: "person-backlog",
+          first_name: "Hidden",
+          last_name: "Backlog",
+          sequence_state: null,
+        },
+      ],
+      open: [
+        {
+          person_id: "person-open",
+          first_name: "Olive",
+          last_name: "Open",
+          title: "Founder",
+          company: "Open Labs",
+          sequence_state: "open",
+        },
+      ],
+      in_conversation: [
+        {
+          person_id: "person-talking",
+          first_name: "Connie",
+          last_name: "Conversation",
+          title: "VP Engineering",
+          company: "Talking Systems",
+          sequence_state: "in_conversation",
+        },
+      ],
+      done: [
+        {
+          person_id: "person-done",
+          first_name: "Dana",
+          last_name: "Done",
+          title: "Product Lead",
+          company: "Done Works",
+          sequence_state: "done",
+        },
+      ],
+    });
+
+    render(<BoardView />);
+
+    const filters = await screen.findByRole("group", {
+      name: "Filter contacts by sequence status",
+    });
+    expect(within(filters).getByRole("button", { name: "All 3" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(within(filters).getByRole("button", { name: "Open 1" })).toBeInTheDocument();
+    expect(
+      within(filters).getByRole("button", { name: "In conversation 1" }),
+    ).toBeInTheDocument();
+    expect(within(filters).getByRole("button", { name: "Done 1" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Hidden Backlog/ })).not.toBeInTheDocument();
+
+    fireEvent.click(within(filters).getByRole("button", { name: "In conversation 1" }));
+
+    expect(screen.getByRole("link", { name: /Connie Conversation/ })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Olive Open/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Dana Done/ })).not.toBeInTheDocument();
+  });
+
+  it("searches active Contacts by identity, role, and company", async () => {
+    api.getBoard.mockResolvedValue({
+      backlog: [],
+      open: [
+        {
+          person_id: "person-maya",
+          first_name: "Maya",
+          last_name: "Chen",
+          title: "VP Product Engineering",
+          company: "Northstar Labs",
+          sequence_state: "open",
+        },
+        {
+          person_id: "person-jordan",
+          first_name: "Jordan",
+          last_name: "Patel",
+          title: "Founder",
+          company: "Applied Bio Systems",
+          sequence_state: "open",
+        },
+      ],
+      in_conversation: [],
+      done: [],
+    });
+
+    render(<BoardView />);
+
+    const search = await screen.findByRole("searchbox", { name: "Search active contacts" });
+    fireEvent.change(search, { target: { value: "northstar" } });
+
+    expect(screen.getByRole("link", { name: /Maya Chen/ })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Jordan Patel/ })).not.toBeInTheDocument();
+
+    fireEvent.change(search, { target: { value: "no such contact" } });
+
+    expect(screen.getByRole("status")).toHaveTextContent("No contacts match");
   });
 
   it("labels an Apollo-hidden surname honestly on Board and person file", async () => {
@@ -231,7 +341,7 @@ describe("Board and person-file routes", () => {
     expect(person.container).not.toHaveTextContent("***");
   });
 
-  it("renders kept people in Backlog without starting their sequence", async () => {
+  it("keeps unsequenced backlog people off Contacts", async () => {
     api.getBoard.mockResolvedValue({
       backlog: [
         {
@@ -251,12 +361,9 @@ describe("Board and person-file routes", () => {
 
     render(<BoardView />);
 
-    const backlog = await screen.findByRole("region", { name: "Backlog" });
-    expect(within(backlog).getByRole("link", { name: /Hudson Liao/ })).toHaveAttribute(
-      "href",
-      "#/people/person-kept",
-    );
-    expect(screen.getByRole("region", { name: "Open" })).toHaveTextContent("None");
+    expect(await screen.findByRole("heading", { name: "No active contacts" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Hudson Liao/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("table", { name: "Active sourcing contacts" })).not.toBeInTheDocument();
   });
 
   it("updates a person sequence through labeled pressed-state controls", async () => {
@@ -276,7 +383,7 @@ describe("Board and person-file routes", () => {
     expect(container.querySelector(".tool-card")).not.toBeInTheDocument();
   });
 
-  it("refreshes Board buckets after a person-file write", async () => {
+  it("refreshes Contacts after a person-file write", async () => {
     render(<BoardView />);
     await screen.findByRole("link", { name: /Alyssa Lee/ });
     window.dispatchEvent(new CustomEvent("sourcecado:board-changed"));
@@ -352,7 +459,7 @@ describe("Board and person-file routes", () => {
     expect(
       screen.queryByRole("button", { name: /sourcing chat/i }),
     ).not.toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Back to Board" })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: "Back to Contacts" })).toHaveAttribute(
       "href",
       "#/board",
     );

--- a/desktop/surfaces/gui/tests/boardPersonStyles.test.ts
+++ b/desktop/surfaces/gui/tests/boardPersonStyles.test.ts
@@ -3,16 +3,28 @@ import { describe, expect, it } from "vitest";
 
 const styles = readFileSync("src/styles.css", "utf8");
 
-describe("Board and person-file styles", () => {
-  it("uses scoped responsive grids and touch-sized sequence controls", () => {
+describe("Contacts and person-file styles", () => {
+  it("uses a dense bounded Contacts table with safe horizontal overflow", () => {
     expect(styles).toMatch(
-      /\.board-grid\s*\{[^}]*grid-template-columns:\s*repeat\(4, minmax\(0, 1fr\)\);/,
+      /\.contacts-list\s*\{[^}]*border:\s*1px solid var\(--border\);[^}]*background:\s*var\(--surface\);/,
     );
+    expect(styles).toMatch(
+      /\.contacts-table-scroll\s*\{[^}]*overflow-x:\s*auto;/,
+    );
+    expect(styles).toMatch(
+      /\.contacts-table\s*\{[^}]*width:\s*100%;[^}]*min-width:\s*820px;[^}]*border-collapse:\s*collapse;/,
+    );
+    expect(styles).toMatch(
+      /\.contacts-table tbody tr\s*\{[^}]*height:\s*56px;[^}]*border-bottom:\s*1px solid var\(--border\);/,
+    );
+    expect(styles).toMatch(
+      /@media \(max-width: 767px\)[\s\S]*?\.contacts-filters button,\s*\.contacts-search input\s*\{[^}]*min-height:\s*44px;/,
+    );
+  });
+
+  it("keeps person sequence and chat controls touch sized", () => {
     expect(styles).toMatch(
       /\.person-sequence-action\s*\{[^}]*min-height:\s*44px;/,
-    );
-    expect(styles).toMatch(
-      /@media \(max-width: 767px\)[\s\S]*?\.board-grid,\s*\.person-summary-grid\s*\{[^}]*grid-template-columns:\s*1fr;/,
     );
     expect(styles).toMatch(
       /\.person-chat-action button\s*\{[^}]*min-height:\s*44px;/,

--- a/desktop/surfaces/gui/tests/replyFiling.test.tsx
+++ b/desktop/surfaces/gui/tests/replyFiling.test.tsx
@@ -75,6 +75,14 @@ function boardWith(open: unknown[], inConversation: unknown[]) {
   return { open, in_conversation: inConversation, done: [] };
 }
 
+function contactRow(link: HTMLElement): HTMLTableRowElement {
+  const row = link.closest("tr");
+  if (!(row instanceof HTMLTableRowElement)) {
+    throw new Error("contact link is not inside a table row");
+  }
+  return row;
+}
+
 function personFile(overrides: Record<string, unknown> = {}) {
   return {
     person: {
@@ -135,7 +143,7 @@ function personFile(overrides: Record<string, unknown> = {}) {
   };
 }
 
-describe("reply filing on the Board and the person file", () => {
+describe("reply filing on Contacts and the person file", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     api.getBoard.mockResolvedValue(boardWith([WAITING], [REPLIED]));
@@ -147,14 +155,14 @@ describe("reply filing on the Board and the person file", () => {
     api.searchPersonDriveEvidence.mockResolvedValue({ files: [] });
   });
 
-  it("shows last contact, replied state, and the follow-up flag on the board", async () => {
+  it("shows last contact, replied state, and the follow-up flag on Contacts", async () => {
     render(<BoardView />);
 
-    const waiting = await screen.findByRole("link", { name: /Ada Analytic/ });
+    const waiting = contactRow(await screen.findByRole("link", { name: /Ada Analytic/ }));
     expect(waiting).toHaveTextContent("We wrote · 2026-08-20");
     expect(waiting).not.toHaveTextContent("Needs follow-up");
 
-    const talking = screen.getByRole("link", { name: /Bob Builder/ });
+    const talking = contactRow(screen.getByRole("link", { name: /Bob Builder/ }));
     expect(talking).toHaveTextContent("They replied · 2026-08-26");
     expect(talking).toHaveTextContent("Needs follow-up");
   });
@@ -163,7 +171,7 @@ describe("reply filing on the Board and the person file", () => {
     api.getBoard.mockResolvedValue(boardWith([NEEDS_REVIEW], []));
     render(<BoardView />);
 
-    const row = await screen.findByRole("link", { name: /Cleo Chen/ });
+    const row = contactRow(await screen.findByRole("link", { name: /Cleo Chen/ }));
     expect(row).toHaveTextContent("Reply needs review");
     expect(row).not.toHaveTextContent("They replied");
   });
@@ -177,9 +185,9 @@ describe("reply filing on the Board and the person file", () => {
     );
     render(<BoardView />);
 
-    expect(await screen.findByRole("link", { name: /Ada Analytic/ })).toHaveTextContent(
-      "No contact yet",
-    );
+    expect(
+      contactRow(await screen.findByRole("link", { name: /Ada Analytic/ })),
+    ).toHaveTextContent("No contact yet");
   });
 
   it("checks for replies on demand and reports what the refresh did", async () => {

--- a/desktop/surfaces/gui/tests/shell.test.tsx
+++ b/desktop/surfaces/gui/tests/shell.test.tsx
@@ -130,17 +130,17 @@ describe("App shell routing", () => {
     expect(await screen.findByRole("heading", { level: 1, name: "Skills" })).toBeInTheDocument();
   });
 
-  it("renders Board as a direct durable rail destination", async () => {
+  it("renders Contacts as a direct durable rail destination", async () => {
     window.location.hash = "#/board";
 
     render(<App />);
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Board" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { level: 1, name: "Contacts" })).toBeInTheDocument();
     expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
-    expect(screen.getByRole("link", { name: "Board" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("link", { name: "Contacts" })).toHaveAttribute("aria-current", "page");
   });
 
-  it("renders a decoded person file under the active Board destination", async () => {
+  it("renders a decoded person file under the active Contacts destination", async () => {
     window.location.hash = "#/people/person%20one";
 
     render(<App />);
@@ -148,7 +148,7 @@ describe("App shell routing", () => {
     expect(await screen.findByRole("heading", { level: 1, name: "Alyssa" })).toBeInTheDocument();
     expect(api.getPerson).toHaveBeenCalledWith("person one");
     expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
-    expect(screen.getByRole("link", { name: "Board" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("link", { name: "Contacts" })).toHaveAttribute("aria-current", "page");
   });
 
   it("opens a newly created person chat before the cached session list refreshes", async () => {
@@ -296,7 +296,7 @@ describe("App shell routing", () => {
     const nav = await screen.findByRole("navigation", { name: "Sourcecado" });
     expect(within(nav).getByRole("button", { name: "New chat" })).toBeInTheDocument();
     expect(within(nav).getByRole("button", { name: /Search/ })).toHaveTextContent("⌘K");
-    expect(within(nav).getByRole("link", { name: "Board" })).toBeInTheDocument();
+    expect(within(nav).getByRole("link", { name: "Contacts" })).toBeInTheDocument();
     expect(within(nav).getByRole("link", { name: "Scheduled" })).toBeInTheDocument();
     expect(within(nav).getByRole("link", { name: "Connections" })).toBeInTheDocument();
     expect(within(nav).getByRole("link", { name: "Skills" })).toHaveAttribute("aria-current", "page");
@@ -741,14 +741,14 @@ describe("App shell routing", () => {
     expect(screen.queryByRole("dialog", { name: "Search Sourcecado" })).not.toBeInTheDocument();
   });
 
-  it("navigates to Board from command search", async () => {
+  it("navigates to Contacts from command search", async () => {
     render(<App />);
 
     fireEvent.keyDown(window, { key: "k", metaKey: true });
     const dialog = await screen.findByRole("dialog", { name: "Search Sourcecado" });
-    fireEvent.click(within(dialog).getByRole("button", { name: "Board" }));
+    fireEvent.click(within(dialog).getByRole("button", { name: "Contacts" }));
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Board" })).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { level: 1, name: "Contacts" })).toBeInTheDocument();
     expect(window.location.hash).toBe("#/board");
   });
 

--- a/docs/superpowers/specs/2026-08-25-sourcecado-sourcing-director-spring.md
+++ b/docs/superpowers/specs/2026-08-25-sourcecado-sourcing-director-spring.md
@@ -49,7 +49,7 @@ Getting a real email address spends Apollo credits. The director does that on pu
 
 ### 3. Keep work in motion
 
-Outreach is not one email and a prayer. A person the director keeps appears in the Board's Backlog before outreach starts. Each person we are actively working is a sequence. The assistant keeps the picture of what is waiting in Backlog, what is open, what is in conversation, and what is done, so the director is not reconstructing it from Gmail search.
+Outreach is not one email and a prayer. A person the director keeps remains durable before outreach starts, but Contacts begins when that person enters an active sequence. The assistant keeps the compact picture of what is open, what is in conversation, and what is done, so the director is not reconstructing it from Gmail search.
 
 Follow-ups, "what did we last say," and "is this still alive" are the assistant's job. The conversation itself stays human.
 
@@ -69,7 +69,7 @@ The director opens Sourcecado and is in the thread with the assistant.
 
 They can say the target and get people back. They can say "write this one" and get a draft. They can say "what do I need for this conversation" and the brief is already on the person.
 
-When they want the operating picture, they open the dashboard: who is in Backlog, who is queued to write, which sequences are in conversation, what is done. It is the EA putting the board on the table for the principal. It is not a CRM they have to live in.
+When they want the operating picture, they open Contacts: who is queued to write, which sequences are in conversation, and what is done. It is the EA putting the active work on the table for the principal. It is not a CRM they have to live in.
 
 When they need the record, they open the person. A small panel of the same brief sits beside whatever they are doing, so they do not have to leave the work to remember who this is.
 
@@ -121,9 +121,9 @@ Team tenancy and hosted shared login.
 
 These are true. They are not the outline of the work. They exist so an implementation pass does not re-litigate the job.
 
-- Chat is home. The operating board is a destination in the rail.
+- Chat is home. Contacts is the active-sequence destination in the rail.
 - A sequence is a person we are working. A company is how we tag that person, not a separate kind of work item. Do not call it a deal.
-- Kept people appear in the Board's Backlog before they enter a sequence. Backlog is a Board lane, not a sequence state.
+- Kept people remain durable in the internal Board projection before they enter a sequence. They appear in Contacts only after entering Open, In conversation, or Done.
 - Sequences move Open → In conversation → Done. Exactly three sequence states. The director or the assistant moves them.
 - Intake is Apollo search from a target the director named.
 - A draft may be queued from Apollo fields and the target. Cited web research is welcome in the brief. It is not a gate on drafting.


### PR DESCRIPTION
## Summary

- rename the user-facing Board destination to Contacts while preserving the durable internal route and Board data boundary
- replace four lane cards with a searchable sequence table and Open, In conversation, and Done filters
- preserve Person File navigation, reply refresh, last-contact truth, follow-up attention, responsive behavior, and keyboard accessibility
- keep unsequenced people durable in the internal Board projection but outside the Contacts surface
- align the current product and design documentation with the approved Contacts scope

## Verification

- `make test` — 1,951 Python tests passed, 3 skipped; 550 GUI tests passed
- `make build` — TypeScript and Vite production build passed
- focused Contacts, shell, reply-filing, responsive-style, loading, empty, and failure tests passed

Closes #159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced the Board view with Contacts, featuring active-sequence filters for Open, In conversation, and Done.
  * Added contact search across names, roles, and companies.
  * Improved contact rows with avatars, sequence status, and responsive layouts.
  * Kept people without active sequences out of Contacts while preserving their person files.

* **Documentation**
  * Updated product guidance, specifications, and navigation terminology from Board to Contacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->