### PR TITLE
Polish Inbox naming and chat composer actions

### DIFF
--- a/desktop/surfaces/gui/src/app/GlobalRail.tsx
+++ b/desktop/surfaces/gui/src/app/GlobalRail.tsx
@@ -148,7 +148,7 @@ export function GlobalRail({ open, route, sessions, scheduledApprovalCount, memo
             badge={heldEffectCount}
             badgeLabel={`Held actions: ${heldEffectCount} waiting for your answer`}
           >
-            Needs your answer
+            Inbox
           </RailLink>
         </div>
         <div className="thread-groups">

--- a/desktop/surfaces/gui/src/chat/Composer.tsx
+++ b/desktop/surfaces/gui/src/chat/Composer.tsx
@@ -25,19 +25,29 @@ export function Composer({
         rows={2}
         onChange={(event) => onDraftChange(event.currentTarget.value)}
       />
-      <ComposerPrimitive.Send aria-label="Send message">
-        Send
-      </ComposerPrimitive.Send>
       {running ? (
-        <ComposerPrimitive.Cancel aria-label="Stop run">
-          Stop
+        <ComposerPrimitive.Cancel
+          className="sourcecado-composer-action"
+          aria-label="Stop run"
+        >
+          <span className="sourcecado-stop-icon" aria-hidden="true" />
         </ComposerPrimitive.Cancel>
-      ) : null}
-      {running ? (
-        <p className="sourcecado-composer-running">
-          You can keep drafting while Sourcecado works.
-        </p>
-      ) : null}
+      ) : (
+        <ComposerPrimitive.Send
+          className="sourcecado-composer-action"
+          aria-label="Send message"
+        >
+          <svg viewBox="0 0 20 20" aria-hidden="true" focusable="false">
+            <path d="M10 15.5v-11M5.5 9 10 4.5 14.5 9" />
+          </svg>
+        </ComposerPrimitive.Send>
+      )}
+      <p
+        className={`sourcecado-composer-running ${running ? "is-visible" : ""}`}
+        aria-hidden={!running}
+      >
+        You can keep drafting while Sourcecado works.
+      </p>
     </ComposerPrimitive.Root>
   );
 }

--- a/desktop/surfaces/gui/src/chat/ThreadView.tsx
+++ b/desktop/surfaces/gui/src/chat/ThreadView.tsx
@@ -29,7 +29,9 @@ type ThreadViewProps = {
   readonly onQueueRemove: (itemId: string) => void;
 };
 
-function Starter({
+const SUGGESTED_ACTION = "Review the active contacts that need follow-up this week";
+
+function SuggestedAction({
   label,
   prompt,
   onDraftChange,
@@ -42,12 +44,18 @@ function Starter({
   return (
     <button
       type="button"
+      className="sourcecado-suggestion"
       onClick={() => {
         aui.composer.setText(prompt);
         onDraftChange(prompt);
       }}
     >
-      {label}
+      <span className="sourcecado-suggestion-icon" aria-hidden="true">
+        <svg viewBox="0 0 20 20" focusable="false">
+          <path d="M4 14.5c1.8-3.5 4.2-5.7 7.4-6.8M9.8 4.5l3.8 2.7-2.7 3.8" />
+        </svg>
+      </span>
+      <span>{label}</span>
     </button>
   );
 }
@@ -124,32 +132,8 @@ export function ThreadView({
           <>
             <ThreadPrimitive.Empty>
               <section className="sourcecado-empty-thread">
-                <img
-                  className="sourcecado-empty-mascot"
-                  src="/brand/mascot/owl-mapping.jpg"
-                  alt=""
-                  width={96}
-                  height={96}
-                />
-                <p className="eyebrow">Start with a sourcing outcome</p>
-                <p>Build a shortlist, find a why-now signal, or prepare outreach for review.</p>
-                <div className="sourcecado-starters">
-                  <Starter
-                    label="Build a candidate shortlist"
-                    prompt="Build a candidate shortlist for this week’s highest-priority role."
-                    onDraftChange={onDraftChange}
-                  />
-                  <Starter
-                    label="Find why-now signals"
-                    prompt="Find fresh why-now signals for the people we should work next."
-                    onDraftChange={onDraftChange}
-                  />
-                  <Starter
-                    label="Prepare outreach for review"
-                    prompt="Prepare personalized outreach drafts for review; do not send them."
-                    onDraftChange={onDraftChange}
-                  />
-                </div>
+                <h2>What are you sourcing today?</h2>
+                <p>Name a target, review an active sequence, or prepare outreach.</p>
               </section>
             </ThreadPrimitive.Empty>
             <ThreadPrimitive.Messages
@@ -178,7 +162,18 @@ export function ThreadView({
         onEdit={onQueueEdit}
         onRemove={onQueueRemove}
       />
-      <Composer initialDraft={initialDraft} onDraftChange={onDraftChange} />
+      <div className="sourcecado-composer-zone">
+        {!loading && !loadError ? (
+          <ThreadPrimitive.Empty>
+            <SuggestedAction
+              label={SUGGESTED_ACTION}
+              prompt={`${SUGGESTED_ACTION}.`}
+              onDraftChange={onDraftChange}
+            />
+          </ThreadPrimitive.Empty>
+        ) : null}
+        <Composer initialDraft={initialDraft} onDraftChange={onDraftChange} />
+      </div>
     </ThreadPrimitive.Root>
     <Inspector />
     </div>

--- a/desktop/surfaces/gui/src/routes/QuarantinePage.tsx
+++ b/desktop/surfaces/gui/src/routes/QuarantinePage.tsx
@@ -203,7 +203,7 @@ export function QuarantinePage() {
   if (state.status === "loading") {
     return (
       <main className="route-page" aria-busy="true">
-        <h1>Needs your answer</h1>
+        <h1>Inbox</h1>
         <div className="route-skeleton" aria-label="Loading held actions" />
       </main>
     );
@@ -212,7 +212,7 @@ export function QuarantinePage() {
   if (state.status === "failed") {
     return (
       <main className="route-page">
-        <h1>Needs your answer</h1>
+        <h1>Inbox</h1>
         <p>Could not load held actions.</p>
         <button type="button" onClick={load}>
           Try again
@@ -223,7 +223,7 @@ export function QuarantinePage() {
 
   return (
     <main className="route-page quarantine-page">
-      <h1>Needs your answer</h1>
+      <h1>Inbox</h1>
       <p className="route-lede">
         Actions that reach the outside world are recorded before Sourcecado
         attempts them. If it stops before recording what happened, the action

--- a/desktop/surfaces/gui/src/styles/chat.css
+++ b/desktop/surfaces/gui/src/styles/chat.css
@@ -559,7 +559,6 @@
 }
 
 .sourcecado-approval-actions button,
-.sourcecado-starters button,
 .sourcecado-load-error button {
   min-height: 38px;
   padding: 0 11px;
@@ -582,38 +581,31 @@
   width: min(620px, 100%);
   margin: auto;
   padding: 24px;
+}
+
+.sourcecado-load-error {
   border: 1px solid var(--border);
   border-radius: 11px;
   background: var(--surface);
 }
 
-.sourcecado-empty-mascot {
-  display: block;
-  width: 96px;
-  height: 96px;
-  margin: 0 0 12px;
-  border-radius: 8px;
-  object-fit: cover;
+.sourcecado-empty-thread {
+  text-align: center;
 }
 
-.sourcecado-empty-thread > p:not(.eyebrow),
+.sourcecado-empty-thread h2 {
+  margin: 0;
+  color: var(--text);
+  font-size: clamp(24px, 4vw, 30px);
+  font-weight: 550;
+  letter-spacing: -0.025em;
+}
+
+.sourcecado-empty-thread > p,
 .sourcecado-load-error p {
   margin: 7px 0 0;
   color: var(--muted);
   line-height: 1.55;
-}
-
-.sourcecado-starters {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 8px;
-  margin-top: 18px;
-}
-
-.sourcecado-starters button {
-  min-height: 54px;
-  padding: 9px 11px;
-  text-align: left;
 }
 
 .sourcecado-load-error {
@@ -667,49 +659,139 @@
   border: 0;
 }
 
-.sourcecado-composer {
-  display: grid;
+.sourcecado-composer-zone {
   width: min(808px, calc(100% - 48px));
   min-width: 0;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 8px;
   justify-self: center;
+  padding: 0 0 18px;
+}
+
+.sourcecado-suggestion {
+  display: flex;
+  width: fit-content;
+  max-width: 100%;
+  min-height: 38px;
+  align-items: center;
+  gap: 9px;
+  margin: 0 0 8px 8px;
+  padding: 5px 10px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 140ms ease, color 140ms ease;
+}
+
+.sourcecado-suggestion:hover,
+.sourcecado-suggestion:focus-visible {
+  background: var(--raised);
+  color: var(--text);
+}
+
+.sourcecado-suggestion:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.sourcecado-suggestion-icon {
+  display: grid;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 24px;
+  place-items: center;
+  border-radius: 6px;
+  background: var(--accent-tint);
+  color: var(--accent-deep);
+}
+
+.sourcecado-suggestion-icon svg {
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: currentcolor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.7;
+}
+
+.sourcecado-composer {
+  display: grid;
+  width: 100%;
+  min-width: 0;
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-areas:
+    "input action"
+    "status status";
+  gap: 8px;
   align-items: end;
-  padding: 14px 0 18px;
-  border-top: 1px solid var(--border);
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--surface);
+  box-shadow: 0 12px 30px color-mix(in srgb, var(--text) 8%, transparent);
 }
 
 .sourcecado-composer textarea {
+  grid-area: input;
   width: 100%;
   min-width: 0;
   min-height: 44px;
   max-height: 160px;
   overflow-y: auto;
   resize: none;
-  padding: 11px 13px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--surface);
+  padding: 10px 4px;
+  border: 0;
+  outline: 0;
+  background: transparent;
   color: var(--text);
   font-family: inherit;
   font-size: 15px;
   line-height: 1.45;
 }
 
-.sourcecado-composer > button {
-  min-width: 68px;
+.sourcecado-composer-action {
+  grid-area: action;
+  width: 44px;
+  height: 44px;
+  min-width: 44px;
   min-height: 44px;
-  padding: 0 14px;
+  padding: 0;
   border: 1px solid var(--accent);
-  border-radius: 8px;
+  border-radius: 999px;
   background: var(--accent);
   color: var(--surface);
-  font: inherit;
-  font-weight: 650;
+  display: grid;
+  place-items: center;
   cursor: pointer;
+  transition: background-color 140ms ease, border-color 140ms ease, color 140ms ease;
 }
 
-.sourcecado-composer > button:disabled {
+.sourcecado-composer-action svg {
+  width: 20px;
+  height: 20px;
+  fill: none;
+  stroke: currentcolor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+
+.sourcecado-stop-icon {
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+  background: currentcolor;
+}
+
+.sourcecado-composer-action:focus-visible {
+  outline: 2px solid var(--accent-deep);
+  outline-offset: 2px;
+}
+
+.sourcecado-composer-action:disabled {
   border-color: var(--border);
   background: var(--raised);
   color: var(--muted);
@@ -718,9 +800,16 @@
 
 .sourcecado-composer-running {
   grid-column: 1 / -1;
+  grid-area: status;
+  min-height: 17px;
   margin: 0;
   color: var(--muted);
   font-size: 12px;
+  visibility: hidden;
+}
+
+.sourcecado-composer-running.is-visible {
+  visibility: visible;
 }
 
 @media (max-width: 767px) {
@@ -746,19 +835,19 @@
     font-size: 15px;
   }
 
-  .sourcecado-starters {
-    grid-template-columns: 1fr;
-  }
-
-  .sourcecado-starters button,
   .sourcecado-approval-actions button,
   .sourcecado-load-error button {
     min-height: 44px;
   }
 
-  .sourcecado-composer {
+  .sourcecado-composer-zone {
     width: calc(100% - 32px);
     padding-bottom: 12px;
+  }
+
+  .sourcecado-suggestion {
+    min-height: 44px;
+    margin-left: 0;
   }
 
   .sourcecado-composer textarea {
@@ -781,6 +870,13 @@
 @media (max-height: 520px) {
   .sourcecado-composer textarea {
     max-height: 96px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sourcecado-suggestion,
+  .sourcecado-composer-action {
+    transition: none;
   }
 }
 

--- a/desktop/surfaces/gui/tests/chatPage.test.tsx
+++ b/desktop/surfaces/gui/tests/chatPage.test.tsx
@@ -435,7 +435,7 @@ describe("ChatPage Warm Operator thread", () => {
     );
   });
 
-  it("moves from a transcript skeleton to sourcing-specific starters", async () => {
+  it("moves from a transcript skeleton to one suggestion above the composer", async () => {
     const conversation = deferred<{
       id: string;
       title: string | null;
@@ -461,13 +461,42 @@ describe("ChatPage Warm Operator thread", () => {
       });
     });
 
-    const starter = await screen.findByRole("button", {
-      name: "Build a candidate shortlist",
+    const suggestion = await screen.findByRole("button", {
+      name: "Review the active contacts that need follow-up this week",
     });
-    fireEvent.click(starter);
-    expect(screen.getByRole("textbox", { name: "Message Sourcecado" })).toHaveValue(
-      "Build a candidate shortlist for this week’s highest-priority role.",
+    const composer = screen.getByRole("textbox", { name: "Message Sourcecado" });
+    expect(
+      suggestion.compareDocumentPosition(composer) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(screen.getAllByRole("button", { name: /follow-up this week/ })).toHaveLength(1);
+    expect(screen.queryByRole("button", { name: "Build a candidate shortlist" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Find why-now signals" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Prepare outreach for review" })).toBeNull();
+  });
+
+  it("fills only the active thread draft from the suggestion without sending", async () => {
+    api.getSession.mockResolvedValue({
+      id: "thread-alpha",
+      title: null,
+      messages: [],
+      events: [],
+    });
+
+    render(<ChatPage sessionId="thread-alpha" />);
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Review the active contacts that need follow-up this week",
+      }),
     );
+    expect(screen.getByRole("textbox", { name: "Message Sourcecado" })).toHaveValue(
+      "Review the active contacts that need follow-up this week.",
+    );
+    expect(chatSend).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem("sourcecado.chat.draft.v1:thread-alpha")).toBe(
+      "Review the active contacts that need follow-up this week.",
+    );
+    expect(window.localStorage.getItem("sourcecado.chat.draft.v1:thread-beta")).toBeNull();
   });
 
   it("keeps the draft through a contextual load failure and retry", async () => {
@@ -729,7 +758,8 @@ describe("ChatPage Warm Operator thread", () => {
       target: { value: "Preserve this next instruction" },
     });
     expect(composer).toHaveValue("Preserve this next instruction");
-    expect(screen.getByRole("button", { name: "Send message" })).toBeEnabled();
+    expect(screen.queryByRole("button", { name: "Send message" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Stop run" })).toBeEnabled();
     expect(screen.getByText("You can keep drafting while Sourcecado works.")).toBeInTheDocument();
 
     act(() => {
@@ -776,6 +806,13 @@ describe("ChatPage Warm Operator thread", () => {
     render(<ChatPage sessionId="thread-alpha" />);
     await screen.findByRole("heading", { level: 1, name: "Alpha" });
     const composer = screen.getByRole("textbox", { name: "Message Sourcecado" });
+    const idleAction = screen.getByRole("button", { name: "Send message" });
+    const composerRoot = idleAction.closest(".sourcecado-composer");
+    expect(idleAction).toHaveClass("sourcecado-composer-action");
+    expect(composerRoot?.querySelectorAll(".sourcecado-composer-action")).toHaveLength(1);
+    expect(
+      screen.getByText("You can keep drafting while Sourcecado works."),
+    ).toHaveAttribute("aria-hidden", "true");
     fireEvent.change(composer, { target: { value: "Keep this next prompt" } });
     act(() => {
       onChatEvent?.({
@@ -790,7 +827,14 @@ describe("ChatPage Warm Operator thread", () => {
       });
     });
 
-    fireEvent.click(await screen.findByRole("button", { name: "Stop run" }));
+    const stop = await screen.findByRole("button", { name: "Stop run" });
+    expect(screen.queryByRole("button", { name: "Send message" })).not.toBeInTheDocument();
+    expect(stop).toHaveClass("sourcecado-composer-action");
+    expect(composerRoot?.querySelectorAll(".sourcecado-composer-action")).toHaveLength(1);
+    expect(
+      screen.getByText("You can keep drafting while Sourcecado works."),
+    ).toHaveAttribute("aria-hidden", "false");
+    fireEvent.click(stop);
     expect(chatCancel).toHaveBeenCalledWith("thread-alpha", "run-cancel-me");
     expect(composer).not.toBeDisabled();
     expect(composer).toHaveValue("Keep this next prompt");
@@ -1395,10 +1439,10 @@ describe("ChatPage Warm Operator thread", () => {
     });
     const composer = screen.getByRole("textbox", { name: "Message Sourcecado" });
     fireEvent.change(composer, { target: { value: "Queue this follow-up" } });
-    const send = screen.getByRole("button", { name: "Send message" });
 
-    expect(send).toBeEnabled();
-    fireEvent.click(send);
+    expect(screen.queryByRole("button", { name: "Send message" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Stop run" })).toBeEnabled();
+    fireEvent.keyDown(composer, { key: "Enter", code: "Enter" });
     await waitFor(() => expect(chatQueue).toHaveBeenCalledOnce());
     expect(chatQueue.mock.calls[0]?.[0]).toMatchObject({
       type: "queue_add",

--- a/desktop/surfaces/gui/tests/chatStyles.test.ts
+++ b/desktop/surfaces/gui/tests/chatStyles.test.ts
@@ -42,6 +42,42 @@ describe("Warm Operator thread styles", () => {
     );
   });
 
+  it("keeps one fixed composer action slot when Send becomes Stop", () => {
+    expect(styles).toMatch(
+      /\.sourcecado-composer\s*\{[^}]*grid-template-areas:\s*"input action"\s*"status status";/,
+    );
+    expect(styles).toMatch(
+      /\.sourcecado-composer-action\s*\{[^}]*grid-area:\s*action;[^}]*width:\s*44px;[^}]*height:\s*44px;/,
+    );
+    expect(styles).toMatch(
+      /\.sourcecado-composer-running\s*\{[^}]*min-height:\s*17px;[^}]*visibility:\s*hidden;/,
+    );
+    expect(styles).toMatch(
+      /\.sourcecado-composer-running\.is-visible\s*\{[^}]*visibility:\s*visible;/,
+    );
+  });
+
+  it("keeps the empty-thread suggestion understated above the composer", () => {
+    expect(styles).toMatch(
+      /\.sourcecado-composer-zone\s*\{[^}]*width:\s*min\(808px, calc\(100% - 48px\)\);/,
+    );
+    expect(styles).toMatch(
+      /\.sourcecado-suggestion\s*\{[^}]*border:\s*0;[^}]*background:\s*transparent;/,
+    );
+  });
+
+  it("keeps the new composer actions usable on narrow and reduced-motion layouts", () => {
+    expect(styles).toMatch(
+      /@media \(max-width: 767px\)[\s\S]*?\.sourcecado-composer-zone\s*\{[^}]*width:\s*calc\(100% - 32px\);/,
+    );
+    expect(styles).toMatch(
+      /@media \(max-width: 767px\)[\s\S]*?\.sourcecado-suggestion\s*\{[^}]*min-height:\s*44px;/,
+    );
+    expect(styles).toMatch(
+      /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.sourcecado-suggestion[\s\S]*?\.sourcecado-composer-action\s*\{[^}]*transition:\s*none;/,
+    );
+  });
+
   it("keeps persisted queue rows bounded with touch-sized narrow controls", () => {
     expect(styles).toMatch(
       /\.sourcecado-queue\s*\{[^}]*min-width:\s*0;[^}]*max-width:[^;]+;/,

--- a/desktop/surfaces/gui/tests/quarantinePage.test.tsx
+++ b/desktop/surfaces/gui/tests/quarantinePage.test.tsx
@@ -46,6 +46,23 @@ describe("the external-effect review queue", () => {
     api.settleQuarantinedEffect.mockReset();
   });
 
+  it("uses the Inbox heading while held actions are loading", () => {
+    api.getQuarantinedEffects.mockReturnValue(new Promise(() => undefined));
+
+    render(<QuarantinePage />);
+
+    expect(screen.getByRole("heading", { level: 1, name: "Inbox" })).toBeInTheDocument();
+  });
+
+  it("keeps the Inbox heading when held actions cannot load", async () => {
+    api.getQuarantinedEffects.mockRejectedValue(new Error("unavailable"));
+
+    render(<QuarantinePage />);
+
+    await screen.findByText("Could not load held actions.");
+    expect(screen.getByRole("heading", { level: 1, name: "Inbox" })).toBeInTheDocument();
+  });
+
   it("says the outcome is unknown rather than calling it a failure", async () => {
     api.getQuarantinedEffects.mockResolvedValue([HELD_SEND]);
 
@@ -184,6 +201,7 @@ describe("the external-effect review queue", () => {
     render(<QuarantinePage />);
 
     await screen.findByText(/Every action Sourcecado started has a recorded outcome/);
+    expect(screen.getByRole("heading", { level: 1, name: "Inbox" })).toBeInTheDocument();
     expect(screen.queryByLabelText("Your name")).toBeNull();
   });
 

--- a/desktop/surfaces/gui/tests/shell.test.tsx
+++ b/desktop/surfaces/gui/tests/shell.test.tsx
@@ -300,6 +300,10 @@ describe("App shell routing", () => {
     expect(within(nav).getByRole("link", { name: "Scheduled" })).toBeInTheDocument();
     expect(within(nav).getByRole("link", { name: "Connections" })).toBeInTheDocument();
     expect(within(nav).getByRole("link", { name: "Skills" })).toHaveAttribute("aria-current", "page");
+    expect(within(nav).getByRole("link", { name: "Inbox" })).toHaveAttribute(
+      "href",
+      "#/quarantine",
+    );
     expect(within(nav).getByRole("link", { name: "Settings" })).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## User problem

The held-action destination still used the long "Needs your answer" name, while the empty and running chat composer states were visually heavy and shifted controls during active work.

Closes #161.

## What changed

- Renamed the existing quarantine destination and every page state heading to Inbox without changing its route, body copy, counts, or settlement behavior.
- Replaced the three empty-thread starter cards with one understated sourcing suggestion above the composer. It writes only to the active thread draft and never sends automatically.
- Replaced the simultaneous Send and Stop buttons with one fixed 44px action slot. Send becomes an icon-only, accessibly named Stop action while a run is active.
- Preserved draft editing, Enter-to-queue behavior during a run, cancellation, narrow layouts, and reduced-motion behavior.

## Boundaries

- Included: Inbox naming, empty-thread suggestion, composer visual structure, Send-to-Stop transformation, and regression coverage.
- Explicitly not included: Inbox consolidation or behavior changes, new approval semantics, backend changes, or suggestion personalization.
- Product invariants preserved: explicit approval before external effects, durable held-action handling, per-thread draft isolation, and sidecar-authoritative queues.

## Verification

### Automated tests

- Tests added or updated: shell routing, quarantine loading/failure/empty states, suggestion placement and draft isolation, active-run queue/cancel behavior, action-slot geometry contract, narrow viewport, and reduced motion.
- Commands run:
  - `npx vitest run --config vitest.config.ts --reporter=verbose tests/chatPage.test.tsx tests/chatStyles.test.ts tests/quarantinePage.test.tsx tests/shell.test.tsx`
  - `npm test`
  - `npm run build`
  - `/Users/fisher/Documents/GitHub2026/Sourcecado/desktop/.venv/bin/pytest -q`
- Results: 119 focused tests passed; 559 GUI tests passed; 1,951 sidecar tests passed with 3 skipped and one pre-existing Starlette deprecation warning; production build passed with the existing chunk-size warning.

### Live behavior demonstration

- Starting state: Empty local chat rendered at desktop 1440x960 and narrow 390x844 viewports with mocked local API responses and transport.
- Action performed: Selected the suggestion, started a run, inspected the Stop state, opened the narrow navigation, and enabled reduced motion.
- Expected result: One suggestion above the composer, no automatic send, Inbox keeps `#/quarantine`, Send and Stop use identical geometry, the draft remains editable, and narrow/reduced-motion behavior remains usable.
- Observed result and evidence: Headless Chromium passed all assertions with no console errors. Send and Stop both measured `{x: 1183, y: 861, width: 44, height: 44}` after the fixed status row was added; desktop and narrow screenshots were visually inspected.

## AI Accountability Note

### AI helped with

The implementation, strict red-green-refactor test cycles, mockup translation, responsive CSS, and browser regression harness.

### I verified

The complete diff, focused tests, full GUI suite, full sidecar suite, production build, desktop and narrow screenshots, keyboard queue submission, cancellation, accessibility names, reduced motion, and exact Send/Stop bounding boxes.

### I am still uncertain about

A reviewer should exercise the Stop action against a live sidecar transport in addition to the deterministic component and headless-browser coverage.

## Safety and integrations

- [x] No credential, OAuth grant, token, private user data, or raw authorization material was committed or pasted into the PR.
- [x] External effects remain behind the correct permission and approval policy.
- [x] Paid or credit-sensitive actions remain deliberate, approval-gated, and outside mandatory course work.
- [x] Source references and restricted data remain scoped correctly when applicable.

## Reviewer checklist

- [ ] The change matches the ticket and respects its non-goals.
- [ ] The normal and important failure paths are covered.
- [ ] Automated verification is appropriate and passes.
- [ ] The live behavior demonstration is credible when required.
- [ ] The diff is understandable and safe to merge.
- [ ] I am giving meaningful Peer Approval, not a rubber stamp.
