### PR TITLE
P1: Add a compact Scheduled list and readable task detail

### DIFF
--- a/desktop/surfaces/gui/src/app/AppShell.tsx
+++ b/desktop/surfaces/gui/src/app/AppShell.tsx
@@ -365,7 +365,7 @@ export function AppShell() {
   } else if (route.kind === "memory") {
     outlet = <MemoryPage />;
   } else if (route.kind === "scheduled") {
-    outlet = <ScheduledPage />;
+    outlet = <ScheduledPage jobId={route.jobId} />;
   } else if (route.kind === "quarantine") {
     outlet = <QuarantinePage />;
   } else if (route.kind === "connections") {

--- a/desktop/surfaces/gui/src/app/route.ts
+++ b/desktop/surfaces/gui/src/app/route.ts
@@ -2,7 +2,7 @@ export type AppRoute =
   | { kind: "board" }
   | { kind: "person"; personId: string }
   | { kind: "connections"; connectorId?: string }
-  | { kind: "scheduled" }
+  | { kind: "scheduled"; jobId?: number }
   | { kind: "settings" }
   | { kind: "skills" }
   | { kind: "memory" }
@@ -33,6 +33,14 @@ export function parseHash(hash: string): AppRoute {
     }
   }
   if (hash === "#/scheduled") return { kind: "scheduled" };
+  if (hash.startsWith("#/scheduled/")) {
+    const rawJobId = hash.slice("#/scheduled/".length);
+    const jobId = Number(rawJobId);
+    if (/^\d+$/.test(rawJobId) && Number.isSafeInteger(jobId) && jobId > 0) {
+      return { kind: "scheduled", jobId };
+    }
+    return { kind: "scheduled" };
+  }
   if (hash === "#/settings") return { kind: "settings" };
   if (hash === "#/skills") return { kind: "skills" };
   if (hash === "#/memory") return { kind: "memory" };

--- a/desktop/surfaces/gui/src/routes/ScheduledPage.tsx
+++ b/desktop/surfaces/gui/src/routes/ScheduledPage.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useState, type FormEvent } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 
 import {
   ScheduleApiError,
@@ -70,12 +72,52 @@ function formatTimestamp(stamp: string | null): string {
   }).format(date);
 }
 
-function formatDuration(durationMs: number): string {
+function formatHistoryTimestamp(stamp: string): string {
+  const date = new Date(stamp);
+  if (Number.isNaN(date.getTime())) return stamp;
+  const day = new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+  }).format(date);
+  const time = new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
+  return `${day} at ${time}`;
+}
+
+function formatDuration(durationMs: number, status: ScheduleRunStatus): string {
+  if (status === "running") return "In progress";
   // Legacy rows written before duration tracking existed always recorded 0;
   // showing "0ms" reads as an instant run instead of "never measured".
   if (durationMs === 0) return "Legacy run";
   if (durationMs < 1000) return `${durationMs}ms`;
   return `${(durationMs / 1000).toFixed(1)}s`;
+}
+
+function ScheduleMarkdown({ children }: { children: string }) {
+  return (
+    <div className="schedule-markdown">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        skipHtml
+        components={{
+          a: ({ children: linkChildren, ...props }) => (
+            <a {...props} target="_blank" rel="noreferrer noopener">
+              {linkChildren}
+            </a>
+          ),
+          table: ({ children: tableChildren, ...props }) => (
+            <div className="schedule-markdown-table">
+              <table {...props}>{tableChildren}</table>
+            </div>
+          ),
+        }}
+      >
+        {children}
+      </ReactMarkdown>
+    </div>
+  );
 }
 
 function LoadingSchedule() {
@@ -216,7 +258,7 @@ function CreateAutomationForm({
   );
 }
 
-function ScheduleReceipt({ receipt }: { receipt: ScheduleRun }) {
+function ScheduleReceipt({ receipt, heading }: { receipt: ScheduleRun; heading: string }) {
   const label = RUN_STATUS_LABELS[receipt.status];
   return (
     <li
@@ -224,10 +266,12 @@ function ScheduleReceipt({ receipt }: { receipt: ScheduleRun }) {
       aria-label={`${label} run ${receipt.id}`}
     >
       <header>
-        <span className="schedule-run-status">{label}</span>
-        <span>{formatDuration(receipt.durationMs)}</span>
+        <h2>{heading}</h2>
+        <span className="schedule-run-status">
+          {label} · {formatDuration(receipt.durationMs, receipt.status)}
+        </span>
       </header>
-      <p>{receipt.summary || "No summary was recorded."}</p>
+      <ScheduleMarkdown>{receipt.summary || "No summary was recorded."}</ScheduleMarkdown>
       {receipt.status === "waiting_approval" && (
         <div className="schedule-waiting-context">
           <strong>This run is paused—not complete.</strong>
@@ -261,7 +305,97 @@ function ScheduleReceipt({ receipt }: { receipt: ScheduleRun }) {
   );
 }
 
-function ScheduleJobCard({
+function RunFeedbackMessage({ feedback }: { feedback: RunFeedback | undefined }) {
+  if (feedback?.kind === "running") {
+    return (
+      <p className="schedule-run-feedback" role="status">
+        Running now. The next scheduled time remains unchanged.
+      </p>
+    );
+  }
+  if (feedback?.kind === "already_running") {
+    return (
+      <p className="schedule-run-feedback warning" role="status">
+        <strong>Already running.</strong> {feedback.message}
+      </p>
+    );
+  }
+  if (feedback?.kind === "failed") {
+    return (
+      <div className="schedule-run-feedback error" role="alert">
+        <strong>This run couldn’t be started.</strong>
+        <span>Check that Sourcecado is available, then try again.</span>
+      </div>
+    );
+  }
+  return null;
+}
+
+function ScheduleTaskList({
+  jobs,
+  templates,
+  onCreateFromTemplate,
+}: {
+  jobs: ScheduleJob[];
+  templates: ScheduleTemplate[];
+  onCreateFromTemplate: (template: ScheduleTemplate) => void;
+}) {
+  return (
+    <>
+      {jobs.length > 0 && (
+        <section className="schedule-task-list" aria-label="Saved scheduled tasks">
+          {jobs.map((job) => (
+            <a
+              key={job.id}
+              className="schedule-task-card"
+              href={`#/scheduled/${job.id}`}
+              aria-label={`Open ${job.name}`}
+            >
+              <strong>{job.name}</strong>
+              <p>{job.prompt}</p>
+              <span className="schedule-task-meta">
+                <span>{CADENCE_LABELS[job.cadence] || job.cadence}</span>
+                <span className="schedule-active-pill">Active</span>
+              </span>
+            </a>
+          ))}
+        </section>
+      )}
+
+      {templates.length > 0 && (
+        <section className="schedule-template-section" aria-labelledby="schedule-template-heading">
+          <h2 id="schedule-template-heading">Start from a template</h2>
+          <div className="schedule-template-grid">
+            {templates.map((template) => (
+              <button
+                key={template.id}
+                type="button"
+                className="schedule-template-card"
+                aria-label={`Use ${template.name} template`}
+                onClick={() => onCreateFromTemplate(template)}
+              >
+                <span className="schedule-template-mark" aria-hidden="true">
+                  ✦
+                </span>
+                <span>
+                  <strong>{template.name}</strong>
+                  <p>{template.description}</p>
+                  <small>
+                    {CADENCE_LABELS[template.cadences[0] || ""] ||
+                      template.cadences[0] ||
+                      "Choose a cadence"}
+                  </small>
+                </span>
+              </button>
+            ))}
+          </div>
+        </section>
+      )}
+    </>
+  );
+}
+
+function ScheduleDetail({
   job,
   receipts,
   feedback,
@@ -273,72 +407,125 @@ function ScheduleJobCard({
   onRun: () => void;
 }) {
   const running = feedback?.kind === "running";
+  const boundedReceipts = receipts.slice(0, 10);
+  const [selectedRunId, setSelectedRunId] = useState<number | null>(receipts[0]?.id ?? null);
+  useEffect(() => {
+    setSelectedRunId(receipts[0]?.id ?? null);
+  }, [job.id, receipts[0]?.id]);
+  const selectedReceipt =
+    receipts.find((receipt) => receipt.id === selectedRunId) || receipts[0] || null;
   return (
-    <article className="schedule-job" aria-label={job.name}>
-      <header className="schedule-job-header">
+    <>
+      <nav className="schedule-breadcrumb" aria-label="Breadcrumb">
+        <a href="#/scheduled">Scheduled tasks</a>
+        <span aria-hidden="true">/</span>
+        <span>{job.name}</span>
+      </nav>
+      <header className="schedule-detail-header">
         <div>
-          <p className="schedule-eyebrow">{CADENCE_LABELS[job.cadence] || job.cadence}</p>
-          <h2>{job.name}</h2>
+          <h1>{job.name}</h1>
+          <label className="schedule-active-switch">
+            <input type="checkbox" role="switch" aria-label="Active" checked readOnly disabled />
+            <span>Active</span>
+          </label>
         </div>
-        <button
-          type="button"
-          aria-label={running ? `Running ${job.name}` : `Run ${job.name} now`}
-          aria-busy={running || undefined}
-          disabled={running}
-          onClick={onRun}
-        >
-          {running ? "Running…" : "Run now"}
-        </button>
+        <div className="schedule-detail-actions">
+          <button type="button" aria-label="Edit task" disabled>
+            <span aria-hidden="true">✎</span>
+          </button>
+          <button type="button" aria-label="Delete task" disabled>
+            <span aria-hidden="true">⌫</span>
+          </button>
+          <button
+            type="button"
+            aria-label={running ? `Running ${job.name}` : `Run ${job.name} now`}
+            aria-busy={running || undefined}
+            disabled={running}
+            onClick={onRun}
+          >
+            {running ? (
+              "Running…"
+            ) : (
+              <>
+                <span aria-hidden="true">▷</span> Run now
+              </>
+            )}
+          </button>
+        </div>
       </header>
 
-      <p className="schedule-job-prompt">{job.prompt}</p>
-      <dl className="schedule-job-facts">
-        <div>
-          <dt>Next run</dt>
-          <dd>
-            <time dateTime={job.nextRunAt || undefined}>{formatTimestamp(job.nextRunAt)}</time>
-          </dd>
-        </div>
-        <div>
-          <dt>Cadence</dt>
-          <dd>{CADENCE_LABELS[job.cadence] || job.cadence}</dd>
-        </div>
-      </dl>
+      <RunFeedbackMessage feedback={feedback} />
 
-      {feedback?.kind === "running" && (
-        <p className="schedule-run-feedback" role="status">
-          Running now. The next scheduled time remains unchanged.
-        </p>
-      )}
-      {feedback?.kind === "already_running" && (
-        <p className="schedule-run-feedback warning" role="status">
-          <strong>Already running.</strong> {feedback.message}
-        </p>
-      )}
-      {feedback?.kind === "failed" && (
-        <div className="schedule-run-feedback error" role="alert">
-          <strong>This run couldn’t be started.</strong>
-          <span>Check that Sourcecado is available, then try again.</span>
-        </div>
-      )}
+      <div className="schedule-detail-grid">
+        <aside className="schedule-history" aria-labelledby="schedule-history-heading">
+          <h2 id="schedule-history-heading">History</h2>
+          {boundedReceipts.length === 0 ? (
+            <p>No runs yet.</p>
+          ) : (
+            <ul>
+              {boundedReceipts.map((receipt) => (
+                <li key={receipt.id}>
+                  <button
+                    type="button"
+                    aria-pressed={selectedReceipt?.id === receipt.id}
+                    onClick={() => setSelectedRunId(receipt.id)}
+                  >
+                    <span>{formatHistoryTimestamp(receipt.startedAt)}</span>
+                    <span>{RUN_STATUS_LABELS[receipt.status]}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </aside>
 
-      <section className="schedule-receipts" aria-labelledby={`schedule-runs-${job.id}`}>
-        <h3 id={`schedule-runs-${job.id}`}>Run receipts</h3>
-        {receipts.length === 0 ? (
-          <p>No runs yet. Run it now or wait for the next scheduled time.</p>
-        ) : (
-          <ul aria-label="Run receipts">
-            {receipts.map((receipt) => (
-              <ScheduleReceipt key={receipt.id} receipt={receipt} />
-            ))}
-          </ul>
-        )}
-      </section>
-    </article>
+        <article className="schedule-detail-body">
+          {selectedReceipt && (
+            <section className="schedule-selected-receipt" aria-label="Selected run receipt">
+              <ul aria-label="Run receipts">
+                <ScheduleReceipt
+                  receipt={selectedReceipt}
+                  heading={
+                    selectedReceipt.id === boundedReceipts[0]?.id
+                      ? "Latest receipt"
+                      : "Run receipt"
+                  }
+                />
+              </ul>
+            </section>
+          )}
+          <section className="schedule-detail-section">
+            <h2>Instructions</h2>
+            <p>{job.prompt}</p>
+          </section>
+          <section className="schedule-detail-section schedule-repeat-row">
+            <div>
+              <h2>Repeats</h2>
+              <p>{CADENCE_LABELS[job.cadence] || job.cadence}</p>
+            </div>
+            <p>
+              Next run{" "}
+              <time dateTime={job.nextRunAt || undefined}>{formatTimestamp(job.nextRunAt)}</time>
+            </p>
+          </section>
+          <section className="schedule-detail-section">
+            <h2>Approvals</h2>
+            <p>
+              No automatic approvals. Enrichment and sending still pause in Inbox for an explicit
+              decision.
+            </p>
+          </section>
+          <p className="schedule-retention-note">
+            Deleting this task stops future runs. Existing receipts and the scheduled thread remain
+            available as history.
+          </p>
+        </article>
+      </div>
+    </>
   );
 }
 
-export function ScheduledPage() {
+export function ScheduledPage({ jobId }: { jobId?: number } = {}) {
   const [state, setState] = useState<PageState>({ status: "loading" });
   const [loadAttempt, setLoadAttempt] = useState(0);
   const [showCreate, setShowCreate] = useState(false);
@@ -347,6 +534,9 @@ export function ScheduledPage() {
   const [saving, setSaving] = useState(false);
   const [createFeedback, setCreateFeedback] = useState<string | null>(null);
   const [runFeedback, setRunFeedback] = useState<Record<number, RunFeedback>>({});
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [sortBy, setSortBy] = useState<"next_run" | "name">("next_run");
 
   useEffect(() => {
     let active = true;
@@ -375,11 +565,40 @@ export function ScheduledPage() {
     [state],
   );
 
-  function openCreate() {
+  const visibleJobs = useMemo(() => {
+    if (state.status !== "loaded") return [];
+    const query = searchQuery.trim().toLocaleLowerCase();
+    return state.schedule.jobs
+      .filter(
+        (job) =>
+          !query ||
+          job.name.toLocaleLowerCase().includes(query) ||
+          job.prompt.toLocaleLowerCase().includes(query),
+      )
+      .sort((left, right) => {
+        if (sortBy === "name") return left.name.localeCompare(right.name);
+        if (left.nextRunAt === right.nextRunAt) return left.name.localeCompare(right.name);
+        if (left.nextRunAt === null) return 1;
+        if (right.nextRunAt === null) return -1;
+        return left.nextRunAt.localeCompare(right.nextRunAt);
+      });
+  }, [searchQuery, sortBy, state]);
+  const selectedJob =
+    state.status === "loaded" && jobId !== undefined
+      ? state.schedule.jobs.find((job) => job.id === jobId)
+      : undefined;
+  const selectedReceipts =
+    state.status === "loaded" && selectedJob
+      ? state.schedule.runs
+          .filter((receipt) => receipt.jobId === selectedJob.id)
+          .sort((left, right) => right.id - left.id)
+      : [];
+
+  function openCreate(template?: ScheduleTemplate) {
     if (state.status !== "loaded") return;
-    const firstTemplate = state.schedule.templates?.[0];
-    if (!firstTemplate) return;
-    setDraft(draftFromTemplate(firstTemplate));
+    const selectedTemplate = template || state.schedule.templates?.[0];
+    if (!selectedTemplate) return;
+    setDraft(draftFromTemplate(selectedTemplate));
     setCreateErrors({});
     setCreateFeedback(null);
     setShowCreate(true);
@@ -470,22 +689,67 @@ export function ScheduledPage() {
 
   return (
     <main className="route-page scheduled-page">
-      <header className="scheduled-page-header">
-        <div>
-          <h1>Scheduled</h1>
-          <p>Run repeatable sourcing work and keep a durable receipt for every attempt.</p>
-        </div>
-        {state.status === "loaded" && state.schedule.jobs.length > 0 && !showCreate && (
-          <button type="button" onClick={openCreate} disabled={!state.schedule.templates?.length}>
-            Create automation
-          </button>
-        )}
-      </header>
+      {jobId === undefined && (
+        <>
+          <header className="scheduled-page-header">
+            <div>
+              <h1>Scheduled tasks</h1>
+              <p>Run tasks on a schedule or whenever you need them.</p>
+            </div>
+            <div className="schedule-list-actions">
+              <button
+                type="button"
+                className="schedule-search-toggle"
+                aria-label="Search scheduled tasks"
+                aria-expanded={searchOpen}
+                aria-controls="schedule-search"
+                onClick={() => setSearchOpen((open) => !open)}
+              >
+                <span aria-hidden="true">⌕</span>
+              </button>
+              <label>
+                <span className="schedule-visually-hidden">Sort scheduled tasks</span>
+                <select
+                  aria-label="Sort scheduled tasks"
+                  value={sortBy}
+                  onChange={(event) => setSortBy(event.target.value as "next_run" | "name")}
+                >
+                  <option value="next_run">Sort by Next run</option>
+                  <option value="name">Sort by Name</option>
+                </select>
+              </label>
+              <button
+                type="button"
+                className="schedule-primary-action"
+                onClick={() => openCreate()}
+                disabled={state.status !== "loaded" || !state.schedule.templates?.length}
+              >
+                New task
+              </button>
+            </div>
+          </header>
+          {searchOpen && (
+            <div className="schedule-search" id="schedule-search">
+              <label htmlFor="schedule-search-input">Search scheduled tasks</label>
+              <input
+                id="schedule-search-input"
+                type="search"
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.target.value)}
+              />
+            </div>
+          )}
+        </>
+      )}
 
       {state.status === "loading" && <LoadingSchedule />}
       {state.status === "failed" && (
         <section className="route-error" role="alert">
-          <h2>Automations couldn’t be loaded</h2>
+          {jobId === undefined ? (
+            <h2>Automations couldn’t be loaded</h2>
+          ) : (
+            <h1>Automations couldn’t be loaded</h1>
+          )}
           <p>Check that Sourcecado is available, then try again.</p>
           <button type="button" onClick={() => setLoadAttempt((attempt) => attempt + 1)}>
             Retry loading automations
@@ -494,71 +758,87 @@ export function ScheduledPage() {
       )}
       {state.status === "loaded" && (
         <>
-          {waitingApprovalCount > 0 && (
-            <aside className="schedule-inbox-summary" role="status">
-              <strong>
-                {waitingApprovalCount} approval{waitingApprovalCount === 1 ? "" : "s"} waiting in
-                Inbox
-              </strong>
-              <span>Open the matching scheduled thread to review the approval in context.</span>
-            </aside>
-          )}
-          {createFeedback && (
-            <p className="schedule-create-feedback" role="status">
-              {createFeedback}
-            </p>
-          )}
-          {showCreate && draft && (
-            <CreateAutomationForm
-              templates={state.schedule.templates || []}
-              draft={draft}
-              errors={createErrors}
-              saving={saving}
-              onChange={setDraft}
-              onCancel={() => {
-                setShowCreate(false);
-                setDraft(null);
-                setCreateErrors({});
-              }}
-              onSubmit={(event) => void submitCreate(event)}
+          {jobId !== undefined && selectedJob && (
+            <ScheduleDetail
+              job={selectedJob}
+              receipts={selectedReceipts}
+              feedback={runFeedback[jobId]}
+              onRun={() => void runNow(selectedJob)}
             />
           )}
-          {createErrors.form && (
-            <p className="schedule-create-feedback error" role="alert">
-              {createErrors.form}
-            </p>
-          )}
-          {state.schedule.jobs.length === 0 && !showCreate && (
-            <section className="schedule-empty">
-              <p className="schedule-eyebrow">Template ready</p>
-              <h2>No automations yet</h2>
-              <p>
-                Start with a weekly sourcing review. You can adjust its name and instructions
-                before saving.
-              </p>
-              <button
-                type="button"
-                onClick={openCreate}
-                disabled={!state.schedule.templates?.length}
-              >
-                Create automation
-              </button>
+          {jobId !== undefined && !selectedJob && (
+            <section className="route-error" role="alert">
+              <h1>Scheduled task not found</h1>
+              <p>This saved task is no longer available.</p>
+              <a href="#/scheduled">Back to Scheduled tasks</a>
             </section>
           )}
-          {state.schedule.jobs.length > 0 && (
-            <div className="schedule-jobs">
-              {state.schedule.jobs.map((job) => (
-                <ScheduleJobCard
-                  key={job.id}
-                  job={job}
-                  receipts={state.schedule.runs
-                    .filter((receipt) => receipt.jobId === job.id)
-                    .sort((a, b) => b.id - a.id)}
-                  feedback={runFeedback[job.id]}
-                  onRun={() => void runNow(job)}
+          {jobId === undefined && (
+            <>
+              {waitingApprovalCount > 0 && (
+                <aside className="schedule-inbox-summary" role="status">
+                  <strong>
+                    {waitingApprovalCount} approval
+                    {waitingApprovalCount === 1 ? "" : "s"} waiting in Inbox
+                  </strong>
+                  <span>Open the matching scheduled thread to review the approval in context.</span>
+                </aside>
+              )}
+              {createFeedback && (
+                <p className="schedule-create-feedback" role="status">
+                  {createFeedback}
+                </p>
+              )}
+              {showCreate && draft && (
+                <CreateAutomationForm
+                  templates={state.schedule.templates || []}
+                  draft={draft}
+                  errors={createErrors}
+                  saving={saving}
+                  onChange={setDraft}
+                  onCancel={() => {
+                    setShowCreate(false);
+                    setDraft(null);
+                    setCreateErrors({});
+                  }}
+                  onSubmit={(event) => void submitCreate(event)}
                 />
-              ))}
-            </div>
+              )}
+              {createErrors.form && (
+                <p className="schedule-create-feedback error" role="alert">
+                  {createErrors.form}
+                </p>
+              )}
+              {state.schedule.jobs.length === 0 && !showCreate && (
+                <section className="schedule-empty">
+                  <p className="schedule-eyebrow">Template ready</p>
+                  <h2>No automations yet</h2>
+                  <p>
+                    Start with a weekly sourcing review. You can adjust its name and instructions
+                    before saving.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => openCreate()}
+                    disabled={!state.schedule.templates?.length}
+                  >
+                    Create automation
+                  </button>
+                </section>
+              )}
+              {state.schedule.jobs.length > 0 && (
+                <ScheduleTaskList
+                  jobs={visibleJobs}
+                  templates={state.schedule.templates || []}
+                  onCreateFromTemplate={openCreate}
+                />
+              )}
+              {state.schedule.jobs.length > 0 && visibleJobs.length === 0 && (
+                <p className="schedule-no-results" role="status">
+                  No saved tasks match “{searchQuery.trim()}”.
+                </p>
+              )}
+            </>
           )}
         </>
       )}

--- a/desktop/surfaces/gui/src/styles/route.css
+++ b/desktop/surfaces/gui/src/styles/route.css
@@ -1129,7 +1129,7 @@
 /* Scheduled routines and durable run receipts */
 .scheduled-page {
   width: 100%;
-  max-width: 1040px;
+  max-width: 900px;
   margin: 0 auto;
 }
 
@@ -1151,11 +1151,11 @@
 }
 
 .scheduled-page-header,
-.schedule-job-header,
+.schedule-detail-header,
 .schedule-create-form > header,
 .schedule-receipt > header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
 }
@@ -1167,12 +1167,62 @@
   line-height: 1.5;
 }
 
-.scheduled-page-header > button,
+.scheduled-page-header h1,
+.schedule-detail-header h1 {
+  font-size: 31px;
+  letter-spacing: -.035em;
+}
+
+.schedule-list-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.scheduled-page .schedule-search-toggle {
+  width: 44px;
+  padding: 0;
+}
+
+.schedule-list-actions select {
+  min-height: 44px;
+  padding: 0 34px 0 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+}
+
+.schedule-list-actions .schedule-primary-action,
 .schedule-form-actions button,
-.schedule-job-header > button {
+.schedule-detail-actions button:last-child {
   border-color: var(--accent);
   background: var(--accent);
   color: var(--surface);
+}
+
+.schedule-search {
+  display: grid;
+  max-width: 560px;
+  gap: 6px;
+  margin-top: 16px;
+}
+
+.schedule-search label {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.schedule-search input {
+  min-height: 44px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
 }
 
 .schedule-eyebrow {
@@ -1183,8 +1233,7 @@
   text-transform: uppercase;
 }
 
-.schedule-loading,
-.schedule-jobs {
+.schedule-loading {
   display: grid;
   gap: 14px;
   margin-top: 24px;
@@ -1365,50 +1414,132 @@
   color: var(--muted);
 }
 
-.schedule-job {
-  padding: 22px;
+.schedule-task-list {
+  display: grid;
+  gap: 10px;
+  margin-top: 24px;
+}
+
+.schedule-task-card {
+  display: grid;
+  width: 100%;
+  max-width: 405px;
+  gap: 8px;
+  padding: 17px;
   border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--surface);
+  color: var(--text);
+  text-decoration: none;
+  transition: border-color 100ms ease, background 100ms ease;
 }
 
-.schedule-job-header h2 {
+.schedule-task-card:hover {
+  border-color: var(--accent);
+  background: var(--accent-tint);
+}
+
+.schedule-task-card:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.schedule-task-card > strong {
+  font-size: 15px;
+  font-weight: 650;
+}
+
+.schedule-task-card > p {
+  display: -webkit-box;
   margin: 0;
-  font-size: 19px;
-  letter-spacing: -.015em;
-}
-
-.schedule-job-prompt {
-  margin: 16px 0;
+  overflow: hidden;
   color: var(--muted);
-  line-height: 1.55;
+  line-height: 1.5;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
 }
 
-.schedule-job-facts {
+.schedule-task-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 14px;
+  color: var(--muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.schedule-active-pill {
+  margin-left: auto;
+  padding: 2px 7px;
+  border-radius: 4px;
+  background: var(--raised);
+  color: var(--muted);
+  font-weight: 650;
+}
+
+.schedule-template-section {
+  margin-top: 32px;
+  padding-top: 24px;
+  border-top: 1px solid var(--border);
+}
+
+.schedule-template-section > h2 {
+  margin: 0 0 12px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.schedule-template-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
-  margin: 0;
+  gap: 8px 20px;
 }
 
-.schedule-job-facts > div {
-  padding: 11px 12px;
-  border-radius: 8px;
+.scheduled-page .schedule-template-card {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr);
+  align-items: start;
+  gap: 10px;
+  padding: 12px;
+  border-color: transparent;
+  background: transparent;
+  text-align: left;
+}
+
+.scheduled-page .schedule-template-card:hover {
   background: var(--raised);
 }
 
-.schedule-job-facts :where(dt, dd) {
-  margin: 0;
+.schedule-template-card p {
+  margin: 3px 0 0;
+  color: var(--muted);
+  font-weight: 400;
+  line-height: 1.45;
 }
 
-.schedule-job-facts dt {
+.schedule-template-card small {
+  display: block;
+  margin-top: 4px;
   color: var(--muted);
   font-size: 11px;
+  font-weight: 400;
 }
 
-.schedule-job-facts dd {
-  margin-top: 4px;
-  font-weight: 600;
+.schedule-template-mark {
+  display: grid;
+  width: 36px;
+  height: 36px;
+  place-items: center;
+  border-radius: 8px;
+  background: var(--raised);
+  color: var(--accent-deep);
+}
+
+.schedule-no-results {
+  margin: 24px 0 0;
+  color: var(--muted);
 }
 
 .schedule-run-feedback {
@@ -1426,36 +1557,176 @@
   flex-direction: column;
 }
 
-.schedule-receipts {
-  margin-top: 22px;
-  padding-top: 18px;
+.schedule-breadcrumb {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 22px;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.schedule-breadcrumb a {
+  flex: 0 0 auto;
+  color: inherit;
+  text-decoration: none;
+}
+
+.schedule-breadcrumb span:last-child {
+  overflow: hidden;
+  color: var(--text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.schedule-detail-header h1 {
+  overflow-wrap: anywhere;
+}
+
+.schedule-active-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.schedule-active-switch input {
+  position: relative;
+  appearance: none;
+  width: 39px;
+  height: 23px;
+  margin: 0;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--raised);
+}
+
+.schedule-active-switch input::before {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 17px;
+  height: 17px;
+  border-radius: 999px;
+  background: var(--muted);
+  content: "";
+  transform: translateX(16px);
+}
+
+.schedule-active-switch input:checked {
+  border-color: var(--accent);
+  background: var(--accent-tint);
+}
+
+.schedule-active-switch input:checked::before {
+  background: var(--accent);
+}
+
+.schedule-detail-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.schedule-detail-actions button:first-child,
+.schedule-detail-actions button:nth-child(2) {
+  width: 44px;
+  padding: 0;
+}
+
+.schedule-detail-actions button:nth-child(2) {
+  border-color: var(--error);
+  color: var(--error);
+}
+
+.schedule-detail-actions button:disabled,
+.schedule-active-switch input:disabled {
+  cursor: not-allowed;
+  opacity: .48;
+}
+
+.schedule-detail-grid {
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr);
+  gap: 42px;
+  margin-top: 24px;
+  padding-top: 24px;
   border-top: 1px solid var(--border);
 }
 
-.schedule-receipts h3 {
-  margin: 0 0 10px;
+.schedule-history {
+  min-width: 0;
+}
+
+.schedule-history h2,
+.schedule-detail-section h2 {
+  margin: 0;
   font-size: 14px;
 }
 
-.schedule-receipts > p {
-  margin: 0;
+.schedule-history > p {
+  margin: 12px 0 0;
   color: var(--muted);
 }
 
-.schedule-receipts > ul,
+.schedule-history ul,
+.schedule-selected-receipt > ul,
 .schedule-artifacts {
   display: grid;
-  gap: 8px;
+  gap: 0;
   margin: 0;
   padding: 0;
   list-style: none;
 }
 
+.schedule-history ul {
+  margin-top: 8px;
+}
+
+.schedule-history button {
+  display: flex;
+  width: 100%;
+  min-height: 44px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 8px;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 500;
+  text-align: left;
+}
+
+.schedule-history button[aria-pressed="true"] {
+  background: var(--accent-tint);
+  color: var(--accent-deep);
+}
+
+.schedule-detail-body {
+  min-width: 0;
+}
+
+.schedule-selected-receipt {
+  min-width: 0;
+}
+
+.schedule-selected-receipt > ul {
+  margin-top: 0;
+}
+
 .schedule-receipt {
+  min-width: 0;
   padding: 13px 14px;
   border: 1px solid var(--border);
   border-radius: 8px;
-  background: var(--canvas);
+  background: var(--surface);
 }
 
 .schedule-receipt.receipt-waiting_approval {
@@ -1475,18 +1746,67 @@
 }
 
 .schedule-receipt > header {
+  align-items: center;
   color: var(--muted);
   font-size: 11px;
 }
 
-.schedule-run-status {
+.schedule-receipt > header h2 {
+  margin: 0;
   color: var(--text);
+  font-size: 14px;
+}
+
+.schedule-run-status {
+  color: var(--accent-deep);
   font-weight: 700;
 }
 
-.schedule-receipt > p {
-  margin: 8px 0 0;
+.schedule-markdown {
+  min-width: 0;
+  margin-top: 8px;
+  overflow-wrap: anywhere;
   line-height: 1.5;
+}
+
+.schedule-markdown > :first-child {
+  margin-top: 0;
+}
+
+.schedule-markdown > :last-child {
+  margin-bottom: 0;
+}
+
+.schedule-markdown :where(p, ul, ol, pre, blockquote, .schedule-markdown-table) {
+  margin: 0 0 10px;
+}
+
+.schedule-markdown pre,
+.schedule-markdown code {
+  max-width: 100%;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.schedule-markdown-table {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.schedule-markdown table {
+  width: max-content;
+  min-width: 100%;
+  border-collapse: collapse;
+}
+
+.schedule-markdown :where(th, td) {
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  text-align: left;
+}
+
+.schedule-markdown a {
+  color: var(--accent-deep);
 }
 
 .schedule-waiting-context {
@@ -1538,6 +1858,49 @@
   text-decoration: none;
 }
 
+.schedule-detail-section {
+  margin-top: 20px;
+  padding-top: 18px;
+  border-top: 1px solid var(--border);
+}
+
+.schedule-detail-section > p,
+.schedule-detail-section > div > p {
+  margin: 8px 0 0;
+  color: var(--muted);
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+.schedule-repeat-row {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.schedule-repeat-row > p {
+  flex: 0 0 auto;
+  font-variant-numeric: tabular-nums;
+}
+
+.schedule-retention-note {
+  margin: 20px 0 0;
+  padding: 10px 12px;
+  border-radius: 7px;
+  background: var(--raised);
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+@media (max-width: 1050px) and (min-width: 768px) {
+  .schedule-detail-grid {
+    grid-template-columns: 260px minmax(0, 1fr);
+    gap: 32px;
+  }
+}
+
 .rail-link {
   justify-content: space-between;
   gap: 8px;
@@ -1558,7 +1921,7 @@
 
 @media (max-width: 767px) {
   .scheduled-page-header,
-  .schedule-job-header {
+  .schedule-detail-header {
     align-items: stretch;
     flex-direction: column;
   }
@@ -1569,18 +1932,46 @@
     flex-direction: column;
   }
 
-  .schedule-job-header button {
+  .schedule-list-actions {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .schedule-list-actions label,
+  .schedule-list-actions select,
+  .schedule-list-actions .schedule-primary-action {
     width: 100%;
   }
 
-  .schedule-job-facts {
-    grid-template-columns: 1fr;
-  }
-
-  .schedule-job,
   .schedule-create-form,
   .schedule-empty {
     padding: 17px;
+  }
+
+  .schedule-task-card {
+    max-width: none;
+  }
+
+  .schedule-template-grid,
+  .schedule-detail-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .schedule-detail-actions {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .schedule-history ul {
+    display: grid;
+    grid-auto-columns: minmax(180px, 1fr);
+    grid-auto-flow: column;
+    overflow-x: auto;
+  }
+
+  .schedule-repeat-row {
+    align-items: flex-start;
+    flex-direction: column;
   }
 
   .schedule-form-actions {

--- a/desktop/surfaces/gui/tests/route.test.ts
+++ b/desktop/surfaces/gui/tests/route.test.ts
@@ -15,6 +15,12 @@ describe("app route parser", () => {
     expect(parseHash("#/memory")).toEqual({ kind: "memory" });
   });
 
+  it("parses a durable Scheduled task detail and rejects malformed task ids", () => {
+    expect(parseHash("#/scheduled/42")).toEqual({ kind: "scheduled", jobId: 42 });
+    expect(parseHash("#/scheduled/not-a-task")).toEqual({ kind: "scheduled" });
+    expect(parseHash("#/scheduled/0")).toEqual({ kind: "scheduled" });
+  });
+
   it("falls back safely when a person id is malformed", () => {
     expect(parseHash("#/people/%E0%A4%A")).toEqual({ kind: "board" });
   });

--- a/desktop/surfaces/gui/tests/scheduledPage.test.tsx
+++ b/desktop/surfaces/gui/tests/scheduledPage.test.tsx
@@ -79,10 +79,122 @@ describe("ScheduledPage", () => {
 
     const { container } = render(<ScheduledPage />);
 
-    expect(screen.getByRole("heading", { level: 1, name: "Scheduled" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: "Scheduled tasks" })).toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveTextContent("Loading automations");
     expect(container.querySelectorAll(".schedule-job-skeleton")).toHaveLength(2);
     expect(container.querySelectorAll(".schedule-receipt-skeleton")).toHaveLength(3);
+  });
+
+  it("opens a durable task detail with labeled instructions and honest lifecycle stubs", async () => {
+    api.getSchedule.mockResolvedValue(schedule({ jobs: [job] }));
+
+    render(<ScheduledPage jobId={job.id} />);
+
+    expect(
+      await screen.findByRole("heading", { level: 1, name: "Weekly priority review" }),
+    ).toBeInTheDocument();
+    const breadcrumb = screen.getByRole("navigation", { name: "Breadcrumb" });
+    expect(within(breadcrumb).getByRole("link", { name: "Scheduled tasks" })).toHaveAttribute(
+      "href",
+      "#/scheduled",
+    );
+    expect(screen.getByRole("heading", { level: 2, name: "Instructions" })).toBeInTheDocument();
+    expect(screen.getByText(job.prompt)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: "Repeats" })).toBeInTheDocument();
+    expect(screen.getByText("Every Monday at 9:00 AM")).toBeInTheDocument();
+    expect(screen.getByText(/Next run/)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2, name: "Approvals" })).toBeInTheDocument();
+    expect(screen.getByText(/No automatic approvals/)).toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: "Active" })).toBeChecked();
+    expect(screen.getByRole("switch", { name: "Active" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Edit task" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Delete task" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Run Weekly priority review now" })).toBeEnabled();
+    expect(screen.getByText(/Existing receipts and the scheduled thread remain available/)).toBeInTheDocument();
+  });
+
+  it("renders safe GFM in a bounded selectable run history", async () => {
+    const receipts = Array.from({ length: 12 }, (_, index) =>
+      run({
+        id: index + 1,
+        startedAt: `2026-08-${String(index + 1).padStart(2, "0")}T09:00:00Z`,
+        summary:
+          index === 11
+            ? "**Top priorities**\n\n- [Maya](https://example.test/maya) needs a response\n- Jordan is due\n\n<script>unsafe()</script>"
+            : `Receipt **${index + 1}**`,
+      }),
+    );
+    api.getSchedule.mockResolvedValue(schedule({ jobs: [job], runs: receipts }));
+
+    const { container } = render(<ScheduledPage jobId={job.id} />);
+
+    const history = await screen.findByRole("complementary", { name: "History" });
+    const historyButtons = within(history).getAllByRole("button");
+    expect(historyButtons).toHaveLength(10);
+    expect(historyButtons[0]).toHaveAttribute("aria-pressed", "true");
+    expect(historyButtons[0]).toHaveTextContent(/\bat\b/);
+    expect(screen.getByText("Top priorities", { selector: "strong" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Maya" })).toHaveAttribute(
+      "href",
+      "https://example.test/maya",
+    );
+    expect(container.querySelector("script")).toBeNull();
+    expect(container).not.toHaveTextContent("unsafe()");
+
+    fireEvent.click(historyButtons[1]);
+
+    expect(historyButtons[1]).toHaveAttribute("aria-pressed", "true");
+    const selectedReceipt = screen.getByRole("region", { name: "Selected run receipt" });
+    expect(within(selectedReceipt).getByText("Completed · 2.1s")).toBeInTheDocument();
+    expect(within(selectedReceipt).getByText("11", { selector: "strong" })).toBeInTheDocument();
+  });
+
+  it("keeps saved tasks compact and navigates each one to its durable detail route", async () => {
+    api.getSchedule.mockResolvedValue(
+      schedule({
+        jobs: [job],
+        runs: [run({ summary: "This receipt belongs on the detail page only." })],
+      }),
+    );
+
+    render(<ScheduledPage />);
+
+    expect(
+      await screen.findByRole("heading", { level: 1, name: "Scheduled tasks" }),
+    ).toBeInTheDocument();
+    const task = screen.getByRole("link", { name: /Weekly priority review/ });
+    expect(task).toHaveAttribute("href", "#/scheduled/4");
+    expect(within(task).getByText("Every Monday at 9:00 AM")).toBeInTheDocument();
+    expect(within(task).getByText("Active")).toBeInTheDocument();
+    expect(within(task).queryByText(/Next/)).not.toBeInTheDocument();
+    expect(screen.queryByText("This receipt belongs on the detail page only.")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Run Weekly priority review now" })).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Use Weekly sourcing review template" }),
+    ).toBeInTheDocument();
+  });
+
+  it("searches saved tasks without mixing templates into the result", async () => {
+    const dailyJob: ScheduleJob = {
+      ...job,
+      id: 5,
+      name: "Daily reply triage",
+      prompt: "Review new replies that need action.",
+    };
+    api.getSchedule.mockResolvedValue(schedule({ jobs: [job, dailyJob] }));
+
+    render(<ScheduledPage />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Search scheduled tasks" }));
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search scheduled tasks" }), {
+      target: { value: "weekly" },
+    });
+
+    expect(screen.getByRole("link", { name: /Weekly priority review/ })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Daily reply triage/ })).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Use Weekly sourcing review template" }),
+    ).toBeInTheDocument();
   });
 
   it("offers a template-backed create action from the empty state", async () => {
@@ -146,10 +258,9 @@ describe("ScheduledPage", () => {
         prompt: template.defaultPrompt,
       }),
     );
-    const routine = await screen.findByRole("article", { name: "Weekly priority review" });
-    expect(within(routine).getAllByText("Every Monday at 9:00 AM")).not.toHaveLength(0);
-    expect(within(routine).getByText("Next run")).toBeInTheDocument();
-    expect(within(routine).getByRole("time")).toHaveAttribute("datetime", job.nextRunAt);
+    const routine = await screen.findByRole("link", { name: /Weekly priority review/ });
+    expect(within(routine).getByText("Every Monday at 9:00 AM")).toBeInTheDocument();
+    expect(routine).toHaveAttribute("href", "#/scheduled/4");
     expect(window.location.hash).toBe("#/scheduled");
   });
 
@@ -191,17 +302,25 @@ describe("ScheduledPage", () => {
       }),
     );
 
-    render(<ScheduledPage />);
+    render(<ScheduledPage jobId={job.id} />);
 
-    const routine = await screen.findByRole("article", { name: "Weekly priority review" });
-    const receipts = within(routine).getByRole("list", { name: "Run receipts" });
-    expect(within(receipts).getByText("Running")).toBeInTheDocument();
-    expect(within(receipts).getByText("Completed")).toBeInTheDocument();
-    expect(within(receipts).getByText("Failed")).toBeInTheDocument();
-    expect(within(receipts).getByText("Waiting for approval")).toBeInTheDocument();
-    expect(within(receipts).getByText("Partial")).toBeInTheDocument();
-    expect(within(receipts).getByText("This run is paused—not complete.")).toBeInTheDocument();
-    expect(within(receipts).getByText("1 approval waiting in Inbox")).toBeInTheDocument();
+    const history = await screen.findByRole("complementary", { name: "History" });
+    expect(within(history).getByText("Running")).toBeInTheDocument();
+    expect(within(history).getByText("Completed")).toBeInTheDocument();
+    expect(within(history).getByText("Failed")).toBeInTheDocument();
+    expect(within(history).getByText("Waiting for approval")).toBeInTheDocument();
+    expect(within(history).getByText("Partial")).toBeInTheDocument();
+    fireEvent.click(within(history).getByRole("button", { name: /Waiting for approval/ }));
+    expect(screen.getByText("This run is paused—not complete.")).toBeInTheDocument();
+    expect(screen.getByText("1 approval waiting in Inbox")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open scheduled thread" })).toHaveAttribute(
+      "href",
+      "#/chat/sched-4",
+    );
+    fireEvent.click(within(history).getByRole("button", { name: /Running/ }));
+    const selectedReceipt = screen.getByRole("region", { name: "Selected run receipt" });
+    expect(within(selectedReceipt).getByText(/In progress/)).toBeInTheDocument();
+    expect(within(selectedReceipt).queryByText(/Legacy run/)).not.toBeInTheDocument();
   });
 
   it("renders a genuinely unknown status as needs-review, not failed", async () => {
@@ -212,11 +331,10 @@ describe("ScheduledPage", () => {
       }),
     );
 
-    render(<ScheduledPage />);
+    render(<ScheduledPage jobId={job.id} />);
 
-    const routine = await screen.findByRole("article", { name: "Weekly priority review" });
-    const receipts = within(routine).getByRole("list", { name: "Run receipts" });
-    expect(within(receipts).getByText("Needs review")).toBeInTheDocument();
+    const receipts = await screen.findByRole("list", { name: "Run receipts" });
+    expect(within(receipts).getByText(/Needs review/)).toBeInTheDocument();
     expect(within(receipts).queryByText("Failed")).not.toBeInTheDocument();
   });
 
@@ -228,11 +346,10 @@ describe("ScheduledPage", () => {
       }),
     );
 
-    render(<ScheduledPage />);
+    render(<ScheduledPage jobId={job.id} />);
 
-    const routine = await screen.findByRole("article", { name: "Weekly priority review" });
-    expect(within(routine).getByText("Legacy run")).toBeInTheDocument();
-    expect(within(routine).queryByText("0ms")).not.toBeInTheDocument();
+    expect(await screen.findByText(/Legacy run/)).toBeInTheDocument();
+    expect(screen.queryByText("0ms")).not.toBeInTheDocument();
   });
 
   it("shows artifact metadata and opens the isolated scheduled thread", async () => {
@@ -254,7 +371,7 @@ describe("ScheduledPage", () => {
       }),
     );
 
-    render(<ScheduledPage />);
+    render(<ScheduledPage jobId={job.id} />);
 
     const receipt = await screen.findByRole("listitem", { name: /Completed run/ });
     expect(within(receipt).getByRole("link", { name: "Priority shortlist" })).toHaveAttribute(
@@ -269,25 +386,30 @@ describe("ScheduledPage", () => {
 
   it("keeps the next scheduled time visible while Run now is in progress", async () => {
     let resolveRun!: (value: { run: ScheduleRun }) => void;
-    api.getSchedule.mockResolvedValue(schedule({ jobs: [job] }));
+    api.getSchedule.mockResolvedValue(
+      schedule({ jobs: [job], runs: [run({ id: 9, summary: "Previous result." })] }),
+    );
     api.runScheduleJob.mockReturnValue(
       new Promise<{ run: ScheduleRun }>((resolve) => {
         resolveRun = resolve;
       }),
     );
 
-    render(<ScheduledPage />);
-    const routine = await screen.findByRole("article", { name: "Weekly priority review" });
-    fireEvent.click(within(routine).getByRole("button", { name: "Run Weekly priority review now" }));
+    window.location.hash = "#/scheduled/4";
+    render(<ScheduledPage jobId={job.id} />);
+    await screen.findByRole("heading", { level: 1, name: "Weekly priority review" });
+    fireEvent.click(screen.getByRole("button", { name: "Run Weekly priority review now" }));
 
-    expect(within(routine).getByRole("button", { name: "Running Weekly priority review" })).toBeDisabled();
-    expect(within(routine).getByRole("time")).toHaveAttribute("datetime", job.nextRunAt);
-    expect(within(routine).getByRole("status")).toHaveTextContent("Running now");
+    expect(screen.getByRole("button", { name: "Running Weekly priority review" })).toBeDisabled();
+    expect(screen.getByRole("time")).toHaveAttribute("datetime", job.nextRunAt);
+    expect(screen.getByRole("status")).toHaveTextContent("Running now");
 
-    resolveRun({ run: run({ id: 10 }) });
-    expect(await within(routine).findByText("Completed")).toBeInTheDocument();
-    expect(within(routine).getByRole("button", { name: "Run Weekly priority review now" })).toBeEnabled();
-    expect(window.location.hash).toBe("#/scheduled");
+    resolveRun({ run: run({ id: 10, summary: "Fresh manual result." }) });
+    const selectedReceipt = await screen.findByRole("region", { name: "Selected run receipt" });
+    expect(within(selectedReceipt).getByText(/Completed/)).toBeInTheDocument();
+    expect(within(selectedReceipt).getByText("Fresh manual result.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Run Weekly priority review now" })).toBeEnabled();
+    expect(window.location.hash).toBe("#/scheduled/4");
   });
 
   it("keeps an already-running conflict contextual and retryable", async () => {
@@ -299,32 +421,32 @@ describe("ScheduledPage", () => {
       ),
     );
 
-    render(<ScheduledPage />);
-    const routine = await screen.findByRole("article", { name: "Weekly priority review" });
-    fireEvent.click(within(routine).getByRole("button", { name: "Run Weekly priority review now" }));
+    render(<ScheduledPage jobId={job.id} />);
+    await screen.findByRole("heading", { level: 1, name: "Weekly priority review" });
+    fireEvent.click(screen.getByRole("button", { name: "Run Weekly priority review now" }));
 
     await waitFor(() =>
-      expect(within(routine).getByRole("status")).toHaveTextContent("Already running"),
+      expect(screen.getByRole("status")).toHaveTextContent("Already running"),
     );
-    expect(within(routine).getByRole("status")).toHaveTextContent("Wait for its current receipt");
-    expect(within(routine).getByRole("button", { name: "Run Weekly priority review now" })).toBeEnabled();
-    expect(within(routine).getByRole("time")).toHaveAttribute("datetime", job.nextRunAt);
+    expect(screen.getByRole("status")).toHaveTextContent("Wait for its current receipt");
+    expect(screen.getByRole("button", { name: "Run Weekly priority review now" })).toBeEnabled();
+    expect(screen.getByRole("time")).toHaveAttribute("datetime", job.nextRunAt);
   });
 
   it("shows safe run and page-load recovery", async () => {
     api.getSchedule.mockRejectedValueOnce(new Error("token=schedule-secret /private/state"));
-    const { container } = render(<ScheduledPage />);
+    const { container } = render(<ScheduledPage jobId={job.id} />);
 
     const pageAlert = await screen.findByRole("alert");
     expect(pageAlert).toHaveTextContent("Automations couldn’t be loaded");
     expect(container).not.toHaveTextContent("schedule-secret");
     api.getSchedule.mockResolvedValueOnce(schedule({ jobs: [job] }));
     fireEvent.click(within(pageAlert).getByRole("button", { name: "Retry loading automations" }));
-    const routine = await screen.findByRole("article", { name: "Weekly priority review" });
+    await screen.findByRole("heading", { level: 1, name: "Weekly priority review" });
 
     api.runScheduleJob.mockRejectedValueOnce(new Error("provider-secret /private/state"));
-    fireEvent.click(within(routine).getByRole("button", { name: "Run Weekly priority review now" }));
-    const runAlert = await within(routine).findByRole("alert");
+    fireEvent.click(screen.getByRole("button", { name: "Run Weekly priority review now" }));
+    const runAlert = await screen.findByRole("alert");
     expect(runAlert).toHaveTextContent("This run couldn’t be started");
     expect(runAlert).toHaveTextContent(/try again/i);
     expect(container).not.toHaveTextContent("provider-secret");

--- a/desktop/surfaces/gui/tests/scheduledStyles.test.ts
+++ b/desktop/surfaces/gui/tests/scheduledStyles.test.ts
@@ -9,15 +9,38 @@ describe("Scheduled route styles", () => {
       /\.schedule-create-form :where\(input, select\)[\s\S]*?min-height:\s*44px;/,
     );
     expect(css).toMatch(/\.schedule-thread-link[\s\S]*?min-height:\s*44px;/);
+    expect(css).toMatch(/\.schedule-history button[\s\S]*?min-height:\s*44px;/);
   });
 
-  it("stacks job and form actions on narrow screens", () => {
+  it("uses compact task cards and a dedicated history-detail grid", () => {
+    expect(css).toMatch(/\.schedule-task-list\s*\{[^}]*display:\s*grid;/);
+    expect(css).toMatch(/\.scheduled-page\s*\{[^}]*max-width:\s*900px;/);
+    expect(css).toMatch(/\.schedule-task-card\s*\{[^}]*max-width:\s*405px;/);
     expect(css).toMatch(
-      /@media \(max-width: 767px\)[\s\S]*?\.scheduled-page-header,[\s\S]*?\.schedule-job-header[\s\S]*?flex-direction:\s*column;/,
+      /\.schedule-detail-grid\s*\{[^}]*grid-template-columns:\s*320px\s+minmax\(0,\s*1fr\);[^}]*gap:\s*42px;/,
+    );
+    expect(css).toMatch(/\.schedule-markdown-table\s*\{[^}]*overflow-x:\s*auto;/);
+  });
+
+  it("stacks list and detail actions on narrow screens", () => {
+    expect(css).toMatch(
+      /@media \(max-width: 767px\)[\s\S]*?\.scheduled-page-header,[\s\S]*?\.schedule-detail-header[\s\S]*?flex-direction:\s*column;/,
     );
     expect(css).toMatch(
-      /@media \(max-width: 767px\)[\s\S]*?\.schedule-job-header button[\s\S]*?width:\s*100%;/,
+      /@media \(max-width: 767px\)[\s\S]*?\.schedule-detail-grid[\s\S]*?grid-template-columns:\s*minmax\(0,\s*1fr\);/,
     );
+  });
+
+  it("keeps keyboard focus visible and disabled lifecycle stubs honest", () => {
+    expect(css).toMatch(/\.schedule-task-card:focus-visible[\s\S]*?outline:/);
+    expect(css).toMatch(
+      /\.schedule-detail-actions button:disabled[\s\S]*?cursor:\s*not-allowed;/,
+    );
+    expect(css).toMatch(
+      /\.schedule-active-switch input\s*\{[^}]*appearance:\s*none;[^}]*border-radius:\s*999px;/,
+    );
+    expect(css).toMatch(/\.schedule-active-switch input\s*\{[^}]*width:\s*39px;[^}]*height:\s*23px;/);
+    expect(css).toMatch(/\.schedule-markdown a\s*\{[^}]*color:\s*var\(--accent-deep\);/);
   });
 
   it("visually distinguishes waiting, partial, failed, and unknown receipts", () => {

--- a/desktop/surfaces/gui/tests/shell.test.tsx
+++ b/desktop/surfaces/gui/tests/shell.test.tsx
@@ -186,7 +186,36 @@ describe("App shell routing", () => {
 
     render(<App />);
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Scheduled" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { level: 1, name: "Scheduled tasks" }),
+    ).toBeInTheDocument();
+  });
+
+  it("restores a direct Scheduled task detail route", async () => {
+    window.location.hash = "#/scheduled/4";
+    api.getSchedule.mockResolvedValue({
+      jobs: [
+        {
+          id: 4,
+          name: "Weekly priority review",
+          templateId: "weekly_sourcing_review",
+          cadence: "weekly_monday_0900",
+          cron: "0 9 * * 1",
+          prompt: "Review priority sourcing work.",
+          createdAt: "2026-08-25T10:00:00Z",
+          nextRunAt: "2026-08-31T09:00:00-07:00",
+        },
+      ],
+      runs: [],
+      templates: [],
+    });
+
+    render(<App />);
+
+    expect(
+      await screen.findByRole("heading", { level: 1, name: "Weekly priority review" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("navigation", { name: "Breadcrumb" })).toBeInTheDocument();
   });
 
   it("renders a direct Connections hash route", async () => {
@@ -346,7 +375,9 @@ describe("App shell routing", () => {
 
     fireEvent.click(screen.getByRole("link", { name: "Scheduled" }));
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Scheduled" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { level: 1, name: "Scheduled tasks" }),
+    ).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Scheduled" })).toHaveAttribute("aria-current", "page");
   });
 
@@ -634,7 +665,9 @@ describe("App shell routing", () => {
 
     render(<App />);
 
-    expect(await screen.findByRole("heading", { level: 1, name: "Scheduled" })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("heading", { level: 1, name: "Scheduled tasks" }),
+    ).toBeInTheDocument();
     expect(api.setLastDestination).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole("link", { name: "Skills" }));


### PR DESCRIPTION
## User problem

Scheduled rendered every prompt and receipt in one expanded page, hiding the saved instruction and making repeated work hard to scan. Operators also had no durable task-detail destination and Markdown summaries appeared as raw syntax.

Closes #162

## What changed

- Replaced expanded automation cards at #/scheduled with the approved compact Scheduled tasks list, search, next-run sorting, saved-task state, and template-backed creation.
- Added durable #/scheduled/:jobId routing with breadcrumb recovery and one dedicated task detail page.
- Matched the approved v4 mockup hierarchy and density: 900px content rail, 405px task card, 31px headings, 320px history rail, icon lifecycle affordances, active switch, receipt header, labeled sections, and retention note.
- Added a bounded selectable history of 10 receipts with truthful status and duration language. Running receipts say In progress; legacy zero-duration terminal receipts remain labeled Legacy run.
- Rendered summaries as safe GFM with raw HTML skipped, bounded tables and code, and safe external artifact URLs preserved through the existing API allowlist.
- Kept Run now real, overlap-safe, and contextual. Waiting approvals remain visibly incomplete, never auto-resume, and link to the scheduled thread.
- Added disabled Edit, Delete, and Active/Pause affordances only. No lifecycle mutation backend was added; #163 owns that work.

## Boundaries

- Included: list and detail UI, routing, search and sort, create flow preservation, Run now, history selection, Markdown, artifacts, scheduled-thread links, loading, empty, missing, failure, responsive, keyboard, and reduced-motion states.
- Explicitly not included: edit, pause, resume, or delete persistence; new schedule APIs; automatic approval; automatic resume; auto-send; auto-enrichment.
- Product invariants preserved: enrichment and sending still require explicit Sourcecado approval, scheduled conversations remain read-only, and external URLs remain http/https allowlisted.

## Verification

### Automated tests

- Tests added or updated: route.test.ts, scheduledPage.test.tsx, scheduledStyles.test.ts, and shell.test.tsx.
- Commands run on current commit 0e60eafa2b180c38a7bd54bd4348c5ffefd46570 after rebasing onto origin/main:
  - make test
  - make build
- Results:
  - Python: 1,951 passed, 3 skipped; one pre-existing Starlette deprecation warning.
  - GUI: 567 passed across 61 files.
  - TypeScript and Vite production build: passed.
  - Vite retained the existing bundle-size advisory only.

### Live behavior demonstration

Local launch with isolated state:

1. From repository root run make setup if dependencies are not installed.
2. In terminal one, create an isolated state directory and start the sidecar with the same local-only token:
   - export SOURCECADO_QA_STATE=$(mktemp -d)
   - CLUB_STATE_DIR=$SOURCECADO_QA_STATE CLUB_API_TOKEN=issue162-local-review make sidecar
3. In terminal two start the UI:
   - VITE_CLUB_TOKEN=issue162-local-review make gui
4. Open http://127.0.0.1:5180/#/scheduled. The sidecar seeds the default weekly task when the isolated state is empty.
5. The deterministic UI fixture matrix is in desktop/surfaces/gui/tests/scheduledPage.test.tsx. Run npm --prefix desktop/surfaces/gui test -- --run tests/scheduledPage.test.tsx to exercise completed, running, failed, waiting approval, partial, interrupted/unknown vocabulary, GFM, artifacts, overlap, empty, loading, error, and Run now without external effects.

Affected routes and interactions:

- #/scheduled: compact saved-task list, search, sort, template cards, New task, create form, empty/loading/error states.
- #/scheduled/:jobId: breadcrumb, disabled lifecycle stubs, Run now, bounded history selection, GFM receipt, artifacts, thread link, approvals, cadence, next run, retention note, missing-task recovery.
- Responsive evidence: Chrome verified desktop and 375x812 layouts; document width remained 375px with no horizontal overflow.
- Console evidence: zero warning or error entries after list load, list-to-detail navigation, receipt selection, search, and phone-width checks.
- Raw visual comparison: checked against parallel-ui-mockups.html v4 plus scheduled-list-v4.png and scheduled-detail-v4.png. Local captured evidence is available at /tmp/sourcecado-162-scheduled-list.png and /tmp/sourcecado-162-scheduled-detail.png for the independent reviewer on this host.

## AI Accountability Note

### AI helped with

Codebase tracing, TDD test design, implementation, browser-state verification, responsive checks, and visual comparison against the user-approved v4 mockup.

### I verified

Every changed route and state contract, safe Markdown behavior, lifecycle non-goals, the full test suite, production build, desktop layout, phone-width layout, focusable controls, list-to-detail navigation, waiting-approval truth, and browser console health.

### I am still uncertain about

The reviewer should challenge visual fidelity across system light mode and whether ten visible history entries is the ideal long-term bound. The bound is intentionally client-side and does not discard receipts.

## Safety and integrations

- [x] No credential, OAuth grant, token, private user data, or raw authorization material was committed or pasted into the PR.
- [x] External effects remain behind the correct permission and approval policy.
- [x] Paid or credit-sensitive actions remain deliberate and approval-gated.
- [x] Source references and restricted data remain scoped correctly.

## Reviewer checklist

- [ ] The change matches #162 and the approved v4 mockup.
- [ ] List and direct-detail routes recover after refresh.
- [ ] Waiting approval, unknown, interrupted, failed, partial, and running receipts stay truthful.
- [ ] Run now preserves overlap protection and next-run time.
- [ ] GFM, artifacts, unsafe URLs, and long content remain bounded.
- [ ] Disabled lifecycle controls do not imply persistence.
- [ ] Desktop and narrow layouts are usable with keyboard-visible focus.