### PR TITLE
Match chat composer to approved mockup

### DIFF
--- a/desktop/surfaces/gui/src/chat/Composer.tsx
+++ b/desktop/surfaces/gui/src/chat/Composer.tsx
@@ -18,36 +18,42 @@ export function Composer({
   }, [aui, initialDraft]);
 
   return (
-    <ComposerPrimitive.Root className="sourcecado-composer">
-      <ComposerPrimitive.Input
-        aria-label="Message Sourcecado"
-        placeholder="Ask Sourcecado about this week’s sourcing work"
-        rows={2}
-        onChange={(event) => onDraftChange(event.currentTarget.value)}
-      />
-      {running ? (
-        <ComposerPrimitive.Cancel
-          className="sourcecado-composer-action"
-          aria-label="Stop run"
-        >
-          <span className="sourcecado-stop-icon" aria-hidden="true" />
-        </ComposerPrimitive.Cancel>
-      ) : (
-        <ComposerPrimitive.Send
-          className="sourcecado-composer-action"
-          aria-label="Send message"
-        >
-          <svg viewBox="0 0 20 20" aria-hidden="true" focusable="false">
-            <path d="M10 15.5v-11M5.5 9 10 4.5 14.5 9" />
-          </svg>
-        </ComposerPrimitive.Send>
-      )}
+    <>
+      <ComposerPrimitive.Root className="sourcecado-composer">
+        <ComposerPrimitive.Input
+          aria-label="Message Sourcecado"
+          placeholder="Ask Sourcecado about this week’s sourcing work"
+          rows={2}
+          onChange={(event) => onDraftChange(event.currentTarget.value)}
+        />
+        {running ? (
+          <ComposerPrimitive.Cancel
+            className="sourcecado-composer-action"
+            aria-label="Stop run"
+          >
+            <span className="sourcecado-composer-action-visual" aria-hidden="true">
+              <span className="sourcecado-stop-icon" />
+            </span>
+          </ComposerPrimitive.Cancel>
+        ) : (
+          <ComposerPrimitive.Send
+            className="sourcecado-composer-action"
+            aria-label="Send message"
+          >
+            <span className="sourcecado-composer-action-visual" aria-hidden="true">
+              <svg viewBox="0 0 20 20" focusable="false">
+                <path d="M10 15.5v-11M5.5 9 10 4.5 14.5 9" />
+              </svg>
+            </span>
+          </ComposerPrimitive.Send>
+        )}
+      </ComposerPrimitive.Root>
       <p
         className={`sourcecado-composer-running ${running ? "is-visible" : ""}`}
         aria-hidden={!running}
       >
         You can keep drafting while Sourcecado works.
       </p>
-    </ComposerPrimitive.Root>
+    </>
   );
 }

--- a/desktop/surfaces/gui/src/styles/chat.css
+++ b/desktop/surfaces/gui/src/styles/chat.css
@@ -596,8 +596,8 @@
 .sourcecado-empty-thread h2 {
   margin: 0;
   color: var(--text);
-  font-size: clamp(24px, 4vw, 30px);
-  font-weight: 550;
+  font-size: 28px;
+  font-weight: 500;
   letter-spacing: -0.025em;
 }
 
@@ -660,10 +660,10 @@
 }
 
 .sourcecado-composer-zone {
-  width: min(808px, calc(100% - 48px));
+  width: min(720px, calc(100% - 40px));
   min-width: 0;
   justify-self: center;
-  padding: 0 0 18px;
+  padding: 0 0 22px;
 }
 
 .sourcecado-suggestion {
@@ -672,14 +672,15 @@
   max-width: 100%;
   min-height: 38px;
   align-items: center;
-  gap: 9px;
-  margin: 0 0 8px 8px;
-  padding: 5px 10px;
+  gap: 10px;
+  margin: 0 0 9px 10px;
+  padding: 0 11px;
   border: 0;
   border-radius: 7px;
   background: transparent;
   color: var(--muted);
   font: inherit;
+  font-size: 13px;
   text-align: left;
   cursor: pointer;
   transition: background-color 140ms ease, color 140ms ease;
@@ -722,12 +723,11 @@
   width: 100%;
   min-width: 0;
   grid-template-columns: minmax(0, 1fr) auto;
-  grid-template-areas:
-    "input action"
-    "status status";
-  gap: 8px;
+  grid-template-areas: "input action";
+  gap: 10px;
+  min-height: 88px;
   align-items: end;
-  padding: 12px;
+  padding: 13px;
   border: 1px solid var(--border);
   border-radius: 10px;
   background: var(--surface);
@@ -738,11 +738,11 @@
   grid-area: input;
   width: 100%;
   min-width: 0;
-  min-height: 44px;
+  min-height: 54px;
   max-height: 160px;
   overflow-y: auto;
   resize: none;
-  padding: 10px 4px;
+  padding: 0;
   border: 0;
   outline: 0;
   background: transparent;
@@ -759,19 +759,29 @@
   min-width: 44px;
   min-height: 44px;
   padding: 0;
+  border: 0;
+  background: transparent;
+  display: grid;
+  place-items: end;
+  align-self: end;
+  cursor: pointer;
+  transition: color 140ms ease;
+}
+
+.sourcecado-composer-action-visual {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
   border: 1px solid var(--accent);
   border-radius: 999px;
   background: var(--accent);
   color: var(--surface);
-  display: grid;
-  place-items: center;
-  cursor: pointer;
-  transition: background-color 140ms ease, border-color 140ms ease, color 140ms ease;
 }
 
-.sourcecado-composer-action svg {
-  width: 20px;
-  height: 20px;
+.sourcecado-composer-action-visual svg {
+  width: 18px;
+  height: 18px;
   fill: none;
   stroke: currentcolor;
   stroke-linecap: round;
@@ -780,8 +790,8 @@
 }
 
 .sourcecado-stop-icon {
-  width: 12px;
-  height: 12px;
+  width: 11px;
+  height: 11px;
   border-radius: 2px;
   background: currentcolor;
 }
@@ -792,19 +802,20 @@
 }
 
 .sourcecado-composer-action:disabled {
-  border-color: var(--border);
-  background: var(--raised);
-  color: var(--muted);
   cursor: default;
 }
 
-.sourcecado-composer-running {
-  grid-column: 1 / -1;
-  grid-area: status;
-  min-height: 17px;
-  margin: 0;
+.sourcecado-composer-action:disabled .sourcecado-composer-action-visual {
+  border-color: var(--border);
+  background: var(--raised);
   color: var(--muted);
-  font-size: 12px;
+}
+
+.sourcecado-composer-running {
+  min-height: 16px;
+  margin: 7px 0 0 13px;
+  color: var(--muted);
+  font-size: 11px;
   visibility: hidden;
 }
 
@@ -848,6 +859,7 @@
   .sourcecado-suggestion {
     min-height: 44px;
     margin-left: 0;
+    padding-block: 3px;
   }
 
   .sourcecado-composer textarea {
@@ -875,7 +887,8 @@
 
 @media (prefers-reduced-motion: reduce) {
   .sourcecado-suggestion,
-  .sourcecado-composer-action {
+  .sourcecado-composer-action,
+  .sourcecado-composer-action-visual {
     transition: none;
   }
 }

--- a/desktop/surfaces/gui/tests/chatPage.test.tsx
+++ b/desktop/surfaces/gui/tests/chatPage.test.tsx
@@ -810,9 +810,15 @@ describe("ChatPage Warm Operator thread", () => {
     const composerRoot = idleAction.closest(".sourcecado-composer");
     expect(idleAction).toHaveClass("sourcecado-composer-action");
     expect(composerRoot?.querySelectorAll(".sourcecado-composer-action")).toHaveLength(1);
+    const runningNote = screen.getByText(
+      "You can keep drafting while Sourcecado works.",
+    );
+    expect(runningNote).toHaveAttribute("aria-hidden", "true");
+    expect(runningNote.closest(".sourcecado-composer")).toBeNull();
+    expect(runningNote.parentElement).toHaveClass("sourcecado-composer-zone");
     expect(
-      screen.getByText("You can keep drafting while Sourcecado works."),
-    ).toHaveAttribute("aria-hidden", "true");
+      idleAction.querySelector(".sourcecado-composer-action-visual"),
+    ).toBeInTheDocument();
     fireEvent.change(composer, { target: { value: "Keep this next prompt" } });
     act(() => {
       onChatEvent?.({
@@ -831,9 +837,10 @@ describe("ChatPage Warm Operator thread", () => {
     expect(screen.queryByRole("button", { name: "Send message" })).not.toBeInTheDocument();
     expect(stop).toHaveClass("sourcecado-composer-action");
     expect(composerRoot?.querySelectorAll(".sourcecado-composer-action")).toHaveLength(1);
+    expect(runningNote).toHaveAttribute("aria-hidden", "false");
     expect(
-      screen.getByText("You can keep drafting while Sourcecado works."),
-    ).toHaveAttribute("aria-hidden", "false");
+      stop.querySelector(".sourcecado-composer-action-visual .sourcecado-stop-icon"),
+    ).toBeInTheDocument();
     fireEvent.click(stop);
     expect(chatCancel).toHaveBeenCalledWith("thread-alpha", "run-cancel-me");
     expect(composer).not.toBeDisabled();

--- a/desktop/surfaces/gui/tests/chatStyles.test.ts
+++ b/desktop/surfaces/gui/tests/chatStyles.test.ts
@@ -44,13 +44,16 @@ describe("Warm Operator thread styles", () => {
 
   it("keeps one fixed composer action slot when Send becomes Stop", () => {
     expect(styles).toMatch(
-      /\.sourcecado-composer\s*\{[^}]*grid-template-areas:\s*"input action"\s*"status status";/,
+      /\.sourcecado-composer\s*\{[^}]*grid-template-areas:\s*"input action";[^}]*min-height:\s*88px;[^}]*padding:\s*13px;/,
     );
     expect(styles).toMatch(
       /\.sourcecado-composer-action\s*\{[^}]*grid-area:\s*action;[^}]*width:\s*44px;[^}]*height:\s*44px;/,
     );
     expect(styles).toMatch(
-      /\.sourcecado-composer-running\s*\{[^}]*min-height:\s*17px;[^}]*visibility:\s*hidden;/,
+      /\.sourcecado-composer-action-visual\s*\{[^}]*width:\s*38px;[^}]*height:\s*38px;/,
+    );
+    expect(styles).toMatch(
+      /\.sourcecado-composer-running\s*\{[^}]*min-height:\s*16px;[^}]*margin:\s*7px 0 0 13px;[^}]*font-size:\s*11px;[^}]*visibility:\s*hidden;/,
     );
     expect(styles).toMatch(
       /\.sourcecado-composer-running\.is-visible\s*\{[^}]*visibility:\s*visible;/,
@@ -59,10 +62,13 @@ describe("Warm Operator thread styles", () => {
 
   it("keeps the empty-thread suggestion understated above the composer", () => {
     expect(styles).toMatch(
-      /\.sourcecado-composer-zone\s*\{[^}]*width:\s*min\(808px, calc\(100% - 48px\)\);/,
+      /\.sourcecado-composer-zone\s*\{[^}]*width:\s*min\(720px, calc\(100% - 40px\)\);/,
     );
     expect(styles).toMatch(
       /\.sourcecado-suggestion\s*\{[^}]*border:\s*0;[^}]*background:\s*transparent;/,
+    );
+    expect(styles).toMatch(
+      /\.sourcecado-empty-thread h2\s*\{[^}]*font-size:\s*28px;[^}]*font-weight:\s*500;/,
     );
   });
 
@@ -74,7 +80,7 @@ describe("Warm Operator thread styles", () => {
       /@media \(max-width: 767px\)[\s\S]*?\.sourcecado-suggestion\s*\{[^}]*min-height:\s*44px;/,
     );
     expect(styles).toMatch(
-      /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.sourcecado-suggestion[\s\S]*?\.sourcecado-composer-action\s*\{[^}]*transition:\s*none;/,
+      /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.sourcecado-suggestion[\s\S]*?\.sourcecado-composer-action,[\s\S]*?\.sourcecado-composer-action-visual\s*\{[^}]*transition:\s*none;/,
     );
   });
 


### PR DESCRIPTION
## User problem

The first #161 implementation preserved behavior but drifted materially from its approved composer mockup: the desktop surface was 808×95 instead of 720×88, the visible action was 44px instead of 38px, the empty heading was 30px instead of 28px, and the running helper was inside the bordered form.

This is the narrow visual-fidelity follow-up to #187. Closes #161.

## What changed

- Capped the desktop composer at 720px and restored the approved 88px minimum height, 13px padding, and single-row layout.
- Rendered a 38px visual Send/Stop circle inside the existing 44px accessible button target.
- Matched the approved 28px, medium-weight empty-state heading and desktop suggestion spacing.
- Moved the running helper below the bordered form while reserving its external row, so Send and Stop retain identical coordinates.
- Kept narrow layouts responsive without reproducing the raw mockup artifact's 900px horizontal overflow.

## Boundaries

- Included: composer geometry, heading weight, action visual size, helper placement, and regression coverage.
- Explicitly not included: Inbox body changes, approval behavior, queue semantics, cancellation semantics, or backend changes.
- Product invariants preserved: the Stop action remains accessibly named, the target remains 44px, drafts stay editable, Enter still queues during active runs, and cancellation remains sidecar-addressed.

## Verification

### Automated tests

- Tests added or updated: form geometry contract, 44px target/38px visual split, external helper placement, idle/running structure, narrow layout, and reduced motion.
- Commands run:
  - `npx vitest run --config vitest.config.ts --reporter=verbose tests/chatPage.test.tsx tests/chatStyles.test.ts`
  - `npm test`
  - `npm run build`
  - `/Users/fisher/Documents/GitHub2026/Sourcecado/desktop/.venv/bin/pytest -q`
- Results: 63 focused tests passed; 559 GUI tests passed; 1,951 sidecar tests passed with 3 skipped and one pre-existing Starlette deprecation warning; production build passed with the existing chunk-size warning.

### Live behavior demonstration

- Starting state: Raw approved mockup and current product rendered in headless Chromium at 1440×960 and 390×844 in dark mode; narrow product also used reduced motion.
- Action performed: Measured idle geometry, filled the suggestion, started a run, and re-measured the Stop state and helper.
- Expected result: 720×88 desktop surface, 28px heading, 38px visual circle inside a 44px target, helper below the border, identical idle/running action coordinates, and no narrow overflow.
- Observed result and evidence: Desktop measured 720×88, 28px, 38×38 inside 44×44. Send and Stop targets stayed at x=1138/y=857 and their visuals at x=1144/y=863. Narrow stayed at scrollWidth 390, form height 88, target x=316/y=751, and visual x=322/y=757. Both pages had zero console errors.

## AI Accountability Note

### AI helped with

The strict red-green-refactor cycle, raw-mockup comparison, component geometry, responsive verification, and browser measurements.

### I verified

The complete four-file diff, focused and full automated suites, production build, raw mockup metrics, dark desktop and narrow screenshots, reduced motion, helper placement, and exact idle/running coordinates.

### I am still uncertain about

No known functional uncertainty. Review should focus on visual fidelity and confirm that reserving the helper row outside the border is the preferred no-shift interpretation.

## Safety and integrations

- [x] No credential, OAuth grant, token, private user data, or raw authorization material was committed or pasted into the PR.
- [x] External effects remain behind the correct permission and approval policy.
- [x] Paid or credit-sensitive actions remain deliberate, approval-gated, and outside mandatory course work.
- [x] Source references and restricted data remain scoped correctly when applicable.

## Reviewer checklist

- [ ] The change matches the ticket and respects its non-goals.
- [ ] The normal and important failure paths are covered.
- [ ] Automated verification is appropriate and passes.
- [ ] The live behavior demonstration is credible when required.
- [ ] The diff is understandable and safe to merge.
- [ ] I am giving meaningful Peer Approval, not a rubber stamp.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the chat composer layout with a narrower, more compact design.
  * Improved spacing and sizing for the message field, suggestions, status text, and empty-thread heading.
  * Updated Send and Stop controls with clearer visual treatment and improved reduced-motion support.

* **Bug Fixes**
  * Running-status messaging now displays beneath the composer without disrupting draft text while a response is in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->